### PR TITLE
Don't capture messages when encountering unsupported Particle elements

### DIFF
--- a/PocketKit/Sources/Sync/Particle/Decodable/ArticleComponent+Decodable.swift
+++ b/PocketKit/Sources/Sync/Particle/Decodable/ArticleComponent+Decodable.swift
@@ -26,7 +26,6 @@ extension ArticleComponent: Decodable {
 
         guard let componentType = ComponentType(rawValue: rawType) else {
             self = .unsupported(rawType)
-            Crashlogger.capture(message: "Encountered unsupported \(ArticleComponent.self) type: \(rawType)")
             return
         }
 

--- a/PocketKit/Sources/Sync/Particle/Decodable/InlineModifer+Decodable.swift
+++ b/PocketKit/Sources/Sync/Particle/Decodable/InlineModifer+Decodable.swift
@@ -16,7 +16,6 @@ extension InlineModifier: Decodable {
         let container = try decoder.container(keyedBy: InlineModifierTypeKey.self)
         let typeString = try container.decode(String.self, forKey: .type)
         guard let type = InlineModifierType(rawValue: typeString) else {
-            Crashlogger.capture(message: "Encountered unsupported \(InlineModifier.self) type: \(typeString)")
             self = .unsupported(typeString)
             return
         }

--- a/PocketKit/Sources/Sync/Particle/Decodable/InlineStyle+Decodable.swift
+++ b/PocketKit/Sources/Sync/Particle/Decodable/InlineStyle+Decodable.swift
@@ -39,7 +39,6 @@ extension InlineStyle: Decodable {
             case .strong:
                 return .strong
             case .none:
-                Crashlogger.capture(message: "Encountered unsupported \(InlineStyle.self) type: \(rawStyle)")
                 return .unsupported(rawStyle)
             }
         }()


### PR DESCRIPTION
These captures are causing a huge performance issue so disabling for
now. We can come up with a way to capture them in a more efficient
manner in the future.