### PR TITLE
Initial MArticle support for code blocks

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -77,6 +77,7 @@ class ArticleViewController: UIViewController {
         collectionView.register(cellClass: EmptyCell.self)
         collectionView.register(cellClass: ArticleMetadataCell.self)
         collectionView.register(cellClass: DividerComponentCell.self)
+        collectionView.register(cellClass: CodeBlockComponentCell.self)
         navigationItem.largeTitleDisplayMode = .never
 
         readerSettings.objectWillChange.sink { _ in
@@ -152,6 +153,10 @@ extension ArticleViewController: UICollectionViewDataSource {
                 return cell
             case .divider:
                 let cell: DividerComponentCell = collectionView.dequeueCell(for: indexPath)
+                return cell
+            case .codeBlock(let codeBlockComponent):
+                let cell: CodeBlockComponentCell = collectionView.dequeueCell(for: indexPath)
+                presenter.present(component: codeBlockComponent, in: cell.textView)
                 return cell
             default:
                 let empty: EmptyCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Article/CodeBlockComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/CodeBlockComponentCell.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+
+class CodeBlockComponentCell: UICollectionViewCell {
+    struct Constants {
+        static let contentInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    }
+    
+    private var scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.backgroundColor = UIColor(.ui.grey6)
+        view.contentInset = Constants.contentInset
+        return view
+    }()
+    
+    lazy var textView: UITextView = {
+        let view = UITextView()
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = .zero
+        view.isEditable = false
+        view.isScrollEnabled = false
+        view.dataDetectorTypes = []
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(scrollView)
+        scrollView.addSubview(textView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            
+            textView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            textView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            textView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}

--- a/Tests iOS/Fixtures/marticle.json
+++ b/Tests iOS/Fixtures/marticle.json
@@ -28,7 +28,8 @@
     {
         "__typename": "MarticleCodeBlock",
         "language": 1,
-        "text": "<some><code>"
+        "text": "<some></some><code></code>"
+        
     },
     {
         "__typename": "Video",

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -174,7 +174,8 @@ class Tests_iOS: XCTestCase {
             "Commodo Consectetur Dapibus",
             "Purus Vulputate",
             "Nulla vitae elit libero, a pharetra augue. Cras justo odio, dapibus ac facilisis in, egestas eget quam.",
-            "Photo by: Bibendum Vestibulum Mollis"
+            "Photo by: Bibendum Vestibulum Mollis",
+            "<some></some><code></code>"
         ]
 
         for expectedString in expectedContent {


### PR DESCRIPTION
This pull request adds initial MArticle support for code blocks.

- [x] Create `CodeBlockComponentCell`
- [x] Register and utilize `CodeBlockComponentCell` for layout
- [x] Add support for presenting code blocks to `ArticleComponentPresenter`

_How_ the code block is presented is … interesting. `UITextView` does _not_ like being told what its content size is for long horizontal text. Even if you do manage to set its width appropriately, it refuses to draw past the bounds of the text view. One might think, "oh, I'll just update the text container size". Well, that doesn't work either.

SO.

There is a non-scrollable `UITextView` that dynamically sizes itself within a scroll view, which is itself sized to the height of the cell. Therefore, the text view's height will always be correct, its width will expand to fit the content, thus causing the parent scroll view to update its content size and allow for horizontal scrolling of long text. Fun times.