### PR TITLE
fix(ui): correctly load list thumbnails

### DIFF
--- a/Shared/ItemListView.swift
+++ b/Shared/ItemListView.swift
@@ -24,7 +24,7 @@ struct ItemListView: View {
     var body: some View {
         List(items) { item in
             ZStack(alignment: .leading) {
-                ItemRow(item: item, loader: RemoteImageLoader(url: item.url, session: URLSession.shared))
+                ItemRow(item: item, loader: RemoteImageLoader(url: item.thumbnailURL, session: URLSession.shared))
                 NavigationLink(destination: ItemDestinationView(item: item)) { }
                     .hidden()
             }


### PR DESCRIPTION
Initialize a remote image loader with the thumbnail URL of an item, and not the item's URL.