### PR TITLE
Add support for MArticle bulleted lists

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -136,20 +136,17 @@ extension ArticleViewController: UICollectionViewDataSource {
             switch presenter.component {
             case .text(let textComponent):
                 let cell: MarkdownComponentCell = collectionView.dequeueCell(for: indexPath)
-                cell.attributedContent = presenter.attributedContent(for: textComponent)
+                presenter.present(component: textComponent, in: cell)
                 return cell
             case .heading(let headerComponent):
                 let cell: MarkdownComponentCell = collectionView.dequeueCell(for: indexPath)
-                cell.attributedContent = presenter.attributedContent(for: headerComponent)
+                presenter.present(component: headerComponent, in: cell)
                 return cell
             case .image(let image):
                 let cell: ImageComponentCell = collectionView.dequeueCell(for: indexPath)
-                cell.attributedCaption = presenter.attributedCaption(for: image.caption)
-                cell.attributedCredit = presenter.attributedCredit(for: image.credit)
-                presenter.loadImage(into: cell.imageView, availableWidth: availableItemWidth) {
+                presenter.present(component: image, in: cell, availableWidth: availableItemWidth) {
                     collectionView.collectionViewLayout.invalidateLayout()
                 }
-
                 return cell
             case .divider:
                 let cell: DividerComponentCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -158,6 +158,10 @@ extension ArticleViewController: UICollectionViewDataSource {
                 let cell: CodeBlockComponentCell = collectionView.dequeueCell(for: indexPath)
                 presenter.present(component: codeBlockComponent, in: cell.textView)
                 return cell
+            case .bulletedList(let bulletedListComponent):
+                let cell: MarkdownComponentCell = collectionView.dequeueCell(for: indexPath)
+                presenter.present(component: bulletedListComponent, in: cell)
+                return cell
             default:
                 let empty: EmptyCell = collectionView.dequeueCell(for: indexPath)
                 return empty

--- a/Tests iOS/Fixtures/marticle.json
+++ b/Tests iOS/Fixtures/marticle.json
@@ -47,22 +47,22 @@
             {
                 "__typename": "BulletedListElement",
                 "content": "Pharetra Dapibus Ultricies",
-                "level": 1
+                "level": 0
             },
             {
                 "__typename": "BulletedListElement",
                 "content": "netus et malesuada",
-                "level": 2
+                "level": 1
             },
             {
                 "__typename": "BulletedListElement",
                 "content": "quis commodo odio",
-                "level": 3
+                "level": 2
             },
             {
                 "__typename": "BulletedListElement",
                 "content": "tincidunt ornare massa",
-                "level": 4
+                "level": 3
             }
         ]
     },

--- a/Tests iOS/Fixtures/marticle.json
+++ b/Tests iOS/Fixtures/marticle.json
@@ -48,6 +48,21 @@
                 "__typename": "BulletedListElement",
                 "content": "Pharetra Dapibus Ultricies",
                 "level": 1
+            },
+            {
+                "__typename": "BulletedListElement",
+                "content": "netus et malesuada",
+                "level": 2
+            },
+            {
+                "__typename": "BulletedListElement",
+                "content": "quis commodo odio",
+                "level": 3
+            },
+            {
+                "__typename": "BulletedListElement",
+                "content": "tincidunt ornare massa",
+                "level": 4
             }
         ]
     },

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -171,11 +171,20 @@ class Tests_iOS: XCTestCase {
             "by Jacob and David",
             "WIRED",
             "January 1, 2021",
+            
             "Commodo Consectetur Dapibus",
+            
             "Purus Vulputate",
+            
             "Nulla vitae elit libero, a pharetra augue. Cras justo odio, dapibus ac facilisis in, egestas eget quam.",
             "Photo by: Bibendum Vestibulum Mollis",
-            "<some></some><code></code>"
+            
+            "<some></some><code></code>",
+            
+            "Pharetra Dapibus Ultricies",
+            "netus et malesuada",
+            "quis commodo odio",
+            "tincidunt ornare massa"
         ]
 
         for expectedString in expectedContent {


### PR DESCRIPTION
This pull requests adds (initial) support for MArticle bulleted lists by piggybacking off of previously implemented functionality. Since bulleted lists are comprised of rows that are Markdown components, we can create a styled attributed string for each row's content, indent it appropriately, and then join all rows into one attributed string to then present in a text view. 

With this pull request, it appears that we've solidified a pattern for adding components:
1. Ensure that `isEmpty` returns the correct value for your `ArticleComponent` case
2. Return the component's appropriate size in the `size(fittingWitdh:)` function in `ArticleComponentPresenter`
3. Add or modify an overloaded `present(component:in:...)` function in `ArticleComponentPresenter`
4. Create and register any necessary collection view cell classes
5. Return the correct cell for the component, calling the correct presenter function for rendering.

This pull request refactors a teeny bit of code to follow more closely to the above.