### PR TITLE
Fix navigation sync on iPad

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -22,7 +22,7 @@ class HomeViewController: UIViewController {
 
     private let source: Sync.Source
     private let tracker: Tracker
-    private let readerSettings: ReaderSettings
+    private let model: MainViewModel
     private let sectionProvider: HomeViewControllerSectionProvider
     private let savedRecommendationsService: SavedRecommendationsService
     private var subscriptions: [AnyCancellable] = []
@@ -50,10 +50,10 @@ class HomeViewController: UIViewController {
         collectionViewLayout: layout
     )
 
-    init(source: Sync.Source, tracker: Tracker, readerSettings: ReaderSettings) {
+    init(source: Sync.Source, tracker: Tracker, model: MainViewModel) {
         self.source = source
         self.tracker = tracker
-        self.readerSettings = readerSettings
+        self.model = model
         self.savedRecommendationsService = source.savedRecommendationsService()
         self.sectionProvider = HomeViewControllerSectionProvider()
 
@@ -219,21 +219,9 @@ extension HomeViewController: UICollectionViewDelegate {
 
         switch indexPath.section {
         case 0:
-            let slateDetail = SlateDetailViewController(
-                source: source,
-                readerSettings: readerSettings,
-                tracker: tracker,
-                slateID: slates[indexPath.item].id
-            )
-
-            navigationController?.pushViewController(slateDetail, animated: true)
+            model.selectedSlateID = slates[indexPath.item].id
         default:
-            let article = ArticleViewController(
-                readerSettings: readerSettings,
-                tracker: tracker
-            )
-            article.item = slates[indexPath.section - 1].recommendations[indexPath.item]
-            navigationController?.pushViewController(article, animated: true)
+            model.selectedRecommendation = slates[indexPath.section - 1].recommendations[indexPath.item]
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -74,7 +74,7 @@ class SlateDetailViewController: UIViewController {
     private let savedRecommendationsService: SavedRecommendationsService
     private var subscriptions: [AnyCancellable] = []
     private let tracker: Tracker
-    private let readerSettings: ReaderSettings
+    private let model: MainViewModel
     
     private let slateID: String
     private var slate: Slate? {
@@ -95,12 +95,12 @@ class SlateDetailViewController: UIViewController {
     
     init(
         source: Source,
-        readerSettings: ReaderSettings,
+        model: MainViewModel,
         tracker: Tracker,
         slateID: String
     ) {
         self.source = source
-        self.readerSettings = readerSettings
+        self.model = model
         self.tracker = tracker
         self.slateID = slateID
         self.savedRecommendationsService = source.savedRecommendationsService()
@@ -170,9 +170,6 @@ extension SlateDetailViewController: UICollectionViewDelegate {
             return
         }
 
-        let article = ArticleViewController(readerSettings: readerSettings, tracker: tracker)
-        article.item = recommendation
-
-        navigationController?.pushViewController(article, animated: true)
+        model.selectedRecommendation = recommendation
     }
 }

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -22,6 +22,15 @@ class ItemViewController: UIViewController {
         return UIContext.articleView.screen
     }
 
+    var savedItem: SavedItem? {
+        didSet {
+            itemHost.item = savedItem
+            observer = savedItem?.observe(\.isFavorite, options: [.initial]) { [weak self] _, _ in
+                self?.buildOverflowMenu()
+            }
+        }
+    }
+
     weak var delegate: ItemViewControllerDelegate?
 
     init(
@@ -52,19 +61,14 @@ class ItemViewController: UIViewController {
                 action: #selector(showWebView)
             )
         ]
-
-        model.$selectedItem.sink { [weak self] selectedItem in
-            self?.itemHost.item = selectedItem
-            self?.observer = selectedItem?.observe(\.isFavorite, options: [.initial]) { [weak self] _, _ in
-                self?.buildOverflowMenu()
-            }
-        }.store(in: &subscriptions)
     }
 
     override func loadView() {
         view = UIView()
-        view.addSubview(itemHost.view)
+
+        itemHost.willMove(toParent: self)
         addChild(itemHost)
+        view.addSubview(itemHost.view)
         itemHost.didMove(toParent: self)
 
         itemHost.view.translatesAutoresizingMaskIntoConstraints = false

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -67,6 +67,7 @@ class CompactMainCoordinator: NSObject {
 
         super.init()
 
+        tabBarController.delegate = self
         myList.delegate = self
 
         collapsedSubscription = model.$isCollapsed
@@ -147,5 +148,15 @@ extension CompactMainCoordinator: UINavigationControllerDelegate {
         if viewController === myList.viewControllers.first {
             model.selectedItem = nil
         }
+    }
+}
+
+extension CompactMainCoordinator: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let index = tabBarController.viewControllers?.firstIndex(of: viewController) else {
+            return
+        }
+
+        model.selectedSection = MainViewModel.AppSection.allCases[index]
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -11,6 +11,12 @@ class MainViewModel: ObservableObject {
     var selectedItem: SavedItem?
 
     @Published
+    var selectedRecommendation: Slate.Recommendation?
+
+    @Published
+    var selectedSlateID: String?
+
+    @Published
     var readerSettings = ReaderSettings()
 
     @Published


### PR DESCRIPTION
MainViewModel:
  - add properties for selectedRecommendation and selectedSlateID

Compact coordinator:
  - Observe selectedRecommendation and push recommendation reader when
    it becomes populated
  - Observe selectedSlateID and push slate detail when it is populated
  - Unset selectedSlateID when navigating away from slate detail
  - Unset selectedRecommendation when navigating away from reader

Regular coordinator:
  - Observe selectedRecommendation and show the recommendation in reader
  - Observe selectedSlateID and push slate detail–in primary view–when it is populated
  - Unset selectedSlateID when navigating away from slate detail
  - Rename `item` to `itemVC` for clarity

ItemViewController:
  - Don't bother observing the selected item on the main view model. The
    coordinators observe that property and simply set the item when it
    changes.

Other VCs:
  - Remove manual pushing of view controllers in favor of modifying the
    view model and allowing coordinators to manage navigation.