### PR TITLE
Better handling, capturing, and presentation of authentication errors

### DIFF
--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -49,7 +49,7 @@ class LoggedOutViewModelTests: XCTestCase {
 
 extension LoggedOutViewModelTests {
     func test_logIn_onFxAError_setsPresentedAlert() async {
-        mockAuthenticationSession.error = FakeError.error
+        mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()
 
         let alertExpectation = expectation(description: "set presented alert")
@@ -59,6 +59,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         await viewModel.logIn()
+
         wait(for: [alertExpectation], timeout: 1)
     }
 
@@ -81,7 +82,7 @@ extension LoggedOutViewModelTests {
 
 extension LoggedOutViewModelTests {
     func test_signUp_onFxAError_setsPresentedAlert() async {
-        mockAuthenticationSession.error = FakeError.error
+        mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()
 
         let alertExpectation = expectation(description: "set presented alert")


### PR DESCRIPTION
This pull request introduces better support for handling, capturing, and presentation of authentication errors.

## Presentation

Under certain circumstances, errors should be presented to the user:
1. If the FxA URL could not be generated
2. If the FxA redirect could not be parsed.

The thought behind this is that if a user _sees_ these errors, they will reach out to support.

## Capturing

Under certain circumstances, errors should be captured and bubbled up to Sentry. Currently, any and all errors that occur during FxA authentication will bubble up to Sentry.

## Handling

Under certain circumstances, errors should be ignored:
1. When tapping "Cancel" when a web session is started, it is treated as an error. This error can be ignored; other errors thrown by the web session will be captured.