### PR TITLE
Initial MArticle support for tables as unsupported

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
@@ -49,6 +49,8 @@ class ArticleComponentPresenter {
             return componentSize(of: bulletedList, availableWidth: availableWidth)
         case .numberedList(let numberedList):
             return componentSize(of: numberedList, availableWidth: availableWidth)
+        case .table:
+            return CGSize(width: availableWidth, height: 84)
         default:
             return .zero
         }

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -43,6 +43,7 @@ class ArticleViewController: UIViewController {
 
     private let readerSettings: ReaderSettings
     private let tracker: Tracker
+    private let viewModel: MainViewModel
 
     private var subscriptions: [AnyCancellable] = []
     
@@ -63,9 +64,10 @@ class ArticleViewController: UIViewController {
         - Constants.contentInsets.trailing
     }
 
-    init(readerSettings: ReaderSettings, tracker: Tracker) {
+    init(readerSettings: ReaderSettings, tracker: Tracker, viewModel: MainViewModel) {
         self.readerSettings = readerSettings
         self.tracker = tracker
+        self.viewModel = viewModel
 
         super.init(nibName: nil, bundle: nil)
 
@@ -78,6 +80,7 @@ class ArticleViewController: UIViewController {
         collectionView.register(cellClass: ArticleMetadataCell.self)
         collectionView.register(cellClass: DividerComponentCell.self)
         collectionView.register(cellClass: CodeBlockComponentCell.self)
+        collectionView.register(cellClass: UnsupportedComponentCell.self)
         navigationItem.largeTitleDisplayMode = .never
 
         readerSettings.objectWillChange.sink { _ in
@@ -162,6 +165,12 @@ extension ArticleViewController: UICollectionViewDataSource {
             case .numberedList(let numberedListComponent):
                 let cell: MarkdownComponentCell = collectionView.dequeueCell(for: indexPath)
                 presenter.present(component: numberedListComponent, in: cell)
+                return cell
+            case .table:
+                let cell: UnsupportedComponentCell = collectionView.dequeueCell(for: indexPath)
+                cell.action = { [weak self] in
+                    self?.viewModel.presentedWebReaderURL = self?.item?.readerURL
+                }
                 return cell
             default:
                 let empty: EmptyCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Article/UnsupportedComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/UnsupportedComponentCell.swift
@@ -1,0 +1,92 @@
+import UIKit
+import Textile
+
+
+private extension Style {
+    static let label: Self = .body.sansSerif.with(size: .p3)
+    static let button: Self = .body.sansSerif.with(size: .p3).with(color: .ui.white).with(weight: .semibold)
+}
+
+class UnsupportedComponentCell: UICollectionViewCell {
+    private lazy var label: UILabel = {
+        let label = UILabel()
+        label.attributedText = NSAttributedString(
+            string: "This element is currently unsupported.",
+            style: .label
+        )
+        return label
+    }()
+    
+    private lazy var button: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = UIColor(.ui.teal2)
+        config.attributedTitle = AttributedString(
+            NSAttributedString(
+                string: "Open in Web View",
+                style: .button
+            )
+        )
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
+        
+        let button = UIButton(
+            configuration: config,
+            primaryAction: UIAction { _ in
+                self.action?()
+            }
+        )
+        return button
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [label, button])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    private lazy var topDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(.ui.grey6)
+        return view
+    }()
+    
+    private lazy var bottomDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(.ui.grey6)
+        return view
+    }()
+    
+    var action: (() -> Void)? = nil
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(topDivider)
+        contentView.addSubview(stackView)
+        contentView.addSubview(bottomDivider)
+        
+        topDivider.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        bottomDivider.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            topDivider.topAnchor.constraint(equalTo: contentView.topAnchor),
+            topDivider.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+            topDivider.heightAnchor.constraint(equalToConstant: 1),
+            
+            stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            stackView.widthAnchor.constraint(lessThanOrEqualTo: contentView.widthAnchor),
+            stackView.heightAnchor.constraint(lessThanOrEqualTo: contentView.heightAnchor),
+            
+            bottomDivider.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            bottomDivider.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+            bottomDivider.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -36,7 +36,7 @@ class ItemViewController: UIViewController {
     ) {
         self.source = source
         self.tracker = tracker
-        self.itemHost = ArticleViewController(readerSettings: model.readerSettings, tracker: tracker)
+        self.itemHost = ArticleViewController(readerSettings: model.readerSettings, tracker: tracker, viewModel: model)
         self.model = model
         self.moreButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "ellipsis"),

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -107,7 +107,8 @@ class CompactMainCoordinator: NSObject {
     func show(recommendation: Slate.Recommendation, animated: Bool) {
         let article = ArticleViewController(
             readerSettings: model.readerSettings,
-            tracker: tracker.childTracker(hosting: .articleView.screen)
+            tracker: tracker.childTracker(hosting: .articleView.screen),
+            viewModel: model
         )
         article.hidesBottomBarWhenPushed = true
         article.item = recommendation

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -66,7 +66,8 @@ class RegularMainCoordinator: NSObject {
 
         recommendationVC = ArticleViewController(
             readerSettings: model.readerSettings,
-            tracker: tracker.childTracker(hosting: .articleView.screen)
+            tracker: tracker.childTracker(hosting: .articleView.screen),
+            viewModel: model
         )
 
         readerRoot = UINavigationController(rootViewController: itemVC)

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -187,7 +187,9 @@ class Tests_iOS: XCTestCase {
             "▪\u{fe0e} tincidunt ornare massa",
             
             "1. Amet Commodo Fringilla",
-            "2. nunc sed augue"
+            "2. nunc sed augue",
+            
+            "This element is currently unsupported."
         ]
 
         for expectedString in expectedContent {


### PR DESCRIPTION
This pull request adds support for "rendering" tables by displaying that they are unsupported, with the ability to optionally present the item in web view. 

![image](https://user-images.githubusercontent.com/1158092/143952427-dabf45ff-37f5-4480-8b2a-68ba9fcf2c3f.png)
