### PR TITLE
Properly observe reader settings

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -83,7 +83,7 @@ class ArticleViewController: UIViewController {
         collectionView.register(cellClass: YouTubeVideoComponentCell.self)
         navigationItem.largeTitleDisplayMode = .never
 
-        readerSettings.objectWillChange.sink { _ in
+        self.readerSettings.objectWillChange.sink { _ in
             DispatchQueue.main.async {
                 self.collectionView.reloadData()
             }


### PR DESCRIPTION
The reader view wasn't responding to changes in reader settings.
Observing our own property, as opposed to the parameter being passed in
fixes the issue, though I don't fully understand why. We should be
observing the same instance either way.