### PR TITLE
fix(sync): interpret graphql timestamps as seconds

### DIFF
--- a/Sync/Item+Extensions.swift
+++ b/Sync/Item+Extensions.swift
@@ -31,8 +31,7 @@ extension Item {
             return
         }
         
-        let interval = round(timeInterval / 1000)
-        timestamp = Date(timeIntervalSince1970: interval)
+        timestamp = Date(timeIntervalSince1970: timeInterval)
     }
 
     public var particle: Article? {


### PR DESCRIPTION
I believe the mock data was returning unix timestamps in milliseconds, rather than in seconds as the backend currently does. Simple change: interpret the timestamp as a unix timestamp in seconds, rather than milliseconds.