### PR TITLE
Foxfooding Bug Fixes

### DIFF
--- a/PocketKit/Sources/PocketKit/Activity/ActivityType+Pocket.swift
+++ b/PocketKit/Sources/PocketKit/Activity/ActivityType+Pocket.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+
+extension UIActivity.ActivityType {
+    static let copyLink = UIActivity.ActivityType("com.pocket.copy-link")
+    static let copySelection = UIActivity.ActivityType("com.pocket.copy-selection")
+}

--- a/PocketKit/Sources/PocketKit/Activity/CopyLinkActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/CopyLinkActivity.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+
+class CopyLinkActivity: UIActivity {
+    private var link: URL? = nil
+    
+    static override var activityCategory: UIActivity.Category {
+        return .action
+    }
+    
+    override var activityType: UIActivity.ActivityType? {
+        return .copyLink
+    }
+    
+    override var activityTitle: String? {
+        return "Copy link"
+    }
+    
+    override var activityImage: UIImage? {
+        return UIImage(systemName: "link")
+    }
+    
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return activityItems.first { $0 is URL } != nil
+    }
+    
+    override func prepare(withActivityItems activityItems: [Any]) {
+        guard let link = activityItems.first(where: { $0 is URL }) as? URL else {
+            return
+        }
+        
+        self.link = link
+    }
+    
+    override func perform() {
+        UIPasteboard.general.url = link
+    }
+}

--- a/PocketKit/Sources/PocketKit/Activity/CopyLinkWithSelectionActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/CopyLinkWithSelectionActivity.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+
+class CopyLinkWithSelectionActivity: UIActivity {
+    private var link: URL? = nil
+    private var highlight: String? = nil
+    
+    static override var activityCategory: UIActivity.Category {
+        return .action
+    }
+    
+    override var activityType: UIActivity.ActivityType? {
+        return .copySelection
+    }
+    
+    override var activityTitle: String? {
+        return "Copy link with selection"
+    }
+    
+    override var activityImage: UIImage? {
+        return UIImage(systemName: "highlighter")
+    }
+    
+    override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return activityItems.first { $0 is URL } != nil && activityItems.first { $0 is String} != nil
+    }
+
+    override func prepare(withActivityItems activityItems: [Any]) {
+        guard let link = activityItems.first(where: { $0 is URL }) as? URL,
+        let highlight = activityItems.first(where: { $0 is String}) as? String else {
+            return
+        }
+
+        self.link = link
+        self.highlight = highlight
+    }
+
+    override func perform() {
+        guard let link = link, let highlight = highlight else {
+            return
+        }
+        
+        let components = [link.absoluteString, "\"\(highlight)\""]
+        let string = components.joined(separator: "\n\n")
+
+        UIPasteboard.general.string = string
+    }
+}
+

--- a/PocketKit/Sources/PocketKit/Activity/PocketActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/PocketActivity.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+
+protocol PocketActivity {
+    var activityItems: [Any] { get }
+    var applicationActivities: [UIActivity]? { get }
+}
+

--- a/PocketKit/Sources/PocketKit/Activity/PocketItemActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/PocketItemActivity.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Sync
+
+
+struct PocketItemActivity: PocketActivity {
+    var applicationActivities: [UIActivity]? {
+        [
+            CopyLinkActivity(),
+            CopyLinkWithSelectionActivity()
+        ]
+    }
+    
+    let activityItems: [Any]
+   
+    init(item: Item, additionalText: String? = nil) {
+        self.activityItems = Self.activityItems(for: item, additionalText: additionalText)
+    }
+    
+    private static func activityItems(for item: Item, additionalText: String?) -> [Any] {
+        let items = [
+            item.url.flatMap(ActivityItemSource.init),
+            additionalText.flatMap(ActivityItemSource.init)
+        ].compactMap { $0 }
+        return items
+    }
+}

--- a/PocketKit/Sources/PocketKit/Activity/UIActivityViewController+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Activity/UIActivityViewController+Extensions.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+
+extension UIActivityViewController {
+    convenience init(activity: PocketActivity) {
+        self.init(
+            activityItems: activity.activityItems,
+            applicationActivities: activity.applicationActivities
+        )
+    }
+}

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -188,23 +188,13 @@ extension ArticleViewController: TextContentCellDelegate {
         _ cell: TextContentCell,
         didShareSelecedText selectedText: String
     ) {
-        guard let url = item?.url else {
+        guard let item = item else {
             return
         }
-
-        let text = [item?.title, "\"\(selectedText)\""]
-            .compactMap { $0 }
-            .joined(separator: "\n\n")
-
-        // wrap the URL and text in an ActivityItemSource to preserve separation when sharing
-        let activityItems = [url, text].map(ActivityItemSource.init)
-
-        let shareSheet = UIActivityViewController(
-            activityItems: activityItems,
-            applicationActivities: nil
-        )
-
-        present(shareSheet, animated: true)
+        
+        let activity = PocketItemActivity(item: item, additionalText: selectedText)
+        let sheet = UIActivityViewController(activity: activity)
+        present(sheet, animated: true)
     }
     
     func textContentCell(

--- a/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemPresenter.swift
@@ -67,8 +67,7 @@ class ItemPresenter: ItemRow {
 
     public var activityItems: [Any] {
         return [
-            item.url.flatMap(ActivityItemSource.init),
-            item.title.flatMap(ActivityItemSource.init)
+            item.url.flatMap(ActivityItemSource.init)
         ].compactMap { $0 }
     }
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -28,7 +28,9 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        Crashlogger.start(dsn: Keys.shared.sentryDSN)
+        if !CommandLine.arguments.contains("disableSentry") {
+            Crashlogger.start(dsn: Keys.shared.sentryDSN)
+        }
         
         if CommandLine.arguments.contains("clearUserDefaults") {
             userDefaults.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)

--- a/PocketKit/Sources/PocketKit/PocketSceneCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneCoordinator.swift
@@ -182,16 +182,11 @@ extension PocketSceneCoordinator: ItemViewControllerDelegate {
     }
 
     func itemViewController(_ itemViewController: ItemViewController, didTapShareItem item: Item) {
-        let items = [
-            item.url.flatMap(ActivityItemSource.init),
-            item.title.flatMap(ActivityItemSource.init)
-        ].compactMap { $0 }
+        let activity = PocketItemActivity(item: item)
+        let sheet = UIActivityViewController(activity: activity)
 
         showInReaderAsModal(
-            UIActivityViewController(
-                activityItems: items,
-                applicationActivities: nil
-            ),
+            sheet,
             within: itemViewController,
             detents: [.large()]
         )

--- a/PocketKit/Sources/PocketKit/Sync+Textile.swift
+++ b/PocketKit/Sources/PocketKit/Sync+Textile.swift
@@ -47,6 +47,10 @@ extension TextContent {
             if range.location + range.length > attributedText.length {
                 range.length = attributedText.length - range.location
             }
+            
+            guard let _ = Range(range, in: attributedText.string) else {
+                return
+            }
 
             attributedText.addAttributes(attrs, range: range)
         }


### PR DESCRIPTION
1. Fixes a crash when applying (some) modifiers. Range inconsistencies post-unescaping would in some cases cause a crash. This is a temporary resolution that will be more properly rectified during our upcoming work in article view.
2. Adds support for disabling Sentry via launch arg. This code went poof! So, let's bring it back.
3. Adds support for copying an item link, as well as the link and any selected text when viewing an article.
  - Currently, the new share support exists within the article view, since the work is "skeleton" work that will have to be refactored once merged with other work in active development.
  - The list (to be fixed post-refactor) will currently only copy the item URL when sharing.