### PR TITLE
Present confirmation when deleting item from list

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		16E32B0226851AEB000CC36D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16D47E7F26851AB40095D5A4 /* Assets.xcassets */; };
 		16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */; };
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
+		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
 		F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */; };
 		F2843C202714D97000E03ED5 /* ReportViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */; };
 		F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */; };
@@ -113,6 +114,7 @@
 		16D47E7F26851AB40095D5A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshTests.swift; sourceTree = "<group>"; };
 		16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAnItemTests.swift; sourceTree = "<group>"; };
+		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
 		F227F0C3265E96290031F985 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/System/Library/Frameworks/CoreText.framework; sourceTree = DEVELOPER_DIR; };
 		F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportARecommendationTests.swift; sourceTree = "<group>"; };
 		F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewElement.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */,
 				F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */,
 				1613B2B2275571940014F301 /* SettingsViewElement.swift */,
+				F20BB0382744542F00AE5E70 /* AlertElement.swift */,
 			);
 			path = Elements;
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				1674057726CAC35F0061434E /* DeleteAnItemTests.swift in Sources */,
 				1613B2B12755696B0014F301 /* SignOutTests.swift in Sources */,
 				166BAD0C2656E76B00E401F0 /* UserListElement.swift in Sources */,
+				F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */,
 				166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */,
 				F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */,
 				1648D5A727024C6400F67C4B /* SlateDetailElement.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -192,9 +192,31 @@ extension ItemViewController {
             return
         }
 
-        source.delete(item: item)
-        delegate?.itemViewControllerDidDeleteItem(self)
-        track(identifier: .itemDelete, item: item)
+        let actions = [
+            UIAlertAction(title: "No", style: .default) { [weak self] _ in
+                self?.model.presentedAlert = nil
+            },
+            UIAlertAction(title: "Yes", style: .destructive) { [weak self] _ in
+                self?.model.presentedAlert = nil
+                
+                guard let self = self else {
+                    return
+                }
+                
+                self.source.delete(item: item)
+                self.delegate?.itemViewControllerDidDeleteItem(self)
+                self.track(identifier: .itemDelete, item: item)
+            }
+        ]
+        
+        let alert = PocketAlert(
+            title: "Are you sure you want to delete this item?",
+            message: nil,
+            preferredStyle: .alert,
+            actions: actions,
+            preferredAction: nil
+        )
+        model.presentedAlert = alert
     }
 
     private func share() {

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -34,6 +34,9 @@ class MainViewModel: ObservableObject {
 
     @Published
     var sharedActivity: PocketActivity?
+    
+    @Published
+    var presentedAlert: PocketAlert?
 
     let settings: SettingsViewModel
 

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -138,6 +138,14 @@ class RegularMainCoordinator: NSObject {
                 self?.model.selectedRecommendationToReport = nil
             }
         }.store(in: &longSubscriptions)
+        
+        model.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            guard let alert = alert else {
+                return
+            }
+            
+            self?.present(alert: alert)
+        }.store(in: &longSubscriptions)
     }
 
     func setCompactViewController(_ compact: UIViewController) {
@@ -302,6 +310,19 @@ class RegularMainCoordinator: NSObject {
 
         modal.popoverPresentationController?.barButtonItem = itemVC.popoverAnchor
         splitController.present(modal, animated: true)
+    }
+    
+    private func present(alert: PocketAlert) {
+        let alertController = UIAlertController(
+            title: alert.title,
+            message: alert.message,
+            preferredStyle: alert.preferredStyle
+        )
+        
+        alert.actions.forEach { alertController.addAction($0) }
+        alertController.preferredAction = alert.preferredAction
+        
+        splitController.present(alertController, animated: true)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
@@ -148,7 +148,28 @@ extension MyListViewController: MyListItemCellDelegate {
     }
 
     func myListItemCellDidTapDeleteButton(_ cell: MyListItemCell) {
-        item(for: cell)?.delete()
+        guard let item = item(for: cell) else {
+            return
+        }
+
+        let actions = [
+            UIAlertAction(title: "No", style: .default) { [weak self] _ in
+                self?.model.presentedAlert = nil
+            },
+            UIAlertAction(title: "Yes", style: .destructive) { [weak self] _ in
+                self?.model.presentedAlert = nil
+                item.delete()
+            }
+        ]
+
+        let alert = PocketAlert(
+            title: "Are you sure you want to delete this item?",
+            message: nil,
+            preferredStyle: .alert,
+            actions: actions,
+            preferredAction: nil
+        )
+        model.presentedAlert = alert
     }
 
     func myListItemCellDidTapArchiveButton(_ cell: MyListItemCell) {

--- a/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
@@ -100,11 +100,6 @@ class MyListViewController: UIViewController {
 
     private func handle(myListEvent event: MyListViewModel.Event) {
         switch event {
-        case .itemUpdated(let id):
-            var snapshot = dataSource.snapshot()
-            snapshot.reconfigureItems([id])
-            dataSource.apply(snapshot, animatingDifferences: true)
-
         case .itemsLoaded(let snapshot):
             dataSource.apply(snapshot, animatingDifferences: true)
 

--- a/PocketKit/Sources/PocketKit/MyList/MyListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListViewModel.swift
@@ -18,6 +18,15 @@ class MyListViewModel: NSObject {
         itemsController.fetchedObjects?.count ?? 0
     }
 
+    var presentedAlert: PocketAlert? {
+        get {
+            main.presentedAlert
+        }
+        set {
+            main.presentedAlert = newValue
+        }
+    }
+
     init(source: Source, tracker: Tracker, main: MainViewModel) {
         self.source = source
         self.tracker = tracker

--- a/PocketKit/Sources/PocketKit/MyList/MyListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListViewModel.swift
@@ -75,37 +75,15 @@ class MyListViewModel: NSObject {
 }
 
 extension MyListViewModel: NSFetchedResultsControllerDelegate {
-
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
         let _snapshot = snapshot as NSDiffableDataSourceSnapshot<String, NSManagedObjectID>
         events.send(.itemsLoaded(_snapshot))
-    }
-
-    func controller(
-        _ controller: NSFetchedResultsController<NSFetchRequestResult>,
-        didChange anObject: Any,
-        at indexPath: IndexPath?,
-        for type: NSFetchedResultsChangeType,
-        newIndexPath: IndexPath?
-    ) {
-        switch type {
-        case .update:
-            guard let id = (anObject as? NSManagedObject)?.objectID else {
-                return
-            }
-
-            events.send(.itemUpdated(id))
-        default:
-            // other changes are handled by `controller(_: didChangeContentWith:)`
-            break
-        }
     }
 }
 
 extension MyListViewModel {
     enum Event {
         case itemSelected(SavedItem?)
-        case itemUpdated(NSManagedObjectID)
         case itemsLoaded(NSDiffableDataSourceSnapshot<String, NSManagedObjectID>)
     }
 

--- a/PocketKit/Sources/PocketKit/PocketAlert.swift
+++ b/PocketKit/Sources/PocketKit/PocketAlert.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+
+struct PocketAlert {
+    let title: String?
+    let message: String?
+    let preferredStyle: UIAlertController.Style
+    let actions: [UIAlertAction]
+    let preferredAction: UIAlertAction?
+}

--- a/Tests iOS/DeleteAnItemTests.swift
+++ b/Tests iOS/DeleteAnItemTests.swift
@@ -78,6 +78,7 @@ class DeleteAnItemTests: XCTestCase {
         }
 
         app.deleteButton.wait().tap()
+        app.alert.yes.wait().tap()
         XCTAssertFalse(itemCell.exists)
 
         wait(for: [expectRequest], timeout: 1)
@@ -119,6 +120,7 @@ class DeleteAnItemTests: XCTestCase {
             .tap()
 
         app.deleteButton.wait().tap()
+        app.alert.yes.wait().tap()
         wait(for: [expectRequest], timeout: 1)
         guard let requestBody = deleteRequestBody else {
             XCTFail("Expected request body to not be nil")

--- a/Tests iOS/Support/Elements/AlertElement.swift
+++ b/Tests iOS/Support/Elements/AlertElement.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+
+struct AlertElement: PocketUIElement {
+    let element: XCUIElement
+
+    init(_ element: XCUIElement) {
+        self.element = element
+    }
+
+    var no: XCUIElement {
+        element.buttons["No"]
+    }
+    
+    var yes: XCUIElement {
+        element.buttons["Yes"]
+    }
+}
+

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -75,6 +75,10 @@ struct PocketAppElement {
     var shareButton: XCUIElement {
         app.buttons["Share"]
     }
+    
+    var alert: AlertElement {
+        AlertElement(app.alerts.element(boundBy: 0))
+    }
 
     @discardableResult
     func launch(


### PR DESCRIPTION
This pull request adds support for presenting a confirmation dialog when performing a destructive action, such as deleting an item from a user's list. This is done by setting the appropriate new property on the main view model, which will build and present an alert controller to be presented by the parent split controller. The idea here is that each area that requires a confirmation dialog (i.e alert) will build its own definition of what needs to be presented and request that it be presented by the main view model.