### PR TITLE
feat(analytics): initial snowplow support

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
+        }
+      },
+      {
         "package": "InflectorKit",
         "repositoryURL": "https://github.com/apollographql/InflectorKit",
         "state": {
@@ -62,6 +71,15 @@
           "branch": null,
           "revision": "f7c3de2d9fc09d7a61f7259521d97091fb2f8bda",
           "version": "7.1.3"
+        }
+      },
+      {
+        "package": "SnowplowTracker",
+        "repositoryURL": "https://github.com/snowplow/snowplow-objc-tracker",
+        "state": {
+          "branch": null,
+          "revision": "2cf806e834a75ce801c46f0182f23b481655762b",
+          "version": "2.2.1"
         }
       },
       {
@@ -123,8 +141,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
-          "version": "2.30.0"
+          "revision": "9a992ee3de1f8da9f2968fc96b26714834f3105f",
+          "version": "2.31.1"
         }
       },
       {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
         "state": {
           "branch": null,
-          "revision": "84e28febb0a6cc3b4b08968c0d7043afd288004e",
-          "version": "0.45.0"
+          "revision": "f3d9f55144b636a2569f938f5969e50174d39009",
+          "version": "0.46.0"
         }
       },
       {
@@ -29,30 +29,12 @@
         }
       },
       {
-        "package": "InflectorKit",
-        "repositoryURL": "https://github.com/apollographql/InflectorKit",
-        "state": {
-          "branch": null,
-          "revision": "b1d0099abe36facd198113633f502889842906af",
-          "version": "0.0.2"
-        }
-      },
-      {
         "package": "Kingfisher",
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": "fix/xcode-13",
           "revision": "f012224344f09421588a28e9f6259968e3574f8b",
           "version": null
-        }
-      },
-      {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
-        "state": {
-          "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
         }
       },
       {
@@ -69,8 +51,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "f7c3de2d9fc09d7a61f7259521d97091fb2f8bda",
-          "version": "7.1.3"
+          "revision": "d9b37a6664cf2467efda861e1383ec806a221b18",
+          "version": "7.1.4"
         }
       },
       {
@@ -80,15 +62,6 @@
           "branch": null,
           "revision": "2cf806e834a75ce801c46f0182f23b481655762b",
           "version": "2.2.1"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
         }
       },
       {
@@ -107,15 +80,6 @@
           "branch": null,
           "revision": "8cf77babe5901693396436f4f418a6db0f328b78",
           "version": "3.1.2"
-        }
-      },
-      {
-        "package": "Stencil",
-        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
-        "state": {
-          "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
         }
       },
       {

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Pocket.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AnalyticsTests"
+               BuildableName = "AnalyticsTests"
+               BlueprintName = "AnalyticsTests"
+               ReferencedContainer = "container:PocketKit">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -56,6 +70,16 @@
                BuildableName = "Tests iOS.xctest"
                BlueprintName = "Tests iOS"
                ReferencedContainer = "container:Pocket.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AnalyticsTests"
+               BuildableName = "AnalyticsTests"
+               BlueprintName = "AnalyticsTests"
+               ReferencedContainer = "container:PocketKit">
             </BuildableReference>
          </TestableReference>
       </Testables>

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "apollo-ios",
+        "package": "Apollo",
         "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
         "state": {
           "branch": null,
           "revision": "84e28febb0a6cc3b4b08968c0d7043afd288004e",
           "version": "0.45.0"
+        }
+      },
+      {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
         }
       },
       {
@@ -38,12 +47,21 @@
         }
       },
       {
-        "package": "sentry-cocoa",
+        "package": "Sentry",
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
         "state": {
           "branch": null,
           "revision": "f7c3de2d9fc09d7a61f7259521d97091fb2f8bda",
           "version": "7.1.3"
+        }
+      },
+      {
+        "package": "SnowplowTracker",
+        "repositoryURL": "https://github.com/snowplow/snowplow-objc-tracker",
+        "state": {
+          "branch": null,
+          "revision": "2cf806e834a75ce801c46f0182f23b481655762b",
+          "version": "2.2.1"
         }
       },
       {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .library(name: "PocketKit", targets: ["PocketKit"]),
         .library(name: "Textile", targets: ["Textile"]),
         .library(name: "Sync", targets: ["Sync"]),
+        .library(name: "Analytics", targets: ["Analytics"]),
         .executable(name: "ApolloCodegen", targets: ["ApolloCodegen"]),
     ],
     dependencies: [
@@ -17,9 +18,10 @@ let package = Package(
         .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .branch("fix/xcode-13")),
         .package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "7.0.0")),
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
+        .package(name: "SnowplowTracker", url: "https://github.com/snowplow/snowplow-objc-tracker", .upToNextMinor(from: "2.2.0"))
     ],
     targets: [
-        .target(name: "PocketKit", dependencies: ["Sync", "Textile"]),
+        .target(name: "PocketKit", dependencies: ["Sync", "Textile", "Analytics"]),
         .testTarget(name: "PocketKitTests", dependencies: ["PocketKit"]),
 
         .target(
@@ -41,6 +43,14 @@ let package = Package(
             name: "SyncTests",
             dependencies: ["Sync"],
             resources: [.copy("Fixtures")]
+        ),
+        
+        .target(
+            name: "Analytics",
+            dependencies: ["SnowplowTracker"]
+        ),
+        .testTarget(name: "AnalyticsTests",
+                    dependencies: ["Analytics"]
         ),
 
         .executableTarget(

--- a/PocketKit/Sources/Analytics/Environment.swift
+++ b/PocketKit/Sources/Analytics/Environment.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import SnowplowTracker
+
+
+struct UIContextsKey: EnvironmentKey {
+    static var defaultValue: [UIContext] = []
+}
+
+struct TrackerKey: EnvironmentKey {
+    static var defaultValue: Tracker = NoopTracker()
+}
+
+public extension EnvironmentValues {
+    var uiContexts: [UIContext] {
+        get { self[UIContextsKey.self] }
+        set { self[UIContextsKey.self] = newValue }
+    }
+    
+    var tracker: Tracker {
+        get { self[TrackerKey.self] }
+        set { self[TrackerKey.self] = newValue }
+    }
+}
+
+public struct NoopTracker: Tracker {
+    public init() { }
+    
+    public func addPersistentContext(_ context: SnowplowContext) {
+        fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
+    }
+    
+    public func track<T: SnowplowEvent>(event: T, _ contexts: [SnowplowContext]?) {
+        fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
+    }
+}

--- a/PocketKit/Sources/Analytics/SnowplowTracking.swift
+++ b/PocketKit/Sources/Analytics/SnowplowTracking.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SnowplowTracker
+
+
+public protocol SnowplowEvent: Encodable {
+    static var schema: String { get }
+}
+
+public protocol SnowplowContext: Encodable {
+    static var schema: String { get }
+}
+
+extension SnowplowContext {
+    var jsonEncoded: Data? {
+        return try? JSONEncoder().encode(self)
+    }
+}
+
+public protocol SnowplowTracking {
+    func track(event: SelfDescribing)
+}
+
+public class PocketSnowplowTracker: SnowplowTracking {
+    private let tracker: TrackerController
+    
+    public init() {
+        let endpoint = ProcessInfo.processInfo.environment["SNOWPLOW_ENDPOINT"] ?? "d.getpocket.com"
+        let appID = ProcessInfo.processInfo.environment["SNOWPLOW_IDENTIFIER"] ?? "pocket-ios-next"
+       
+        let networkConfiguration = NetworkConfiguration(endpoint: endpoint, method: .post)
+        
+        let trackerConfiguration = TrackerConfiguration()
+        trackerConfiguration.appId = appID
+        trackerConfiguration.devicePlatform = .mobile
+        trackerConfiguration.base64Encoding = false
+        trackerConfiguration.logLevel = .off
+        trackerConfiguration.applicationContext = false
+        trackerConfiguration.platformContext = false
+        trackerConfiguration.geoLocationContext = false
+        trackerConfiguration.sessionContext = false
+        trackerConfiguration.screenContext = false
+        trackerConfiguration.screenViewAutotracking = false
+        trackerConfiguration.lifecycleAutotracking = false
+        trackerConfiguration.installAutotracking = false
+        trackerConfiguration.exceptionAutotracking = false
+        trackerConfiguration.diagnosticAutotracking = false
+        
+        tracker = Snowplow.createTracker(
+            namespace: appID,
+            network: networkConfiguration,
+            configurations: [trackerConfiguration]
+        )
+    }
+    
+    public func track(event: SelfDescribing) {
+        tracker.track(event)
+    }
+}

--- a/PocketKit/Sources/Analytics/Tracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SnowplowTracker
+
+
+public protocol Tracker {
+    func addPersistentContext(_ context: SnowplowContext)
+    func track<T: SnowplowEvent>(event: T, _ contexts: [SnowplowContext]?)
+}
+
+public extension Tracker {
+    func addPersistentContexts(_ contexts: [SnowplowContext]) {
+        contexts.forEach { addPersistentContext($0) }
+    }
+}
+
+public class PocketTracker: Tracker {
+    private let snowplow: SnowplowTracking
+    
+    private var persistentContexts: [SnowplowContext] = []
+    
+    public init(snowplow: SnowplowTracking) {
+        self.snowplow = snowplow
+    }
+    
+    public func addPersistentContext(_ context: SnowplowContext) {
+        persistentContexts.append(context)
+    }
+    
+    public func track<T: SnowplowEvent>(event: T, _ contexts: [SnowplowContext]?) {
+        guard let event = snowplowEvent(from: event) else {
+            return
+        }
+        
+        let contexts = contexts ?? []
+        let merged = contexts + persistentContexts
+        let snowplowContexts = snowplowContexts(from: merged)
+        event.contexts.addObjects(from: snowplowContexts)
+        
+        snowplow.track(event: event)
+    }
+}
+
+extension PocketTracker {
+    private func snowplowEvent<T: SnowplowEvent>(from event: T) -> SelfDescribing? {
+        guard let data = try? JSONEncoder().encode(event),
+              let deserialized = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let eventJSON = SelfDescribingJson(schema: type(of: event).schema, andData: deserialized as NSObject) else {
+                  return nil
+              }
+        return SelfDescribing(eventData: eventJSON)
+    }
+    
+    private func snowplowContexts(from contexts: [SnowplowContext]) -> [SelfDescribingJson] {
+        var uiHierarchy: UInt = 0
+        // UIContexts are returned outside-in, such that the parent precedes the child.
+        // However, in Snowplow, the hierarchy starts at the lowest-level of the contexts.
+        // Since we don't know how deeply nested the view hierarchy will be up-front,
+        // we have to reverse the contexts to go inside-out, such that the child precedes the parent,
+        // and update the hierarchy appropriately.
+        let contexts = contexts.reversed().map { (context) -> SnowplowContext in
+            if let context = context as? UIContext {
+                let context = context.with(hierarchy: uiHierarchy)
+                uiHierarchy += 1
+                return context
+            }
+            
+            return context
+        }
+        
+        return contexts.compactMap { context -> SelfDescribingJson? in
+            guard let data = context.jsonEncoded,
+                  let deserialized = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let context = SelfDescribingJson(schema: type(of: context).schema, andData: deserialized as NSObject) else {
+                      return nil
+                  }
+            return context
+        }
+    }
+}
+
+private extension UIContext {
+    func with(hierarchy: UIHierarchy) -> UIContext {
+        UIContext(
+            type: type,
+            hierarchy: hierarchy,
+            identifier: identifier,
+            componentDetail: componentDetail,
+            index: index
+        )
+    }
+}

--- a/PocketKit/Sources/Analytics/UIContext.swift
+++ b/PocketKit/Sources/Analytics/UIContext.swift
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+
+// MARK: - Trackable
+public typealias UIHierarchy = UInt
+public typealias UIIndex = UInt
+
+public enum UIType: String, Encodable {
+    case card
+    case list
+    case screen
+    case reader
+    case link
+    case button
+}
+
+public enum UIIdentifier: String, Encodable {
+    case home
+    case reader
+    case item
+    case articleLink = "article_link"
+    case switchToWebView = "switch_to_web_view"
+}
+
+public enum UIComponentDetail: String, Encodable {
+    case itemRow = "item_row"
+}
+
+public struct UIContext: SnowplowContext {
+    public static let schema = "iglu:com.pocket/ui/jsonschema/1-0-3"
+    let type: UIType
+    let hierarchy: UIHierarchy
+    let identifier: UIIdentifier
+    let componentDetail: UIComponentDetail?
+    let index: UIIndex?
+    
+    public init(
+        type: UIType,
+        hierarchy: UIHierarchy,
+        identifier: UIIdentifier,
+        componentDetail: UIComponentDetail? = nil,
+        index: UIIndex? = nil
+    ) {
+        self.type = type
+        self.hierarchy = hierarchy
+        self.identifier = identifier
+        self.componentDetail = componentDetail
+        self.index = index
+    }
+}
+
+private extension UIContext {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case hierarchy
+        case identifier
+        case componentDetail = "component_detail"
+        case index
+    }
+}
+
+public extension UIContext {
+    struct Home {
+        public var list = UIContext(type: .screen, hierarchy: 0, identifier: .home)
+        
+        public func item(index: UIIndex) -> UIContext {
+            UIContext(type: .card, hierarchy: 0, identifier: .item, componentDetail: .itemRow, index: index)
+        }
+    }
+    
+    struct ArticleView {
+        public var screen = UIContext(type: .screen, hierarchy: 0, identifier: .reader)
+        public var link = UIContext(type: .link, hierarchy: 0, identifier: .articleLink)
+        public var switchToWebView = UIContext(type: .button, hierarchy: 0, identifier: .switchToWebView)
+    }
+    
+    static let home = Home()
+    static let articleView = ArticleView()
+}
+
+// MARK: - SwiftUI
+public struct TrackableView<T: View>: View {
+    private var content: T
+    
+    @Environment(\.uiContexts)
+    private var viewContexts: [UIContext]
+    
+    private var currentContext: UIContext
+    
+    init(_ context: UIContext, _ content: () -> T) {
+        self.content = content()
+        self.currentContext = context
+    }
+    
+    public var body: some View {
+        content.environment(\.uiContexts, viewContexts + [currentContext])
+    }
+}
+
+public extension View {
+    @ViewBuilder
+    func trackable(_ context: UIContext) -> TrackableView<Self> {
+        TrackableView(context) { self }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/APIUser.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/APIUser.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+struct APIUser: SnowplowContext {
+    static var schema = "iglu:com.pocket/api_user/jsonschema/1-0-1"
+    
+    let id: UInt
+}
+
+extension APIUser {
+    init(consumerKey: String) {
+        let components = consumerKey.components(separatedBy: "-")
+        let id: UInt
+        if let identifier = components.first, let apiID = UInt(identifier) {
+            id = apiID
+        } else {
+            id = 1
+        }
+        
+        self.id = id
+    }
+}
+
+private extension APIUser {
+    enum CodingKeys: String, CodingKey {
+        case id = "api_id"
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/AppBackground.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/AppBackground.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+struct AppBackground: SnowplowEvent {
+    static let schema = "iglu:com.pocket/app_background/jsonschema/1-0-0"
+    
+    let secondsSinceLastOpen: UInt64?
+    let secondsSinceLastBackground: UInt64?
+    
+    init(secondsSinceLastOpen: UInt64?, secondsSinceLastBackground: UInt64?) {
+        self.secondsSinceLastOpen = secondsSinceLastOpen
+        self.secondsSinceLastBackground = secondsSinceLastBackground
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        if let secondsSinceLastOpen = secondsSinceLastOpen {
+            try container.encode(secondsSinceLastOpen, forKey: .secondsSinceLastOpen)
+        } else {
+            try container.encodeNil(forKey: .secondsSinceLastOpen)
+        }
+        
+        if let secondsSinceLastBackground = secondsSinceLastBackground {
+            try container.encode(secondsSinceLastBackground, forKey: .secondsSinceLastBackground)
+        } else {
+            try container.encodeNil(forKey: .secondsSinceLastBackground)
+        }
+    }
+}
+
+private extension AppBackground {
+    enum CodingKeys: String, CodingKey {
+        case secondsSinceLastOpen = "seconds_since_last_open"
+        case secondsSinceLastBackground = "seconds_since_last_background"
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/AppOpen.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/AppOpen.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+struct AppOpen: SnowplowEvent {
+    static let schema = "iglu:com.pocket/app_open/jsonschema/1-0-0"
+    
+    let secondsSinceLastOpen: UInt64?
+    let secondsSinceLastBackground: UInt64?
+    
+    init(secondsSinceLastOpen: UInt64?, secondsSinceLastBackground: UInt64?) {
+        self.secondsSinceLastOpen = secondsSinceLastOpen
+        self.secondsSinceLastBackground = secondsSinceLastBackground
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        if let secondsSinceLastOpen = secondsSinceLastOpen {
+            try container.encode(secondsSinceLastOpen, forKey: .secondsSinceLastOpen)
+        } else {
+            try container.encodeNil(forKey: .secondsSinceLastOpen)
+        }
+        
+        if let secondsSinceLastBackground = secondsSinceLastBackground {
+            try container.encode(secondsSinceLastBackground, forKey: .secondsSinceLastBackground)
+        } else {
+            try container.encodeNil(forKey: .secondsSinceLastBackground)
+        }
+    }
+}
+
+private extension AppOpen {
+    enum CodingKeys: String, CodingKey {
+        case secondsSinceLastOpen = "seconds_since_last_open"
+        case secondsSinceLastBackground = "seconds_since_last_background"
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/Content.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/Content.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-struct AuthorizeRequest: Codable, Equatable {
-    let guid: String
-    let username: String
-    let password: String
-    let consumerKey: String
-    let grantType: String
-    let account: Bool
+import Foundation
+import Analytics
+
+
+struct Content: SnowplowContext {
+    static let schema = "iglu:com.pocket/content/jsonschema/1-0-0"
+    
+    let url: URL
 }

--- a/PocketKit/Sources/PocketKit/Analytics/ContentOpen.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/ContentOpen.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+struct ContentOpen: SnowplowEvent {
+    static let schema = "iglu:com.pocket/content_open/jsonschema/1-0-0"
+    
+    let destination: Destination
+    let trigger: Trigger
+}
+
+extension ContentOpen {
+    enum Destination: String, Encodable {
+        case `internal`
+        case external
+    }
+    
+    enum Trigger: String, Encodable {
+        case click
+        case auto
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/Engagement.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/Engagement.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+enum EngagementType: String, Encodable {
+    case general
+    case save
+    case report
+    case dismiss
+}
+
+struct Engagement: SnowplowEvent {
+    static let schema = "iglu:com.pocket/engagement/jsonschema/1-0-1"
+    
+    private let type: EngagementType
+    private let value: String?
+    
+    init(type: EngagementType, value: String?) {
+        self.type = type
+        self.value = value
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/Impression.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/Impression.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+struct Impression: SnowplowEvent {
+    static let schema = "iglu:com.pocket/impression/jsonschema/1-0-1"
+    
+    private let component: Component
+    private let requirement: Requirement
+    
+    init(component: Component, requirement: Requirement) {
+        self.component = component
+        self.requirement = requirement
+    }
+}
+
+extension Impression {
+    enum Component: String, Encodable {
+        case ui
+        case card
+        case content
+        case screen
+        case pushNotification
+        
+        enum CodingKeys: String, CodingKey {
+            case ui
+            case card
+            case content
+            case screen
+            case pushNotification = "push_notification"
+        }
+    }
+    
+    enum Requirement: String, Encodable {
+        case instant
+        case viewable
+    }
+}

--- a/PocketKit/Sources/PocketKit/Analytics/SnowplowUser.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/SnowplowUser.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+
+
+struct SnowplowUser: SnowplowContext {
+    static let schema = "iglu:com.pocket/user/jsonschema/1-0-0"
+    
+    let guid: String
+    let userID: String
+}
+
+extension SnowplowUser {
+    enum CodingKeys: String, CodingKey {
+        case guid = "hashed_guid"
+        case userID = "hashed_user_id"
+    }
+}

--- a/PocketKit/Sources/PocketKit/Article/TextContentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/TextContentCell.swift
@@ -6,6 +6,11 @@ protocol TextContentCellDelegate: AnyObject {
         _ cell: TextContentCell,
         didShareSelecedText selectedText: String
     )
+    
+    func textContentCell(
+        _ cell: TextContentCell,
+        shouldOpenURL url: URL
+    ) -> Bool
 }
 
 class TextContentCell: UICollectionViewCell {
@@ -23,6 +28,7 @@ class TextContentCell: UICollectionViewCell {
         textView.textContainerInset = .zero
         textView.isEditable = false
         textView.isScrollEnabled = false
+        textView.delegate = self
         textView.shareDelegate = self
 
         contentView.addSubview(textView)
@@ -47,6 +53,12 @@ class TextContentCell: UICollectionViewCell {
 
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}
+
+extension TextContentCell: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        return delegate?.textContentCell(self, shouldOpenURL: URL) ?? true
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Authorization/AuthorizationState.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/AuthorizationState.swift
@@ -1,7 +1,12 @@
 import Combine
 
 
+struct Authorization {
+    let guid: String
+    let response: AuthorizeResponse
+}
+
 class AuthorizationState: ObservableObject {
     @Published
-    var authToken: AuthorizeResponse?
+    var authorization: Authorization?
 }

--- a/PocketKit/Sources/PocketKit/Date+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Date+Extensions.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+
+extension Date: RawRepresentable {
+    private static let dateFormatter = ISO8601DateFormatter()
+    
+    public var rawValue: String {
+        return Self.dateFormatter.string(from: self)
+    }
+    
+    public init?(rawValue: String) {
+        guard let date = Self.dateFormatter.date(from: rawValue) else {
+            return nil
+        }
+        
+        self = date
+    }
+}

--- a/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
@@ -11,9 +11,12 @@ import Foundation
 class ItemPresenter: ItemRow {
     @Published
     private var item: Item
+    
+    let index: Int
 
-    init(item: Item) {
+    init(item: Item, index: Int) {
         self.item = item
+        self.index = index
     }
 
     public var title: String {

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Combine
+import Analytics
 
 
 protocol ItemViewControllerDelegate: AnyObject {
@@ -10,11 +11,15 @@ protocol ItemViewControllerDelegate: AnyObject {
 class ItemViewController: UIViewController {
     private let itemHost: ArticleViewController
     private var subscriptions: [AnyCancellable] = []
+    
+    var uiContext: SnowplowContext {
+        return UIContext.articleView.screen
+    }
 
     weak var delegate: ItemViewControllerDelegate?
 
-    init(selection: ItemSelection, readerSettings: ReaderSettings) {
-        itemHost = ArticleViewController(readerSettings: readerSettings)
+    init(selection: ItemSelection, readerSettings: ReaderSettings, tracker: Tracker) {
+        itemHost = ArticleViewController(readerSettings: readerSettings, tracker: tracker)
 
         super.init(nibName: nil, bundle: nil)
 

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -13,7 +13,9 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
             coordinator: PocketSceneCoordinator(
                 accessTokenStore: Services.shared.accessTokenStore,
                 authClient: Services.shared.authClient,
-                source: Services.shared.source
+                source: Services.shared.source,
+                tracker: Services.shared.tracker,
+                session: Services.shared.session
             )
         )
     }

--- a/PocketKit/Sources/PocketKit/SceneTracker.swift
+++ b/PocketKit/Sources/PocketKit/SceneTracker.swift
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Analytics
+import SwiftUI
+import Combine
+
+
+class SceneTracker {
+    static let dateLastOpenedKey = "SceneTracker.dateLastOpened"
+    static let dateLastBackgroundedKey = "SceneTracker.dateLastBackgrounded"
+    
+    private let tracker: Tracker
+    private let userDefaults: UserDefaults
+    private let notificationCenter: NotificationCenter
+    
+    private var previousStatus: Status? = nil
+    
+    private var subscriptions: Set<AnyCancellable> = []
+    
+    @AppStorage
+    private var dateLastOpened: Date?
+    
+    @AppStorage
+    private var dateLastBackgrounded: Date?
+    
+    init(tracker: Tracker, userDefaults: UserDefaults, notificationCenter: NotificationCenter = .default) {
+        self.tracker = tracker
+        self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
+        
+        _dateLastOpened = AppStorage(Self.dateLastOpenedKey, store: userDefaults)
+        
+        _dateLastBackgrounded = AppStorage(Self.dateLastBackgroundedKey, store: userDefaults)
+        
+        createSubscriptions()
+    }
+    
+    private func createSubscriptions() {
+        self.notificationCenter
+            .publisher(for: UIScene.didActivateNotification)
+            .sink { [weak self] _ in self?.trackActivate() }
+            .store(in: &subscriptions)
+        
+        self.notificationCenter
+            .publisher(for: UIScene.didEnterBackgroundNotification)
+            .sink { [weak self] _ in self?.trackEnterBackground() }
+            .store(in: &subscriptions)
+    }
+    
+    private func trackActivate() {
+        guard previousStatus == nil || previousStatus == .background else {
+            return
+        }
+        
+        let event = AppOpen(
+            secondsSinceLastOpen: secondsSince(.active),
+            secondsSinceLastBackground: secondsSince(.background)
+        )
+        tracker.track(event: event, nil)
+        
+        dateLastOpened = Date.now
+        previousStatus = .active
+    }
+    
+    private func trackEnterBackground() {
+        guard previousStatus == .active || previousStatus == nil else {
+            return
+        }
+        
+        let event = AppBackground(
+            secondsSinceLastOpen: secondsSince(.active),
+            secondsSinceLastBackground: secondsSince(.background)
+        )
+        
+        tracker.track(event: event, nil)
+        
+        dateLastBackgrounded = Date.now
+        previousStatus = .background
+    }
+    
+    private func secondsSince(_ status: Status) -> UInt64? {
+        switch status {
+        case .active:
+            guard let lastOpened = dateLastOpened else {
+                return nil
+            }
+            
+            let now = Date.now
+            let seconds = now.timeIntervalSince(lastOpened)
+            return UInt64(seconds)
+        case .background:
+            guard let lastBackgrounded = dateLastBackgrounded else {
+                return nil
+            }
+            
+            let now = Date.now
+            let seconds = now.timeIntervalSince(lastBackgrounded)
+            return UInt64(seconds)
+        }
+    }
+}
+
+private extension SceneTracker {
+    enum Status {
+        case active
+        case background
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -4,18 +4,25 @@
 
 import Sync
 import Foundation
+import Analytics
 
 
 struct Services {
     static let shared = Services()
 
+    let userDefaults: UserDefaults
+    let session: Session
     let keychain: Keychain
     let accessTokenStore: AccessTokenStore
     let urlSession: URLSessionProtocol
     let authClient: AuthorizationClient
     let source: Source
+    let tracker: Tracker
+    let sceneTracker: SceneTracker
 
     private init() {
+        userDefaults = .standard
+        session = Session(userDefaults: userDefaults)
         keychain = SecItemKeychain()
         accessTokenStore = KeychainAccessTokenStore(keychain: keychain)
 
@@ -26,8 +33,16 @@ struct Services {
         )
 
         source = Source(
+            sessionProvider: session,
             accessTokenProvider: accessTokenStore,
             consumerKey: Keys.shared.pocketApiConsumerKey
         )
+
+        let snowplow = PocketSnowplowTracker()
+        tracker = PocketTracker(snowplow: snowplow)
+        
+        sceneTracker = SceneTracker(tracker: tracker, userDefaults: userDefaults)
     }
 }
+
+extension Session: SessionProvider { }

--- a/PocketKit/Sources/PocketKit/Session.swift
+++ b/PocketKit/Sources/PocketKit/Session.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+
+class Session {
+    static let guidKey = "Session.guid"
+    static let userIDKey = "Session.userID"
+    
+    @AppStorage
+    var guid: String?
+    
+    @AppStorage
+    var userID: String?
+    
+    init(userDefaults: UserDefaults) {
+        _guid = AppStorage(Self.guidKey,store: userDefaults)
+        _userID = AppStorage(Self.userIDKey, store: userDefaults)
+    }
+}

--- a/PocketKit/Sources/PocketKit/StaticDataCleaner.swift
+++ b/PocketKit/Sources/PocketKit/StaticDataCleaner.swift
@@ -8,15 +8,22 @@ import SwiftUI
 
 
 struct StaticDataCleaner {
+    static let hasClearedStaticDataKey = "StatisDataCleaner.hasClearedStaticData"
     private let bundle: Bundle
     private let source: Source
 
-    @AppStorage("hasClearedStaticData")
-    private var hasClearedStaticData: Bool = false
+    @AppStorage
+    private var hasClearedStaticData: Bool
 
-    init(bundle: Bundle, source: Source) {
+    init(bundle: Bundle, source: Source, userDefaults: UserDefaults) {
         self.bundle = bundle
         self.source = source
+        
+        _hasClearedStaticData = AppStorage(
+            wrappedValue: false,
+            Self.hasClearedStaticDataKey,
+            store: userDefaults
+        )
     }
 
     private var currentBuildNumber: Int? {

--- a/PocketKit/Sources/PocketKit/URLSessionProtocol.swift
+++ b/PocketKit/Sources/PocketKit/URLSessionProtocol.swift
@@ -6,26 +6,10 @@ import Foundation
 
 
 protocol URLSessionProtocol {
-    func dataTask(
-        with request: URLRequest,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) -> URLSessionDataTaskProtocol
+    func data(
+        for request: URLRequest,
+        delegate: URLSessionTaskDelegate?
+    ) async throws -> (Data, URLResponse)
 }
 
-protocol URLSessionDataTaskProtocol {
-    func resume()
-    func cancel()
-}
-
-extension URLSession: URLSessionProtocol {
-    func dataTask(
-        with request: URLRequest,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) -> URLSessionDataTaskProtocol {
-        return self.dataTask(with: request, completionHandler: completionHandler) as URLSessionDataTask
-    }
-}
-
-extension URLSessionDataTask: URLSessionDataTaskProtocol {
-
-}
+extension URLSession: URLSessionProtocol { }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -21,12 +21,14 @@ public class Source {
     }()
 
     public convenience init(
+        sessionProvider: SessionProvider,
         accessTokenProvider: AccessTokenProvider,
         consumerKey: String
     ) {
         self.init(
             space: Space(container: .createDefault()),
             apollo: ApolloClient.createDefault(
+                sessionProvider: sessionProvider,
                 accessTokenProvider: accessTokenProvider,
                 consumerKey: consumerKey
             ),

--- a/PocketKit/Sources/Textile/Views/ItemRow.swift
+++ b/PocketKit/Sources/Textile/Views/ItemRow.swift
@@ -17,6 +17,7 @@ private extension Style {
 }
 
 public protocol ItemRow: ObservableObject {
+    var index: Int { get }
     var title: String { get }
     var domain: String { get }
     var timeToRead: String? { get }
@@ -81,13 +82,15 @@ public struct ItemRowView<Model: ItemRow>: View {
 
 struct ItemRow_Previews: PreviewProvider {
     class DummyModel: ItemRow, Identifiable {
+        var index = 0
+        
         var id = "hi"
-
+        
         var title: String = """
         Cum sociis natoque penatibus et magnis dis parturient montes,
         nascetur ridiculus mus. Donec sed odio dui.
         """
-
+        
         var domain: String = "Etiam Sem Magna Parturient Bibendum"
         var timeToRead: String? = "5 min"
         var thumbnailURL: URL? = URL(string: "http://placekitten.com/200/300")!

--- a/PocketKit/Tests/AnalyticsTests/SnowplowTrackerTests.swift
+++ b/PocketKit/Tests/AnalyticsTests/SnowplowTrackerTests.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Analytics
+import SnowplowTracker
+
+
+class SnowplowTrackerTests: XCTestCase {
+    func test_trackCreatesCorrectEventWithContexts() {
+        let mock = MockSnowplow()
+        let tracker = PocketTracker(snowplow: mock)
+        
+        let persistent = PersistentContext(value: "persistent")
+        tracker.addPersistentContext(persistent)
+        
+        let contextA = MockContext(value: "A")
+        let contextB = MockContext(value: "B")
+        let event = MockEvent(value: 0)
+        
+        tracker.track(event: event, [contextA, contextB])
+        
+        XCTAssertEqual(mock.trackCalls.last?.event.schema, MockEvent.schema)
+        XCTAssertEqual(mock.trackCalls.last?.event.payload, ["value": event.value as NSNumber])
+        let eventContexts = mock.trackCalls.last?.event.contexts as! [SelfDescribingJson]
+        
+        let eventContextData = eventContexts.map { $0.data as! [String: String] }
+        XCTAssertEqual(eventContextData, [
+            ["value": persistent.value],
+            ["value": contextB.value],
+            ["value": contextA.value]
+        ])
+        let eventContextSchemas = eventContexts.map { $0.schema }
+        XCTAssertEqual(eventContextSchemas, [
+            "persistent-context",
+            "mock-context",
+            "mock-context"
+        ])
+    }
+}

--- a/PocketKit/Tests/AnalyticsTests/Support/Calls.swift
+++ b/PocketKit/Tests/AnalyticsTests/Support/Calls.swift
@@ -17,8 +17,5 @@ struct Calls<T> {
     var last: T? {
         return calls.last
     }
-    
-    var count: Int {
-        return calls.count
-    }
 }
+

--- a/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
+++ b/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Analytics
+import SnowplowTracker
+
+
+class MockSnowplow: SnowplowTracking {
+    struct TrackCall {
+        let event: SelfDescribing
+    }
+    
+    private(set) var trackCalls = Calls<TrackCall>()
+    
+    func track(event: SelfDescribing) {
+        trackCalls.add(TrackCall(event: event))
+    }
+}
+
+struct MockEvent: SnowplowEvent {
+    static var schema = "mock-event"
+    
+    let value: Int
+}
+
+struct MockContext: SnowplowContext {
+    static var schema = "mock-context"
+    
+    let value: String
+}
+
+struct PersistentContext: SnowplowContext {
+    static var schema = "persistent-context"
+    
+    let value: String
+}

--- a/PocketKit/Tests/PocketKitTests/SceneTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SceneTrackerTests.swift
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Analytics
+@testable import PocketKit
+
+
+class SceneTrackerTests: XCTestCase {
+    var userDefaults: UserDefaults!
+    var notificationCenter: NotificationCenter!
+    var tracker: MockTracker!
+    var sceneTracker: SceneTracker!
+    
+    override func setUp() {
+        userDefaults = UserDefaults()
+        notificationCenter = NotificationCenter()
+        tracker = MockTracker()
+        sceneTracker = SceneTracker(
+            tracker: tracker,
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
+        )
+    }
+    
+    override func tearDown() {
+        userDefaults.removeObject(forKey: SceneTracker.dateLastOpenedKey)
+        userDefaults.removeObject(forKey: SceneTracker.dateLastBackgroundedKey)
+    }
+    
+    // MARK: - AppOpen
+    
+    func test_trackAppOpenWithNoPreviousOpenOrBackground() {
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        
+        XCTAssertTrue(tracker.trackCalls.wasCalled)
+        
+        let event = tracker.trackCalls.last?.event as? AppOpen
+        XCTAssertNotNil(event)
+        
+        XCTAssertNil(event!.secondsSinceLastOpen)
+        XCTAssertNil(event!.secondsSinceLastBackground)
+    }
+    
+    func test_doesNotTrackSecondAppOpenIfCurrentlyActive() {
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        
+        XCTAssertEqual(tracker.trackCalls.count, 1)
+    }
+    
+    func test_trackAppOpenAfterPreviousOpenAndBackground() {
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: nil)
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        
+        let event = tracker.trackCalls.last?.event as? AppOpen
+        XCTAssertNotNil(event)
+        XCTAssertNotNil(event!.secondsSinceLastOpen)
+        XCTAssertNotNil(event!.secondsSinceLastBackground)
+    }
+    
+    // MARK: - AppBackground
+    
+    func test_trackAppBackgroundAfterOpenButNoPreviousBackground() {
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: nil)
+        
+        let event = tracker.trackCalls.last?.event as? AppBackground
+        XCTAssertNotNil(event)
+        XCTAssertNotNil(event!.secondsSinceLastOpen)
+        XCTAssertNil(event!.secondsSinceLastBackground)
+    }
+    
+    func test_trackAppBackgroundAfterPreviousOpenAndBackground() {
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: nil)
+        notificationCenter.post(name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.post(name: UIScene.didEnterBackgroundNotification, object: nil)
+        
+        let event = tracker.trackCalls.last?.event as? AppBackground
+        XCTAssertNotNil(event)
+        XCTAssertNotNil(event!.secondsSinceLastOpen)
+        XCTAssertNotNil(event!.secondsSinceLastBackground)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Analytics
+
+
+class MockTracker: Tracker {
+    struct TrackCall {
+        let event: SnowplowEvent
+        let contexts: [SnowplowContext]?
+    }
+    
+    private var persistentContexts: [SnowplowContext] = []
+    
+    private(set) var trackCalls = Calls<TrackCall>()
+    
+    func addPersistentContext(_ context: SnowplowContext) {
+        
+    }
+    
+    func track<T: SnowplowEvent>(event: T, _ contexts: [SnowplowContext]?) {
+        trackCalls.add(TrackCall(event: event, contexts: contexts))
+    }
+}
+
+struct MockEvent: SnowplowEvent {
+    static var schema = "mock-event"
+    
+    let value: Int
+}
+
+struct MockContext: SnowplowContext {
+    static var schema = "mock-context"
+    
+    let value: String
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockURLSession.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockURLSession.swift
@@ -5,40 +5,27 @@
 import Foundation
 @testable import PocketKit
 
-class MockURLSessionDataTask: URLSessionDataTaskProtocol {
-    var resumeCalls = 0
-
-    func resume() {
-        resumeCalls += 1
-    }
-    
-    func cancel() { }
-}
-
 class MockURLSession: URLSessionProtocol {
-    struct DataTaskCall {
+    struct DataCall {
         let request: URLRequest
     }
 
-    typealias DataTaskImpl = (URLRequest, (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
+    typealias DataImpl = (URLRequest) throws -> (Data, URLResponse)
 
-    private var dataTaskWithCompletionImpl: DataTaskImpl?
+    private var dataImpl: DataImpl?
 
-    var dataTaskCalls: [DataTaskCall] = []
+    var dataTaskCalls: [DataCall] = []
 
-    func dataTask(
-        with request: URLRequest,
-        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) -> URLSessionDataTaskProtocol {
-        guard let impl = dataTaskWithCompletionImpl else {
+    func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        guard let impl = dataImpl else {
             fatalError("\(Self.self).\(#function) is not stubbed")
         }
-
-        dataTaskCalls.append(DataTaskCall(request: request))
-        return impl(request, completionHandler)
+        
+        dataTaskCalls.append(DataCall(request: request))
+        return try impl(request)
     }
 
-    func stubDataTaskWithCompletion(impl: @escaping DataTaskImpl) {
-        dataTaskWithCompletionImpl = impl
+    func stubData(_ impl: @escaping DataImpl) {
+        dataImpl = impl
     }
 }

--- a/Tests iOS/Fixtures/guid.json
+++ b/Tests iOS/Fixtures/guid.json
@@ -1,0 +1,1 @@
+{ "guid": "sample-guid"}

--- a/Tests iOS/Fixtures/successful-auth.json
+++ b/Tests iOS/Fixtures/successful-auth.json
@@ -7,3 +7,4 @@
         "user_id": "<the-user-id>"
     }
 }
+

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -43,6 +43,14 @@ class Tests_iOS: XCTestCase {
                 Fixture.data(name: "hello", ext: "html")
             }
         }
+        
+        server.routes.get("v3/guid") { _, _ in
+            Response(
+                status: .created,
+                headers: [("X-Source", "Pocket")],
+                content: Fixture.data(name: "guid")
+            )
+        }
 
         try server.start()
     }
@@ -56,7 +64,8 @@ class Tests_iOS: XCTestCase {
         app.launch(
             arguments: [
                 "clearKeychain",
-                "clearCoreData"
+                "clearCoreData",
+                "clearUserDefaults"
             ]
         )
         

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -33,6 +33,10 @@
 	<string>$(POCKET_API_CONSUMER_KEY)</string>
 	<key>SentryDSN</key>
 	<string>$(SENTRY_DSN)</string>
+	<key>SnowplowEndpoint</key>
+	<string>$(SNOWPLOW_ENDPOINT)</string>
+	<key>SnowplowIdentifier</key>
+	<string>$(SNOWPLOW_IDENTIFIER)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
This pull request introduces a subset of the initial requirements for this app, where the subset is those available based on the current development status of the app.

## Dependencies

[+] [Snowplow](https://github.com/snowplow/snowplow-objc-tracker) / [Docs](https://docs.snowplowanalytics.com/)

## Config

To set up which endpoint to send Snowplow events to, and with what identifier, add the following build settings to the `secrets.xcconfig` file:

- SNOWPLOW_ENDPOINT
  - Format: `http%3a%2f%2fYOUR_ENDPOINT_HERE`
    - Due to how `.xcconfig` files are used, a `//` is considered a comment. App setup assumed the endpoint to be percent-escaped.
- SNOWPLOW_IDENTIFIER
  - The identifier dictating which app (scheme) is sending the events.

## Analytics

- `app_open`
- `app_background`
- `content_open`
  - When an item is selected from `My List`
  - When a link is opened from Artivle View
- `impression`
  - When an item is scrolled to in `My List`
- `engagement`
  - When the user switches to web view in Article View

### Not Yet Implemented

- `impression`
  - When a user opens the app or switches tabs
    - The user is currently always on `My List`, and the navigation is yet to be defined / implemented.
- `engagement`
  - Item actions (not yet implemented within this Pull Request)
    - Save / Archive
    - Share
    - Favorite / Unfavorite
    - Add Tags
    - Delete

## Tracking

Tracking is performed using an object that conforms to the `Tracker` protocol. A Pocket-specific tracker can be found in `Tracker.swift` (`PocketTracker`). This Pocket-specific tracker requires one dependency - an object capable of sending events / contexts to Snowplow. The pre-defined Pocket-specific dependency can be found in `SnowplowTracking.swift` (`PocketSnowplowTracker`). This tracker uses the newly-added `Snowplow` dependency to build the correct event, attaching the appropriate contexts as well.

The app-wide dependency can be found in `Services.swift` as the `tracker` property.

Once implemented, tracking is simple - call `track(event:_)` with the appropriate `SnowplowEvent` and `SnowplowContext` objects. For defining events and contexts, see below.
  
## Defining Events / Contexts

### Event

To define a Snowplow event, simply conform to the `SnowplowEvent` protocol. This will require you to define a schema for the event, as well as ensure that the object is encodable.

```swift
struct MyEvent: SnowplowEvent {
    static let schema = "iglu:..."

    let value: Int
}
```

### Context

Defining a Snowplow context is very similar to defining an event, but conforming to `SnowplowContext` instead.

```swift
struct MyContext: SnowplowContext {
    static let schema = "iglu:..."

    let value: Int
}
```

## SwiftUI

This pull request introduces the concept of a `TrackableView`, which, when used in conjunction with nested SwiftUI views, creates a stack containing the contexts of each view on the stack, so long as the view is tracked.

To create a trackable view, you can either initialize a `TrackableView` (which wraps a given SwiftUI view, capturing its context), or use the `.trackable` convenience function on any view, supplying the correct context for the view.

```swift
// Define an event that can be sent to Snowplow.
struct ContentEvent: SnowplowEvent {
    let schema = ...

    let value = "Hello, world"
}

// Dummy row that contains a button that will send an event to Snowplow.
struct ContentRow: View {
    @Environment(\.uiContexts)
    var uiContexts: [UIContext]

    @Environment(\.tracker)
    var tracker: Tracker

    var body: some View {
        Button("Hello, world") {
            // When this event is tracked, the uiContexts will be the list contained in ContentView, 
            // as well as this button's parent view (ContentRow) since it was marked as trackable within its parent.
            tracker.track(ContentEvent(), uiContexts)
        }
    }    
}

// Dummy (trackable) view that lists n number of (trackable) rows.
struct ContentView: View {
    var body: some View {
        List {
            ForEach(...) { content in
                ContentRow().trackable(
                    UIContext(type: .card, identifier: .home, hierarchy: index(of: content), componentDetail: .itemRow)
                )
            }
        }.trackable(UIContext(type: .list, identifier: .home, hierarchy: 0, componentDetail: nil))
    }
}
```

### Under the Hood

When calling `.trackable` on a view, that view is added to a "stack" of views that are being tracked, so that we can later appropriately send an event with its "stack" of views sent as the context of the event, in this case that it was a row within a list. `TrackableView` is a wrapper view of sorts that simply presents the content of its initial closure, but internally adds the new trackable view to its stack of already-tracked views. The new context(s) are then forwarded to the view that is being presented _by_ the `TrackableView`, such that when a given view tracks an event, it contains the stack of views up to and including itself. Note that not all nested views will be tracked; only those modified by `trackable` will be tracked.

TL;DR - Upon tracking an event, the hierarchy of these views is updated to reflect the Pocket requirement from Snowplow. The view hierarchy is inside-out, where the deepest nested view is hierarchy 0, and the top level n.

## GUID

The persistent `SnowplowUser` context requires the addition of a server-generated `guid`. This `guid` is generated at sign-in as a pre-requesite to authenticating with Pocket, at which point it is always used when signing in. It is then added to all subsequent GraphQL queries as well.