### PR TITLE
Additional tracking to Home tab

### DIFF
--- a/PocketKit/Sources/Analytics/UIContext.swift
+++ b/PocketKit/Sources/Analytics/UIContext.swift
@@ -31,6 +31,7 @@ public enum UIIdentifier: String, Encodable {
     case itemUnfavorite = "item_unfavorite"
     case itemShare = "item_share"
     case slateDetail = "discover_topic"
+    case recommendation = "recommendation"
 }
 
 public enum UIComponentDetail: String, Encodable {
@@ -96,6 +97,10 @@ public extension UIContext {
     
     struct SlateDetail {
         public let screen = UIContext(type: .screen, identifier: .slateDetail)
+        
+        public func recommendation(index: UIIndex) -> UIContext {
+            UIContext(type: .card, hierarchy: 0, identifier: .recommendation, componentDetail: .homeCard, index: index)
+        }
     }
     
     static let home = Home()

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -128,6 +128,9 @@ extension HomeViewController {
                 cell.saveButton.mode = .save
                 tapAction = UIAction(identifier: .saveRecommendation) { [weak self] _ in
                     self?.source.save(recommendation: recommendation)
+
+                    let engagement = Engagement(type: .save, value: nil)
+                    self?.tracker.track(event: engagement, self?.contexts(for: indexPath))
                 }
             }
             cell.saveButton.addAction(tapAction, for: .primaryActionTriggered)
@@ -137,7 +140,6 @@ extension HomeViewController {
             cell.titleLabel.attributedText = presenter.attributedTitle
             cell.subtitleLabel.attributedText = presenter.attributedDetail
             cell.excerptLabel.attributedText = presenter.attributedExcerpt
-
 
             return cell
         }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -238,6 +238,9 @@ extension HomeViewController: UICollectionViewDelegate {
 
             navigationController?.pushViewController(slateDetail, animated: true)
         default:
+            let engagement = Engagement(type: .general, value: nil)
+            tracker.track(event: engagement, contexts(for: indexPath))
+            
             let article = ArticleViewController(
                 readerSettings: readerSettings,
                 tracker: tracker.childTracker(hosting: UIContext.articleView.screen)
@@ -245,8 +248,8 @@ extension HomeViewController: UICollectionViewDelegate {
             article.item = slates[indexPath.section - 1].recommendations[indexPath.item]
             navigationController?.pushViewController(article, animated: true)
             
-            let engagement = Engagement(type: .general, value: nil)
-            tracker.track(event: engagement, contexts(for: indexPath))
+            let contentOpen = ContentOpen(destination: .internal, trigger: .click)
+            tracker.track(event: contentOpen, contexts(for: indexPath))
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -165,6 +165,29 @@ class SlateDetailViewController: UIViewController {
 }
 
 extension SlateDetailViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard let slate = slate else {
+            return
+        }
+        
+        let snowplowSlate = SnowplowSlate(
+            id: slate.id,
+            requestID: slate.requestID,
+            experiment: slate.experimentID,
+            index: UIIndex(indexPath.item)
+        )
+        
+        let recommendation = slate.recommendations[indexPath.item]
+        guard let recommendationID = recommendation.id else {
+            return
+        }
+        
+        let snowplowRecommendation = SnowplowRecommendation(id: recommendationID, index: UIIndex(indexPath.item))
+        let context = UIContext.slateDetail.recommendation(index: UIIndex(indexPath.row))
+        let impression = Impression(component: .content, requirement: .instant)
+        tracker.track(event: impression, [context, snowplowSlate, snowplowRecommendation])
+    }
+ 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let recommendation = slate?.recommendations[indexPath.item] else {
             return

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -50,6 +50,9 @@ class SlateDetailViewController: UIViewController {
                 cell.saveButton.mode = .save
                 tapAction = UIAction(identifier: .saveRecommendation) { [weak self] _ in
                     self?.source.save(recommendation: recommendation)
+
+                    let engagement = Engagement(type: .save, value: nil)
+                    self?.tracker.track(event: engagement, self?.contexts(for: indexPath))
                 }
             }
             cell.saveButton.addAction(tapAction, for: .primaryActionTriggered)

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -166,8 +166,35 @@ class SlateDetailViewController: UIViewController {
 
 extension SlateDetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        guard let slate = slate else {
+        let impression = Impression(component: .content, requirement: .instant)
+        tracker.track(event: impression, contexts(for: indexPath))
+    }
+ 
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let recommendation = slate?.recommendations[indexPath.item] else {
             return
+        }
+        
+        let engagement = Engagement(type: .general, value: nil)
+        tracker.track(event: engagement, contexts(for: indexPath))
+
+        let article = ArticleViewController(
+            readerSettings: readerSettings,
+            tracker: tracker.childTracker(hosting: UIContext.articleView.screen)
+        )
+        article.item = recommendation
+
+        navigationController?.pushViewController(article, animated: true)
+        
+        let contentOpen = ContentOpen(destination: .internal, trigger: .click)
+        tracker.track(event: contentOpen, contexts(for: indexPath))
+    }
+}
+
+extension SlateDetailViewController {
+    private func contexts(for indexPath: IndexPath) -> [SnowplowContext] {
+        guard let slate = slate else {
+            return []
         }
         
         let snowplowSlate = SnowplowSlate(
@@ -179,26 +206,17 @@ extension SlateDetailViewController: UICollectionViewDelegate {
         
         let recommendation = slate.recommendations[indexPath.item]
         guard let recommendationID = recommendation.id else {
-            return
+            return []
         }
-        
         let snowplowRecommendation = SnowplowRecommendation(id: recommendationID, index: UIIndex(indexPath.item))
-        let context = UIContext.slateDetail.recommendation(index: UIIndex(indexPath.row))
-        let impression = Impression(component: .content, requirement: .instant)
-        tracker.track(event: impression, [context, snowplowSlate, snowplowRecommendation])
-    }
- 
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let recommendation = slate?.recommendations[indexPath.item] else {
-            return
+        
+        guard let url = recommendation.readerURL else {
+            return []
         }
-
-        let article = ArticleViewController(
-            readerSettings: readerSettings,
-            tracker: tracker.childTracker(hosting: UIContext.articleView.screen)
-        )
-        article.item = recommendation
-
-        navigationController?.pushViewController(article, animated: true)
+        let content = Content(url: url)
+        
+        let context = UIContext.slateDetail.recommendation(index: UIIndex(indexPath.row))
+     
+        return [context, content, snowplowSlate, snowplowRecommendation]
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -67,6 +67,7 @@ class CompactMainCoordinator: NSObject {
 
         super.init()
 
+        tabBarController.delegate = self
         myList.delegate = self
 
         collapsedSubscription = model.$isCollapsed
@@ -147,5 +148,15 @@ extension CompactMainCoordinator: UINavigationControllerDelegate {
         if viewController === myList.viewControllers.first {
             model.selectedItem = nil
         }
+    }
+}
+
+extension CompactMainCoordinator: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let index = tabBarController.viewControllers?.firstIndex(of: viewController) else {
+            return
+        }
+        
+        model.selectedSection = MainViewModel.AppSection.allCases[index]
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Analytics
 import Sync
+import Combine
 
 
 class MainCoordinator {
@@ -10,6 +11,8 @@ class MainCoordinator {
 
     private let compact: CompactMainCoordinator
     private let regular: RegularMainCoordinator
+    
+    private var subscriptions: Set<AnyCancellable> = []
 
     init(
         model: MainViewModel,
@@ -29,6 +32,21 @@ class MainCoordinator {
         )
 
         regular.setCompactViewController(compact.viewController)
+        
+        model.$selectedSection
+            .sink { section in
+                let context: UIContext
+                switch section {
+                case .home:
+                    context = UIContext.home.screen
+                case .myList:
+                    context = UIContext.myList.screen
+                }
+
+                let impression = Impression(component: .screen, requirement: .instant)
+                tracker.track(event: impression, [context])
+            }
+            .store(in: &subscriptions)
     }
 
     func showList() {

--- a/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
@@ -4,12 +4,16 @@
 extension Slate {
     static func build(
         id: String = "slate-1",
+        requestID: String = "slate-1-request",
+        experimentID: String = "slate-1-experiment",
         name: String = "A slate",
         description: String = "For use in tests",
         recommendations: [Slate.Recommendation] = []
     ) -> Slate {
         Slate(
             id: id,
+            requestID: requestID,
+            experimentID: experimentID,
             name: name,
             description: description,
             recommendations: recommendations


### PR DESCRIPTION
This pull request builds on the work done in #73 to include the following:

- [x] Track impressions within the main Home view
- [x] Track impressions within the slate detail view
- [x] Track engagement events when a card is tapped within the home view
- [x] Track content_open events when a card is tapped within the home view
- [x] Track engagement events when a card is tapped within the slate detail view
- [x] Track content_open events when a card is tapped within the slate detail view
- [x] Track engagement events when the save button is tapped
- [x] Track impression events when switching sections (e.g Home -> My List)