### PR TITLE
Correctly set AuthorizationClient.Error descriptions

### DIFF
--- a/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
@@ -76,7 +76,7 @@ public class AuthorizationClient {
 }
 
 extension AuthorizationClient {
-    enum Error: Swift.Error, Equatable {
+    enum Error: LocalizedError, Equatable {
         static func ==(lhs: AuthorizationClient.Error, rhs: AuthorizationClient.Error) -> Bool {
             switch (lhs, rhs) {
             case (.invalidRedirect, .invalidRedirect):
@@ -92,7 +92,7 @@ extension AuthorizationClient {
         case invalidComponents
         case other(Swift.Error)
 
-        var localizedDescription: String {
+        var errorDescription: String? {
             switch self {
             case .invalidRedirect:
                 return "Could not successfully handle the server redirect."


### PR DESCRIPTION
Using `Swift.Error`, you cannot (anymore) override `localizedDescription` to provide a description. One should instead conform to `LocalizedError`, which _inherits_ from `Swift.Error`, but allows for custom descriptions:

> A specialized error that provides localized messages describing the error and why it occurred.

This pull request makes `AuthorizationClient.Error` conform to `LocalizedError` and provide better human-readable descriptions.