### PR TITLE
Initial MArticle support for blockquotes

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleComponentPresenter.swift
@@ -14,6 +14,7 @@ private extension Style {
     static let imageCaption: Self = .body.sansSerif.with(size: .p3)
     
     static let codeBlock: Self = .body.monospace
+    static let blockquote: Self = .body.sansSerif
 }
 
 class ArticleComponentPresenter {
@@ -51,6 +52,8 @@ class ArticleComponentPresenter {
             return componentSize(of: numberedList, availableWidth: availableWidth)
         case .table:
             return CGSize(width: availableWidth, height: 84)
+        case .blockquote(let blockquote):
+            return componentSize(of: blockquote, availableWidth: availableWidth)
         default:
             return .zero
         }
@@ -108,6 +111,10 @@ class ArticleComponentPresenter {
         let presenter = ListComponentPresenter(component: component, readerSettings: readerSettings)
         cell.attributedContent = presenter.attributedContent
     }
+    
+    func present(component: BlockquoteComponent, in cell: BlockquoteComponentCell) {
+        cell.attributedBlockquote = attributedBlockquote(for: component)
+    }
 }
 
 private extension ArticleComponentPresenter {
@@ -142,6 +149,13 @@ private extension ArticleComponentPresenter {
     
     func attributedCodeBlock(for component: CodeBlockComponent) -> NSAttributedString? {
         NSAttributedString(string: component.text, style: .codeBlock.adjustingSize(by: readerSettings.fontSizeAdjustment))
+    }
+    
+    func attributedBlockquote(for component: BlockquoteComponent) -> NSAttributedString? {
+        NSAttributedString.styled(
+            markdown: component.content,
+            styler: NSAttributedString.defaultStyler(with: readerSettings)
+        )
     }
 }
 
@@ -204,6 +218,15 @@ private extension ArticleComponentPresenter {
         }
 
         return Self.size(of: content, availableWidth: availableWidth)
+    }
+    
+    func componentSize(of component: BlockquoteComponent, availableWidth: CGFloat) -> CGSize {
+        guard !component.content.isEmpty, let blockquote = attributedBlockquote(for: component) else {
+            return .zero
+        }
+        
+        let width = availableWidth - BlockquoteComponentCell.Constants.dividerWidth - BlockquoteComponentCell.Constants.stackSpacing
+        return Self.size(of: blockquote, availableWidth: width)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -81,6 +81,7 @@ class ArticleViewController: UIViewController {
         collectionView.register(cellClass: DividerComponentCell.self)
         collectionView.register(cellClass: CodeBlockComponentCell.self)
         collectionView.register(cellClass: UnsupportedComponentCell.self)
+        collectionView.register(cellClass: BlockquoteComponentCell.self)
         navigationItem.largeTitleDisplayMode = .never
 
         readerSettings.objectWillChange.sink { _ in
@@ -171,6 +172,10 @@ extension ArticleViewController: UICollectionViewDataSource {
                 cell.action = { [weak self] in
                     self?.viewModel.presentedWebReaderURL = self?.item?.readerURL
                 }
+                return cell
+            case .blockquote(let blockquoteComponent):
+                let cell: BlockquoteComponentCell = collectionView.dequeueCell(for: indexPath)
+                presenter.present(component: blockquoteComponent, in: cell)
                 return cell
             default:
                 let empty: EmptyCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Article/BlockquoteComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/BlockquoteComponentCell.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+
+class BlockquoteComponentCell: UICollectionViewCell {
+    struct Constants {
+        static let dividerWidth: CGFloat = 6
+        static let stackSpacing: CGFloat = 12
+    }
+    private lazy var divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(.ui.grey6)
+        return view
+    }()
+    
+    private lazy var textView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = .zero
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        return textView
+    }()
+    
+    private lazy var stackView: UIStackView = {
+       let stackView = UIStackView(arrangedSubviews: [divider, textView])
+        stackView.spacing = Constants.stackSpacing
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    var attributedBlockquote: NSAttributedString? {
+        get {
+            textView.attributedText
+        }
+        set {
+            textView.attributedText = newValue
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(stackView)
+
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            divider.widthAnchor.constraint(equalToConstant: Constants.dividerWidth),
+            divider.heightAnchor.constraint(equalTo: stackView.heightAnchor),
+            
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -189,7 +189,9 @@ class Tests_iOS: XCTestCase {
             "1. Amet Commodo Fringilla",
             "2. nunc sed augue",
             
-            "This element is currently unsupported."
+            "This element is currently unsupported.",
+            
+            "Pellentesque Ridiculus Porta"
         ]
 
         for expectedString in expectedContent {


### PR DESCRIPTION
This pull request adds support for block quotes by rendering them as typically found when rendering markdown. This implementation supports "basic" markdown styling within the block quote itself, such as **bold**, _italic_, etc.

![image](https://user-images.githubusercontent.com/1158092/144127587-b92f8499-9317-4801-a519-8baf3b2c0d83.png)
