### PR TITLE
Obtain session guid and user id from FxA redirect

### DIFF
--- a/PocketKit/Sources/PocketKit/LoggedOut/PocketLoggedOutViewModel.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/PocketLoggedOutViewModel.swift
@@ -41,20 +41,14 @@ class PocketLoggedOutViewModel {
             return
         }
 
-        do {
-            let guid = try await authorizationClient.requestGUID()
-
-            let (_, response) = await authentication(contextProvider)
-            if let response = response {
-                appSession.currentSession = Session(
-                    guid: guid,
-                    accessToken: response.accessToken,
-                    userIdentifier: response.userIdentifier
-                )
-            } else {
-                presentedAlert = PocketAlert(LoggedOutError.error) { [weak self] in self?.presentedAlert = nil }
-            }
-        } catch {
+        let (_, response) = await authentication(contextProvider)
+        if let response = response {
+            appSession.currentSession = Session(
+                guid: response.guid,
+                accessToken: response.accessToken,
+                userIdentifier: response.userIdentifier
+            )
+        } else {
             presentedAlert = PocketAlert(LoggedOutError.error) { [weak self] in self?.presentedAlert = nil }
         }
     }

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -31,7 +31,6 @@ struct Services {
         appSession = AppSession()
         authClient = AuthorizationClient(
             consumerKey: Keys.shared.pocketApiConsumerKey,
-            urlSession: urlSession,
             authenticationSession: ASWebAuthenticationSession.self
         )
 

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -7,7 +7,7 @@ import XCTest
 import AuthenticationServices
 
 
-class AuthorizationServiceTests: XCTestCase {
+class AuthorizationClientTests: XCTestCase {
     var urlSession: MockURLSession!
     var client: AuthorizationClient!
 
@@ -15,222 +15,15 @@ class AuthorizationServiceTests: XCTestCase {
         urlSession = MockURLSession()
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
     }
 }
 
-// MARK: - GUID
-extension AuthorizationServiceTests {
-    func test_guid_sendsGETRequestWithCorrectParameters() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let data = "sample-guid".data(using: .utf8)!
-            return (data, .ok!)
-        }
-
-        _ = try? await client.requestGUID()
-        let calls = self.urlSession.dataTaskCalls
-        XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls[0].request.url?.path, "/v3/guid")
-        XCTAssertEqual(calls[0].request.httpMethod, "GET")
-    }
-
-    func test_guid_whenServerRespondsWith200_invokesCompletionWithGUID() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "1.1",
-                headerFields: ["X-Source": "Pocket"]
-            )!
-
-            let responseBody = """
-            {
-                "guid": "sample-guid"
-            }
-            """.data(using: .utf8)!
-
-            return (responseBody, response)
-        }
-
-        do {
-            let guid = try await client.requestGUID()
-            XCTAssertEqual(guid, "sample-guid")
-        } catch {
-            XCTFail("requestGUID() should not throw an error in this context: \(error)")
-        }
-    }
-
-    func test_guid_when200AndDataIsEmpty_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "1.1",
-                headerFields: ["X-Source": "Pocket"]
-            )!
-
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.invalidResponse = error else {
-                XCTFail("Unexpected error: \(error). Expected an invalid response")
-                return
-            }
-        }
-    }
-
-    func test_guid_when200AndResponseDoesNotContainAccessToken_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "1.1",
-                headerFields: ["X-Source": "Pocket"]
-            )!
-
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.invalidResponse = error else {
-                XCTFail("Unexpected error: \(error). Expected an invalid response")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenStatusIs300_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(url: request.url, statusCode: 300)!
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.unexpectedRedirect = error else {
-                XCTFail("Unexpected error: \(error). Expected an unexpected redirect")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenErrorIsNotNil_invokesCompletionWithError() async {
-        urlSession.stubData { _ throws -> (Data, URLResponse) in
-            throw ExampleError.anError
-        }
-        
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.generic(let internalError) = error else {
-                XCTFail("Unexpected error: \(error). Expected a generic error")
-                return
-            }
-            
-            XCTAssertEqual(internalError as? ExampleError, ExampleError.anError)
-        }
-    }
-
-    func test_guid_whenStatusIs400_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(url: request.url, statusCode: 400)!
-            return (Data(), response)
-        }
-        
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.badRequest = error else {
-                XCTFail("Unexpected error: \(error). Expected a bad request")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenStatusIs401_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(url: request.url, statusCode: 401)!
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.invalidCredentials = error else {
-                XCTFail("Unexpected error: \(error). Expected invalid credentials")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenStatusIs500_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(url: request.url, statusCode: 500)!
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.serverError = error else {
-                XCTFail("Unexpected error: \(error). Expected a server error")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenStatusIs9001_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 9001)!
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.unexpectedError = error else {
-                XCTFail("Unexpected error: \(error). Expected an unexpected error")
-                return
-            }
-        }
-    }
-
-    func test_guid_whenSourceHeaderIsInvalid_invokesCompletionWithError() async {
-        urlSession.stubData { (request) throws -> (Data, URLResponse) in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "1.1",
-                headerFields: ["X-Source": "not-Pocket"]
-            )!
-            
-            return (Data(), response)
-        }
-
-        do {
-            _ = try await client.requestGUID()
-        } catch {
-            guard case AuthorizationClient.Error.invalidSource = error else {
-                XCTFail("Unexpected error: \(error). Expected an invalid source")
-                return
-            }
-        }
-    }
-}
-
-extension AuthorizationServiceTests {
+extension AuthorizationClientTests {
     func test_logIn_buildsCorrectRequest() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
 
@@ -248,19 +41,18 @@ extension AuthorizationServiceTests {
     func test_logIn_onSuccess_returnsAccessTokenAndUserIdentifier() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
 
         let (_, response) = await client.logIn(from: self)
+        XCTAssertEqual(response?.guid, "test-guid")
         XCTAssertEqual(response?.accessToken, "test-access-token")
-        XCTAssertEqual(response?.userIdentifier, "")
+        XCTAssertEqual(response?.userIdentifier, "test-id")
     }
 
     func test_logIn_onError_returnsNilResponse() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockErrorAuthenticationSession.self
         )
 
@@ -269,11 +61,10 @@ extension AuthorizationServiceTests {
     }
 }
 
-extension AuthorizationServiceTests {
+extension AuthorizationClientTests {
     func test_signUp_buildsCorrectRequest() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
 
@@ -291,19 +82,18 @@ extension AuthorizationServiceTests {
     func test_signUp_onSuccess_returnsAccessTokenAndUserIdentifier() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
 
         let (_, response) = await client.signUp(from: self)
+        XCTAssertEqual(response?.guid, "test-guid")
         XCTAssertEqual(response?.accessToken, "test-access-token")
-        XCTAssertEqual(response?.userIdentifier, "")
+        XCTAssertEqual(response?.userIdentifier, "test-id")
     }
 
     func test_signUp_onError_returnsNilResponse() async {
         client = AuthorizationClient(
             consumerKey: "the-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockErrorAuthenticationSession.self
         )
 
@@ -312,7 +102,7 @@ extension AuthorizationServiceTests {
     }
 }
 
-extension AuthorizationServiceTests: ASWebAuthenticationPresentationContextProviding {
+extension AuthorizationClientTests: ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         UIWindow()
     }

--- a/PocketKit/Tests/PocketKitTests/PocketLoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketLoggedOutViewModelTests.swift
@@ -23,34 +23,6 @@ class PocketLoggedOutViewModelTests: XCTestCase {
 }
 
 extension PocketLoggedOutViewModelTests {
-    func test_logIn_onGUIDError_setsPresentedAlert() {
-        let urlSession = MockURLSession()
-        urlSession.stubData { _ in
-            throw FakeError.error
-        }
-
-        let client = AuthorizationClient(
-            consumerKey: "test-consumer-key",
-            urlSession: urlSession,
-            authenticationSession: MockErrorAuthenticationSession.self
-        )
-
-        viewModel = PocketLoggedOutViewModel(
-            authorizationClient: client,
-            appSession: appSession
-        )
-        viewModel.contextProvider = self
-
-        let alertExpectation = expectation(description: "set presented alert")
-        viewModel.$presentedAlert.dropFirst().sink { alert in
-            XCTAssertNotNil(alert)
-            alertExpectation.fulfill()
-        }.store(in: &subscriptions)
-
-        viewModel.logIn()
-        wait(for: [alertExpectation], timeout: 1)
-    }
-
     func test_logIn_onFxAError_setsPresentedAlert() {
         let urlSession = MockURLSession()
         urlSession.stubData { request in
@@ -59,7 +31,6 @@ extension PocketLoggedOutViewModelTests {
 
         let client = AuthorizationClient(
             consumerKey: "test-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockErrorAuthenticationSession.self
         )
         viewModel = PocketLoggedOutViewModel(
@@ -87,7 +58,6 @@ extension PocketLoggedOutViewModelTests {
 
         let client = AuthorizationClient(
             consumerKey: "test-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
         viewModel = PocketLoggedOutViewModel(
@@ -98,9 +68,9 @@ extension PocketLoggedOutViewModelTests {
 
         let sessionExpectation = expectation(description: "published error event")
         appSession.$currentSession.dropFirst().sink { session in
-            XCTAssertEqual(session?.guid, "sample-guid")
+            XCTAssertEqual(session?.guid, "test-guid")
             XCTAssertEqual(session?.accessToken, "test-access-token")
-            XCTAssertEqual(session?.userIdentifier, "")
+            XCTAssertEqual(session?.userIdentifier, "test-id")
             sessionExpectation.fulfill()
         }.store(in: &subscriptions)
 
@@ -110,34 +80,6 @@ extension PocketLoggedOutViewModelTests {
 }
 
 extension PocketLoggedOutViewModelTests {
-    func test_signUp_onGUIDError_setsPresentedAlert() {
-        let urlSession = MockURLSession()
-        urlSession.stubData { _ in
-            throw FakeError.error
-        }
-
-        let client = AuthorizationClient(
-            consumerKey: "test-consumer-key",
-            urlSession: urlSession,
-            authenticationSession: MockErrorAuthenticationSession.self
-        )
-
-        viewModel = PocketLoggedOutViewModel(
-            authorizationClient: client,
-            appSession: appSession
-        )
-        viewModel.contextProvider = self
-
-        let alertExpectation = expectation(description: "set presented alert")
-        viewModel.$presentedAlert.dropFirst().sink { alert in
-            XCTAssertNotNil(alert)
-            alertExpectation.fulfill()
-        }.store(in: &subscriptions)
-
-        viewModel.signUp()
-        wait(for: [alertExpectation], timeout: 1)
-    }
-
     func test_signUp_onFxAError_setsPresentedAlert() {
         let urlSession = MockURLSession()
         urlSession.stubData { request in
@@ -146,7 +88,6 @@ extension PocketLoggedOutViewModelTests {
 
         let client = AuthorizationClient(
             consumerKey: "test-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockErrorAuthenticationSession.self
         )
         viewModel = PocketLoggedOutViewModel(
@@ -174,7 +115,6 @@ extension PocketLoggedOutViewModelTests {
 
         let client = AuthorizationClient(
             consumerKey: "test-consumer-key",
-            urlSession: urlSession,
             authenticationSession: MockAuthenticationSession.self
         )
         viewModel = PocketLoggedOutViewModel(
@@ -185,9 +125,9 @@ extension PocketLoggedOutViewModelTests {
 
         let sessionExpectation = expectation(description: "published error event")
         appSession.$currentSession.dropFirst().sink { session in
-            XCTAssertEqual(session?.guid, "sample-guid")
+            XCTAssertEqual(session?.guid, "test-guid")
             XCTAssertEqual(session?.accessToken, "test-access-token")
-            XCTAssertEqual(session?.userIdentifier, "")
+            XCTAssertEqual(session?.userIdentifier, "test-id")
             sessionExpectation.fulfill()
         }.store(in: &subscriptions)
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
@@ -19,7 +19,7 @@ class MockAuthenticationSession: AuthenticationSession {
     var startCalls = 0
     func start() -> Bool {
         startCalls += 1
-        completionHandler?(URL(string: "\(scheme!)://fxa?access_token=test-access-token")!, nil)
+        completionHandler?(URL(string: "\(scheme!)://fxa?guid=test-guid&access_token=test-access-token&id=test-id")!, nil)
         return true
     }
 }


### PR DESCRIPTION
The FxA redirect will soon be updated to add `guid` and `id` query parameters to the preexisting `access_token`. This lets us remove the solo request for the `guid` preceding login, simplifying the network requests greatly from a previously-required 3 (one each for: guid, fxa, user ID), to 1 (guid, fxa, and user ID in a single response).