### PR TITLE
Add missing license headers

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 // swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 

--- a/PocketKit/Sources/ApolloCodegen/DownloadSchema.swift
+++ b/PocketKit/Sources/ApolloCodegen/DownloadSchema.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import ArgumentParser
 import ApolloCodegenLib

--- a/PocketKit/Sources/ApolloCodegen/FileStructure.swift
+++ b/PocketKit/Sources/ApolloCodegen/FileStructure.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 struct FileStructure {

--- a/PocketKit/Sources/ApolloCodegen/GenerateCode.swift
+++ b/PocketKit/Sources/ApolloCodegen/GenerateCode.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import ApolloCodegenLib
 import ArgumentParser

--- a/PocketKit/Sources/ApolloCodegen/main.swift
+++ b/PocketKit/Sources/ApolloCodegen/main.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import ArgumentParser
 
 struct ApolloCodegen: ParsableCommand {

--- a/PocketKit/Sources/PocketKit/Article/ActivityItemSource.swift
+++ b/PocketKit/Sources/PocketKit/Article/ActivityItemSource.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 ///

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/EmptyCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/EmptyCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/PocketKit/Article/TextContentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/TextContentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/PocketKit/Authorization/AuthorizationState.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/AuthorizationState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 
 

--- a/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Kingfisher

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Textile
 import Foundation

--- a/PocketKit/Sources/PocketKit/Home/SlateHeaderPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateHeaderPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/SlateHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateHeaderView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/PocketKit/Home/UIButton+recommendationButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/UIButton+recommendationButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Combine
 import Analytics

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import SwiftUI
 import SafariServices

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Analytics
 import Sync

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Sync
 import Foundation

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import SwiftUI
 import SafariServices

--- a/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarView.swift
+++ b/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/PocketSceneCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneCoordinator.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import SwiftUI

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 

--- a/PocketKit/Sources/PocketKit/Style+ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/Style+ReaderSettings.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 
 

--- a/PocketKit/Sources/PocketKit/UICollectionView+registration.swift
+++ b/PocketKit/Sources/PocketKit/UICollectionView+registration.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 // @generated
 //  This file was automatically generated and should not be edited.
 

--- a/PocketKit/Sources/Sync/Bundle+sync.swift
+++ b/PocketKit/Sources/Sync/Bundle+sync.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 extension Bundle {

--- a/PocketKit/Sources/Sync/LastRefresh.swift
+++ b/PocketKit/Sources/Sync/LastRefresh.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 

--- a/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 

--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Sources/Sync/Operations/ItemMutationOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/ItemMutationOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Apollo
 

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 

--- a/PocketKit/Sources/Sync/Slates/Slate.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import Foundation
 

--- a/PocketKit/Sources/Sync/Source+async.swift
+++ b/PocketKit/Sources/Sync/Source+async.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 extension Source {
     public func refresh(maxItems: Int = 400) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/PocketKit/Sources/Sync/SyncEvent.swift
+++ b/PocketKit/Sources/Sync/SyncEvent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public enum SyncEvent {
     case finished
     case error(Error)

--- a/PocketKit/Sources/Textile/Style/Icons/ImageAsset.swift
+++ b/PocketKit/Sources/Textile/Style/Icons/ImageAsset.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public struct ImageAsset {
     let name: String
 

--- a/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public enum LineBreakMode {
     case byTruncatingTail
     case none

--- a/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public enum TextAlignment {
     case left
     case right

--- a/PocketKit/Sources/Textile/Views/ActivitySheet.swift
+++ b/PocketKit/Sources/Textile/Views/ActivitySheet.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import UIKit
 

--- a/PocketKit/Sources/Textile/Views/DividerView.swift
+++ b/PocketKit/Sources/Textile/Views/DividerView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 

--- a/PocketKit/Tests/PocketKitTests/SignOutOnFirstLaunchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SignOutOnFirstLaunchTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import PocketKit
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Apollo

--- a/PocketKit/Tests/SyncTests/Operations/FetchListTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/FetchListTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import CoreData

--- a/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import Combine

--- a/PocketKit/Tests/SyncTests/Support/MockAccessTokenProvider.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockAccessTokenProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 

--- a/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 

--- a/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 

--- a/PocketKit/Tests/SyncTests/Support/NSPersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/NSPersistentContainer+testContainer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 
 @testable import Sync

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/Support/TestError.swift
+++ b/PocketKit/Tests/SyncTests/Support/TestError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 enum TestError: Error {
     case anError
 }

--- a/Tests iOS/Support/Elements/TabBarElement.swift
+++ b/Tests iOS/Support/Elements/TabBarElement.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 


### PR DESCRIPTION
This pull request adds missing license headers. I believe this is a side-effect of our change to a dedicated Swift package, but that's okay!