### PR TITLE
Initial marticle support for divider components

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
@@ -38,6 +38,8 @@ class ArticleComponentPresenter {
             return componentSize(of: text, availableWidth: availableWidth)
         case .image(let image):
             return componentSize(of: image, availableWidth: availableWidth)
+        case .divider:
+            return CGSize(width: availableWidth, height: 16)
         default:
             return .zero
         }

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -76,6 +76,7 @@ class ArticleViewController: UIViewController {
         collectionView.register(cellClass: ImageComponentCell.self)
         collectionView.register(cellClass: EmptyCell.self)
         collectionView.register(cellClass: ArticleMetadataCell.self)
+        collectionView.register(cellClass: DividerComponentCell.self)
         navigationItem.largeTitleDisplayMode = .never
 
         readerSettings.objectWillChange.sink { _ in
@@ -148,6 +149,9 @@ extension ArticleViewController: UICollectionViewDataSource {
                     collectionView.collectionViewLayout.invalidateLayout()
                 }
 
+                return cell
+            case .divider:
+                let cell: DividerComponentCell = collectionView.dequeueCell(for: indexPath)
                 return cell
             default:
                 let empty: EmptyCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Article/DIviderComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/DIviderComponentCell.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+
+class DividerComponentCell: UICollectionViewCell {
+    private struct Constants {
+        static let dividerHeight: CGFloat = 1
+    }
+    
+    private lazy var dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(.ui.grey6)
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(dividerView)
+        
+        dividerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dividerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            dividerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            dividerView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+            dividerView.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}


### PR DESCRIPTION
- [x] Create cell for divider components
- [x] Return the correct height for a divider component item

This pull request sets the height of a divider component cell to `16`, which is some number that I thought looked nice. This height does _not_ account for the inter-item spacing; that will be visible _in addition to_ the height of this cell. The divider itself within the view is 1pt.