### PR TITLE
Recommendation cells: Increase tappable area of save button

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -107,9 +107,9 @@ class RecommendationCell: UICollectionViewCell {
             textStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
 
             buttonStackTopConstraintHero,
-            buttonStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-            buttonStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+            buttonStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
 
         [titleLabel, subtitleLabel, excerptLabel].forEach(textStack.addArrangedSubview)
@@ -147,14 +147,14 @@ class RecommendationCell: UICollectionViewCell {
 extension RecommendationCell {
     struct Hero {
         static let textStackTopMargin: CGFloat = 16
-        static let buttonStackTopMargin: CGFloat = 18
+        static let buttonStackTopMargin: CGFloat = 10
         static let textStackSpacing: CGFloat = 8
         static let numberOfSubtitleLines = 1
     }
 
     struct Mini {
         static let textStackTopMargin: CGFloat = 10
-        static let buttonStackTopMargin: CGFloat = 12
+        static let buttonStackTopMargin: CGFloat = 4
         static let textStackSpacing: CGFloat = 4
         static let numberOfSubtitleLines = 2
     }

--- a/PocketKit/Sources/PocketKit/Home/RecommendationOverflowButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationOverflowButton.swift
@@ -7,7 +7,12 @@ class RecommendationOverflowButton: UIButton {
         super.init(frame: .zero)
 
         configuration = .plain()
-        configuration?.contentInsets = .zero
+        configuration?.contentInsets = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 8,
+            bottom: 8,
+            trailing: 8
+        )
         configuration?.image = UIImage(asset: .alert)
             .withRenderingMode(.alwaysTemplate)
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
@@ -47,7 +47,13 @@ class RecommendationSaveButton: UIButton {
     init() {
         super.init(frame: .zero)
         configuration = .plain()
-        configuration?.contentInsets = .zero
+        configuration?.contentInsets = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 8,
+            bottom: 8,
+            trailing: 8
+        )
+
         configuration?.imagePadding = 4
 
         configuration?.imageColorTransformer = UIConfigurationColorTransformer { [weak self] _ in


### PR DESCRIPTION
We increase the tappable area of the button by setting the button's
contentInsets to something more reasonable (8pts on each edge) instead
of using a content inset of `.zero`.

In order to keep things aligned and spaced properly, we pin the edges of
the button to the edge of the cell (as opposed to the cell's layout
margin) and decrease the spacing between the excerpt text and the
button. These changes offset the additional space that is now occupied
by the button itself while maintaining the same visual alignment and
spacing.

https://getpocket.atlassian.net/browse/IN-252

# Before
![before](https://user-images.githubusercontent.com/323541/141201675-23a874e9-18d3-45f5-971e-d70e237de5f9.png)

# After
![after](https://user-images.githubusercontent.com/323541/141201709-259bf69a-857e-4e2b-8ead-b9fef56f55fc.png)

