### PR TITLE
fix: show URL as item title when title is missing or empty

### DIFF
--- a/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
@@ -17,7 +17,9 @@ class ItemPresenter: ItemRow {
     }
 
     public var title: String {
-        item.title ?? item.thumbnailURL?.absoluteString ?? "Missing Title"
+        [item.title, item.url?.absoluteString]
+            .compactMap { $0 }
+            .first { !$0.isEmpty } ?? ""
     }
 
     public var domain: String {


### PR DESCRIPTION
https://getpocket.atlassian.net/browse/IN-168