### PR TITLE
Refactor ReadableViewModel to send events over delegation

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -11,7 +11,7 @@ protocol ArticleComponentTextCellDelegate: AnyObject {
 // An object that conforms to this protocol is capable of delegating actions
 // commonly performed within the cell, typically interactions with a PocketTextView.
 protocol ArticleComponentTextCell: ArticleComponentTextViewDelegate {
-    var delegate: ArticleComponentTextCellDelegate? { get }
+    var delegate: ArticleComponentTextCellDelegate? { get set }
 }
 
 // Apply default implementations of PocketTextViewDelegate callbacks

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -7,8 +7,8 @@ import Kingfisher
 
 
 protocol ReadableViewControllerDelegate: AnyObject {
-    func readableViewController(_ controller: ReadableViewController, willOpenURL url: URL)
-    func readableViewControlled(_ controller: ReadableViewController, shareWithAdditionalText text: String?)
+    func readableViewController(_ controller: ReadableViewController, openURL url: URL)
+    func readableViewController(_ controller: ReadableViewController, shareWithAdditionalText text: String?)
 }
 
 class ReadableViewController: UIViewController {
@@ -45,7 +45,6 @@ class ReadableViewController: UIViewController {
     }
 
     private let readerSettings: ReaderSettings
-    private let tracker: Tracker
     private let viewModel: MainViewModel
 
     private var subscriptions: [AnyCancellable] = []
@@ -59,9 +58,8 @@ class ReadableViewController: UIViewController {
         return self.buildSection(index: $0, environment: $1)
     }
 
-    init(readerSettings: ReaderSettings, tracker: Tracker, viewModel: MainViewModel) {
+    init(readerSettings: ReaderSettings, viewModel: MainViewModel) {
         self.readerSettings = readerSettings
-        self.tracker = tracker
         self.viewModel = viewModel
 
         super.init(nibName: nil, bundle: nil)
@@ -159,6 +157,10 @@ extension ReadableViewController: UICollectionViewDataSource {
                 return empty
             }
             
+            if let cell = cell as? ArticleComponentTextCell {
+                cell.delegate = self
+            }
+            
             return cell
         }
     }
@@ -169,15 +171,15 @@ extension ReadableViewController: ArticleComponentTextCellDelegate {
         _ cell: ArticleComponentTextCell,
         didShareText selectedText: String?
     ) {
-        delegate?.readableViewControlled(self, shareWithAdditionalText: selectedText)
+        delegate?.readableViewController(self, shareWithAdditionalText: selectedText)
     }
     
     func articleComponentTextCell(
         _ cell: ArticleComponentTextCell,
         shouldOpenURL url: URL
     ) -> Bool {
-        delegate?.readableViewController(self, willOpenURL: url)
-        return true
+        delegate?.readableViewController(self, openURL: url)
+        return false
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ArchivedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ArchivedItemViewModel.swift
@@ -3,14 +3,18 @@ import Sync
 import Foundation
 import Textile
 import UIKit
+import Analytics
 
 
 class ArchivedItemViewModel: ReadableViewModel {
-    weak var delegate: ReadableViewModelDelegate? = nil
-
     @Published
     private var _actions: [ReadableAction] = []
     var actions: Published<[ReadableAction]>.Publisher { $_actions }
+    
+    private var _events = PassthroughSubject<ReadableEvent, Never>()
+    var events: EventPublisher {
+        _events.eraseToAnyPublisher()
+    }
 
     var components: [ArticleComponent]? {
         item.item?.article?.components
@@ -41,19 +45,35 @@ class ArchivedItemViewModel: ReadableViewModel {
     }
 
     private let item: ArchivedItem
+    let mainViewModel: MainViewModel
+    let tracker: Tracker
 
-    init(item: ArchivedItem) {
+    init(item: ArchivedItem, mainViewModel: MainViewModel, tracker: Tracker) {
         self.item = item
+        self.mainViewModel = mainViewModel
+        self.tracker = tracker
 
         _actions = [
-            .save { self.delegate?.readableViewModelDidSave(self) },
-            .favorite { self.delegate?.readableViewModelDidFavorite(self) }
+            .displaySettings { [weak self] in self?.displaySettings() },
+            .save { [weak self] in self?.save() },
+            .favorite { [weak self] in self?.favorite() },
+            .delete { [weak self] in self?.confirmDelete() },
+            .share { [weak self] in self?.share() },
         ]
     }
-
-    func shareActivity(additionalText: String?) -> PocketItemActivity? {
-        PocketItemActivity(url: url, additionalText: additionalText)
+    
+    func delete() {
+        // TODO: Delete archived item
+        _events.send(.delete)
     }
+}
 
-    func delete() { }
+extension ArchivedItemViewModel {
+    private func save() {
+        track(identifier: .itemSave)
+    }
+    
+    private func favorite() {
+        track(identifier: .itemFavorite)
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAction.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAction.swift
@@ -55,4 +55,22 @@ extension ReadableAction {
             handler: handler
         )
     }
+    
+    static func displaySettings(_ handler: @escaping () -> ()) -> ReadableAction {
+        return ReadableAction(
+            title: "Display Settings",
+            accessibilityIdentifier: "item-action-menu-display-settings",
+            image: UIImage(systemName: "textformat.size"),
+            handler: handler
+        )
+    }
+    
+    static func share(_ handler: @escaping () -> ()) -> ReadableAction {
+        return ReadableAction(
+            title: "Share",
+            accessibilityIdentifier: "item-action-menu-share",
+            image: UIImage(systemName: "square.and.arrow.up"),
+            handler: handler
+        )
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAuthor.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAuthor.swift
@@ -1,0 +1,8 @@
+import Sync
+
+
+protocol ReadableAuthor {
+    var name: String? { get }
+}
+extension Author: ReadableAuthor { }
+extension UnmanagedItem.Author : ReadableAuthor { }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
@@ -1,0 +1,4 @@
+enum ReadableEvent {
+    case archive
+    case delete
+}

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -3,26 +3,17 @@ import Sync
 import Foundation
 import Textile
 import UIKit
+import Analytics
 
 
-protocol ReadableAuthor {
-    var name: String? { get }
-}
-extension Author: ReadableAuthor { }
-extension UnmanagedItem.Author : ReadableAuthor { }
-
-protocol ReadableViewModelDelegate: AnyObject {
-    func readableViewModelDidFavorite(_ readableViewModel: ReadableViewModel)
-    func readableViewModelDidUnfavorite(_ readableViewModel: ReadableViewModel)
-    func readableViewModelDidArchive(_ readableViewModel: ReadableViewModel)
-    func readableViewModelDidDelete(_ readableViewModel: ReadableViewModel)
-    func readableViewModelDidSave(_ readableViewModel: ReadableViewModel)
-}
-
-protocol ReadableViewModel: AnyObject {
-    var delegate: ReadableViewModelDelegate? { get set }
+protocol ReadableViewModel: ReadableViewControllerDelegate {
+    typealias EventPublisher = AnyPublisher<ReadableEvent, Never>
+    
+    var mainViewModel: MainViewModel { get }
+    var tracker: Tracker { get }
     
     var actions: Published<[ReadableAction]>.Publisher { get }
+    var events: EventPublisher { get }
     
     var components: [ArticleComponent]? { get }
     var textAlignment: TextAlignment { get }
@@ -32,6 +23,87 @@ protocol ReadableViewModel: AnyObject {
     var publishDate: Date? { get }
     var url: URL? { get }
     
-    func shareActivity(additionalText: String?) -> PocketItemActivity?
     func delete()
+}
+
+// MARK: - ReadableViewControllerDelegate
+
+extension ReadableViewModel {
+    func readableViewController(_ controller: ReadableViewController, openURL url: URL) {
+        open(url: url)
+    }
+    
+    func readableViewController(_ controller: ReadableViewController, shareWithAdditionalText text: String?) {
+        share(additionalText: text)
+    }
+}
+
+// MARK: - Shared Actions
+
+extension ReadableViewModel {
+    func displaySettings() {
+        mainViewModel.isPresentingReaderSettings = true
+    }
+    
+    func open(url: URL) {
+        mainViewModel.presentedWebReaderURL = url
+        
+        let additionalContexts: [Context] = [ContentContext(url: url)]
+
+        let contentOpen = ContentOpenEvent(destination: .external, trigger: .click)
+        let link = UIContext.articleView.link
+        let contexts = additionalContexts + [link]
+        tracker.track(event: contentOpen, contexts)
+    }
+    
+    func share(additionalText: String? = nil) {
+        guard let url = url else {
+            return
+        }
+        
+        mainViewModel.sharedActivity = PocketItemActivity(url: url, additionalText: additionalText)
+        
+        track(identifier: .itemShare)
+    }
+    
+    func confirmDelete() {
+        let actions = [
+            UIAlertAction(title: "No", style: .default) { [weak self] _ in
+                self?.mainViewModel.presentedAlert = nil
+            },
+            UIAlertAction(title: "Yes", style: .destructive) { [weak self] _ in
+                self?.mainViewModel.presentedAlert = nil
+
+                guard let self = self else {
+                    return
+                }
+                
+                self.delete()
+            }
+        ]
+
+        let alert = PocketAlert(
+            title: "Are you sure you want to delete this item?",
+            message: nil,
+            preferredStyle: .alert,
+            actions: actions,
+            preferredAction: nil
+        )
+        mainViewModel.presentedAlert = alert
+
+    }
+    
+    func track(identifier: UIContext.Identifier) {
+        guard let url = url else {
+            return
+        }
+
+        let contexts: [Context] = [
+            UIContext.button(identifier: identifier),
+            ContentContext(url: url)
+        ]
+
+        let event = SnowplowEngagement(type: .general, value: nil)
+        tracker.track(event: event, contexts)
+    }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -351,7 +351,11 @@ extension HomeViewController: UICollectionViewDelegate {
             tracker.track(event: engagement, contexts(for: indexPath))
             
             let recommendation = slates[indexPath.section - 1].recommendations[indexPath.item]
-            let viewModel = RecommendationViewModel(recommendation: recommendation)
+            let viewModel = RecommendationViewModel(
+                recommendation: recommendation,
+                mainViewModel: model,
+                tracker: tracker.childTracker(hosting: .articleView.screen)
+            )
             model.selectedHomeReadableViewModel = viewModel
 
             let open = ContentOpenEvent(destination: .internal, trigger: .click)

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -266,7 +266,11 @@ extension SlateDetailViewController: UICollectionViewDelegate {
         let engagement = SnowplowEngagement(type: .general, value: nil)
         tracker.track(event: engagement, contexts(for: indexPath))
 
-        let viewModel = RecommendationViewModel(recommendation: recommendation)
+        let viewModel = RecommendationViewModel(
+            recommendation: recommendation,
+            mainViewModel: model,
+            tracker: tracker.childTracker(hosting: .articleView.screen)
+        )
         model.selectedHomeReadableViewModel = viewModel
 
         let contentOpen = ContentOpenEvent(destination: .internal, trigger: .click)

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -44,7 +44,11 @@ class CompactMainCoordinator: NSObject {
                     )
                 ),
                 ItemsListViewController(
-                    model: ArchivedItemsListViewModel(source: source, mainViewModel: model)
+                    model: ArchivedItemsListViewModel(
+                        source: source,
+                        mainViewModel: model,
+                        tracker: tracker.childTracker(hosting: .articleView.screen)
+                    )
                 )
             ]
         )
@@ -115,12 +119,15 @@ class CompactMainCoordinator: NSObject {
     }
 
     func show(item: SavedItem, animated: Bool) {
-        let viewModel = SavedItemViewModel(item: item, source: source)
+        let viewModel = SavedItemViewModel(
+            item: item,
+            source: source,
+            mainViewModel: model,
+            tracker: tracker.childTracker(hosting: .articleView.screen)
+        )
         let readableHost = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         readableHost.delegate = self
         readableHost.hidesBottomBarWhenPushed = true
@@ -142,9 +149,7 @@ class CompactMainCoordinator: NSObject {
     func showHome(viewModel: ReadableViewModel, animated: Bool) {
         let viewController = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         
         home.pushViewController(viewController, animated: animated)
@@ -153,9 +158,7 @@ class CompactMainCoordinator: NSObject {
     func showMyList(viewModel: ReadableViewModel, animated: Bool) {
         let viewController = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         viewController.delegate = self
         viewController.hidesBottomBarWhenPushed = true

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -52,7 +52,7 @@ class RegularMainCoordinator: NSObject {
                     )
                 ),
                 ItemsListViewController(
-                    model: ArchivedItemsListViewModel(source: source, mainViewModel: model)
+                    model: ArchivedItemsListViewModel(source: source, mainViewModel: model, tracker: tracker.childTracker(hosting: .myList.screen))
                 )
             ]
         )
@@ -172,9 +172,7 @@ class RegularMainCoordinator: NSObject {
     func showMyList(viewModel: ReadableViewModel) {
         let viewController = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         readerRoot.viewControllers = [viewController]
 
@@ -184,9 +182,7 @@ class RegularMainCoordinator: NSObject {
     func showHome(viewModel: ReadableViewModel) {
         let viewController = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         readerRoot.viewControllers = [viewController]
 
@@ -225,12 +221,14 @@ class RegularMainCoordinator: NSObject {
     }
     
     func show(archivedItem: ArchivedItem) {
-        let viewModel = ArchivedItemViewModel(item: archivedItem)
+        let viewModel = ArchivedItemViewModel(
+            item: archivedItem,
+            mainViewModel: model,
+            tracker: tracker.childTracker(hosting: .articleView.screen)
+        )
         let viewController = ReadableHostViewController(
             mainViewModel: model,
-            readableViewModel: viewModel,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            source: source
+            readableViewModel: viewModel
         )
         readerRoot.viewControllers = [viewController]
         

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -1,6 +1,7 @@
 import Sync
 import Combine
 import UIKit
+import Analytics
 
 
 class ArchivedItemsListViewModel: ItemsListViewModel {
@@ -13,6 +14,7 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
 
     private let source: Source
     private let mainViewModel: MainViewModel
+    private let tracker: Tracker
 
     private var archivedItems: [ArchivedItem] = [] {
         didSet {
@@ -23,14 +25,14 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
     }
     private var archivedItemsByID: [String: ArchivedItem] = [:]
 
-
     @Published
     private var selectedFilters: Set<ItemsListFilter> = .init()
     private let availableFilters: [ItemsListFilter] = ItemsListFilter.allCases
 
-    init(source: Source, mainViewModel: MainViewModel) {
+    init(source: Source, mainViewModel: MainViewModel, tracker: Tracker) {
         self.source = source
         self.mainViewModel = mainViewModel
+        self.tracker = tracker
         self.events = .init()
     }
 
@@ -76,7 +78,11 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
             return
         }
         
-        let viewModel = ArchivedItemViewModel(item: archivedItem)
+        let viewModel = ArchivedItemViewModel(
+            item: archivedItem,
+            mainViewModel: mainViewModel,
+            tracker: tracker.childTracker(hosting: .articleView.screen)
+        )
         mainViewModel.selectedMyListReadableViewModel = viewModel
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -95,7 +95,12 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             guard let item = bareItem(with: objectID) else {
                 return 
             }
-            let viewModel = SavedItemViewModel(item: item, source: source)
+            let viewModel = SavedItemViewModel(
+                item: item,
+                source: source,
+                mainViewModel: main,
+                tracker: tracker.childTracker(hosting: .articleView.screen)
+            )
             main.selectedMyListReadableViewModel = viewModel
         case .filterButton(let filterID):
             if selectedFilters.contains(filterID) {


### PR DESCRIPTION
1. Move from using a ReadableViewModelDelegate to using published events
2. Move tracking from ReadableHostViewController to its related view models
3. Move URL opening into ReadableViewModels
    - Tracking URL opens and sharing selected text were actually broken 🙃 

There's a new pattern I've introduced into the view models for the event publishers:

```swift
private var _events: PassthroughSubject<ReadableEvent, Never> = .init()
var events: AnyPublisher<ReadableEvent, Never> {
    _events.eraseToAnyPublisher()
}
```

The reason I introduced this pattern is to add a little more safety with regard to _who_ can send an event. `events` here is a "read-only" publisher, whereas its underlying implementation lets us send events appropriately (whose implementation detail is also now hidden).