### PR TITLE
Isolate environment initialization to Services struct

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		166EFAE326825D9600A027CD /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE126825D9600A027CD /* Services.swift */; };
 		166EFAE526825DC000A027CD /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE426825DC000A027CD /* Keys.swift */; };
 		166EFAE626825DC000A027CD /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE426825DC000A027CD /* Keys.swift */; };
+		166EFAE8268281F300A027CD /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE7268281F300A027CD /* ReaderToolbar.swift */; };
+		166EFAEA2682821300A027CD /* WebReaderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE92682821300A027CD /* WebReaderScreen.swift */; };
 		167F8084264B011600D8F507 /* Sails in Frameworks */ = {isa = PBXBuildFile; productRef = 167F8083264B011600D8F507 /* Sails */; };
 		167F8086264B1DB300D8F507 /* AccessTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F8085264B1DB300D8F507 /* AccessTokenStore.swift */; };
 		167F8087264B1DB300D8F507 /* AccessTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F8085264B1DB300D8F507 /* AccessTokenStore.swift */; };
@@ -221,6 +223,8 @@
 		166C424B26682959004CA5BB /* AttributedStringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringView.swift; sourceTree = "<group>"; };
 		166EFAE126825D9600A027CD /* Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; };
 		166EFAE426825DC000A027CD /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
+		166EFAE7268281F300A027CD /* ReaderToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
+		166EFAE92682821300A027CD /* WebReaderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebReaderScreen.swift; sourceTree = "<group>"; };
 		167F8085264B1DB300D8F507 /* AccessTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenStore.swift; sourceTree = "<group>"; };
 		167F8088264B1E1700D8F507 /* AccessTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenStoreTests.swift; sourceTree = "<group>"; };
 		167F808A264B213900D8F507 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
@@ -511,10 +515,12 @@
 			isa = PBXGroup;
 			children = (
 				166BAD042656E76B00E401F0 /* ItemElement.swift */,
-				166BAD052656E76B00E401F0 /* SignInScreen.swift */,
-				166BAD062656E76B00E401F0 /* ReaderScreen.swift */,
-				166BAD072656E76B00E401F0 /* UserListScreen.swift */,
 				166BAD082656E76B00E401F0 /* PocketApp.swift */,
+				166BAD062656E76B00E401F0 /* ReaderScreen.swift */,
+				166EFAE7268281F300A027CD /* ReaderToolbar.swift */,
+				166BAD052656E76B00E401F0 /* SignInScreen.swift */,
+				166BAD072656E76B00E401F0 /* UserListScreen.swift */,
+				166EFAE92682821300A027CD /* WebReaderScreen.swift */,
 			);
 			path = Elements;
 			sourceTree = "<group>";
@@ -1124,6 +1130,8 @@
 				166BAD0D2656E76B00E401F0 /* PocketApp.swift in Sources */,
 				166BAD0B2656E76B00E401F0 /* ReaderScreen.swift in Sources */,
 				166A81C52637406C0015AA1D /* Tests_iOS.swift in Sources */,
+				166EFAE8268281F300A027CD /* ReaderToolbar.swift in Sources */,
+				166EFAEA2682821300A027CD /* WebReaderScreen.swift in Sources */,
 				166BAD0A2656E76B00E401F0 /* SignInScreen.swift in Sources */,
 				166BACF82656E3C600E401F0 /* Fixture.swift in Sources */,
 				166BAD092656E76B00E401F0 /* ItemElement.swift in Sources */,

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		166BAD0B2656E76B00E401F0 /* ReaderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD062656E76B00E401F0 /* ReaderScreen.swift */; };
 		166BAD0C2656E76B00E401F0 /* UserListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD072656E76B00E401F0 /* UserListScreen.swift */; };
 		166BAD0D2656E76B00E401F0 /* PocketApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD082656E76B00E401F0 /* PocketApp.swift */; };
+		166EFAE226825D9600A027CD /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE126825D9600A027CD /* Services.swift */; };
+		166EFAE326825D9600A027CD /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE126825D9600A027CD /* Services.swift */; };
+		166EFAE526825DC000A027CD /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE426825DC000A027CD /* Keys.swift */; };
+		166EFAE626825DC000A027CD /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE426825DC000A027CD /* Keys.swift */; };
 		167F8084264B011600D8F507 /* Sails in Frameworks */ = {isa = PBXBuildFile; productRef = 167F8083264B011600D8F507 /* Sails */; };
 		167F8086264B1DB300D8F507 /* AccessTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F8085264B1DB300D8F507 /* AccessTokenStore.swift */; };
 		167F8087264B1DB300D8F507 /* AccessTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167F8085264B1DB300D8F507 /* AccessTokenStore.swift */; };
@@ -215,6 +219,8 @@
 		166BAD072656E76B00E401F0 /* UserListScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserListScreen.swift; sourceTree = "<group>"; };
 		166BAD082656E76B00E401F0 /* PocketApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketApp.swift; sourceTree = "<group>"; };
 		166C424B26682959004CA5BB /* AttributedStringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringView.swift; sourceTree = "<group>"; };
+		166EFAE126825D9600A027CD /* Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; };
+		166EFAE426825DC000A027CD /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
 		167F8085264B1DB300D8F507 /* AccessTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenStore.swift; sourceTree = "<group>"; };
 		167F8088264B1E1700D8F507 /* AccessTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenStoreTests.swift; sourceTree = "<group>"; };
 		167F808A264B213900D8F507 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
@@ -423,8 +429,10 @@
 			children = (
 				167F8091264B2E8F00D8F507 /* Environment.swift */,
 				167F808A264B213900D8F507 /* Keychain.swift */,
+				166EFAE426825DC000A027CD /* Keys.swift */,
 				166A81A92637406B0015AA1D /* PocketApp.swift */,
 				F2D6C792266A6C63002022AD /* SafariView.swift */,
+				166EFAE126825D9600A027CD /* Services.swift */,
 				16973351263CB3580003DE2A /* SignInView.swift */,
 				16B133A8267BBAC000BD0A2B /* StaticDataCleaner.swift */,
 				16E14D2026680666009A0991 /* Sync+Textile.swift */,
@@ -1056,6 +1064,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				162AAD8F263C7A7E00783011 /* AuthorizeRequest.swift in Sources */,
+				166EFAE526825DC000A027CD /* Keys.swift in Sources */,
 				16BE21BC266068FF0037F783 /* ItemPresenter.swift in Sources */,
 				F22DBC0426794ACA002E1895 /* ReaderSettingsView.swift in Sources */,
 				160CD82A2669940600AA84A1 /* ArticleComponentView.swift in Sources */,
@@ -1076,6 +1085,7 @@
 				166A81D22637406C0015AA1D /* PocketApp.swift in Sources */,
 				160CD82726698EF500AA84A1 /* ArticleViewState.swift in Sources */,
 				167F808B264B213900D8F507 /* Keychain.swift in Sources */,
+				166EFAE226825D9600A027CD /* Services.swift in Sources */,
 				16E14D2126680666009A0991 /* Sync+Textile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1090,7 +1100,9 @@
 				F27DED32267956ED00154791 /* ReaderSettings.swift in Sources */,
 				16BD7AF32639E00A00F6471F /* URLSessionProtocol.swift in Sources */,
 				160CD82B2669940600AA84A1 /* ArticleComponentView.swift in Sources */,
+				166EFAE626825DC000A027CD /* Keys.swift in Sources */,
 				16BD7AF02639DE9000F6471F /* AuthorizationClient.swift in Sources */,
+				166EFAE326825D9600A027CD /* Services.swift in Sources */,
 				162AAD94263C9CCD00783011 /* AuthorizeResponse.swift in Sources */,
 				16B133AA267BBAC000BD0A2B /* StaticDataCleaner.swift in Sources */,
 				F22DBC0526794ACA002E1895 /* ReaderSettingsView.swift in Sources */,

--- a/Shared/Authorization/AccessTokenStore.swift
+++ b/Shared/Authorization/AccessTokenStore.swift
@@ -70,9 +70,5 @@ class AccessTokenStore {
 }
 
 extension AccessTokenStore: AccessTokenProvider {
-    var consumerKey: String {
-        // TODO: Find a way to not have to access this directly via bundle
-        // (we are doing the same thing in Environment when instantiating AuthorizationClient
-        return Bundle.main.infoDictionary!["PocketAPIConsumerKey"] as! String
-    }
+
 }

--- a/Shared/Environment.swift
+++ b/Shared/Environment.swift
@@ -4,27 +4,18 @@
 
 import SwiftUI
 import Sync
-import Textile
 
 
 private struct AccessTokenStoreKey: EnvironmentKey {
-    static var defaultValue: AccessTokenStore = AccessTokenStore(
-        keychain: SecItemKeychain()
-    )
+    static var defaultValue: AccessTokenStore = Services.shared.accessTokenStore
 }
 
 private struct AuthorizationClientKey: EnvironmentKey {
-    static var defaultValue: AuthorizationClient = AuthorizationClient(
-        consumerKey: Bundle.main.infoDictionary!["PocketAPIConsumerKey"] as! String,
-        session: URLSession.shared
-    )
+    static var defaultValue: AuthorizationClient = Services.shared.authClient
 }
 
 struct SourceKey: EnvironmentKey {
-    // TODO: Find a way to not require two instances of AccessTokenStore
-    static var defaultValue = Source(
-        accessTokenProvider: AccessTokenStore(keychain: SecItemKeychain())
-    )
+    static var defaultValue = Services.shared.source
 }
 
 extension EnvironmentValues {

--- a/Shared/Item/ItemDestinationView.swift
+++ b/Shared/Item/ItemDestinationView.swift
@@ -94,6 +94,7 @@ private struct ItemToolbar: ViewModifier {
                     Image(systemName: "safari")
                 }
                 .disabled(item.url == nil)
+                .accessibility(identifier: "web-reader-button")
                 
                 Button(action: {
                     isPresentingOverflow = true

--- a/Shared/Item/ItemPresenter.swift
+++ b/Shared/Item/ItemPresenter.swift
@@ -19,7 +19,7 @@ class ItemPresenter: ItemRow {
     }
 
     public var domain: String {
-        item.domain ?? "Unknown Domain"
+        item.domainMetadata?.name ?? item.domain ?? ""
     }
 
     public var timeToRead: String? {

--- a/Shared/Keys.swift
+++ b/Shared/Keys.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+
+struct Keys {
+    static let shared = Keys()
+
+    let pocketApiConsumerKey: String
+
+    private init() {
+        guard let pocketApiConsumerKey = Bundle.main.infoDictionary!["PocketAPIConsumerKey"] as? String else {
+            fatalError("Unable to extract PocketApiConsumerKey from main bundle")
+        }
+
+        self.pocketApiConsumerKey = pocketApiConsumerKey
+    }
+}

--- a/Shared/Services.swift
+++ b/Shared/Services.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sync
+
+
+struct Services {
+    static let shared = Services()
+
+    let keychain: Keychain
+    let accessTokenStore: AccessTokenStore
+    let urlSession: URLSessionProtocol
+    let authClient: AuthorizationClient
+    let source: Source
+
+    private init() {
+        keychain = SecItemKeychain()
+        accessTokenStore = AccessTokenStore(keychain: keychain)
+
+        urlSession = URLSession.shared
+        authClient = AuthorizationClient(
+            consumerKey: Keys.shared.pocketApiConsumerKey,
+            session: urlSession
+        )
+
+        source = Source(
+            accessTokenProvider: accessTokenStore,
+            consumerKey: Keys.shared.pocketApiConsumerKey
+        )
+    }
+}

--- a/Sync/Item+Extensions.swift
+++ b/Sync/Item+Extensions.swift
@@ -9,10 +9,15 @@ extension Item {
     typealias RemoteItem = UserByTokenQuery.Data.UserByToken.SavedItem.Edge.Node
     
     func update(from remoteItem: RemoteItem) {
-        domain = remoteItem.item.domainMetadata?.name ?? remoteItem.item.domain ?? "No Domain"
+        domain = remoteItem.item.domain
         title = remoteItem.item.title
         url = URL(string: remoteItem.url)
         particleJSON = remoteItem.item.particleJson
+
+        if let context = managedObjectContext {
+            domainMetadata = DomainMetadata(context: context)
+            domainMetadata?.name = remoteItem.item.domainMetadata?.name
+        }
 
         if let imageURL = remoteItem.item.topImageUrl {
             thumbnailURL = URL(string: imageURL)

--- a/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19141.11" systemVersion="20E232" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DomainMetadata" representedClassName="DomainMetadata" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="domainMetadata" inverseEntity="Item"/>
+    </entity>
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="domain" optional="YES" attributeType="String"/>
         <attribute name="particleJSON" optional="YES" attributeType="String"/>
@@ -8,8 +12,10 @@
         <attribute name="timeToRead" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
+        <relationship name="domainMetadata" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DomainMetadata" inverseName="item" inverseEntity="DomainMetadata"/>
     </entity>
     <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="134"/>
+        <element name="Item" positionX="-63" positionY="-18" width="128" height="149"/>
+        <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="59"/>
     </elements>
 </model>

--- a/Sync/Source.swift
+++ b/Sync/Source.swift
@@ -19,11 +19,13 @@ public class Source {
 
     public convenience init(
         accessTokenProvider: AccessTokenProvider,
+        consumerKey: String,
         container: NSPersistentContainer = .createDefault(),
         errorSubject: PassthroughSubject<Error, Never>? = nil
     ) {
         let apollo = ApolloClient.createDefault(
-            accessTokenProvider: accessTokenProvider
+            accessTokenProvider: accessTokenProvider,
+            consumerKey: consumerKey
         )
 
         self.init(

--- a/Sync/Space.swift
+++ b/Sync/Space.swift
@@ -39,8 +39,10 @@ class Space {
     }
     
     func save() throws {
-        if context.hasChanges {
-            try context.save()
+        try DispatchQueue.main.sync {
+            if context.hasChanges {
+                try context.save()
+            }
         }
     }
     

--- a/SyncTests/Fixtures/list.json
+++ b/SyncTests/Fixtures/list.json
@@ -20,7 +20,7 @@
                                 "__typename": "[type-name-here]",
                                 "title": "Item 1",
                                 "topImageUrl": "https://example.com/item-1/top-image.jpg",
-                                "domain": null,
+                                "domain": "example.com",
                                 "timeToRead": 6,
                                 "particleJson": "<just-json-things>",
                                 "domainMetadata": {

--- a/SyncTests/SourceTests.swift
+++ b/SyncTests/SourceTests.swift
@@ -105,7 +105,8 @@ class SourceTests: XCTestCase {
 
         do {
             let item = items[0]
-            XCTAssertEqual(item.domain, "WIRED")
+            XCTAssertEqual(item.domain, "example.com")
+            XCTAssertEqual(item.domainMetadata?.name, "WIRED")
             XCTAssertEqual(item.thumbnailURL, URL(string: "https://example.com/item-1/top-image.jpg")!)
             XCTAssertEqual(item.timestamp, Date(timeIntervalSince1970: 0))
             XCTAssertEqual(item.timeToRead, 6)

--- a/SyncTests/Support/MockApolloClient.swift
+++ b/SyncTests/Support/MockApolloClient.swift
@@ -58,18 +58,6 @@ class MockApolloClient: ApolloClientProtocol {
         }
 
         return impl(query, cachePolicy, contextIdentifier, queue, resultHandler)
-
-//        if query is UserByTokenQuery,
-//           let resultHandler = resultHandler as? GraphQLResultHandler<UserByTokenQuery.Data> {
-//            let url = Bundle(for: Self.self).url(forResource: "list", withExtension: "json")!
-//            let jsonData = try! Data(contentsOf: url)
-//            let json = (try! JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any])["data"] as! [String: Any]
-//            let data = try! UserByTokenQuery.Data(jsonObject: json)
-//            let result = GraphQLResult(data: data, extensions: nil, errors: nil, source: .cache, dependentKeys: nil)
-//            resultHandler(.success(result))
-//        }
-//
-//        return MockCancellable()
     }
 
     func stubFetch<Query: GraphQLQuery>(impl: @escaping FetchImpl<Query>) {

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -14,7 +14,7 @@
                         "cursor": "cursor-1",
                         "node": {
                             "__typename": "[type-name-here]",
-                            "url": "https://example.com/item-1",
+                            "url": "http://localhost:8080/hello",
                             "_createdAt": 0,
                             "item": {
                                 "__typename": "[type-name-here]",

--- a/Tests iOS/Fixtures/updated-list.json
+++ b/Tests iOS/Fixtures/updated-list.json
@@ -14,7 +14,7 @@
                         "cursor": "cursor-1",
                         "node": {
                             "__typename": "[type-name-here]",
-                            "url": "https://example.com/item-1",
+                            "url": "http://localhost:8080/hello",
                             "_createdAt": 0,
                             "item": {
                                 "__typename": "[type-name-here]",

--- a/Tests iOS/Support/Elements/PocketApp.swift
+++ b/Tests iOS/Support/Elements/PocketApp.swift
@@ -45,4 +45,12 @@ struct PocketApp {
     func readerView() -> ReaderScreen {
         return ReaderScreen(el: app.scrollViews["article-view"])
     }
+
+    func readerToolbar() -> ReaderToolbar {
+        return ReaderToolbar(el: app.toolbars.element(boundBy: 0))
+    }
+
+    func webReaderView() -> WebReaderScreen {
+        return WebReaderScreen(el: app.webViews.element(boundBy: 0))
+    }
 }

--- a/Tests iOS/Support/Elements/ReaderToolbar.swift
+++ b/Tests iOS/Support/Elements/ReaderToolbar.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+
+struct ReaderToolbar {
+    let el: XCUIElement
+
+    func webReaderButton() -> XCUIElement {
+        return el.buttons["web-reader-button"]
+    }
+
+    func waitForExistence() -> Bool {
+        return el.waitForExistence(timeout: 1)
+    }
+}

--- a/Tests iOS/Support/Elements/WebReaderScreen.swift
+++ b/Tests iOS/Support/Elements/WebReaderScreen.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+
+struct WebReaderScreen {
+    let el: XCUIElement
+
+    func waitForExistence() -> Bool {
+        return el.waitForExistence(timeout: 1)
+    }
+
+    func staticText(matching string: String) -> XCUIElement {
+        return el.staticTexts[string]
+    }
+}

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -37,7 +37,7 @@ class Tests_iOS: XCTestCase {
             )
         }
 
-        server.routes.get("/hello.html") { _, _ in
+        server.routes.get("/hello") { _, _ in
             Response {
                 Status.ok
                 Fixture.data(name: "hello", ext: "html")
@@ -157,5 +157,30 @@ class Tests_iOS: XCTestCase {
             let text = readerView.staticText(containing: expectedString)
             XCTAssertTrue(text.waitForExistence(timeout: 10))
         }
+    }
+
+    func test_3_webReader_displaysWebContent() {
+        app.launch()
+
+        let list = app.userListView()
+        XCTAssertTrue(list.waitForExistence())
+
+        let item = list.itemView(at: 0)
+        XCTAssertTrue(item.waitForExistence())
+        item.tap()
+
+        let readerView = app.readerView()
+        XCTAssertTrue(readerView.waitForExistence())
+
+        let toolbar = app.readerToolbar()
+        XCTAssertTrue(toolbar.waitForExistence())
+
+        let webReaderButton = toolbar.webReaderButton()
+        XCTAssertTrue(webReaderButton.waitForExistence(timeout: 10))
+        webReaderButton.tap()
+
+        let webView = app.webReaderView()
+        XCTAssertTrue(webView.waitForExistence())
+        XCTAssertTrue(webView.staticText(matching: "Hello, world").waitForExistence(timeout: 10))
     }
 }


### PR DESCRIPTION
When setting up service objects (such as AuthorizationClient and
Source), do so in Services and then connect the SwiftUI.Environment to
each service as necessary.

Set up Keys struct to encapsulate keys and other shared secrets (naming
could probably be improved).

Also remove `consumerKey` requirement from `AuthTokenProvider` and just
pass it in since it should never change.