### PR TITLE
Add "Archive" section to "My List" tab

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		166BAD092656E76B00E401F0 /* ItemRowElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD042656E76B00E401F0 /* ItemRowElement.swift */; };
 		166BAD0A2656E76B00E401F0 /* SignInFormElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD052656E76B00E401F0 /* SignInFormElement.swift */; };
 		166BAD0B2656E76B00E401F0 /* ReaderElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD062656E76B00E401F0 /* ReaderElement.swift */; };
-		166BAD0C2656E76B00E401F0 /* UserListElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD072656E76B00E401F0 /* UserListElement.swift */; };
+		166BAD0C2656E76B00E401F0 /* MyListElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD072656E76B00E401F0 /* MyListElement.swift */; };
 		166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166BAD082656E76B00E401F0 /* PocketAppElement.swift */; };
 		166EFAE8268281F300A027CD /* ReaderToolbarElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE7268281F300A027CD /* ReaderToolbarElement.swift */; };
 		166EFAEA2682821300A027CD /* WebReaderElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166EFAE92682821300A027CD /* WebReaderElement.swift */; };
@@ -47,8 +47,12 @@
 		16A6808126EBC78800A64545 /* HomeViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A6808026EBC78800A64545 /* HomeViewElement.swift */; };
 		16BA7D6326851513009A17C1 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA7D6226851513009A17C1 /* main.swift */; };
 		16BA7D6626851579009A17C1 /* PocketKit in Frameworks */ = {isa = PBXBuildFile; productRef = 16BA7D6526851579009A17C1 /* PocketKit */; };
+		16BB40A8279F436100FE8650 /* SelectionSwitcherElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BB40A7279F436100FE8650 /* SelectionSwitcherElement.swift */; };
 		16C2B03F270CF82700D194AA /* RecommendationCellElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */; };
+		16D76883279F3C73004A3694 /* ArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D76882279F3C73004A3694 /* ArchiveTests.swift */; };
 		16E32B0226851AEB000CC36D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 16D47E7F26851AB40095D5A4 /* Assets.xcassets */; };
+		16E4B16D27A31BEC00E01746 /* RequestMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4B16C27A31BEC00E01746 /* RequestMatchers.swift */; };
+		16E4B16F27A3212900E01746 /* Response+factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4B16E27A3212900E01746 /* Response+factories.swift */; };
 		16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */; };
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
@@ -100,7 +104,7 @@
 		166BAD042656E76B00E401F0 /* ItemRowElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemRowElement.swift; sourceTree = "<group>"; };
 		166BAD052656E76B00E401F0 /* SignInFormElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInFormElement.swift; sourceTree = "<group>"; };
 		166BAD062656E76B00E401F0 /* ReaderElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderElement.swift; sourceTree = "<group>"; };
-		166BAD072656E76B00E401F0 /* UserListElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserListElement.swift; sourceTree = "<group>"; };
+		166BAD072656E76B00E401F0 /* MyListElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyListElement.swift; sourceTree = "<group>"; };
 		166BAD082656E76B00E401F0 /* PocketAppElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PocketAppElement.swift; sourceTree = "<group>"; };
 		166EFAE7268281F300A027CD /* ReaderToolbarElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderToolbarElement.swift; sourceTree = "<group>"; };
 		166EFAE92682821300A027CD /* WebReaderElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebReaderElement.swift; sourceTree = "<group>"; };
@@ -112,8 +116,12 @@
 		16A6807E26EBC71300A64545 /* TabBarElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarElement.swift; sourceTree = "<group>"; };
 		16A6808026EBC78800A64545 /* HomeViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewElement.swift; sourceTree = "<group>"; };
 		16BA7D6226851513009A17C1 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		16BB40A7279F436100FE8650 /* SelectionSwitcherElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionSwitcherElement.swift; sourceTree = "<group>"; };
 		16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationCellElement.swift; sourceTree = "<group>"; };
 		16D47E7F26851AB40095D5A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		16D76882279F3C73004A3694 /* ArchiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveTests.swift; sourceTree = "<group>"; };
+		16E4B16C27A31BEC00E01746 /* RequestMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMatchers.swift; sourceTree = "<group>"; };
+		16E4B16E27A3212900E01746 /* Response+factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Response+factories.swift"; sourceTree = "<group>"; };
 		16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshTests.swift; sourceTree = "<group>"; };
 		16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAnItemTests.swift; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
@@ -149,6 +157,7 @@
 			children = (
 				166A81C42637406C0015AA1D /* MyListTests.swift */,
 				164FB66D278F7ECC002959D6 /* MyListFiltersTests.swift */,
+				16D76882279F3C73004A3694 /* ArchiveTests.swift */,
 			);
 			path = MyList;
 			sourceTree = "<group>";
@@ -179,10 +188,10 @@
 		166A81C32637406C0015AA1D /* Tests iOS */ = {
 			isa = PBXGroup;
 			children = (
-				164FB66C278F7E52002959D6 /* MyList */,
 				166A81C62637406C0015AA1D /* Info.plist */,
 				166BACF92656E6A500E401F0 /* Support */,
 				166BACF52656E34B00E401F0 /* Fixtures */,
+				164FB66C278F7E52002959D6 /* MyList */,
 				1674057626CAC35F0061434E /* DeleteAnItemTests.swift */,
 				16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */,
 				168292C726CC64C300830140 /* ShareAnItemTests.swift */,
@@ -203,6 +212,8 @@
 				1612D7E326C32321009A5BFD /* ByteBuffer+read.swift */,
 				F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */,
 				F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */,
+				16E4B16C27A31BEC00E01746 /* RequestMatchers.swift */,
+				16E4B16E27A3212900E01746 /* Response+factories.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -216,7 +227,7 @@
 				166BAD062656E76B00E401F0 /* ReaderElement.swift */,
 				166EFAE7268281F300A027CD /* ReaderToolbarElement.swift */,
 				166BAD052656E76B00E401F0 /* SignInFormElement.swift */,
-				166BAD072656E76B00E401F0 /* UserListElement.swift */,
+				166BAD072656E76B00E401F0 /* MyListElement.swift */,
 				166EFAE92682821300A027CD /* WebReaderElement.swift */,
 				166F8F2626D0488900F898E3 /* XCUIElement+wait.swift */,
 				16A6807E26EBC71300A64545 /* TabBarElement.swift */,
@@ -226,6 +237,7 @@
 				F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */,
 				1613B2B2275571940014F301 /* SettingsViewElement.swift */,
 				F20BB0382744542F00AE5E70 /* AlertElement.swift */,
+				16BB40A7279F436100FE8650 /* SelectionSwitcherElement.swift */,
 			);
 			path = Elements;
 			sourceTree = "<group>";
@@ -394,7 +406,8 @@
 			files = (
 				1674057726CAC35F0061434E /* DeleteAnItemTests.swift in Sources */,
 				1613B2B12755696B0014F301 /* SignOutTests.swift in Sources */,
-				166BAD0C2656E76B00E401F0 /* UserListElement.swift in Sources */,
+				16E4B16D27A31BEC00E01746 /* RequestMatchers.swift in Sources */,
+				166BAD0C2656E76B00E401F0 /* MyListElement.swift in Sources */,
 				F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */,
 				166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */,
 				164FB66E278F7ECC002959D6 /* MyListFiltersTests.swift in Sources */,
@@ -408,8 +421,11 @@
 				16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */,
 				F2843C202714D97000E03ED5 /* ReportViewElement.swift in Sources */,
 				166EFAE8268281F300A027CD /* ReaderToolbarElement.swift in Sources */,
+				16D76883279F3C73004A3694 /* ArchiveTests.swift in Sources */,
 				1613B2B3275571940014F301 /* SettingsViewElement.swift in Sources */,
+				16BB40A8279F436100FE8650 /* SelectionSwitcherElement.swift in Sources */,
 				F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */,
+				16E4B16F27A3212900E01746 /* Response+factories.swift in Sources */,
 				166EFAEA2682821300A027CD /* WebReaderElement.swift in Sources */,
 				16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */,
 				160056F326CC7FFD00700A80 /* FavoriteAnItemTests.swift in Sources */,

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		160056F326CC7FFD00700A80 /* FavoriteAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160056F226CC7FFD00700A80 /* FavoriteAnItemTests.swift */; };
+		1605237E27A4627F00E09FD2 /* XCTestCase+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1605237D27A4627F00E09FD2 /* XCTestCase+extensions.swift */; };
 		1606F21B26EBC1A200238111 /* HomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1606F21A26EBC1A200238111 /* HomeTests.swift */; };
 		1612D7E426C32321009A5BFD /* ByteBuffer+read.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612D7E326C32321009A5BFD /* ByteBuffer+read.swift */; };
 		1613B2B12755696B0014F301 /* SignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1613B2B02755696B0014F301 /* SignOutTests.swift */; };
@@ -87,6 +88,7 @@
 
 /* Begin PBXFileReference section */
 		160056F226CC7FFD00700A80 /* FavoriteAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteAnItemTests.swift; sourceTree = "<group>"; };
+		1605237D27A4627F00E09FD2 /* XCTestCase+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+extensions.swift"; sourceTree = "<group>"; };
 		1606F21A26EBC1A200238111 /* HomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTests.swift; sourceTree = "<group>"; };
 		1612D7E326C32321009A5BFD /* ByteBuffer+read.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ByteBuffer+read.swift"; sourceTree = "<group>"; };
 		1613B2B02755696B0014F301 /* SignOutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutTests.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */,
 				16E4B16C27A31BEC00E01746 /* RequestMatchers.swift */,
 				16E4B16E27A3212900E01746 /* Response+factories.swift */,
+				1605237D27A4627F00E09FD2 /* XCTestCase+extensions.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */,
 				164FB66E278F7ECC002959D6 /* MyListFiltersTests.swift in Sources */,
 				F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */,
+				1605237E27A4627F00E09FD2 /* XCTestCase+extensions.swift in Sources */,
 				1648D5A727024C6400F67C4B /* SlateDetailElement.swift in Sources */,
 				166BAD0B2656E76B00E401F0 /* ReaderElement.swift in Sources */,
 				166F8F2726D0488900F898E3 /* XCUIElement+wait.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/Archive/ArchiveViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Archive/ArchiveViewModel.swift
@@ -1,0 +1,102 @@
+import Sync
+import Combine
+import UIKit
+
+
+class ArchiveViewModel: ItemsListViewModel {
+    typealias ItemIdentifier = String
+    typealias Snapshot = NSDiffableDataSourceSnapshot<ItemListSection, ItemListCell<ItemIdentifier>>
+
+    var events: PassthroughSubject<ItemListEvent<ItemIdentifier>, Never>
+    var presentedAlert: PocketAlert?
+    let selectionItem: SelectionItem = SelectionItem(title: "Archive", image: .init(asset: .archive))
+
+    private let source: Source
+    private var archivedItems: [String: ArchivedItem] = [:]
+
+    @Published
+    private var selectedFilters: Set<ItemListFilter> = .init()
+    private let availableFilters: [ItemListFilter] = ItemListFilter.allCases
+
+    init(source: Source) {
+        self.source = source
+        self.events = .init()
+    }
+
+    func fetch() async throws {
+        let items = try await source.fetchArchivedItems()
+        archivedItems = items.reduce(into: [:]) { partialResult, archivedItem in
+            partialResult[archivedItem.remoteID] = archivedItem
+        }
+
+        let snapshot = buildSnapshot()
+        events.send(.snapshot(snapshot))
+    }
+
+    func filterButton(with id: ItemListFilter) -> TopicChipPresenter {
+        TopicChipPresenter(
+            title: id.rawValue,
+            isSelected: selectedFilters.contains(id)
+        )
+    }
+
+    func item(with cellID: ItemListCell<ItemIdentifier>) -> MyListItemPresenter? {
+        guard case .item(let archivedItemID) = cellID else {
+            return nil
+        }
+
+        return item(with: archivedItemID)
+    }
+
+    func item(with itemID: String) -> MyListItemPresenter? {
+        archivedItems[itemID].flatMap(MyListItemPresenter.init)
+    }
+
+    func fetch() throws {
+        Task {
+            try await self.fetch()
+        }
+    }
+
+    func refresh(_ completion: (() -> ())?) {
+        // TODO: Support pull to refresh
+    }
+
+    func selectCell(with: ItemListCell<ItemIdentifier>) {
+        // TODO: show the item in reader
+    }
+
+    func shareItem(with: ItemListCell<ItemIdentifier>) {
+        // TODO: share the item
+    }
+
+    private func buildSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections(ItemListSection.allCases)
+
+        snapshot.appendItems(
+            ItemListFilter.allCases.map { ItemListCell<ItemIdentifier>.filterButton($0) },
+            toSection: .filters
+        )
+
+        let itemCellIDs = archivedItems.keys.map { ItemListCell<ItemIdentifier>.item($0) }
+        snapshot.appendItems(itemCellIDs, toSection: .items)
+        return snapshot
+    }
+
+    func toggleFavorite(_ cell: ItemListCell<String>) {
+
+    }
+
+    func archive(_ cell: ItemListCell<String>) {
+
+    }
+
+    func delete(_ cell: ItemListCell<String>) {
+
+    }
+
+    func trackImpression(_ cell: ItemListCell<String>) {
+
+    }
+}

--- a/PocketKit/Sources/PocketKit/Article/Recommendation+Readable.swift
+++ b/PocketKit/Sources/PocketKit/Article/Recommendation+Readable.swift
@@ -37,6 +37,6 @@ extension Slate.Recommendation: Readable {
     }
 }
 
-extension Slate.Author: ReadableAuthor {
+extension UnmanagedItem.Author: ReadableAuthor {
     
 }

--- a/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ItemViewController.swift
@@ -81,6 +81,25 @@ class ItemViewController: UIViewController {
     }
 
     func buildOverflowMenu() {
+        let deleteAction = UIAction(
+            title: "Delete",
+            image: UIImage(systemName: "trash"),
+            handler: { [weak self] _ in
+                self?.delete()
+            }
+        )
+        deleteAction.accessibilityIdentifier = "item-action-menu-delete"
+
+        let archiveAction = UIAction(
+            title: "Archive",
+            image: UIImage(systemName: "archivebox"),
+            handler: { [weak self] _ in
+                self?.archive()
+            }
+        )
+        archiveAction.accessibilityIdentifier = "item-action-menu-archive"
+
+
         moreButtonItem.menu = UIMenu(
             image: nil,
             identifier: nil,
@@ -112,20 +131,8 @@ class ItemViewController: UIViewController {
                         )
                     }
                 }(),
-                UIAction(
-                    title: "Archive",
-                    image: UIImage(systemName: "archivebox"),
-                    handler: { [weak self] _ in
-                        self?.archive()
-                    }
-                ),
-                UIAction(
-                    title: "Delete",
-                    image: UIImage(systemName: "trash"),
-                    handler: { [weak self] _ in
-                        self?.delete()
-                    }
-                ),
+                archiveAction,
+                deleteAction,
                 UIAction(
                     title: "Share",
                     image: UIImage(systemName: "square.and.arrow.up"),

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -36,15 +36,15 @@ class CompactMainCoordinator: NSObject {
 
         let myListContainer = MyListContainerViewController(
             viewControllers: [
-                MyListViewController(
-                    model: MyListViewModel(
+                ItemsListViewController(
+                    model: SavedItemsListViewModel(
                         source: source,
                         tracker: tracker.childTracker(hosting: .myList.screen),
                         main: model
                     )
                 ),
-                MyListViewController(
-                    model: ArchiveViewModel(source: source)
+                ItemsListViewController(
+                    model: ArchivedItemsListViewModel(source: source)
                 )
             ]
         )

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -34,16 +34,22 @@ class CompactMainCoordinator: NSObject {
         self.tracker = tracker
         self.model = model
 
-        let myListRoot = MyListViewController(
-            model: MyListViewModel(
-                source: source,
-                tracker: tracker.childTracker(hosting: .myList.screen),
-                main: model
-            )
+        let myListContainer = MyListContainerViewController(
+            viewControllers: [
+                MyListViewController(
+                    model: MyListViewModel(
+                        source: source,
+                        tracker: tracker.childTracker(hosting: .myList.screen),
+                        main: model
+                    )
+                ),
+                MyListViewController(
+                    model: ArchiveViewModel(source: source)
+                )
+            ]
         )
 
-        myListRoot.view.backgroundColor = UIColor(.ui.white1)
-        myList = UINavigationController(rootViewController: myListRoot)
+        myList = UINavigationController(rootViewController: myListContainer)
         myList.navigationBar.prefersLargeTitles = true
         myList.navigationBar.barTintColor = UIColor(.ui.white1)
         myList.navigationBar.tintColor = UIColor(.ui.grey1)

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -43,14 +43,20 @@ class RegularMainCoordinator: NSObject {
         
         navigationSidebar = UINavigationController(rootViewController: NavigationSidebarViewController(model: model))
         
-        myList = MyListViewController(
-            model: MyListViewModel(
-                source: source,
-                tracker: tracker.childTracker(hosting: .myList.screen),
-                main: model
-            )
+        myList = MyListContainerViewController(
+            viewControllers: [
+                MyListViewController(
+                    model: MyListViewModel(
+                        source: source,
+                        tracker: tracker.childTracker(hosting: .myList.screen),
+                        main: model
+                    )
+                ),
+                MyListViewController(
+                    model: ArchiveViewModel(source: source)
+                )
+            ]
         )
-        myList.view.backgroundColor = UIColor(.ui.white1)
         
         home = HomeViewController(
             source: source,

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -45,15 +45,15 @@ class RegularMainCoordinator: NSObject {
         
         myList = MyListContainerViewController(
             viewControllers: [
-                MyListViewController(
-                    model: MyListViewModel(
+                ItemsListViewController(
+                    model: SavedItemsListViewModel(
                         source: source,
                         tracker: tracker.childTracker(hosting: .myList.screen),
                         main: model
                     )
                 ),
-                MyListViewController(
-                    model: ArchiveViewModel(source: source)
+                ItemsListViewController(
+                    model: ArchivedItemsListViewModel(source: source)
                 )
             ]
         )

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItem+ItemsListItem.swift
@@ -1,0 +1,33 @@
+import Sync
+import Foundation
+
+
+extension ArchivedItem: ItemsListItem {
+    var title: String? {
+        item?.title
+    }
+
+    var bestURL: URL? {
+        item?.resolvedURL ?? item?.givenURL ?? url
+    }
+
+    var topImageURL: URL? {
+        item?.topImageURL
+    }
+
+    var domain: String? {
+        item?.domain
+    }
+
+    var domainMetadata: ItemsListItemDomainMetadata? {
+        item?.domainMetadata
+    }
+
+    var timeToRead: Int? {
+        item?.timeToRead
+    }
+}
+
+extension UnmanagedItem.DomainMetadata: ItemsListItemDomainMetadata {
+
+}

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -3,11 +3,11 @@ import Combine
 import UIKit
 
 
-class ArchiveViewModel: ItemsListViewModel {
+class ArchivedItemsListViewModel: ItemsListViewModel {
     typealias ItemIdentifier = String
-    typealias Snapshot = NSDiffableDataSourceSnapshot<ItemListSection, ItemListCell<ItemIdentifier>>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<ItemsListSection, ItemsListCell<ItemIdentifier>>
 
-    var events: PassthroughSubject<ItemListEvent<ItemIdentifier>, Never>
+    var events: PassthroughSubject<ItemsListEvent<ItemIdentifier>, Never>
     var presentedAlert: PocketAlert?
     let selectionItem: SelectionItem = SelectionItem(title: "Archive", image: .init(asset: .archive))
 
@@ -15,8 +15,8 @@ class ArchiveViewModel: ItemsListViewModel {
     private var archivedItems: [String: ArchivedItem] = [:]
 
     @Published
-    private var selectedFilters: Set<ItemListFilter> = .init()
-    private let availableFilters: [ItemListFilter] = ItemListFilter.allCases
+    private var selectedFilters: Set<ItemsListFilter> = .init()
+    private let availableFilters: [ItemsListFilter] = ItemsListFilter.allCases
 
     init(source: Source) {
         self.source = source
@@ -33,14 +33,14 @@ class ArchiveViewModel: ItemsListViewModel {
         events.send(.snapshot(snapshot))
     }
 
-    func filterButton(with id: ItemListFilter) -> TopicChipPresenter {
+    func filterButton(with id: ItemsListFilter) -> TopicChipPresenter {
         TopicChipPresenter(
             title: id.rawValue,
             isSelected: selectedFilters.contains(id)
         )
     }
 
-    func item(with cellID: ItemListCell<ItemIdentifier>) -> MyListItemPresenter? {
+    func item(with cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
         guard case .item(let archivedItemID) = cellID else {
             return nil
         }
@@ -48,8 +48,8 @@ class ArchiveViewModel: ItemsListViewModel {
         return item(with: archivedItemID)
     }
 
-    func item(with itemID: String) -> MyListItemPresenter? {
-        archivedItems[itemID].flatMap(MyListItemPresenter.init)
+    func item(with itemID: String) -> ItemsListItemPresenter? {
+        archivedItems[itemID].flatMap(ItemsListItemPresenter.init)
     }
 
     func fetch() throws {
@@ -62,41 +62,41 @@ class ArchiveViewModel: ItemsListViewModel {
         // TODO: Support pull to refresh
     }
 
-    func selectCell(with: ItemListCell<ItemIdentifier>) {
+    func selectCell(with: ItemsListCell<ItemIdentifier>) {
         // TODO: show the item in reader
     }
 
-    func shareItem(with: ItemListCell<ItemIdentifier>) {
+    func shareItem(with: ItemsListCell<ItemIdentifier>) {
         // TODO: share the item
     }
 
     private func buildSnapshot() -> Snapshot {
         var snapshot = Snapshot()
-        snapshot.appendSections(ItemListSection.allCases)
+        snapshot.appendSections(ItemsListSection.allCases)
 
         snapshot.appendItems(
-            ItemListFilter.allCases.map { ItemListCell<ItemIdentifier>.filterButton($0) },
+            ItemsListFilter.allCases.map { ItemsListCell<ItemIdentifier>.filterButton($0) },
             toSection: .filters
         )
 
-        let itemCellIDs = archivedItems.keys.map { ItemListCell<ItemIdentifier>.item($0) }
+        let itemCellIDs = archivedItems.keys.map { ItemsListCell<ItemIdentifier>.item($0) }
         snapshot.appendItems(itemCellIDs, toSection: .items)
         return snapshot
     }
 
-    func toggleFavorite(_ cell: ItemListCell<String>) {
+    func toggleFavorite(_ cell: ItemsListCell<String>) {
 
     }
 
-    func archive(_ cell: ItemListCell<String>) {
+    func archive(_ cell: ItemsListCell<String>) {
 
     }
 
-    func delete(_ cell: ItemListCell<String>) {
+    func delete(_ cell: ItemsListCell<String>) {
 
     }
 
-    func trackImpression(_ cell: ItemListCell<String>) {
+    func trackImpression(_ cell: ItemsListCell<String>) {
 
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItem.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+
+protocol ItemsListItem {
+    var title: String? { get }
+    var isFavorite: Bool { get }
+    var bestURL: URL? { get }
+    var topImageURL: URL? { get }
+    var domain: String? { get }
+
+    var domainMetadata: ItemsListItemDomainMetadata? { get }
+    var timeToRead: Int? { get }
+}
+
+protocol ItemsListItemDomainMetadata {
+    var name: String? { get }
+}

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -2,26 +2,15 @@ import UIKit
 import Kingfisher
 
 
-protocol MyListItemCellDelegate: AnyObject {
-    func myListItemCellDidTapFavoriteButton(_ cell: MyListItemCell)
-    func myListItemCellDidTapShareButton(_ cell: MyListItemCell)
-    func myListItemCellDidTapDeleteButton(_ cell: MyListItemCell)
-    func myListItemCellDidTapArchiveButton(_ cell: MyListItemCell)
+protocol ItemsListItemCellDelegate: AnyObject {
+    func myListItemCellDidTapFavoriteButton(_ cell: ItemsListItemCell)
+    func myListItemCellDidTapShareButton(_ cell: ItemsListItemCell)
+    func myListItemCellDidTapDeleteButton(_ cell: ItemsListItemCell)
+    func myListItemCellDidTapArchiveButton(_ cell: ItemsListItemCell)
 }
 
-private extension UIConfigurationStateCustomKey {
-    static let model = UIConfigurationStateCustomKey("com.mozilla.pocket.next.MyListItemCell.model")
-}
-
-private extension UICellConfigurationState {
-    var model: MyListItemCell.Model? {
-        set { self[.model] = newValue }
-        get { return self[.model] as? MyListItemCell.Model }
-    }
-}
-
-class MyListItemCell: UICollectionViewCell {
-    weak var delegate: MyListItemCellDelegate?
+class ItemsListItemCell: UICollectionViewCell {
+    weak var delegate: ItemsListItemCellDelegate?
 
     var model: Model? {
         didSet {
@@ -40,7 +29,7 @@ class MyListItemCell: UICollectionViewCell {
     }
 
     private let listContentView = UIListContentView(
-        configuration: MyListItemCell.defaultListContentConfiguration()
+        configuration: ItemsListItemCell.defaultListContentConfiguration()
     )
 
     enum Constants {
@@ -237,7 +226,7 @@ class MyListItemCell: UICollectionViewCell {
     }
 }
 
-extension MyListItemCell {
+extension ItemsListItemCell {
     struct Model: Hashable {
         let attributedTitle: NSAttributedString
         let attributedDetail: NSAttributedString
@@ -282,9 +271,13 @@ extension MyListItemCell {
     }
 }
 
-extension NSLayoutConstraint {
-    func with(priority: UILayoutPriority) -> NSLayoutConstraint {
-        self.priority = priority
-        return self
+private extension UIConfigurationStateCustomKey {
+    static let model = UIConfigurationStateCustomKey("com.mozilla.pocket.next.MyListItemCell.model")
+}
+
+private extension UICellConfigurationState {
+    var model: ItemsListItemCell.Model? {
+        set { self[.model] = newValue }
+        get { return self[.model] as? ItemsListItemCell.Model }
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
@@ -30,25 +30,10 @@ private extension Style {
         }
 }
 
-protocol MyListItemDomainMetadata {
-    var name: String? { get }
-}
+class ItemsListItemPresenter {
+    private let item: ItemsListItem
 
-protocol MyListItem {
-    var title: String? { get }
-    var isFavorite: Bool { get }
-    var bestURL: URL? { get }
-    var topImageURL: URL? { get }
-    var domain: String? { get }
-
-    var domainMetadata: MyListItemDomainMetadata? { get }
-    var timeToRead: Int? { get }
-}
-
-class MyListItemPresenter {
-    private let item: MyListItem
-
-    init(item: MyListItem) {
+    init(item: ItemsListItem) {
         self.item = item
     }
 
@@ -110,52 +95,4 @@ class MyListItemPresenter {
     private var isFavorite: Bool {
         item.isFavorite
     }
-}
-
-extension SavedItem: MyListItem {
-    var topImageURL: URL? {
-        item?.topImageURL
-    }
-
-    var timeToRead: Int? {
-        item.flatMap { Int($0.timeToRead) }
-    }
-
-    var domainMetadata: MyListItemDomainMetadata? {
-        return item?.domainMetadata
-    }
-}
-
-extension DomainMetadata: MyListItemDomainMetadata {
-
-}
-
-extension ArchivedItem: MyListItem {
-    var title: String? {
-        item?.title
-    }
-
-    var bestURL: URL? {
-        item?.resolvedURL ?? item?.givenURL ?? url
-    }
-
-    var topImageURL: URL? {
-        item?.topImageURL
-    }
-
-    var domain: String? {
-        item?.domain
-    }
-
-    var domainMetadata: MyListItemDomainMetadata? {
-        item?.domainMetadata
-    }
-
-    var timeToRead: Int? {
-        item?.timeToRead
-    }
-}
-
-extension UnmanagedItem.DomainMetadata: MyListItemDomainMetadata {
-
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -1,0 +1,44 @@
+import Combine
+import UIKit
+
+
+enum ItemsListSection: Int, CaseIterable {
+    case filters
+    case items
+}
+
+enum ItemsListCell<ItemIdentifier: Hashable>: Hashable {
+    case filterButton(ItemsListFilter)
+    case item(ItemIdentifier)
+}
+
+enum ItemsListFilter: String, Hashable, CaseIterable {
+    case favorites = "Favorites"
+}
+
+enum ItemsListEvent<ItemIdentifier: Hashable> {
+    case deselectEverythingRenameMe
+    case snapshot(NSDiffableDataSourceSnapshot<ItemsListSection, ItemsListCell<ItemIdentifier>>)
+}
+
+protocol ItemsListViewModel: AnyObject {
+    associatedtype ItemIdentifier: Hashable
+
+    var events: PassthroughSubject<ItemsListEvent<ItemIdentifier>, Never> { get }
+    var presentedAlert: PocketAlert? { get set }
+    var selectionItem: SelectionItem { get }
+
+    func fetch() throws
+    func refresh(_ completion: (() -> ())?)
+
+    func item(with cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter?
+    func item(with itemID: ItemIdentifier) -> ItemsListItemPresenter?
+    func filterButton(with id: ItemsListFilter) -> TopicChipPresenter
+    func selectCell(with: ItemsListCell<ItemIdentifier>)
+    func shareItem(with: ItemsListCell<ItemIdentifier>)
+
+    func toggleFavorite(_ cell: ItemsListCell<ItemIdentifier>)
+    func archive(_ cell: ItemsListCell<ItemIdentifier>)
+    func delete(_ cell: ItemsListCell<ItemIdentifier>)
+    func trackImpression(_ cell: ItemsListCell<ItemIdentifier>)
+}

--- a/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+
+struct SelectionItem {
+    let title: String
+    let image: UIImage
+}
+
+protocol SelectableViewController: UIViewController {
+    var selectionItem: SelectionItem { get }
+}
+
+class MyListContainerViewController: UIViewController {
+    private let viewControllers: [SelectableViewController]
+
+    init(viewControllers: [SelectableViewController]) {
+        self.viewControllers = viewControllers
+
+        super.init(nibName: nil, bundle: nil)
+
+        viewControllers.forEach { vc in
+            addChild(vc)
+            vc.didMove(toParent: vc)
+        }
+
+        let selections = viewControllers.map { vc in
+            MyListSelection(title: vc.selectionItem.title, image: vc.selectionItem.image) { [weak self] in
+                self?.select(child: vc)
+            }
+        }
+
+        navigationItem.titleView = MyListTitleView(selections: selections)
+        navigationItem.largeTitleDisplayMode = .never
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.accessibilityIdentifier = "my-list"
+        select(child: viewControllers.first)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    private func select(child: SelectableViewController?) {
+        viewControllers.forEach { $0.view.removeFromSuperview() }
+        navigationItem.backButtonTitle = child?.selectionItem.title
+
+        guard let child = child else {
+            return
+        }
+
+        view.addSubview(child.view)
+        
+        child.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            child.view.topAnchor.constraint(equalTo: view.topAnchor),
+            child.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            child.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            child.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
@@ -45,15 +45,16 @@ class MyListContainerViewController: UIViewController {
     }
     
     private func select(child: SelectableViewController?) {
-        viewControllers.forEach { $0.view.removeFromSuperview() }
-        navigationItem.backButtonTitle = child?.selectionItem.title
-
         guard let child = child else {
             return
         }
 
+        navigationItem.backButtonTitle = child.selectionItem.title
+        viewControllers
+            .compactMap(\.viewIfLoaded)
+            .forEach { $0.removeFromSuperview() }
         view.addSubview(child.view)
-        
+
         child.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             child.view.topAnchor.constraint(equalTo: view.topAnchor),

--- a/PocketKit/Sources/PocketKit/MyList/MyListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListItemCell.swift
@@ -128,12 +128,13 @@ class MyListItemCell: UICollectionViewCell {
         accessibilityIdentifier = "my-list-item"
         contentView.backgroundColor = UIColor(.ui.white1)
 
-        menuButton.menu = UIMenu(
-            children: [
-                UIAction(title: "Archive", handler: { [weak self] _ in self?.handleArchive() }),
-                UIAction(title: "Delete", handler: { [weak self] _ in self?.handleDelete() }),
-            ]
-        )
+        let archiveAction = UIAction(title: "Archive", handler: { [weak self] _ in self?.handleArchive() })
+        archiveAction.accessibilityIdentifier = "item-action-menu-archive"
+
+        let deleteAction = UIAction(title: "Delete", handler: { [weak self] _ in self?.handleDelete() })
+        deleteAction.accessibilityIdentifier = "item-action-menu-delete"
+
+        menuButton.menu = UIMenu(children: [archiveAction, deleteAction])
 
         favoriteButton.addAction(UIAction { [weak self] _ in
             self?.handleFavorite()

--- a/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
@@ -40,6 +40,8 @@ class MyListTitleView: UIView {
         
         buttons = selections.enumerated().map { offset, selection -> UIButton in
             let button = MyListSelectionButton()
+            button.accessibilityLabel = selection.title
+            
             let action = UIAction(title: selection.title, image: selection.image) { _ in
                 self.updateSelection(button)
                 selection.handler()
@@ -50,6 +52,8 @@ class MyListTitleView: UIView {
         }
         buttons.forEach(stackView.addArrangedSubview)
         updateSelection(buttons[0])
+
+        accessibilityIdentifier = "my-list-selection-switcher"
     }
     
     override func layoutSubviews() {

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -1,0 +1,21 @@
+import Sync
+import Foundation
+
+
+extension SavedItem: ItemsListItem {
+    var topImageURL: URL? {
+        item?.topImageURL
+    }
+
+    var timeToRead: Int? {
+        item.flatMap { Int($0.timeToRead) }
+    }
+
+    var domainMetadata: ItemsListItemDomainMetadata? {
+        return item?.domainMetadata
+    }
+}
+
+extension DomainMetadata: ItemsListItemDomainMetadata {
+
+}

--- a/PocketKit/Sources/PocketKit/NSLayoutConstraint+withPriority.swift
+++ b/PocketKit/Sources/PocketKit/NSLayoutConstraint+withPriority.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+
+extension NSLayoutConstraint {
+    func with(priority: UILayoutPriority) -> NSLayoutConstraint {
+        self.priority = priority
+        return self
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -37,7 +37,7 @@ struct Services {
         let snowplow = PocketSnowplowTracker()
         tracker = PocketTracker(snowplow: snowplow)
 
-        source = Source(
+        source = PocketSource(
             sessionProvider: session,
             accessTokenProvider: accessTokenStore,
             consumerKey: Keys.shared.pocketApiConsumerKey,

--- a/PocketKit/Sources/Sync/Archive/ArchiveService.swift
+++ b/PocketKit/Sources/Sync/Archive/ArchiveService.swift
@@ -1,0 +1,28 @@
+import Apollo
+
+
+protocol ArchiveService {
+    func fetch(accessToken: String?) async throws -> [ArchivedItem]
+}
+
+class PocketArchiveService: ArchiveService {
+    private let apollo: ApolloClientProtocol
+
+    init(apollo: ApolloClientProtocol) {
+        self.apollo = apollo
+    }
+
+    func fetch(accessToken: String?) async throws -> [ArchivedItem] {
+        guard let accessToken = accessToken else {
+            return []
+        }
+
+        let filter = SavedItemsFilter(isArchived: true)
+        let query = UserByTokenQuery(token: accessToken, savedItemsFilter: filter)
+
+        return try await apollo.fetch(query: query)
+            .data?.userByToken?.savedItems?.edges?
+            .compactMap { $0?.node?.fragments.savedItemParts }
+            .map(ArchivedItem.init) ?? []
+    }
+}

--- a/PocketKit/Sources/Sync/ArchivedItem.swift
+++ b/PocketKit/Sources/Sync/ArchivedItem.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+
+public struct ArchivedItem: Equatable {
+    public let remoteID: String
+    public let url: URL?
+    public let createdAt: Date
+    public let deletedAt: Date?
+    public let isArchived: Bool
+    public let isFavorite: Bool
+    public let item: UnmanagedItem?
+
+    public init(
+        remoteID: String,
+        url: URL,
+        createdAt: Date,
+        deletedAt: Date?,
+        isArchived: Bool,
+        isFavorite: Bool,
+        item: UnmanagedItem
+    ) {
+        self.remoteID = remoteID
+        self.url = url
+        self.createdAt = createdAt
+        self.deletedAt = deletedAt
+        self.isArchived = isArchived
+        self.isFavorite = isFavorite
+        self.item = item
+    }
+}
+
+extension ArchivedItem {
+    init(itemParts: SavedItemParts) {
+        self.remoteID = itemParts.remoteId
+        self.url = URL(string: itemParts.url)
+        self.createdAt = Date(timeIntervalSince1970: TimeInterval(itemParts._createdAt))
+        self.deletedAt = itemParts._deletedAt.flatMap { Date(timeIntervalSince1970: TimeInterval($0)) }
+        self.isArchived = itemParts.isArchived
+        self.isFavorite = itemParts.isFavorite
+        self.item = itemParts.item.fragments.itemParts.flatMap { UnmanagedItem(remote: $0) }
+    }
+}

--- a/PocketKit/Sources/Sync/Crashlogger.swift
+++ b/PocketKit/Sources/Sync/Crashlogger.swift
@@ -25,6 +25,7 @@ public struct Crashlogger {
     public static func start(dsn: String) {
         SentrySDK.start { options in
             options.dsn = dsn
+            options.enableAutoPerformanceTracking = false
             options.debug = true
         }
     }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -1,0 +1,234 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import CoreData
+import Apollo
+import Combine
+
+
+public typealias SyncEvents = PassthroughSubject<SyncEvent, Never>
+
+public class PocketSource: Source {
+    public let syncEvents: SyncEvents = PassthroughSubject()
+
+    private let space: Space
+    private let apollo: ApolloClientProtocol
+    private let lastRefresh: LastRefresh
+    private let tokenProvider: AccessTokenProvider
+    private let slateService: SlateService
+    private let archiveService: ArchiveService
+
+    private let operations: SyncOperationFactory
+    private let syncQ: OperationQueue = {
+        let q = OperationQueue()
+        q.maxConcurrentOperationCount = 1
+        return q
+    }()
+
+    public convenience init(
+        sessionProvider: SessionProvider,
+        accessTokenProvider: AccessTokenProvider,
+        consumerKey: String,
+        defaults: UserDefaults
+    ) {
+        let apollo = ApolloClient.createDefault(
+            sessionProvider: sessionProvider,
+            accessTokenProvider: accessTokenProvider,
+            consumerKey: consumerKey
+        )
+
+        self.init(
+            space: Space(container: .createDefault()),
+            apollo: apollo,
+            operations: OperationFactory(),
+            lastRefresh: UserDefaultsLastRefresh(defaults: defaults),
+            accessTokenProvider: accessTokenProvider,
+            slateService: APISlateService(apollo: apollo),
+            archiveService: PocketArchiveService(apollo: apollo)
+        )
+    }
+
+    init(
+        space: Space,
+        apollo: ApolloClientProtocol,
+        operations: SyncOperationFactory,
+        lastRefresh: LastRefresh,
+        accessTokenProvider: AccessTokenProvider,
+        slateService: SlateService,
+        archiveService: ArchiveService
+    ) {
+        self.space = space
+        self.apollo = apollo
+        self.operations = operations
+        self.lastRefresh = lastRefresh
+        self.tokenProvider = accessTokenProvider
+        self.slateService = slateService
+        self.archiveService = archiveService
+    }
+
+    public var mainContext: NSManagedObjectContext {
+        space.context
+    }
+
+    public func clear() {
+        lastRefresh.reset()
+        try? space.clear()
+    }
+
+    public func makeItemsController() -> NSFetchedResultsController<SavedItem> {
+        return space.makeItemsController()
+    }
+
+    public func object<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
+        space.object(with: id)
+    }
+}
+
+// MARK: - List items
+extension PocketSource {
+    public func refresh(maxItems: Int = 400, completion: (() -> ())? = nil) {
+        guard let token = tokenProvider.accessToken else {
+            completion?()
+            return
+        }
+
+        let operation = operations.fetchList(
+            token: token,
+            apollo: apollo,
+            space: space,
+            events: syncEvents,
+            maxItems: maxItems,
+            lastRefresh: lastRefresh
+        )
+
+        operation.completionBlock = completion
+        syncQ.addOperation(operation)
+    }
+
+    public func favorite(item: SavedItem) {
+        mutate(item, FavoriteItemMutation.init) { item in
+            item.isFavorite = true
+        }
+    }
+
+    public func unfavorite(item: SavedItem) {
+        mutate(item, UnfavoriteItemMutation.init) { item in
+            item.isFavorite = false
+        }
+    }
+
+    public func delete(item: SavedItem) {
+        mutate(item, DeleteItemMutation.init) { item in
+            space.delete(item)
+        }
+    }
+
+    public func archive(item: SavedItem) {
+        mutate(item, ArchiveItemMutation.init) { item in
+            space.delete(item)
+        }
+    }
+
+    private func mutate<Mutation: GraphQLMutation>(
+        _ item: SavedItem,
+        _ remoteMutation: (String) -> Mutation,
+        localMutation: (SavedItem) -> ()
+    ) {
+        guard let remoteID = item.remoteID else {
+            return
+        }
+
+        localMutation(item)
+        try? space.save()
+
+        let operation = operations.savedItemMutationOperation(
+            apollo: apollo,
+            events: syncEvents,
+            mutation: remoteMutation(remoteID)
+        )
+
+        syncQ.addOperation(operation)
+    }
+}
+
+// MARK: - Slates
+extension PocketSource {
+    public func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
+        return try await slateService.fetchSlateLineup(identifier)
+    }
+
+    public func fetchSlate(_ slateID: String) async throws -> Slate? {
+        return try await slateService.fetchSlate(slateID)
+    }
+
+    public func savedRecommendationsService() -> SavedRecommendationsService {
+        SavedRecommendationsService(space: space)
+    }
+
+    public func save(recommendation: Slate.Recommendation) {
+        guard let url = recommendation.item.resolvedURL ?? recommendation.item.givenURL else {
+            return
+        }
+
+        let savedItem: SavedItem = space.new()
+        savedItem.url = url
+
+        let item: Item = space.new()
+        item.remoteID = recommendation.item.id
+        item.givenURL = recommendation.item.givenURL
+        item.resolvedURL = recommendation.item.resolvedURL
+        item.title = recommendation.item.title
+        item.language = recommendation.item.language
+        item.topImageURL = recommendation.item.topImageURL
+        item.timeToRead = recommendation.item.timeToRead.flatMap(Int32.init) ?? 0
+        item.excerpt = recommendation.item.excerpt
+        item.domain = recommendation.item.domain
+        item.article = recommendation.item.article
+        item.datePublished = recommendation.item.datePublished
+
+        item.domainMetadata = recommendation.item.domainMetadata.flatMap { remote in
+            let domainMeta: DomainMetadata = space.new()
+            domainMeta.name = remote.name
+            domainMeta.logo = remote.logo
+
+            return domainMeta
+        }
+
+        recommendation.item.authors?.forEach { recAuthor in
+            let author: Author = space.new()
+            author.id = recAuthor.id
+            author.name = recAuthor.name
+            author.url = recAuthor.url
+            item.addToAuthors(author)
+        }
+
+        savedItem.item = item
+        try? space.save()
+
+        let operation = operations.saveItemOperation(
+            managedItemID: savedItem.objectID,
+            url: url,
+            events: syncEvents,
+            apollo: apollo,
+            space: space
+        )
+
+        syncQ.addOperation(operation)
+    }
+
+    public func archive(recommendation: Slate.Recommendation) {
+        guard let savedItem = try? space.fetchSavedItem(byRemoteItemID: recommendation.item.id) else {
+            return
+        }
+
+        archive(item: savedItem)
+    }
+}
+
+// MARK: - Archived Items
+extension PocketSource {
+    public func fetchArchivedItems() async throws -> [ArchivedItem] {
+        return try await archiveService.fetch(accessToken: tokenProvider.accessToken)
+    }
+}

--- a/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
@@ -33,68 +33,7 @@ extension Slate.Recommendation {
     init(remote: Remote) {
         self.init(
             id: remote.id,
-            item: Slate.Item(remote: remote.item.fragments.itemParts)
-        )
-    }
-}
-
-extension Slate.Item {
-    typealias Remote = ItemParts
-
-    init(remote: Remote) {
-        self.init(
-            id: remote.remoteId,
-            givenURL: URL(string: remote.givenUrl),
-            resolvedURL: remote.resolvedUrl.flatMap(URL.init),
-            title: remote.title,
-            language: remote.language,
-            topImageURL: remote.topImageUrl.flatMap(URL.init),
-            timeToRead: remote.timeToRead,
-            article: remote.marticle.flatMap {
-                Article(components: $0.map(ArticleComponent.init))
-            },
-            excerpt: remote.excerpt,
-            domain: remote.domain,
-            domainMetadata: (remote.domainMetadata?.fragments.domainMetadataParts).flatMap(Slate.DomainMetadata.init),
-            authors: remote.authors.flatMap { $0.compactMap { $0 }.map(Slate.Author.init) },
-            datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) },
-            images: remote.images.flatMap { $0.compactMap { $0 }.map(Slate.Image.init) }
-        )
-    }
-}
-
-extension Slate.DomainMetadata {
-    typealias Remote = DomainMetadataParts
-
-    init(remote: Remote) {
-        self.init(
-            name: remote.name,
-            logo: remote.logo.flatMap(URL.init)
-        )
-    }
-}
-
-extension Slate.Author {
-    typealias Remote = ItemParts.Author
-
-    init(remote: Remote) {
-        self.init(
-            id: remote.id,
-            name: remote.name,
-            url: remote.url.flatMap(URL.init)
-        )
-    }
-}
-
-extension Slate.Image {
-    typealias Remote = ItemParts.Image
-
-    init(remote: Remote) {
-        self.init(
-            height: remote.height,
-            width: remote.width,
-            src: URL(string: remote.src),
-            imageID: remote.imageId
+            item: UnmanagedItem(remote: remote.item.fragments.itemParts)
         )
     }
 }

--- a/PocketKit/Sources/Sync/Slates/Slate.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate.swift
@@ -11,42 +11,7 @@ public struct Slate: Identifiable, Equatable, Hashable {
 
     public struct Recommendation: Identifiable, Equatable, Hashable {
         public let id: String?
-        public let item: Slate.Item
-    }
-
-    public struct DomainMetadata: Equatable, Hashable {
-        public let name: String?
-        public let logo: URL?
-    }
-
-    public struct Author: Equatable, Hashable {
-        public let id: String
-        public let name: String?
-        public let url: URL?
-    }
-
-    public struct Image: Equatable, Hashable {
-        public let height: Int?
-        public let width: Int?
-        public let src: URL?
-        public let imageID: Int?
-    }
-
-    public struct Item: Equatable, Hashable {
-        public let id: String
-        public let givenURL: URL?
-        public let resolvedURL: URL?
-        public let title: String?
-        public let language: String?
-        public let topImageURL: URL?
-        public let timeToRead: Int?
-        public let article: Article?
-        public let excerpt: String?
-        public let domain: String?
-        public let domainMetadata: DomainMetadata?
-        public let authors: [Author]?
-        public let datePublished: Date?
-        public let images: [Image]?
+        public let item: UnmanagedItem
     }
 }
 

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -1,223 +1,45 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 import CoreData
-import Apollo
-import Combine
+import Foundation
 
 
-public typealias SyncEvents = PassthroughSubject<SyncEvent, Never>
+public protocol Source {
+    var mainContext: NSManagedObjectContext { get }
 
-public class Source {
-    public let syncEvents: SyncEvents = PassthroughSubject()
+    func clear()
 
-    private let space: Space
-    private let apollo: ApolloClientProtocol
-    private let lastRefresh: LastRefresh
-    private let tokenProvider: AccessTokenProvider
-    private let slateService: SlateService
+    func makeItemsController() -> NSFetchedResultsController<SavedItem>
 
-    private let operations: SyncOperationFactory
-    private let syncQ: OperationQueue = {
-        let q = OperationQueue()
-        q.maxConcurrentOperationCount = 1
-        return q
-    }()
+    func object<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
-    public convenience init(
-        sessionProvider: SessionProvider,
-        accessTokenProvider: AccessTokenProvider,
-        consumerKey: String,
-        defaults: UserDefaults
-    ) {
-        let apollo = ApolloClient.createDefault(
-            sessionProvider: sessionProvider,
-            accessTokenProvider: accessTokenProvider,
-            consumerKey: consumerKey
-        )
+    func refresh(maxItems: Int, completion: (() -> ())?)
 
-        self.init(
-            space: Space(container: .createDefault()),
-            apollo: apollo,
-            operations: OperationFactory(),
-            lastRefresh: UserDefaultsLastRefresh(defaults: defaults),
-            accessTokenProvider: accessTokenProvider,
-            slateService: APISlateService(apollo: apollo)
-        )
-    }
+    func favorite(item: SavedItem)
 
-    init(
-        space: Space,
-        apollo: ApolloClientProtocol,
-        operations: SyncOperationFactory,
-        lastRefresh: LastRefresh,
-        accessTokenProvider: AccessTokenProvider,
-        slateService: SlateService
-    ) {
-        self.space = space
-        self.apollo = apollo
-        self.operations = operations
-        self.lastRefresh = lastRefresh
-        self.tokenProvider = accessTokenProvider
-        self.slateService = slateService
-    }
+    func unfavorite(item: SavedItem)
 
-    public var mainContext: NSManagedObjectContext {
-        space.context
-    }
+    func delete(item: SavedItem)
 
-    public func clear() {
-        lastRefresh.reset()
-        try? space.clear()
-    }
+    func archive(item: SavedItem)
 
-    public func makeItemsController() -> NSFetchedResultsController<SavedItem> {
-        return space.makeItemsController()
-    }
+    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup?
 
-    public func object<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
-        space.object(with: id)
-    }
+    func fetchSlate(_ slateID: String) async throws -> Slate?
+
+    func savedRecommendationsService() -> SavedRecommendationsService
+
+    func save(recommendation: Slate.Recommendation)
+
+    func archive(recommendation: Slate.Recommendation)
+
+    func fetchArchivedItems() async throws -> [ArchivedItem]
 }
 
-// MARK: - List items
-extension Source {
-    public func refresh(maxItems: Int = 400, completion: (() -> ())? = nil) {
-        guard let token = tokenProvider.accessToken else {
-            completion?()
-            return
-        }
-
-        let operation = operations.fetchList(
-            token: token,
-            apollo: apollo,
-            space: space,
-            events: syncEvents,
-            maxItems: maxItems,
-            lastRefresh: lastRefresh
-        )
-
-        operation.completionBlock = completion
-        syncQ.addOperation(operation)
+public extension Source {
+    func refresh(completion: (() -> ())?) {
+        self.refresh(maxItems: 400, completion: completion)
     }
 
-    public func favorite(item: SavedItem) {
-        mutate(item, FavoriteItemMutation.init) { item in
-            item.isFavorite = true
-        }
-    }
-
-    public func unfavorite(item: SavedItem) {
-        mutate(item, UnfavoriteItemMutation.init) { item in
-            item.isFavorite = false
-        }
-    }
-
-    public func delete(item: SavedItem) {
-        mutate(item, DeleteItemMutation.init) { item in
-            space.delete(item)
-        }
-    }
-
-    public func archive(item: SavedItem) {
-        mutate(item, ArchiveItemMutation.init) { item in
-            space.delete(item)
-        }
-    }
-
-    private func mutate<Mutation: GraphQLMutation>(
-        _ item: SavedItem,
-        _ remoteMutation: (String) -> Mutation,
-        localMutation: (SavedItem) -> ()
-    ) {
-        guard let remoteID = item.remoteID else {
-            return
-        }
-
-        localMutation(item)
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: syncEvents,
-            mutation: remoteMutation(remoteID)
-        )
-
-        syncQ.addOperation(operation)
-    }
-}
-
-// MARK: - Slates
-extension Source {
-    public func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
-        return try await slateService.fetchSlateLineup(identifier)
-    }
-
-    public func fetchSlate(_ slateID: String) async throws -> Slate? {
-        return try await slateService.fetchSlate(slateID)
-    }
-
-    public func savedRecommendationsService() -> SavedRecommendationsService {
-        SavedRecommendationsService(space: space)
-    }
-
-    public func save(recommendation: Slate.Recommendation) {
-        guard let url = recommendation.item.resolvedURL ?? recommendation.item.givenURL else {
-            return
-        }
-
-        let savedItem: SavedItem = space.new()
-        savedItem.url = url
-
-        let item: Item = space.new()
-        item.remoteID = recommendation.item.id
-        item.givenURL = recommendation.item.givenURL
-        item.resolvedURL = recommendation.item.resolvedURL
-        item.title = recommendation.item.title
-        item.language = recommendation.item.language
-        item.topImageURL = recommendation.item.topImageURL
-        item.timeToRead = recommendation.item.timeToRead.flatMap(Int32.init) ?? 0
-        item.excerpt = recommendation.item.excerpt
-        item.domain = recommendation.item.domain
-        item.article = recommendation.item.article
-        item.datePublished = recommendation.item.datePublished
-
-        item.domainMetadata = recommendation.item.domainMetadata.flatMap { remote in
-            let domainMeta: DomainMetadata = space.new()
-            domainMeta.name = remote.name
-            domainMeta.logo = remote.logo
-
-            return domainMeta
-        }
-
-        recommendation.item.authors?.forEach { recAuthor in
-            let author: Author = space.new()
-            author.id = recAuthor.id
-            author.name = recAuthor.name
-            author.url = recAuthor.url
-            item.addToAuthors(author)
-        }
-
-        savedItem.item = item
-        try? space.save()
-
-        let operation = operations.saveItemOperation(
-            managedItemID: savedItem.objectID,
-            url: url,
-            events: syncEvents,
-            apollo: apollo,
-            space: space
-        )
-
-        syncQ.addOperation(operation)
-    }
-
-    public func archive(recommendation: Slate.Recommendation) {
-        guard let savedItem = try? space.fetchSavedItem(byRemoteItemID: recommendation.item.id) else {
-            return
-        }
-
-        archive(item: savedItem)
+    func refresh() {
+        self.refresh(maxItems: 400, completion: nil)
     }
 }

--- a/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+
+extension UnmanagedItem {
+    typealias Remote = ItemParts
+
+    init(remote: Remote) {
+        self.init(
+            id: remote.remoteId,
+            givenURL: URL(string: remote.givenUrl),
+            resolvedURL: remote.resolvedUrl.flatMap(URL.init),
+            title: remote.title,
+            language: remote.language,
+            topImageURL: remote.topImageUrl.flatMap(URL.init),
+            timeToRead: remote.timeToRead,
+            article: remote.marticle.flatMap {
+                Article(components: $0.map(ArticleComponent.init))
+            },
+            excerpt: remote.excerpt,
+            domain: remote.domain,
+            domainMetadata: (remote.domainMetadata?.fragments.domainMetadataParts).flatMap(DomainMetadata.init),
+            authors: remote.authors.flatMap { $0.compactMap { $0 }.map(Author.init) },
+            datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) },
+            images: remote.images.flatMap { $0.compactMap { $0 }.map(Image.init) }
+        )
+    }
+}
+
+extension UnmanagedItem.DomainMetadata {
+    typealias Remote = DomainMetadataParts
+
+    init(remote: Remote) {
+        self.init(
+            name: remote.name,
+            logo: remote.logo.flatMap(URL.init)
+        )
+    }
+}
+
+extension UnmanagedItem.Author {
+    typealias Remote = ItemParts.Author
+
+    init(remote: Remote) {
+        self.init(
+            id: remote.id,
+            name: remote.name,
+            url: remote.url.flatMap(URL.init)
+        )
+    }
+}
+
+extension UnmanagedItem.Image {
+    typealias Remote = ItemParts.Image
+
+    init(remote: Remote) {
+        self.init(
+            height: remote.height,
+            width: remote.width,
+            src: URL(string: remote.src),
+            imageID: remote.imageId
+        )
+    }
+}

--- a/PocketKit/Sources/Sync/UnmanagedItem.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+
+public struct UnmanagedItem: Equatable, Hashable {
+    public let id: String
+    public let givenURL: URL?
+    public let resolvedURL: URL?
+    public let title: String?
+    public let language: String?
+    public let topImageURL: URL?
+    public let timeToRead: Int?
+    public let article: Article?
+    public let excerpt: String?
+    public let domain: String?
+    public let domainMetadata: DomainMetadata?
+    public let authors: [Author]?
+    public let datePublished: Date?
+    public let images: [Image]?
+
+    public struct DomainMetadata: Equatable, Hashable {
+        public let name: String?
+        public let logo: URL?
+    }
+
+    public struct Author: Equatable, Hashable {
+        public let id: String
+        public let name: String?
+        public let url: URL?
+    }
+
+    public struct Image: Equatable, Hashable {
+        public let height: Int?
+        public let width: Int?
+        public let src: URL?
+        public let imageID: Int?
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/ArchiveViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchiveViewModelTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import Sync
+import Combine
+@testable import PocketKit
+
+
+class ArchiveViewModelTests: XCTestCase {
+    var source: MockSource!
+    var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        self.source = MockSource()
+    }
+
+    override func tearDown() {
+        subscriptions = []
+    }
+
+    func test_fetch_returnsArchivedItemsFromSource() async throws {
+//        let archivedItems = [
+//            ArchivedItem.build(remoteID: "1"),
+//            ArchivedItem.build(remoteID: "2")
+//        ]
+//
+//        source.stubFetchArchivedItems {
+//            return archivedItems
+//        }
+//
+//        let expectEvent = expectation(description: "wait for an event")
+//        let viewModel = ArchiveViewModel(source: source)
+//        viewModel.events.sink { event in
+//            guard case .snapshot(let snapshot) = event else {
+//                XCTFail("Expected a snapshot event")
+//                return
+//            }
+//
+//            XCTAssertEqual(snapshot.itemIdentifiers, archivedItems.map(\.remoteID))
+//            expectEvent.fulfill()
+//        }.store(in: &subscriptions)
+//
+//        try await viewModel.fetch()
+//        wait(for: [expectEvent], timeout: 1)
+//
+//        XCTAssertEqual(
+//            viewModel.archivedItem(id: "1"),
+//            archivedItems[0]
+//        )
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/ArchivedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/ArchivedItem+factories.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import Sync
+
+
+extension ArchivedItem {
+    static func build(remoteID: String = "archived-item-1") -> ArchivedItem {
+        ArchivedItem(
+            remoteID: remoteID,
+            url: URL(string: "http://example.com")!,
+            createdAt: Date(),
+            deletedAt: nil,
+            isArchived: true,
+            isFavorite: false,
+            item: .build(id: "item-1")
+        )
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1,0 +1,81 @@
+import Sync
+import Foundation
+import CoreData
+
+
+class MockSource: Source {
+    private var implementations: [String: Any] = [:]
+
+    var mainContext: NSManagedObjectContext {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func clear() {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func refresh(maxItems: Int, completion: (() -> ())?) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func makeItemsController() -> NSFetchedResultsController<SavedItem> {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func object<T>(id: NSManagedObjectID) -> T? where T : NSManagedObject {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func favorite(item: SavedItem) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func unfavorite(item: SavedItem) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func delete(item: SavedItem) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func archive(item: SavedItem) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func fetchSlate(_ slateID: String) async throws -> Slate? {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func savedRecommendationsService() -> SavedRecommendationsService {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func save(recommendation: Slate.Recommendation) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+
+    func archive(recommendation: Slate.Recommendation) {
+        fatalError("\(Self.self)#\(#function) is not implemented")
+    }
+}
+
+extension MockSource {
+    typealias FetchArchivedItemsImpl = () async throws -> [ArchivedItem]
+
+    func stubFetchArchivedItems(impl: @escaping FetchArchivedItemsImpl) {
+        implementations["fetchArchivedItems()"] = impl
+    }
+
+
+    func fetchArchivedItems() async throws -> [ArchivedItem] {
+        guard let impl = implementations["fetchArchivedItems()"] as? FetchArchivedItemsImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        return try await impl()
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
@@ -1,0 +1,23 @@
+@testable import Sync
+
+
+extension UnmanagedItem {
+    static func build(id: String = "item-1") -> UnmanagedItem {
+        return UnmanagedItem(
+            id: id,
+            givenURL: nil,
+            resolvedURL: nil,
+            title: nil,
+            language: nil,
+            topImageURL: nil,
+            timeToRead: nil,
+            article: nil,
+            excerpt: nil,
+            domain: nil,
+            domainMetadata: nil,
+            authors: nil,
+            datePublished: nil,
+            images: nil
+        )
+    }
+}

--- a/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
@@ -1,0 +1,101 @@
+{
+    "data": {
+        "userByToken": {
+            "__typename": "[type-name-here]",
+            "savedItems": {
+                "__typename": "[type-name-here]",
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "hasNextPage": false,
+                    "endCursor": "cursor-2"
+                },
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-saved-item-1",
+                            "url": "http://example.com/items/archived-item-1",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-1",
+                                "title": "Archived Item 1",
+                                "givenUrl": "http://example.com/items/archived-item-1",
+                                "resolvedUrl": "http://example.com/items/archived-item-1",
+                                "topImageUrl": "https://example.com/archived-item-1/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "marticle": [
+                                    {
+                                        "__typename": "MarticleText",
+                                        "content": "**Commodo Consectetur** _Dapibus_"
+                                    }
+                                ],
+                                "excerpt": "Risus Aenean Ultricies Nullam Vehicula",
+                                "datePublished": "2001-01-01 12:01:01",
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "archived-author-1",
+                                        "name": "Socrates",
+                                        "url": "https://example.com/authors/socrates"
+                                    }
+                                ],
+                                "domainMetadata": {
+                                    "__typename": "[type-name-here]",
+                                    "name": "WIRED",
+                                    "logo": "http://example.com/item-1/domain-logo.jpg"
+                                },
+                                "images": [
+                                    {
+                                        "__typename": "[type-name-here]",
+                                        "height": 1,
+                                        "width": 2,
+                                        "src": "http://example.com/item-1/image-1.jpg",
+                                        "imageId": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-saved-item-2",
+                            "url": "https://example.com/items/archived-item-2",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-2",
+                                "givenUrl": "https://example.com/items/archived-item-2",
+                                "resolvedUrl": "https://example.com/items/archived-item-2",
+                                "title": "Archived Item 2",
+                                "topImageUrl": "https://example.com/items/archived-item-2/images/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "1999-01-01 12:01:01",
+                                "excerpt": "Vehicula Nibh Ligula Porta Magna",
+                                "images": []
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/PocketArchiveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketArchiveServiceTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Sync
+
+
+class PocketArchiveServiceTests: XCTestCase {
+    var apollo: MockApolloClient!
+
+    override func setUpWithError() throws {
+        apollo = MockApolloClient()
+    }
+
+    func subject(apollo: MockApolloClient? = nil) -> PocketArchiveService {
+        PocketArchiveService(apollo: apollo ?? self.apollo)
+    }
+
+    func test_fetch_usesTheCorrectQuery() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "archived-items", asResultType: UserByTokenQuery.self)
+        _ = try await subject().fetch(accessToken: "the-access-token")
+
+        let fetchCall: MockApolloClient.FetchCall<UserByTokenQuery> = apollo.fetchCall(at: 0)
+        XCTAssertEqual(fetchCall.query.savedItemsFilter?.isArchived, true)
+    }
+
+    func test_fetch_returnsMappedArchivedItems() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "archived-items", asResultType: UserByTokenQuery.self)
+        let fetchedItems = try await subject().fetch(accessToken: "the-access-token")
+
+        XCTAssertEqual(fetchedItems.count, 2)
+
+        do {
+            let archivedItem = fetchedItems[0]
+            XCTAssertEqual(archivedItem.remoteID, "archived-saved-item-1")
+            XCTAssertEqual(archivedItem.url, URL(string: "http://example.com/items/archived-item-1"))
+            XCTAssertEqual(archivedItem.createdAt, Date(timeIntervalSince1970: 0))
+            XCTAssertEqual(archivedItem.deletedAt, nil)
+            XCTAssertEqual(archivedItem.isArchived, true)
+            XCTAssertEqual(archivedItem.isFavorite, false)
+
+            let item = archivedItem.item!
+            XCTAssertEqual(item.id, "archived-item-1")
+            XCTAssertEqual(item.title, "Archived Item 1")
+            XCTAssertEqual(item.givenURL, URL(string: "http://example.com/items/archived-item-1"))
+            XCTAssertEqual(item.resolvedURL, URL(string: "http://example.com/items/archived-item-1"))
+            XCTAssertEqual(item.topImageURL, URL(string: "https://example.com/archived-item-1/top-image.jpg"))
+            XCTAssertEqual(item.domain, "wired.com")
+            XCTAssertEqual(item.language, "en")
+            XCTAssertEqual(item.timeToRead, 6)
+            XCTAssertEqual(item.excerpt, "Risus Aenean Ultricies Nullam Vehicula")
+            XCTAssertEqual(item.datePublished, Date(timeIntervalSince1970: 978350461))
+
+            XCTAssertEqual(
+                item.article?.components[0],
+                ArticleComponent.text(TextComponent(content: "**Commodo Consectetur** _Dapibus_"))
+            )
+
+            let author = item.authors?[0]
+            XCTAssertEqual(author?.id, "archived-author-1")
+            XCTAssertEqual(author?.name, "Socrates")
+            XCTAssertEqual(author?.url, URL(string: "https://example.com/authors/socrates"))
+
+            let domainMetadata = item.domainMetadata
+            XCTAssertEqual(domainMetadata?.name, "WIRED")
+            XCTAssertEqual(domainMetadata?.logo, URL(string: "http://example.com/item-1/domain-logo.jpg"))
+
+            let image = item.images?[0]
+            XCTAssertEqual(image?.imageID, 1)
+            XCTAssertEqual(image?.height, 1)
+            XCTAssertEqual(image?.width, 2)
+            XCTAssertEqual(image?.src, URL(string: "http://example.com/item-1/image-1.jpg"))
+        }
+
+        do {
+            let archivedItem = fetchedItems[1]
+            XCTAssertEqual(archivedItem.remoteID, "archived-saved-item-2")
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/ArchivedItem+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/ArchivedItem+factories.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import Sync
+
+
+extension ArchivedItem {
+    static func build(remoteID: String = "archived-item-1") -> ArchivedItem {
+        ArchivedItem(
+            remoteID: remoteID,
+            url: URL(string: "http://example.com")!,
+            createdAt: Date(),
+            deletedAt: nil,
+            isArchived: true,
+            isFavorite: false,
+            item: .build(id: "item-1")
+        )
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/MockArchiveService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockArchiveService.swift
@@ -1,0 +1,20 @@
+@testable import Sync
+
+
+class MockArchiveService: ArchiveService {
+    private var implementations: [String: Any] = [:]
+
+    typealias FetchImpl = () async throws -> [ArchivedItem]
+    func stubFetch(impl: @escaping FetchImpl) {
+        implementations["fetch"] = impl
+    }
+
+    func fetch(accessToken: String?) async throws -> [ArchivedItem] {
+        guard let impl = implementations["fetch"] as? FetchImpl else {
+            fatalError("\(Self.self)#\(#function) is not stubbed")
+        }
+
+        return try await impl()
+    }
+    
+}

--- a/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Slate+Factories.swift
@@ -24,29 +24,8 @@ extension Slate {
 extension Slate.Recommendation {
     static func build(
         id: String? = "recommendation-1",
-        item: Slate.Item = .build()
+        item: UnmanagedItem = .build()
     ) -> Slate.Recommendation {
         return Slate.Recommendation(id: id, item: item)
-    }
-}
-
-extension Slate.Item {
-    static func build(id: String = "item-1") -> Slate.Item {
-        return Slate.Item(
-            id: id,
-            givenURL: nil,
-            resolvedURL: nil,
-            title: nil,
-            language: nil,
-            topImageURL: nil,
-            timeToRead: nil,
-            article: nil,
-            excerpt: nil,
-            domain: nil,
-            domainMetadata: nil,
-            authors: nil,
-            datePublished: nil,
-            images: nil
-        )
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
@@ -1,0 +1,23 @@
+@testable import Sync
+
+
+extension UnmanagedItem {
+    static func build(id: String = "item-1") -> UnmanagedItem {
+        return UnmanagedItem(
+            id: id,
+            givenURL: nil,
+            resolvedURL: nil,
+            title: nil,
+            language: nil,
+            topImageURL: nil,
+            timeToRead: nil,
+            article: nil,
+            excerpt: nil,
+            domain: nil,
+            domainMetadata: nil,
+            authors: nil,
+            datePublished: nil,
+            images: nil
+        )
+    }
+}

--- a/Tests iOS/ArchiveAnItemTests.swift
+++ b/Tests iOS/ArchiveAnItemTests.swift
@@ -64,9 +64,8 @@ class ArchiveAnItemTests: XCTestCase {
         }
 
         app.archiveButton.wait().tap()
-        XCTAssertFalse(itemCell.exists)
-
         wait(for: [expectRequest], timeout: 1)
+        waitForDisappearance(of: itemCell)
     }
 
     func test_archivingAnItemFromReader_archivesItem_andPopsBackToList() {
@@ -95,9 +94,8 @@ class ArchiveAnItemTests: XCTestCase {
 
         app.archiveButton.wait().tap()
 
-        listView.wait()
-        XCTAssertFalse(itemCell.exists)
-
         wait(for: [expectRequest], timeout: 1)
+        listView.wait()
+        waitForDisappearance(of: itemCell)
     }
 }

--- a/Tests iOS/DeleteAnItemTests.swift
+++ b/Tests iOS/DeleteAnItemTests.swift
@@ -65,9 +65,8 @@ class DeleteAnItemTests: XCTestCase {
 
         app.deleteButton.wait().tap()
         app.alert.yes.wait().tap()
-        XCTAssertFalse(itemCell.exists)
-
         wait(for: [expectRequest], timeout: 1)
+        waitForDisappearance(of: itemCell)
     }
 
     func test_deletingAnItemFromReader_deletesItem_andPopsBackToList() {
@@ -103,6 +102,6 @@ class DeleteAnItemTests: XCTestCase {
         wait(for: [expectRequest], timeout: 1)
 
         app.myListView.wait()
-        XCTAssertFalse(itemCell.exists)
+        waitForDisappearance(of: itemCell)
     }
 }

--- a/Tests iOS/Fixtures/archived-items.json
+++ b/Tests iOS/Fixtures/archived-items.json
@@ -1,0 +1,84 @@
+{
+    "data": {
+        "userByToken": {
+            "__typename": "[type-name-here]",
+            "savedItems": {
+                "__typename": "[type-name-here]",
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "hasNextPage": false,
+                    "endCursor": "cursor-2"
+                },
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-item-1",
+                            "url": "http://example.com/items/archived-item-1",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-1",
+                                "title": "Archived Item 1",
+                                "givenUrl": "http://example.com/items/archived-item-1",
+                                "resolvedUrl": "http://example.com/items/archived-item-1",
+                                "topImageUrl": "https://example.com/archived-item-1/top-image.jpg",
+                                "domain": null,
+                                "language": "en",
+                                "timeToRead": 6,
+                                "marticle": #MARTICLE#,
+                                "excerpt": "Risus Aenean Ultricies Nullam Vehicula",
+                                "datePublished": "2001-01-01 12:01:01",
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "archived-author-1",
+                                        "name": "Socrates",
+                                        "url": "https://example.com/authors/socrates"
+                                    }
+                                ],
+                                "domainMetadata": null,
+                                "images": []
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-item-2",
+                            "url": "https://example.com/items/archived-item-2",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-2",
+                                "givenUrl": "https://example.com/items/archived-item-2",
+                                "resolvedUrl": "https://example.com/items/archived-item-2",
+                                "title": "Archived Item 2",
+                                "topImageUrl": "https://example.com/items/archived-item-2/images/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "1999-01-01 12:01:01",
+                                "excerpt": "Vehicula Nibh Ligula Porta Magna",
+                                "images": []
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Tests iOS/MyList/MyListFiltersTests.swift
+++ b/Tests iOS/MyList/MyListFiltersTests.swift
@@ -21,11 +21,20 @@ class MyListFiltersTests: XCTestCase {
         server = Application()
 
         server.routes.post("/graphql") { request, _ in
-            Response {
-                Status.ok
-                Fixture.load(name: "initial-list")
-                    .replacing("MARTICLE", withFixtureNamed: "marticle")
-                    .data
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList()
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else if apiRequest.isToFavoriteAnItem {
+                return Response.favorite()
+            } else if apiRequest.isToUnfavoriteAnItem {
+                return Response.unfavorite()
+            } else {
+                fatalError("Unexpected request")
             }
         }
 
@@ -39,15 +48,15 @@ class MyListFiltersTests: XCTestCase {
 
     func testTappingFavoritesPill_showsOnlyFavoritedItems() {
         app.launch().tabBar.myListButton.wait().tap()
-        XCTAssertEqual(app.userListView.wait().itemCells.count, 2)
+        XCTAssertEqual(app.myListView.wait().itemCells.count, 2)
 
-        app.userListView.favoritesButton.tap()
-        XCTAssertEqual(app.userListView.wait().itemCells.count, 0)
+        app.myListView.favoritesButton.tap()
+        XCTAssertEqual(app.myListView.wait().itemCells.count, 0)
 
-        app.userListView.favoritesButton.tap()
-        app.userListView.itemView(at: 0).favoriteButton.tap()
+        app.myListView.favoritesButton.tap()
+        app.myListView.itemView(at: 0).favoriteButton.tap()
 
-        app.userListView.favoritesButton.tap()
-        XCTAssertEqual(app.userListView.wait().itemCells.count, 1)
+        app.myListView.favoritesButton.tap()
+        XCTAssertEqual(app.myListView.wait().itemCells.count, 1)
     }
 }

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -14,10 +14,23 @@ class ReportARecommendationTests: XCTestCase {
         
         server = Application()
         
-        server.routes.post("/graphql") { _, _ in
-            Response {
-                Status.ok
-                Fixture.data(name: "slates")
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForSlateDetail {
+                return Response.slateDetail()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList()
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else if apiRequest.isToSaveAnItem {
+                return Response.saveItem()
+            } else if apiRequest.isToArchiveAnItem {
+                return Response.archive()
+            } else {
+                fatalError("Unexpected request")
             }
         }
         

--- a/Tests iOS/SignOutTests.swift
+++ b/Tests iOS/SignOutTests.swift
@@ -10,34 +10,28 @@ class SignOutTests: XCTestCase {
     var server: Application!
     var app: PocketAppElement!
 
-    func listResponse(_ fixtureName: String = "initial-list") -> Response {
-        Response {
-            Status.ok
-            Fixture.load(name: fixtureName)
-                .replacing("MARTICLE", withFixtureNamed: "marticle")
-                .data
-        }
-    }
-
-    func slateResponse() -> Response {
-        Response {
-            Status.ok
-            Fixture.data(name: "slates")
-        }
-    }
-
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = PocketAppElement(app: XCUIApplication())
         server = Application()
 
         server.routes.post("/graphql") { request, _ in
-            let requestBody = body(of: request)
+            let apiRequest = ClientAPIRequest(request)
 
-            if requestBody!.contains("getSlateLineup")  {
-                return self.slateResponse()
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForSlateDetail {
+                return Response.slateDetail()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList()
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else if apiRequest.isToSaveAnItem {
+                return Response.saveItem()
+            } else if apiRequest.isToArchiveAnItem {
+                return Response.archive()
             } else {
-                return self.listResponse()
+                fatalError("Unexpected request")
             }
         }
 

--- a/Tests iOS/Support/Elements/MyListElement.swift
+++ b/Tests iOS/Support/Elements/MyListElement.swift
@@ -5,19 +5,27 @@
 import XCTest
 
 
-struct UserListElement: PocketUIElement {
+struct MyListElement: PocketUIElement {
     let element: XCUIElement
 
     init(_ element: XCUIElement) {
         self.element = element
     }
 
+    var selectionSwitcher: SelectionSwitcherElement {
+        return SelectionSwitcherElement(element.otherElements["my-list-selection-switcher"])
+    }
+
+    private var collectionView: XCUIElement {
+        element.otherElements["my-list"].collectionViews.firstMatch
+    }
+
     var itemCells: XCUIElementQuery {
-        element.cells.matching(NSPredicate(format: "identifier = %@", "my-list-item"))
+        collectionView.cells.matching(NSPredicate(format: "identifier = %@", "my-list-item"))
     }
 
     var favoritesButton: XCUIElement {
-        element.cells.matching(
+        collectionView.cells.matching(
             NSPredicate(
                 format: "identifier = %@",
                 "topic-chip"
@@ -33,7 +41,7 @@ struct UserListElement: PocketUIElement {
         return ItemRowElement(itemCells.element(boundBy: index))
     }
 
-    func itemView(withLabelStartingWith string: String) -> ItemRowElement {
+    func itemView(matching string: String) -> ItemRowElement {
         let cell = itemCells.containing(
             .staticText,
             identifier: string

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -24,10 +24,10 @@ struct PocketAppElement {
         return HomeViewElement(app.otherElements["home"])
     }
 
-    var userListView: UserListElement {
-        return UserListElement(app.collectionViews["my-list"])
+    var myListView: MyListElement {
+        return MyListElement(app)
     }
-
+    
     var settingsView: SettingsViewElement {
         return SettingsViewElement(app.collectionViews["settings"])
     }
@@ -65,11 +65,11 @@ struct PocketAppElement {
     }
 
     var deleteButton: XCUIElement {
-        app.buttons["Delete"]
+        app.buttons["item-action-menu-delete"]
     }
 
     var archiveButton: XCUIElement {
-        app.buttons["Archive"]
+        app.buttons["item-action-menu-archive"]
     }
 
     var shareButton: XCUIElement {

--- a/Tests iOS/Support/Elements/SelectionSwitcherElement.swift
+++ b/Tests iOS/Support/Elements/SelectionSwitcherElement.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+
+struct SelectionSwitcherElement: PocketUIElement {
+    let element: XCUIElement
+
+    init(_ element: XCUIElement) {
+        self.element = element
+    }
+
+    var archiveButton: XCUIElement {
+        element.buttons["Archive"]
+    }
+
+    var myListButton: XCUIElement {
+        element.buttons["My List"]
+    }
+}

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Sails
+
+
+struct ClientAPIRequest {
+    private let request: Request
+    private let requestBody: String?
+
+    init(_ request: Request) {
+        self.request = request
+        self.requestBody = body(of: request)
+    }
+
+    var isEmpty: Bool {
+        requestBody == nil
+    }
+
+    var isForMyListContent: Bool {
+        contains("userByToken") && !contains(#""isArchived":true"#)
+    }
+
+    var isForArchivedContent: Bool {
+        contains("userByToken") && contains(#""isArchived":true"#)
+    }
+
+    var isForSlateLineup: Bool {
+        contains("getSlateLineup")
+    }
+
+    var isToArchiveAnItem: Bool {
+        contains("updateSavedItemArchive")
+    }
+
+    var isToDeleteAnItem: Bool {
+        contains("deleteSavedItem")
+    }
+
+    var isToFavoriteAnItem: Bool {
+        contains("updateSavedItemFavorite")
+    }
+
+    var isToUnfavoriteAnItem: Bool {
+        contains("updateSavedItemUnFavorite")
+    }
+
+    var isForSlateDetail: Bool {
+        contains("getSlate(")
+    }
+
+    var isToSaveAnItem: Bool {
+        contains("upsertSavedItem")
+    }
+
+    func contains(_ string: String) -> Bool {
+        requestBody?.contains(string) == true
+    }
+}

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sails
+
+
+extension Response {
+    static func myList(_ fixtureName: String = "initial-list") -> Response {
+        Response {
+            Status.ok
+            Fixture.load(name: fixtureName)
+                .replacing("MARTICLE", withFixtureNamed: "marticle")
+                .data
+        }
+    }
+
+    static func archivedContent() -> Response {
+        myList("archived-items")
+    }
+
+    static func slateLineup(_ fixtureName: String = "slates") -> Response {
+        fixture(named: fixtureName)
+    }
+
+    static func slateDetail() -> Response {
+        fixture(named: "slate-detail")
+    }
+
+    static func saveItem() -> Response {
+        fixture(named: "save-item")
+    }
+
+    static func delete() -> Response {
+        fixture(named: "delete")
+    }
+
+    static func archive() -> Response {
+        fixture(named: "archive")
+    }
+
+    static func favorite() -> Response {
+        fixture(named: "favorite")
+    }
+
+    static func unfavorite() -> Response {
+        fixture(named: "unfavorite")
+    }
+
+    private static func fixture(named fixtureName: String) -> Response {
+        Response {
+            Status.ok
+            Fixture.data(name: fixtureName)
+        }
+    }
+}

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+extension XCTestCase {
+    func waitForDisappearance(of element: XCUIElement) {
+        let doesNotExist = NSPredicate(format: "exists == 0")
+        let elementToNotExist = expectation(for: doesNotExist, evaluatedWith: element)
+        wait(for: [elementToNotExist], timeout: 3)
+    }
+
+    func waitForDisappearance(of element: PocketUIElement) {
+        waitForDisappearance(of: element.element)
+    }
+}


### PR DESCRIPTION
Add "Archive" section to "My List" tab
- Rename `Source` to `PocketSource`
- Extract `Source` protocol from `PocketSource`
- UITests: Updates to page models to reflect MyList container
- Rename UserListElement -> MyListElement
- Rename PockedtAppElement.userListView -> .myListView
- Rename UserListElement.itemView(with:) -> .itemView(matching:)
- Rename Slate.Item to UnmanagedItem
  (so it can be used for archived content and slate content)
- Introduce (Pocket)ArchiveService and Source.fetchArchivedContent
- Extract ItemsListViewModel protocol
  This allows us to use different implementations of the protocol to drive
  a view controller that displays a list of items (i.e. a
  "MyListViewModel" and "ArchiveViewModel")
- Create RequestMatchers and Response+factories
  These help eliminiate a lot of duplication in UI tests around stubbing
  out and asserting on requests to the client api.
- Sentry: Disable automatic performance tracking

https://getpocket.atlassian.net/browse/IN-458
Co-authored-by: David Skuza <dskuza@getpocket.com>