### PR TITLE
Preserve server's ordering of archived items

### DIFF
--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -56,7 +56,7 @@ class ArchiveTests: XCTestCase {
     func test_tappingItem_displaysNativeReaderView() {
         app.launch().tabBar.myListButton.wait().tap()
         app.myListView.selectionSwitcher.archiveButton.wait().tap()
-        app.myListView.itemView(matching: "Archived Item 1").wait().tap()
+        app.myListView.itemView(at: 0).wait().tap()
 
         let expectedContent = [
             "Archived Item 1",


### PR DESCRIPTION
Regarding the failing test that was caused by items occasionally appearing in the wrong order:

With the previous implementation, I ran the failing test 10 times with these results:
```
Executed 10 tests, with 6 failures (0 unexpected) in 74.715 (74.720) seconds
```

With this new implementation, I ran the same test 10 times with these results:
```
Executed 10 tests, with 0 failures (0 unexpected) in 67.473 (67.479) seconds
```