### PR TITLE
Add support for fetching favorited archived items

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		F2843C202714D97000E03ED5 /* ReportViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */; };
 		F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */; };
 		F2A5B6B6271E03C400FB8BF2 /* LaunchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */; };
+		F2FC070327A9B749009F8D98 /* ArchiveFiltersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FC070227A9B749009F8D98 /* ArchiveFiltersTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -132,6 +133,7 @@
 		F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewElement.swift; sourceTree = "<group>"; };
 		F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
 		F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchEnvironment.swift; sourceTree = "<group>"; };
+		F2FC070227A9B749009F8D98 /* ArchiveFiltersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveFiltersTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +162,7 @@
 				166A81C42637406C0015AA1D /* MyListTests.swift */,
 				164FB66D278F7ECC002959D6 /* MyListFiltersTests.swift */,
 				16D76882279F3C73004A3694 /* ArchiveTests.swift */,
+				F2FC070227A9B749009F8D98 /* ArchiveFiltersTests.swift */,
 			);
 			path = MyList;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 				1613B2B3275571940014F301 /* SettingsViewElement.swift in Sources */,
 				16BB40A8279F436100FE8650 /* SelectionSwitcherElement.swift in Sources */,
 				F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */,
+				F2FC070327A9B749009F8D98 /* ArchiveFiltersTests.swift in Sources */,
 				16E4B16F27A3212900E01746 /* Response+factories.swift in Sources */,
 				166EFAEA2682821300A027CD /* WebReaderElement.swift in Sources */,
 				16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -25,7 +25,6 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
     }
     private var archivedItemsByID: [String: ArchivedItem] = [:]
 
-    @Published
     private var selectedFilters: Set<ItemsListFilter> = .init()
     private let availableFilters: [ItemsListFilter] = ItemsListFilter.allCases
 

--- a/PocketKit/Sources/Sync/Archive/ArchiveService.swift
+++ b/PocketKit/Sources/Sync/Archive/ArchiveService.swift
@@ -2,7 +2,7 @@ import Apollo
 
 
 protocol ArchiveService {
-    func fetch(accessToken: String?) async throws -> [ArchivedItem]
+    func fetch(accessToken: String?, isFavorite: Bool) async throws -> [ArchivedItem]
 }
 
 class PocketArchiveService: ArchiveService {
@@ -12,12 +12,12 @@ class PocketArchiveService: ArchiveService {
         self.apollo = apollo
     }
 
-    func fetch(accessToken: String?) async throws -> [ArchivedItem] {
+    func fetch(accessToken: String?, isFavorite: Bool) async throws -> [ArchivedItem] {
         guard let accessToken = accessToken else {
             return []
         }
 
-        let filter = SavedItemsFilter(isArchived: true)
+        let filter = SavedItemsFilter(isFavorite: isFavorite, isArchived: true)
         let query = UserByTokenQuery(token: accessToken, savedItemsFilter: filter)
 
         return try await apollo.fetch(query: query)

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -228,7 +228,7 @@ extension PocketSource {
 
 // MARK: - Archived Items
 extension PocketSource {
-    public func fetchArchivedItems() async throws -> [ArchivedItem] {
-        return try await archiveService.fetch(accessToken: tokenProvider.accessToken)
+    public func fetchArchivedItems(isFavorite: Bool) async throws -> [ArchivedItem] {
+        return try await archiveService.fetch(accessToken: tokenProvider.accessToken, isFavorite: isFavorite)
     }
 }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -31,7 +31,7 @@ public protocol Source {
 
     func archive(recommendation: Slate.Recommendation)
 
-    func fetchArchivedItems() async throws -> [ArchivedItem]
+    func fetchArchivedItems(isFavorite: Bool) async throws -> [ArchivedItem]
 }
 
 public extension Source {
@@ -41,5 +41,9 @@ public extension Source {
 
     func refresh() {
         self.refresh(maxItems: 400, completion: nil)
+    }
+    
+    func fetchArchivedItems() async throws -> [ArchivedItem] {
+        try await fetchArchivedItems(isFavorite: false)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -71,7 +71,7 @@ extension MockSource {
     }
 
 
-    func fetchArchivedItems() async throws -> [ArchivedItem] {
+    func fetchArchivedItems(isFavorite: Bool) async throws -> [ArchivedItem] {
         guard let impl = implementations["fetchArchivedItems()"] as? FetchArchivedItemsImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }

--- a/PocketKit/Tests/SyncTests/PocketArchiveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketArchiveServiceTests.swift
@@ -15,15 +15,23 @@ class PocketArchiveServiceTests: XCTestCase {
 
     func test_fetch_usesTheCorrectQuery() async throws {
         apollo.stubFetch(toReturnFixturedNamed: "archived-items", asResultType: UserByTokenQuery.self)
-        _ = try await subject().fetch(accessToken: "the-access-token")
-
-        let fetchCall: MockApolloClient.FetchCall<UserByTokenQuery> = apollo.fetchCall(at: 0)
-        XCTAssertEqual(fetchCall.query.savedItemsFilter?.isArchived, true)
+        
+        _ = try await subject().fetch(accessToken: "the-access-token", isFavorite: false)
+        
+        let unfavoritedCall: MockApolloClient.FetchCall<UserByTokenQuery> = apollo.fetchCall(at: 0)
+        XCTAssertEqual(unfavoritedCall.query.savedItemsFilter?.isArchived, true)
+        XCTAssertEqual(unfavoritedCall.query.savedItemsFilter?.isFavorite, false)
+        
+        _ = try await subject().fetch(accessToken: "the-access-token", isFavorite: true)
+        
+        let favoritedCall: MockApolloClient.FetchCall<UserByTokenQuery> = apollo.fetchCall(at: 1)
+        XCTAssertEqual(favoritedCall.query.savedItemsFilter?.isArchived, true)
+        XCTAssertEqual(favoritedCall.query.savedItemsFilter?.isFavorite, true)
     }
 
     func test_fetch_returnsMappedArchivedItems() async throws {
         apollo.stubFetch(toReturnFixturedNamed: "archived-items", asResultType: UserByTokenQuery.self)
-        let fetchedItems = try await subject().fetch(accessToken: "the-access-token")
+        let fetchedItems = try await subject().fetch(accessToken: "the-access-token", isFavorite: false)
 
         XCTAssertEqual(fetchedItems.count, 2)
 

--- a/PocketKit/Tests/SyncTests/Support/MockArchiveService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockArchiveService.swift
@@ -9,7 +9,7 @@ class MockArchiveService: ArchiveService {
         implementations["fetch"] = impl
     }
 
-    func fetch(accessToken: String?) async throws -> [ArchivedItem] {
+    func fetch(accessToken: String?, isFavorite: Bool) async throws -> [ArchivedItem] {
         guard let impl = implementations["fetch"] as? FetchImpl else {
             fatalError("\(Self.self)#\(#function) is not stubbed")
         }

--- a/Tests iOS/Fixtures/archived-favorite-items.json
+++ b/Tests iOS/Fixtures/archived-favorite-items.json
@@ -1,0 +1,84 @@
+{
+    "data": {
+        "userByToken": {
+            "__typename": "[type-name-here]",
+            "savedItems": {
+                "__typename": "[type-name-here]",
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "hasNextPage": false,
+                    "endCursor": "cursor-2"
+                },
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "favorited-archived-item-1",
+                            "url": "http://example.com/items/favorited-archived-item-1",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-1",
+                                "title": "Favorited Archived Item 1",
+                                "givenUrl": "http://example.com/items/favorited-archived-item-1",
+                                "resolvedUrl": "http://example.com/items/favorited-archived-item-1",
+                                "topImageUrl": "https://example.com/favorited-archived-item-1/top-image.jpg",
+                                "domain": null,
+                                "language": "en",
+                                "timeToRead": 6,
+                                "marticle": #MARTICLE#,
+                                "excerpt": "Risus Aenean Ultricies Nullam Vehicula",
+                                "datePublished": "2001-01-01 12:01:01",
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "favorited-archived-author-1",
+                                        "name": "Socrates",
+                                        "url": "https://example.com/authors/socrates"
+                                    }
+                                ],
+                                "domainMetadata": null,
+                                "images": []
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "favorited-archived-item-2",
+                            "url": "https://example.com/items/favorited-archived-item-2",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-2",
+                                "givenUrl": "https://example.com/items/favorited-archived-item-2",
+                                "resolvedUrl": "https://example.com/items/favorited-archived-item-2",
+                                "title": "Favorited Archived Item 2",
+                                "topImageUrl": "https://example.com/items/favorited-archived-item-2/images/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "1999-01-01 12:01:01",
+                                "excerpt": "Vehicula Nibh Ligula Porta Magna",
+                                "images": []
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Tests iOS/MyList/ArchiveFiltersTests.swift
+++ b/Tests iOS/MyList/ArchiveFiltersTests.swift
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sails
+import Combine
+import NIO
+
+
+class ArchiveFiltersTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let uiApp = XCUIApplication()
+        app = PocketAppElement(app: uiApp)
+
+        server = Application()
+
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList()
+            } else if apiRequest.isForFavoritedArchivedContent {
+                return Response.favoritedArchivedContent()
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else if apiRequest.isToFavoriteAnItem {
+                return Response.favorite()
+            } else if apiRequest.isToUnfavoriteAnItem {
+                return Response.unfavorite()
+            } else {
+                fatalError("Unexpected request")
+            }
+        }
+
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    func test_archiveView_tappingFavoritesPill_togglesDisplayingFavoritedArchivedContent() {
+        app.launch().tabBar.myListButton.wait().tap()
+        let myList = app.myListView.wait()
+        myList.itemView(matching: "Item 1").wait()
+
+        myList.selectionSwitcher.archiveButton.wait().tap()
+
+        myList.itemView(matching: "Archived Item 1").wait()
+        myList.itemView(matching: "Archived Item 2").wait()
+
+        XCTAssertFalse(myList.itemView(matching: "Item 1").exists)
+        XCTAssertFalse(myList.itemView(matching: "Item 2").exists)
+        
+        app.myListView.favoritesButton.tap()
+        
+        waitForDisappearance(of: myList.itemView(matching: "Archived Item 1"))
+        waitForDisappearance(of: myList.itemView(matching: "Archived Item 2"))
+        
+        myList.itemView(matching: "Favorited Archived Item 1").wait()
+        myList.itemView(matching: "Favorited Archived Item 2").wait()
+        
+        app.myListView.favoritesButton.tap()
+        
+        waitForDisappearance(of: myList.itemView(matching: "Favorited Archived Item 1"))
+        waitForDisappearance(of: myList.itemView(matching: "Favorited Archived Item 2"))
+        
+        myList.itemView(matching: "Archived Item 1").wait()
+        myList.itemView(matching: "Archived Item 2").wait()
+    }
+}
+

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -26,6 +26,10 @@ struct ClientAPIRequest {
     var isForArchivedContent: Bool {
         contains("userByToken") && contains(#""isArchived":true"#)
     }
+    
+    var isForFavoritedArchivedContent: Bool {
+        contains("userByToken") && contains(#""isArchived":true"#) && contains(#""isFavorite":true"#)
+    }
 
     var isForSlateLineup: Bool {
         contains("getSlateLineup")

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -18,6 +18,10 @@ extension Response {
     static func archivedContent() -> Response {
         myList("archived-items")
     }
+    
+    static func favoritedArchivedContent() -> Response {
+        myList("archived-favorite-items")
+    }
 
     static func slateLineup(_ fixtureName: String = "slates") -> Response {
         fixture(named: fixtureName)


### PR DESCRIPTION
This pull request adds support for viewing one's archive of favorited items.

The flow here is that once a user toggles `Favorite`, a blank snapshot will be rendered by the list, until items are fetched, at which point the (un)favorited items will be displayed. The implementation is very similar to that of `SavedItemsListViewModel`.

Behind the scenes, `Source` and its conforming types have been updated with the ability to supply `isFavorite` to the query used when fetching archived items.

Unit tests have been updated to ensure that the correct calls are being made, both through the `PocketArchiveService`, and `PocketSource`.

UI tests have been written to ensure that the toggle works as expected.

I've used the term "favorited" here as the term wrapping the `isFavorite` filter, but I'm happy to change the wording to be more consistent with the filter (which _does_ apply to a single item, but we're fetching a set of items).