### PR TITLE
Clear last refresh timestamp when clearing local storage

### DIFF
--- a/PocketKit/Sources/Sync/LastRefresh.swift
+++ b/PocketKit/Sources/Sync/LastRefresh.swift
@@ -4,6 +4,7 @@ import Foundation
 protocol LastRefresh {
     var lastRefresh: Int? { get }
     func refreshed()
+    func reset()
 }
 
 struct UserDefaultsLastRefresh: LastRefresh {
@@ -27,6 +28,10 @@ struct UserDefaultsLastRefresh: LastRefresh {
 
     func refreshed() {
         defaults.set(Date().timeIntervalSince1970, forKey: Self.lastRefreshedAtKey)
+    }
+
+    func reset() {
+        defaults.set(nil, forKey: Self.lastRefreshedAtKey)
     }
 
     private static let lastRefreshedAtKey = "lastRefreshedAt"

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -68,6 +68,7 @@ public class Source {
     }
 
     public func clear() {
+        lastRefresh.reset()
         try? space.clear()
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
@@ -34,4 +34,16 @@ class MockLastRefresh: LastRefresh {
 
         impl()
     }
+
+    typealias ResetImpl = () -> Void
+    private var resetImpl: ResetImpl?
+    private(set) var resetCallCount = 0
+    func reset() {
+        resetCallCount += 1
+        guard let impl = resetImpl else {
+            return
+        }
+
+        impl()
+    }
 }


### PR DESCRIPTION
This is only necessary when we launch the app with the `clearCoreData`
argument during development.