### PR TITLE
Fix sending impression events with no content

### DIFF
--- a/PocketKit/Sources/PocketKit/Analytics/APIUser.swift
+++ b/PocketKit/Sources/PocketKit/Analytics/APIUser.swift
@@ -3,11 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Analytics
+import Foundation
 
 struct APIUser: SnowplowContext {
     static var schema = "iglu:com.pocket/api_user/jsonschema/1-0-1"
     
     let id: UInt
+    let clientVersion: String
 }
 
 extension APIUser {
@@ -21,11 +23,13 @@ extension APIUser {
         }
         
         self.id = id
+        self.clientVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
     }
 }
 
 private extension APIUser {
     enum CodingKeys: String, CodingKey {
         case id = "api_id"
+        case clientVersion = "client_version"
     }
 }

--- a/PocketKit/Sources/PocketKit/Item/ItemListView.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemListView.swift
@@ -137,6 +137,11 @@ private struct ItemListViewRow: View {
             )
                 .trackable(.home.item(index: UInt(index)))
                 .onAppear {
+                    let contexts = contexts
+                    guard contexts.count > 1 else {
+                        return
+                    }
+                    
                     let impression = Impression(component: .content, requirement: .instant)
                     tracker.track(event: impression, contexts)
                 }


### PR DESCRIPTION
# Fixes

1. When scrolling a user's list, impression events are fired whenever a row comes on-screen. These impression events should _only_ be sent if there is a `content` context to send along with the event. Adding a guard prevents sending impression events incorrectly.
2. To determine the context of (failing) events, the `client_version` property has been added to `APIUser`, where the property refers to the build number of the app. This context is sent with each event tracked.