### PR TITLE
Implement Reader item actions for Archived items

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -43,15 +43,15 @@ class CompactHomeCoordinator: NSObject {
         navigationController.popToRootViewController(animated: false)
         isResetting = true
 
-        model.$selectedReadableViewModel.sink { [weak self] readable in
+        model.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.show(readable)
         }.store(in: &subscriptions)
 
-        model.$selectedSlateDetail.sink { [weak self] slate in
+        model.$selectedSlateDetail.receive(on: DispatchQueue.main).sink { [weak self] slate in
             self?.show(slate)
         }.store(in: &subscriptions)
 
-        model.$selectedRecommendationToReport.sink { [weak self] recommendation in
+        model.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &subscriptions)
 
@@ -84,11 +84,11 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
-        slate.$selectedReadableViewModel.sink { [weak self] readable in
+        slate.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.show(readable)
         }.store(in: &slateDetailSubscriptions)
 
-        slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
+        slate.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &slateDetailSubscriptions)
     }
@@ -104,15 +104,15 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
-        recommendation.$sharedActivity.sink { [weak self] activity in
+        recommendation.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$presentedWebReaderURL.sink { [weak self] url in
+        recommendation.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        recommendation.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: recommendation)
         }.store(in: &readerSubscriptions)
     }

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -33,7 +33,7 @@ class ReadableHostViewController: UIViewController {
             )
         ]
         
-        readableViewModel.actions.sink { [weak self] actions in
+        readableViewModel.actions.receive(on: DispatchQueue.main).sink { [weak self] actions in
             self?.buildOverflowMenu(from: actions)
         }.store(in: &subscriptions)
     }

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -104,7 +104,7 @@ class RegularMainCoordinator: NSObject {
         myList.navigationController?.popToRootViewController(animated: false)
         readerRoot.viewControllers = []
 
-        model.$selectedSection.sink { [weak self] section in
+        model.$selectedSection.receive(on: DispatchQueue.main).sink { [weak self] section in
             self?.show(section)
         }.store(in: &subscriptions)
 
@@ -113,33 +113,33 @@ class RegularMainCoordinator: NSObject {
         }.store(in: &subscriptions)
 
         // My List - Saved Items
-        model.myList.savedItemsList.$presentedAlert.sink { [weak self] alert in
+        model.myList.savedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
-        model.myList.savedItemsList.$sharedActivity.sink { [weak self] activity in
+        model.myList.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
 
-        model.myList.savedItemsList.$selectedReadable.sink { [weak self] readable in
+        model.myList.savedItemsList.$selectedReadable.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.show(readable)
         }.store(in: &subscriptions)
 
         // My List - Archived Items
-        model.myList.archivedItemsList.$presentedAlert.sink { [weak self] alert in
+        model.myList.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
-        model.myList.archivedItemsList.$sharedActivity.sink { [weak self] activity in
+        model.myList.archivedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
 
-        model.myList.archivedItemsList.$selectedReadable.sink { [weak self] readable in
+        model.myList.archivedItemsList.$selectedReadable.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.show(readable)
         }.store(in: &subscriptions)
 
         // HOME
-        model.home.$selectedReadableViewModel.sink { [weak self] readable in
+        model.home.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             if readable != nil {
                 self?.model.home.selectedSlateDetail?.selectedReadableViewModel = nil
                 self?.model.myList.savedItemsList.selectedReadable = nil
@@ -149,11 +149,11 @@ class RegularMainCoordinator: NSObject {
             self?.show(readable)
         }.store(in: &subscriptions)
 
-        model.home.$selectedRecommendationToReport.sink { [weak self] recommendation in
+        model.home.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &subscriptions)
 
-        model.home.$selectedSlateDetail.sink { [weak self] slateDetail in
+        model.home.$selectedSlateDetail.receive(on: DispatchQueue.main).sink { [weak self] slateDetail in
             self?.show(slateDetail)
         }.store(in: &subscriptions)
 
@@ -188,19 +188,19 @@ class RegularMainCoordinator: NSObject {
         model.home.selectedSlateDetail?.selectedReadableViewModel = nil
         model.myList.archivedItemsList.selectedReadable = nil
 
-        readable.$presentedWebReaderURL.sink { [weak self] url in
+        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
 
-        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
-        readable.$presentedAlert.sink { [weak self] alert in
+        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &readerSubscriptions)
 
-        readable.$sharedActivity.sink { [weak self] activity in
+        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
@@ -219,19 +219,19 @@ class RegularMainCoordinator: NSObject {
         model.home.selectedSlateDetail?.selectedReadableViewModel = nil
         model.myList.savedItemsList.selectedReadable = nil
 
-        readable.$presentedWebReaderURL.sink { [weak self] url in
+        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
 
-        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
-        readable.$presentedAlert.sink { [weak self] alert in
+        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &readerSubscriptions)
 
-        readable.$sharedActivity.sink { [weak self] activity in
+        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
@@ -246,15 +246,15 @@ class RegularMainCoordinator: NSObject {
         }
 
         readerSubscriptions = []
-        readable.$presentedWebReaderURL.sink { [weak self] url in
+        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
 
-        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
-        readable.$sharedActivity.sink { [weak self] activity in
+        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
@@ -269,11 +269,11 @@ class RegularMainCoordinator: NSObject {
             return
         }
 
-        slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
+        slate.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &slateDetailSubscriptions)
 
-        slate.$selectedReadableViewModel.sink { [weak self] readable in
+        slate.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             if readable != nil {
                 self?.model.home.selectedReadableViewModel = nil
                 self?.model.myList.savedItemsList.selectedReadable = nil

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -267,6 +267,7 @@ extension ArchivedItemsListViewModel {
         selectedReadable = archivedItemsByID[identifier].flatMap { $0.item }.flatMap {
             ArchivedItemViewModel(
                 item: $0,
+                source: source,
                 tracker: tracker.childTracker(hosting: .articleView.screen)
             )
         }

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -45,28 +45,28 @@ class CompactMyListContainerCoordinator: NSObject {
         navigationController.popToRootViewController(animated: false)
 
         // My List navigation
-        model.savedItemsList.$presentedAlert.sink { [weak self] alert in
+        model.savedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
-        model.savedItemsList.$sharedActivity.sink { [weak self] activity in
+        model.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.savedItemsList.$selectedReadable.sink { [weak self] readable in
+        model.savedItemsList.$selectedReadable.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.push(savedItem: readable)
         }.store(in: &subscriptions)
 
         // Archive navigation
-        model.archivedItemsList.$selectedReadable.sink { [weak self] readable in
+        model.archivedItemsList.$selectedReadable.receive(on: DispatchQueue.main).sink { [weak self] readable in
             self?.push(archivedItem: readable)
         }.store(in: &subscriptions)
 
-        model.archivedItemsList.$sharedActivity.sink { [weak self] activity in
+        model.archivedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.archivedItemsList.$presentedAlert.sink { [weak self] alert in
+        model.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
@@ -80,23 +80,23 @@ class CompactMyListContainerCoordinator: NSObject {
             return
         }
 
-        readable.$presentedAlert.sink { [weak self] alert in
+        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
 
-        readable.$presentedWebReaderURL.sink { [weak self] url in
+        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readableSubscriptions)
 
-        readable.$sharedActivity.sink { [weak self] activity in
+        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readableSubscriptions)
 
-        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readableSubscriptions)
 
-        readable.events.sink { [weak self] event in
+        readable.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             self?.navigationController.popToRootViewController(animated: true)
         }.store(in: &readableSubscriptions)
 
@@ -112,23 +112,23 @@ class CompactMyListContainerCoordinator: NSObject {
             return
         }
 
-        readable.$presentedAlert.sink { [weak self] alert in
+        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
 
-        readable.$presentedWebReaderURL.sink { [weak self] url in
+        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readableSubscriptions)
 
-        readable.$sharedActivity.sink { [weak self] activity in
+        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readableSubscriptions)
 
-        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readableSubscriptions)
 
-        readable.events.sink { [weak self] event in
+        readable.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             self?.navigationController.popToRootViewController(animated: true)
         }.store(in: &readableSubscriptions)
 

--- a/PocketKit/Sources/PocketKit/PocketAlert.swift
+++ b/PocketKit/Sources/PocketKit/PocketAlert.swift
@@ -8,3 +8,19 @@ struct PocketAlert {
     let actions: [UIAlertAction]
     let preferredAction: UIAlertAction?
 }
+
+extension PocketAlert {
+    init(_ error: Error, handler: @escaping () -> Void) {
+        self.init(
+            title: "An error occurred",
+            message: error.localizedDescription,
+            preferredStyle: .alert,
+            actions: [
+                UIAlertAction(title: "Ok", style: .default) { _ in
+                    handler()
+                }
+            ],
+            preferredAction: nil
+        )
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemViewModelTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+import Sync
+import Analytics
+import Combine
+@testable import PocketKit
+
+
+class ArchivedItemViewModelTests: XCTestCase {
+    private var source: MockSource!
+    private var tracker: MockTracker!
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        source = MockSource()
+        tracker = MockTracker()
+    }
+
+    override func tearDown() {
+        subscriptions = []
+    }
+
+    func test_init_buildsCorrectActions() {
+        do {
+            let viewModel = subject() // Unfavorited item
+
+            let titles = viewModel.currentActions.map { $0.title }
+            XCTAssertEqual(
+                titles,
+                ["Display Settings", "Save", "Favorite", "Delete", "Share"]
+            )
+        }
+
+        do {
+            let viewModel = subject(item: ArchivedItem.build(remoteID: "1", isFavorite: true)) // Favorited item
+
+            let titles = viewModel.currentActions.map { $0.title }
+            XCTAssertEqual(
+                titles,
+                ["Display Settings", "Save", "Unfavorite", "Delete", "Share"]
+            )
+        }
+    }
+
+    func test_displaySettings_updatesIsPresentingReaderSettings() {
+        let viewModel = subject()
+        viewModel.invokeAction(title: "Display Settings")
+        XCTAssertEqual(viewModel.isPresentingReaderSettings, true)
+    }
+
+    func test_favorite_publishesAndUpdatesNewActions() {
+        let viewModel = subject() // Unfavorited item
+
+        // Drop first since we build actions on `init`
+        // and only care about the favorite toggle
+        let expectation = expectation(description: "correct actions on favorite")
+        viewModel.actions.dropFirst(1).sink { actions in
+            let titles = actions.map { $0.title }
+            XCTAssertTrue(titles.contains("Unfavorite"))
+
+            expectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Favorite")
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_favorite_sendsQueryToSource() {
+        let expectation = expectation(description: "favorite called")
+        source.stubFavoriteArchivedItem { _ in
+            expectation.fulfill()
+        }
+
+        let item = ArchivedItem.build(remoteID: "1", isFavorite: false)
+        let viewModel = subject(item: item)
+        viewModel.invokeAction(title: "Favorite")
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(source.favoriteArchivedItemCall(at: 0)?.item.remoteID, item.remoteID)
+    }
+
+    func test_favorite_onError_revertsAndPresentsAlert() {
+        let item = ArchivedItem.build(remoteID: "1", isFavorite: false)
+        let viewModel = subject(item: item)
+
+        let expectFavoriteCall = expectation(description: "favorite called")
+        source.stubFavoriteArchivedItem { _ in
+            defer { expectFavoriteCall.fulfill() }
+            throw FakeError.error
+        }
+
+        let expectNewActions = expectation(description: "new actions")
+        viewModel.actions.dropFirst(2).sink { actions in
+            expectNewActions.fulfill()
+        }.store(in: &subscriptions)
+
+        let expectAlert = expectation(description: "expect an alert")
+        viewModel.$presentedAlert.dropFirst(1).sink { _ in
+            expectAlert.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Favorite")
+        wait(for: [expectFavoriteCall, expectNewActions, expectAlert], timeout: 1)
+
+        XCTAssertTrue(viewModel.currentActions.map(\.title).contains("Favorite"))
+        XCTAssertNotNil(viewModel.presentedAlert)
+    }
+
+    func test_unfavorite_sendsQueryToSource() {
+        let expectation = expectation(description: "unfavorite called")
+        source.stubUnfavoriteArchivedItem { _ in
+            expectation.fulfill()
+        }
+
+        let item = ArchivedItem.build(remoteID: "1", isFavorite: true)
+        let viewModel = subject(item: item)
+        viewModel.invokeAction(title: "Unfavorite")
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(source.unfavoriteArchivedItemCall(at: 0)?.item.remoteID, item.remoteID)
+    }
+
+    func test_unfavorite_publishesAndUpdatesNewActions() {
+        let viewModel = subject(item: .build(remoteID: "1", isFavorite: true)) // Favorited item
+
+        // Drop first since we build actions on `init`
+        // and only care about the favorite toggle
+        let expectation = expectation(description: "correct actions on unfavorite")
+        viewModel.actions.dropFirst(1).sink { actions in
+            let titles = actions.map { $0.title }
+            XCTAssertTrue(titles.contains("Favorite"))
+
+            expectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Unfavorite")
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_unfavorite_onError_revertsAndPresentsAlert() {
+        let item = ArchivedItem.build(remoteID: "1", isFavorite: true)
+        let viewModel = subject(item: item)
+
+        let expectUnfavoriteCall = expectation(description: "unfavorite called")
+        source.stubUnfavoriteArchivedItem { _ in
+            defer { expectUnfavoriteCall.fulfill() }
+            throw FakeError.error
+        }
+
+        let expectNewActions = expectation(description: "new actions")
+        viewModel.actions.dropFirst(2).sink { actions in
+            expectNewActions.fulfill()
+        }.store(in: &subscriptions)
+
+        let expectAlert = expectation(description: "expect an alert")
+        viewModel.$presentedAlert.dropFirst(1).sink { _ in
+            expectAlert.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Unfavorite")
+        wait(for: [expectUnfavoriteCall, expectNewActions, expectAlert], timeout: 1)
+
+        XCTAssertTrue(viewModel.currentActions.map(\.title).contains("Unfavorite"))
+        XCTAssertNotNil(viewModel.presentedAlert)
+    }
+
+    func test_delete_sendsDeleteEvent() {
+        let viewModel = subject()
+
+        let expectation = expectation(description: "delete event")
+        viewModel.events.sink { event in
+            guard case .delete = event else {
+                XCTFail("expected delete event, got \(event) instead")
+                return
+            }
+
+            expectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Delete")
+        XCTAssertNotNil(viewModel.presentedAlert)
+
+        viewModel.presentedAlert?.actions.first(where: { $0.title == "Yes" })?.invoke()
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_share_updatesSharedActivity() {
+        let viewModel = subject()
+
+        viewModel.invokeAction(title: "Share")
+
+        XCTAssertNotNil(viewModel.sharedActivity)
+    }
+
+    func test_showWebReader_updatesPresentedWebReaderURL() {
+        let viewModel = subject()
+        viewModel.showWebReader()
+        XCTAssertNotNil(viewModel.presentedWebReaderURL)
+    }
+}
+
+extension ArchivedItemViewModelTests {
+    private func subject(
+        item: ArchivedItem = ArchivedItem.build(remoteID: "1", isFavorite: false),
+        source: Source? = nil,
+        tracker: Tracker? = nil
+    ) -> ArchivedItemViewModel {
+        return ArchivedItemViewModel(item: item, source: source ?? self.source, tracker: tracker ?? self.tracker)
+    }
+}
+
+extension ArchivedItemViewModel {
+    func invokeAction(title: String) {
+        currentActions.first(where: { $0.title == title })?.handler?(nil)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemViewModelTests.swift
@@ -27,7 +27,7 @@ class ArchivedItemViewModelTests: XCTestCase {
             let titles = viewModel.currentActions.map { $0.title }
             XCTAssertEqual(
                 titles,
-                ["Display Settings", "Save", "Favorite", "Delete", "Share"]
+                ["Display Settings", "Favorite", "Re-add", "Delete", "Share"]
             )
         }
 
@@ -37,7 +37,7 @@ class ArchivedItemViewModelTests: XCTestCase {
             let titles = viewModel.currentActions.map { $0.title }
             XCTAssertEqual(
                 titles,
-                ["Display Settings", "Save", "Unfavorite", "Delete", "Share"]
+                ["Display Settings", "Unfavorite", "Re-add", "Delete", "Share"]
             )
         }
     }
@@ -49,6 +49,9 @@ class ArchivedItemViewModelTests: XCTestCase {
     }
 
     func test_favorite_publishesAndUpdatesNewActions() {
+        source.stubFavoriteArchivedItem { _ in }
+
+
         let viewModel = subject() // Unfavorited item
 
         // Drop first since we build actions on `init`
@@ -124,6 +127,8 @@ class ArchivedItemViewModelTests: XCTestCase {
     }
 
     func test_unfavorite_publishesAndUpdatesNewActions() {
+        source.stubUnfavoriteArchivedItem { _ in }
+
         let viewModel = subject(item: .build(remoteID: "1", isFavorite: true)) // Favorited item
 
         // Drop first since we build actions on `init`


### PR DESCRIPTION
This pull request adds support for the following item actions when viewing an archived item:

- [x] Display Settings
- [x] Favorite
- [x] Unfavorite
- [x] Re-add
- [x] Delete
- [x] Share

Additional changes:
1. Receive published values on the main queue when the handler deals with presentation

This code has primarily been reviewed live by both Jacob and myself.