### PR TITLE
Cleanup operation tests

### DIFF
--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -7,8 +7,6 @@ import Apollo
 import Combine
 
 
-
-
 public class Source {
     public let syncEvents: PassthroughSubject<SyncEvent, Never> = PassthroughSubject()
 

--- a/PocketKit/Tests/SyncTests/Operations/FavoriteItemTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/FavoriteItemTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CoreData
 import Combine
+import Apollo
 
 @testable import Sync
 
@@ -9,36 +10,32 @@ class FavoriteItemTests: XCTestCase {
     var apollo: MockApolloClient!
     var space: Space!
     var subscriptions: [AnyCancellable] = []
+    var queue: OperationQueue!
+    var events: PassthroughSubject<SyncEvent, Never>!
 
     override func setUpWithError() throws {
         apollo = MockApolloClient()
         space = Space(container: .testContainer)
+        queue = OperationQueue()
+        events = PassthroughSubject()
+    }
 
+    override func tearDownWithError() throws {
+        subscriptions = []
         try space.clear()
     }
 
-    override func tearDown() {
-        subscriptions = []
-    }
-
-    @discardableResult
-    func seedItem() throws -> Item {
-        let item = space.newItem()
-        item.itemID = "the-item-id"
-        item.url = URL(string: "http://example.com/item-1")!
-        item.title = "Item 1"
-        item.isFavorite = false
-        try space.save()
-
-        return item
-    }
-
-    func performOperation(events: PassthroughSubject<SyncEvent, Never> = PassthroughSubject()) {
+    func performOperation(
+        space: Space? = nil,
+        apollo: ApolloClientProtocol? = nil,
+        itemID: String = "test-item-id",
+        events: PassthroughSubject<SyncEvent, Never>? = nil
+    ) {
         let operation = FavoriteItem(
-            space: space,
-            apollo: apollo,
-            itemID: "test-item-id",
-            events: events
+            space: space ?? self.space,
+            apollo: apollo ?? self.apollo,
+            itemID: itemID,
+            events: events ?? self.events
         )
 
         let expectationToCompleteOperation = expectation(
@@ -49,70 +46,36 @@ class FavoriteItemTests: XCTestCase {
             expectationToCompleteOperation.fulfill()
         }
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
-    }
 
-    private func configureMockClientToReturnFixture(named fixtureName: String) {
-        let expectFavorite = expectation(description: "Expect a favorite item request")
-        apollo.stubPerform { (mutation: FavoriteItemMutation, _, queue, completion) in
-            defer { expectFavorite.fulfill() }
-
-            XCTAssertEqual(mutation.itemID, "test-item-id")
-
-            let data = Fixture
-                .load(name: "favorite")
-                .asGraphQLResult(from: mutation)
-
-            queue.async {
-                completion?(.success(data))
-            }
-
-            return MockCancellable()
-        }
-    }
-
-    private func configureMockClientToFail(with error: Error) {
-        let expectFavorite = expectation(description: "Expect a favorite item request")
-        apollo.stubPerform { (mutation: FavoriteItemMutation, _, queue, completion) in
-            defer { expectFavorite.fulfill() }
-
-            queue.async {
-                completion?(.failure(error))
-            }
-
-            return MockCancellable()
-        }
+        wait(for: [expectationToCompleteOperation], timeout: 1)
     }
 
     func test_favoriteItem_sendsFavoriteItemMutation() throws {
-        try seedItem()
+        try space.seedItem()
+        apollo.stubPerform(toReturnFixtureNamed: "favorite", asResultType: FavoriteItemMutation.self)
 
-        configureMockClientToReturnFixture(named: "favorite")
         performOperation()
 
-        waitForExpectations(timeout: 1)
+        let call: MockApolloClient.PerformCall<FavoriteItemMutation>? = apollo.performCall(at: 0)
+        XCTAssertEqual(call?.mutation.itemID, "test-item-id")
     }
 
     func test_favoriteItem_whenMutationFails_publishesError() throws {
-        _ = try seedItem()
-        let events = PassthroughSubject<SyncEvent, Never>()
+        try space.seedItem()
+        apollo.stubPerform(ofMutationType: FavoriteItemMutation.self, toReturnError: TestError.anError)
 
         var error: Error?
-        let expectError = expectation(description: "Expect an error")
         events.sink { event in
             guard case .error(let e) = event else {
                 return
             }
 
             error = e
-            expectError.fulfill()
         }.store(in: &subscriptions)
 
-        configureMockClientToFail(with: TestError.anError)
-        performOperation(events: events)
+        performOperation()
 
-        waitForExpectations(timeout: 1)
         XCTAssertNotNil(error)
         XCTAssertEqual(error as? TestError, .anError)
     }

--- a/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
@@ -1,0 +1,77 @@
+import XCTest
+import Apollo
+
+
+extension MockApolloClient {
+    func stubPerform<T: GraphQLMutation>(
+        toReturnFixtureNamed fixtureName: String,
+        asResultType: T.Type,
+        handler: (() -> ())? = nil
+    ) {
+        stubPerform { (mutation: T, _, queue, completion) in
+            defer { handler?() }
+
+            let data = Fixture
+                .load(name: fixtureName)
+                .asGraphQLResult(from: mutation)
+
+            queue.async {
+                completion?(.success(data))
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubPerform<T: GraphQLMutation>(
+        ofMutationType: T.Type,
+        toReturnError error: Error,
+        handler: (() -> ())? = nil
+    ) {
+        stubPerform { (mutation: T, _, queue, completion) -> Apollo.Cancellable in
+            defer { handler?() }
+
+            queue.async {
+                completion?(.failure(error))
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubFetch<T: GraphQLQuery>(
+        toReturnFixturedNamed fixtureName: String,
+        asResultType: T.Type,
+        handler: (() -> ())? = nil
+    ) {
+        stubFetch { (query: T, _, _, queue, completion) -> Apollo.Cancellable in
+            defer { handler?() }
+
+            let result = Fixture
+                .load(name: fixtureName)
+                .asGraphQLResult(from: query)
+
+            queue.async {
+                completion?(.success(result))
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubFetch<T: GraphQLQuery>(
+        ofQueryType: T.Type,
+        toReturnError error: Error,
+        handler: (() -> ())? = nil
+    ) {
+        stubFetch { (query: T, _, _, queue, completion) -> Apollo.Cancellable in
+            defer { handler?() }
+
+            queue.async {
+                completion?(.failure(error))
+            }
+
+            return MockCancellable()
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -1,0 +1,21 @@
+import Foundation
+@testable import Sync
+
+extension Space {
+    @discardableResult
+    func seedItem(
+        itemID: String = "the-item-id",
+        url: String = "http://example.com/item-1",
+        title: String = "Item 1",
+        isFavorite: Bool = false
+    ) throws -> Item {
+        let item = newItem()
+        item.itemID = itemID
+        item.url = URL(string: url)!
+        item.title = title
+        item.isFavorite = isFavorite
+
+        try save()
+        return item
+    }
+}


### PR DESCRIPTION
- Extract MockApolloClient+stubs
  These extension methods make it a bit nicer to set up common stubs
- Extract Space+factories (in SyncTests)
  A simple method for seeding an Item in CoreData for use in tests

Make use of these handy little abstractions in tests of operations to
make them a bit slimmer and easier to read.