### PR TITLE
Fix for lines being cut-off in reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -44,7 +44,7 @@ class ArticleComponentTextView: UITextView {
         
         backgroundColor = .clear
         textContainerInset = .zero
-        textContainer?.lineFragmentPadding = .zero
+        self.textContainer.lineFragmentPadding = .zero
         isEditable = false
         isScrollEnabled = false
         delegate = self


### PR DESCRIPTION
Because the `textContainer` parameter can be nil when passed into the
ArticleComponentTextView initializer, we need to reference the
`textContainer` property when setting the line fragment padding.

https://getpocket.atlassian.net/browse/IN-454