### PR TITLE
Reader: Update image component layout

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
@@ -9,7 +9,7 @@ private extension Style {
         .serif
         .title
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.16))
+            paragraph.with(lineHeight: .multiplier(0.825))
         }
         .adjustingSize(by: modifier.fontSizeAdjustment)
     }
@@ -20,7 +20,7 @@ private extension Style {
         .p4
         .with(weight: .medium)
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.57))
+            paragraph.with(lineHeight: .multiplier(1.1))
         }
         .adjustingSize(by: modifier.fontSizeAdjustment)
     }
@@ -30,7 +30,7 @@ private extension Style {
         .sansSerif
         .p4
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.57))
+            paragraph.with(lineHeight: .multiplier(1.1))
         }
         .adjustingSize(by: modifier.fontSizeAdjustment)
     }

--- a/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleViewController.swift
@@ -21,7 +21,7 @@ class ArticleViewController: UIViewController {
                 )
             }
             
-            presenters = item?.components?.map { presenter(for: $0) }
+            presenters = item?.components?.filter { !$0.isEmpty }.map { presenter(for: $0) }
 
             DispatchQueue.main.async {
                 self.collectionView.reloadData()

--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -3,53 +3,37 @@ import Kingfisher
 
 
 class ImageComponentCell: UICollectionViewCell {
+    enum Constants {
+        static let captionSpacing: CGFloat = 8
+        static let layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 24, right: 0)
+    }
+
+    struct ImageSpec {
+        let source: URL
+        let size: CGSize
+    }
+
+    struct Model {
+        let caption: NSAttributedString?
+        let image: ImageSpec?
+    }
+
     let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .center
         imageView.layer.cornerRadius = 4
         imageView.clipsToBounds = true
+        imageView.backgroundColor = UIColor(white: 0.95, alpha: 1)
         imageView.setContentCompressionResistancePriority(.required, for: .vertical)
         return imageView
     }()
 
-    var attributedCaption: NSAttributedString? {
-        get {
-            captionLabel.attributedText
-        }
-        set {
-            captionLabel.attributedText = newValue
-        }
-    }
-
-    var attributedCredit: NSAttributedString? {
-        get {
-            creditLabel.attributedText
-        }
-        set {
-            creditLabel.attributedText = newValue
-        }
-    }
-
-    private let captionLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        label.isUserInteractionEnabled = true
-
-        return label
-    }()
-
-    private let creditLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        label.isUserInteractionEnabled = true
-
-        return label
-    }()
+    private let captionTextView: UITextView = ArticleComponentTextView()
 
     private let stack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
-        stack.spacing = 4
+        stack.spacing = Constants.captionSpacing
 
         return stack
     }()
@@ -59,19 +43,82 @@ class ImageComponentCell: UICollectionViewCell {
 
         contentView.addSubview(stack)
         stack.addArrangedSubview(imageView)
-        stack.addArrangedSubview(captionLabel)
-        stack.addArrangedSubview(creditLabel)
+        stack.addArrangedSubview(captionTextView)
 
+        contentView.layoutMargins = Constants.layoutMargins
         stack.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            stack.topAnchor.constraint(equalTo: contentView.topAnchor),
-            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
         ])
     }
     
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
+    }
+}
+
+extension ImageComponentCell {
+    func configure(model: Model, imageLoaded: ((UIImage) -> Void)? = nil) {
+        captionTextView.attributedText = model.caption
+        captionTextView.isHidden = model.caption == nil
+
+        imageView.image = nil
+        guard let imageSpec = model.image else {
+            return
+        }
+
+        imageView.kf.indicatorType = .activity
+        imageView.kf.setImage(
+            with: imageSpec.source,
+            options: [
+                .scaleFactor(UIScreen.main.scale),
+                .processor(
+                    OnlyResizeDownProcessor(size: imageSpec.size, mode: .aspectFit)
+                )
+            ]
+        ) { result in
+            switch result {
+            case .success(let result):
+                imageLoaded?(result.image)
+            case .failure:
+                break
+            }
+        }
+    }
+}
+
+private class OnlyResizeDownProcessor: ImageProcessor {
+    let identifier = "com.getpocket.image-processor.only-resize-down"
+
+    let resizingProcessor: ResizingImageProcessor
+
+    init(resizingProcessor: ResizingImageProcessor) {
+        self.resizingProcessor = resizingProcessor
+    }
+
+    convenience init(size: CGSize, mode: ContentMode) {
+        self.init(
+            resizingProcessor: ResizingImageProcessor(
+                referenceSize: size,
+                mode: mode
+            )
+        )
+    }
+
+    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        switch item {
+        case .image(let image):
+            guard image.size.height > resizingProcessor.referenceSize.height
+                    || image.size.width > resizingProcessor.referenceSize.width else {
+                        return image
+                    }
+
+            return resizingProcessor.process(item: item, options: options)
+        case .data:
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
@@ -30,6 +30,8 @@ class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, Art
             textView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             textView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             textView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+            // set lower priority to avoid conflict if content turns out to be blank
+                .with(priority: .defaultLow)
         ])
     }
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/MarkdownComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/MarkdownComponentPresenter.swift
@@ -21,12 +21,14 @@ class MarkdownComponentPresenter: ArticleComponentPresenter {
     }
     
     func size(for availableWidth: CGFloat) -> CGSize {
-        content.flatMap {
-            let height = $0.sizeFitting(availableWidth: availableWidth).height
-            + MarkdownComponentCell.Constants.layoutMargins.bottom
+        guard let content = content, !content.string.isEmpty else {
+            return .zero
+        }
 
-            return CGSize(width: availableWidth, height: height)
-        } ?? .zero
+        var size = content.sizeFitting(availableWidth: availableWidth)
+        size.height += MarkdownComponentCell.Constants.layoutMargins.bottom
+
+        return size
     }
     
     func cell(for indexPath: IndexPath, in collectionView: UICollectionView) -> UICollectionViewCell {

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -4,37 +4,37 @@ import Down
 private extension Style {
     static let h1: Style = .header.serif.h1
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.97))
         }
 
     static let h2: Style = .header.serif.h2
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.99))
         }
 
     static let h3: Style = .header.serif.h3
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.95))
         }
 
     static let h4: Style = .header.serif.h4
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.96))
         }
 
     static let h5: Style = .header.serif.h5
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.89))
         }
 
     static let h6: Style = .header.serif.h6
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.18))
+            paragraph.with(lineHeight: .multiplier(0.9))
         }
 
     static let bodyText: Style = .body.serif
         .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.4))
+            paragraph.with(lineHeight: .multiplier(1.14))
         }
 
     static let monospace: Style = .body.monospace

--- a/PocketKit/Sources/Textile/Style/Style+UIKit.swift
+++ b/PocketKit/Sources/Textile/Style/Style+UIKit.swift
@@ -108,7 +108,7 @@ extension NSLineBreakMode {
 }
 
 extension NSParagraphStyle {
-    static func from(_ paragraphStyle: ParagraphStyle, fontDescriptor: FontDescriptor) -> NSParagraphStyle {
+    static func from(_ paragraphStyle: ParagraphStyle) -> NSParagraphStyle {
         let style = NSMutableParagraphStyle()
         style.alignment = NSTextAlignment(paragraphStyle.alignment)
 
@@ -125,9 +125,7 @@ extension NSParagraphStyle {
             style.minimumLineHeight = lineHeight
             style.maximumLineHeight = lineHeight
         case .multiplier(let multiplier):
-            let lineHeight = CGFloat(fontDescriptor.size.size) * multiplier
-            style.minimumLineHeight = lineHeight
-            style.maximumLineHeight = lineHeight
+            style.lineHeightMultiple = multiplier
         case .none:
             break
         }
@@ -141,7 +139,7 @@ public extension Style {
         var attributes: [NSAttributedString.Key: Any] = [
             .style: self,
             .font: UIFontMetrics.default.scaledFont(for: UIFont(fontDescriptor)),
-            .paragraphStyle: NSParagraphStyle.from(paragraph, fontDescriptor: fontDescriptor),
+            .paragraphStyle: NSParagraphStyle.from(paragraph),
             .foregroundColor: UIColor(colorAsset),
         ]
 


### PR DESCRIPTION
- Caption and Credit are now combined into a single text view (using different attributes for each).
- Images have a bottom margin of 24pt

Also used a different approach to handling of line height multipliers that is more in line with how UIKit does things.

### Example
![image-example](https://user-images.githubusercontent.com/323541/147014378-afd170e0-1fea-4fa6-8049-4a9b1593d1ac.png)


