### PR TITLE
Fix incorrect background colors in Home and My List

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -94,6 +94,7 @@ class HomeViewController: UIViewController {
             return self.viewForSupplementaryElement(ofKind: kind, at: indexPath)
         }
 
+        collectionView.backgroundColor = UIColor(.ui.white1)
         collectionView.register(cellClass: RecommendationCell.self)
         collectionView.register(cellClass: TopicChipCell.self)
         collectionView.register(viewClass: SlateHeaderView.self, forSupplementaryViewOfKind: SlateHeaderView.kind)

--- a/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListViewController.swift
@@ -59,6 +59,7 @@ class MyListViewController: UIViewController {
                 return section
             case .items:
                 var config = UICollectionLayoutListConfiguration(appearance: .plain)
+                config.backgroundColor = UIColor(.ui.white1)
                 config.trailingSwipeActionsConfigurationProvider = { [unowned self] indexPath in
                     let archiveAction = UIContextualAction(
                         style: .normal,


### PR DESCRIPTION
Two simple fixes:

1. The background color of the Home collection view was not set, so the resulting color would be the system background rather than the "Pocket" background.
2. After the "My List" refactor to use the modern APIs, it seems as if the collection view was adding implicit decoration items for each section. By explicitly setting each section's `decorationViews` to `[]`, we see the expected color when scrolling to the bottom bottom of the list, as no additional views are rendered as the "background" to each section.