### PR TITLE
Home: Use first image URL if topImageURL is not present

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
@@ -79,7 +79,10 @@ struct RecommendationPresenter {
     }
 
     private var cachedTopImageURL: URL? {
-        return imageCacheURL(for: recommendation.item.topImageURL)
+        let topImageURL = recommendation.item.topImageURL
+        ?? recommendation.item.images?.first { $0.src != nil }?.src
+
+        return imageCacheURL(for: topImageURL)
     }
 
     private var detail: String {

--- a/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
@@ -57,7 +57,8 @@ extension Slate.Item {
             domain: remote.domain,
             domainMetadata: (remote.domainMetadata?.fragments.domainMetadataParts).flatMap(Slate.DomainMetadata.init),
             authors: remote.authors.flatMap { $0.compactMap { $0 }.map(Slate.Author.init) },
-            datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) }
+            datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) },
+            images: remote.images.flatMap { $0.compactMap { $0 }.map(Slate.Image.init) }
         )
     }
 }
@@ -81,6 +82,19 @@ extension Slate.Author {
             id: remote.id,
             name: remote.name,
             url: remote.url.flatMap(URL.init)
+        )
+    }
+}
+
+extension Slate.Image {
+    typealias Remote = ItemParts.Image
+
+    init(remote: Remote) {
+        self.init(
+            height: remote.height,
+            width: remote.width,
+            src: URL(string: remote.src),
+            imageID: remote.imageId
         )
     }
 }

--- a/PocketKit/Sources/Sync/Slates/Slate.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate.swift
@@ -25,6 +25,13 @@ public struct Slate: Identifiable, Equatable, Hashable {
         public let url: URL?
     }
 
+    public struct Image: Equatable, Hashable {
+        public let height: Int?
+        public let width: Int?
+        public let src: URL?
+        public let imageID: Int?
+    }
+
     public struct Item: Equatable, Hashable {
         public let id: String
         public let givenURL: URL?
@@ -39,6 +46,7 @@ public struct Slate: Identifiable, Equatable, Hashable {
         public let domainMetadata: DomainMetadata?
         public let authors: [Author]?
         public let datePublished: Date?
+        public let images: [Image]?
     }
 }
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -73,6 +73,12 @@ class APISlateServiceTests: XCTestCase {
             XCTAssertEqual(item.domain, "slate-2-rec-1.example.com")
             XCTAssertEqual(item.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
 
+            let image = item.images?[0]
+            XCTAssertEqual(image?.height, 0)
+            XCTAssertEqual(image?.width, 0)
+            XCTAssertEqual(image?.src, URL(string: "http://example.com/slate-2-rec-1/image-1.png")!)
+            XCTAssertEqual(image?.imageID, 1)
+
             let domain = item.domainMetadata
             XCTAssertNotNil(domain)
             XCTAssertEqual(domain?.name, "Lifehacker")

--- a/PocketKit/Tests/SyncTests/Fixtures/slates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slates.json
@@ -92,7 +92,15 @@
                                         "content": "Pellentesque Ridiculus Porta"
                                     }
                                 ],
-                                "images": [],
+                                "images": [
+                                    {
+                                        "__typename": "[some-type-name]",
+                                        "height": 0,
+                                        "width": 0,
+                                        "src": "http://example.com/slate-2-rec-1/image-1.png",
+                                        "imageId": 1
+                                    }
+                                ],
                                 "excerpt": "Cursus Aenean Elit",
                                 "datePublished": "2021-01-01 12:01:01",
                                 "domain": "slate-2-rec-1.example.com",

--- a/PocketKit/Tests/SyncTests/SourceTests.swift
+++ b/PocketKit/Tests/SyncTests/SourceTests.swift
@@ -202,7 +202,8 @@ class SourceTests: XCTestCase {
                         url: URL(string: "http://example.com/authors/eb-white")
                     )
                 ],
-                datePublished: Date()
+                datePublished: Date(),
+                images: []
             )
         )
 

--- a/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
@@ -45,7 +45,8 @@ extension Slate.Item {
             domain: nil,
             domainMetadata: nil,
             authors: nil,
-            datePublished: nil
+            datePublished: nil,
+            images: nil
         )
     }
 }


### PR DESCRIPTION
Many collections do not have a `topImageURL` property, causing a lot of
gray rectangles to be rendered on the home tab. To avoid this issue, we
fall back to the first entry in the underlying item's images collection.