### PR TITLE
Force web view when item is not an article, is an image, or is a video

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */; };
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
+		F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */; };
 		F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */; };
 		F2843C202714D97000E03ED5 /* ReportViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */; };
 		F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */; };
@@ -129,6 +130,7 @@
 		16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAnItemTests.swift; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
 		F227F0C3265E96290031F985 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/System/Library/Frameworks/CoreText.framework; sourceTree = DEVELOPER_DIR; };
+		F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeWebViewTests.swift; sourceTree = "<group>"; };
 		F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportARecommendationTests.swift; sourceTree = "<group>"; };
 		F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewElement.swift; sourceTree = "<group>"; };
 		F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				160056F226CC7FFD00700A80 /* FavoriteAnItemTests.swift */,
 				16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */,
 				1606F21A26EBC1A200238111 /* HomeTests.swift */,
+				F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */,
 				F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */,
 				1613B2B02755696B0014F301 /* SignOutTests.swift */,
 			);
@@ -422,6 +425,7 @@
 				1648D5A727024C6400F67C4B /* SlateDetailElement.swift in Sources */,
 				166BAD0B2656E76B00E401F0 /* ReaderElement.swift in Sources */,
 				166F8F2726D0488900F898E3 /* XCUIElement+wait.swift in Sources */,
+				F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */,
 				1606F21B26EBC1A200238111 /* HomeTests.swift in Sources */,
 				166A81C52637406C0015AA1D /* MyListTests.swift in Sources */,
 				1612D7E426C32321009A5BFD /* ByteBuffer+read.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -55,6 +55,10 @@ class CompactHomeCoordinator: NSObject {
             self?.report(recommendation)
         }.store(in: &subscriptions)
 
+        model.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url: url)
+        }.store(in: &subscriptions)
+
         isResetting = false
         navigationController.delegate = self
     }
@@ -91,6 +95,10 @@ class CompactHomeCoordinator: NSObject {
         slate.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &slateDetailSubscriptions)
+
+        slate.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url: url)
+        }.store(in: &subscriptions)
     }
 
     func show(_ recommendation: RecommendationViewModel?) {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -349,11 +349,17 @@ extension HomeViewController: UICollectionViewDelegate {
         default:
             let engagement = SnowplowEngagement(type: .general, value: nil)
             tracker.track(event: engagement, contexts(for: indexPath))
-            
-            model.selectedReadableViewModel = RecommendationViewModel(
-                recommendation: slates[indexPath.section - 1].recommendations[indexPath.item],
-                tracker: tracker.childTracker(hosting: .articleView.screen)
-            )
+
+            let recommendation = slates[indexPath.section - 1].recommendations[indexPath.item]
+
+            if recommendation.item.isArticle == false {
+                model.presentedWebReaderURL = recommendation.item.bestURL
+            } else {
+                model.selectedReadableViewModel = RecommendationViewModel(
+                    recommendation: slates[indexPath.section - 1].recommendations[indexPath.item],
+                    tracker: tracker.childTracker(hosting: .articleView.screen)
+                )
+            }
 
             let open = ContentOpenEvent(destination: .internal, trigger: .click)
             tracker.track(event: open, contexts(for: indexPath))

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -352,7 +352,9 @@ extension HomeViewController: UICollectionViewDelegate {
 
             let recommendation = slates[indexPath.section - 1].recommendations[indexPath.item]
 
-            if recommendation.item.isArticle == false {
+            if recommendation.item.isArticle == false
+                || recommendation.item.hasImage == .isImage
+                || recommendation.item.hasVideo == .isVideo {
                 model.presentedWebReaderURL = recommendation.item.bestURL
             } else {
                 model.selectedReadableViewModel = RecommendationViewModel(

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -267,7 +267,9 @@ extension SlateDetailViewController: UICollectionViewDelegate {
         let engagement = SnowplowEngagement(type: .general, value: nil)
         tracker.track(event: engagement, contexts(for: indexPath))
 
-        if recommendation.item.isArticle == false {
+        if recommendation.item.isArticle == false
+            || recommendation.item.hasImage == .isImage
+            || recommendation.item.hasVideo == .isVideo {
             model.presentedWebReaderURL = recommendation.item.bestURL
         } else {
             model.selectedReadableViewModel = RecommendationViewModel(

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -267,10 +267,14 @@ extension SlateDetailViewController: UICollectionViewDelegate {
         let engagement = SnowplowEngagement(type: .general, value: nil)
         tracker.track(event: engagement, contexts(for: indexPath))
 
-        model.selectedReadableViewModel = RecommendationViewModel(
-            recommendation: recommendation,
-            tracker: tracker.childTracker(hosting: .articleView.screen)
-        )
+        if recommendation.item.isArticle == false {
+            model.presentedWebReaderURL = recommendation.item.bestURL
+        } else {
+            model.selectedReadableViewModel = RecommendationViewModel(
+                recommendation: recommendation,
+                tracker: tracker.childTracker(hosting: .articleView.screen)
+            )
+        }
 
         let contentOpen = ContentOpenEvent(destination: .internal, trigger: .click)
         tracker.track(event: contentOpen, contexts(for: indexPath))

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -14,6 +14,9 @@ class HomeViewModel {
 
     @Published
     var selectedSlateDetail: SlateDetailViewModel?
+
+    @Published
+    var presentedWebReaderURL: URL?
 }
 
 class SlateDetailViewModel {
@@ -24,6 +27,9 @@ class SlateDetailViewModel {
 
     @Published
     var selectedRecommendationToReport: Slate.Recommendation?
+
+    @Published
+    var presentedWebReaderURL: URL?
 
     init(slateID: String) {
         self.slateID = slateID

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -113,6 +113,10 @@ class RegularMainCoordinator: NSObject {
             self?.present(alert)
         }.store(in: &subscriptions)
 
+        model.myList.savedItemsList.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &subscriptions)
+
         model.myList.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
@@ -123,6 +127,10 @@ class RegularMainCoordinator: NSObject {
 
         // My List - Archived Items
         model.myList.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &subscriptions)
+
+        model.myList.archivedItemsList.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
@@ -151,6 +159,10 @@ class RegularMainCoordinator: NSObject {
 
         model.home.$selectedSlateDetail.receive(on: DispatchQueue.main).sink { [weak self] slateDetail in
             self?.show(slateDetail)
+        }.store(in: &subscriptions)
+
+        model.home.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url)
         }.store(in: &subscriptions)
 
         isResetting = false
@@ -247,6 +259,10 @@ class RegularMainCoordinator: NSObject {
 
             self?.show(readable)
         }.store(in: &slateDetailSubscriptions)
+
+        slate.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &subscriptions)
 
         let slateDetailVC = SlateDetailViewController(source: source, model: slate, tracker: tracker)
         home.navigationController?.pushViewController(slateDetailVC, animated: !isResetting)

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -264,7 +264,9 @@ extension ArchivedItemsListViewModel {
             return
         }
 
-        if let isArticle = item.item?.isArticle, isArticle == false {
+        if let isArticle = item.item?.isArticle, isArticle == false
+            || item.item?.hasImage == .isImage
+            || item.item?.hasVideo == .isVideo {
             presentedWebReaderURL = item.bestURL
         } else {
             selectedReadable = SavedItemViewModel(

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -24,6 +24,9 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
     @Published
     var presentedAlert: PocketAlert?
 
+    @Published
+    var presentedWebReaderURL: URL?
+
     private let source: Source
     private let tracker: Tracker
 
@@ -261,11 +264,15 @@ extension ArchivedItemsListViewModel {
             return
         }
 
-        selectedReadable = SavedItemViewModel(
-            item: item,
-            source: source,
-            tracker: tracker.childTracker(hosting: .articleView.screen)
-        )
+        if let isArticle = item.item?.isArticle, isArticle == false {
+            presentedWebReaderURL = item.bestURL
+        } else {
+            selectedReadable = SavedItemViewModel(
+                item: item,
+                source: source,
+                tracker: tracker.childTracker(hosting: .articleView.screen)
+            )
+        }
     }
 
     private func apply(filter: ItemsListFilter, from cell: ItemsListCell<ItemIdentifier>) {

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -49,6 +49,10 @@ class CompactMyListContainerCoordinator: NSObject {
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
+        model.savedItemsList.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url: url)
+        }.store(in: &subscriptions)
+
         model.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
@@ -68,6 +72,10 @@ class CompactMyListContainerCoordinator: NSObject {
 
         model.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
+        }.store(in: &subscriptions)
+
+        model.archivedItemsList.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url: url)
         }.store(in: &subscriptions)
 
         isResetting = false

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -283,7 +283,9 @@ extension SavedItemsListViewModel {
             return
         }
 
-        if let isArticle = item.item?.isArticle, isArticle == false {
+        if let isArticle = item.item?.isArticle, isArticle == false
+            || item.item?.hasImage == .isImage
+            || item.item?.hasVideo == .isVideo {
             presentedWebReaderURL = item.bestURL
         } else {
             selectedReadable = bareItem(with: itemID).flatMap {

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -17,6 +17,9 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     var presentedAlert: PocketAlert?
 
     @Published
+    var presentedWebReaderURL: URL?
+
+    @Published
     var selectedReadable: SavedItemViewModel?
 
     @Published
@@ -276,12 +279,20 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
 
 extension SavedItemsListViewModel {
     private func select(item itemID: ItemIdentifier) {
-        selectedReadable = bareItem(with: itemID).flatMap {
-            SavedItemViewModel(
-                item: $0,
-                source: source,
-                tracker: tracker.childTracker(hosting: .articleView.screen)
-            )
+        guard let item = bareItem(with: itemID) else {
+            return
+        }
+
+        if let isArticle = item.item?.isArticle, isArticle == false {
+            presentedWebReaderURL = item.bestURL
+        } else {
+            selectedReadable = bareItem(with: itemID).flatMap {
+                SavedItemViewModel(
+                    item: $0,
+                    source: source,
+                    tracker: tracker.childTracker(hosting: .articleView.screen)
+                )
+            }
         }
     }
 

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -857,8 +857,8 @@ public final class UserByTokenQuery: GraphQLQuery {
                 self.resultMap = unsafeResultMap
               }
 
-              public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-                return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+              public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+                return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
               }
 
               public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -940,6 +940,7 @@ public final class UserByTokenQuery: GraphQLQuery {
                     GraphQLField("timeToRead", type: .scalar(Int.self)),
                     GraphQLField("domain", type: .scalar(String.self)),
                     GraphQLField("datePublished", type: .scalar(String.self)),
+                    GraphQLField("isArticle", type: .scalar(Bool.self)),
                     GraphQLField("authors", type: .list(.object(Author.selections))),
                     GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
                     GraphQLField("excerpt", type: .scalar(String.self)),
@@ -954,8 +955,8 @@ public final class UserByTokenQuery: GraphQLQuery {
                   self.resultMap = unsafeResultMap
                 }
 
-                public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-                  self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+                public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+                  self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
                 }
 
                 public var __typename: String {
@@ -1054,6 +1055,16 @@ public final class UserByTokenQuery: GraphQLQuery {
                   }
                   set {
                     resultMap.updateValue(newValue, forKey: "datePublished")
+                  }
+                }
+
+                /// true if the item is an article
+                public var isArticle: Bool? {
+                  get {
+                    return resultMap["isArticle"] as? Bool
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "isArticle")
                   }
                 }
 
@@ -3915,8 +3926,8 @@ public final class SaveItemMutation: GraphQLMutation {
           self.resultMap = unsafeResultMap
         }
 
-        public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-          return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+        public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+          return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
         }
 
         public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -3998,6 +4009,7 @@ public final class SaveItemMutation: GraphQLMutation {
               GraphQLField("timeToRead", type: .scalar(Int.self)),
               GraphQLField("domain", type: .scalar(String.self)),
               GraphQLField("datePublished", type: .scalar(String.self)),
+              GraphQLField("isArticle", type: .scalar(Bool.self)),
               GraphQLField("authors", type: .list(.object(Author.selections))),
               GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
               GraphQLField("excerpt", type: .scalar(String.self)),
@@ -4012,8 +4024,8 @@ public final class SaveItemMutation: GraphQLMutation {
             self.resultMap = unsafeResultMap
           }
 
-          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
           }
 
           public var __typename: String {
@@ -4112,6 +4124,16 @@ public final class SaveItemMutation: GraphQLMutation {
             }
             set {
               resultMap.updateValue(newValue, forKey: "datePublished")
+            }
+          }
+
+          /// true if the item is an article
+          public var isArticle: Bool? {
+            get {
+              return resultMap["isArticle"] as? Bool
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "isArticle")
             }
           }
 
@@ -7522,6 +7544,7 @@ public final class GetSlateLineupQuery: GraphQLQuery {
                 GraphQLField("timeToRead", type: .scalar(Int.self)),
                 GraphQLField("domain", type: .scalar(String.self)),
                 GraphQLField("datePublished", type: .scalar(String.self)),
+                GraphQLField("isArticle", type: .scalar(Bool.self)),
                 GraphQLField("authors", type: .list(.object(Author.selections))),
                 GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
                 GraphQLField("excerpt", type: .scalar(String.self)),
@@ -7536,8 +7559,8 @@ public final class GetSlateLineupQuery: GraphQLQuery {
               self.resultMap = unsafeResultMap
             }
 
-            public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-              self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+            public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+              self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
             }
 
             public var __typename: String {
@@ -7636,6 +7659,16 @@ public final class GetSlateLineupQuery: GraphQLQuery {
               }
               set {
                 resultMap.updateValue(newValue, forKey: "datePublished")
+              }
+            }
+
+            /// true if the item is an article
+            public var isArticle: Bool? {
+              get {
+                return resultMap["isArticle"] as? Bool
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "isArticle")
               }
             }
 
@@ -10420,6 +10453,7 @@ public final class GetSlateQuery: GraphQLQuery {
               GraphQLField("timeToRead", type: .scalar(Int.self)),
               GraphQLField("domain", type: .scalar(String.self)),
               GraphQLField("datePublished", type: .scalar(String.self)),
+              GraphQLField("isArticle", type: .scalar(Bool.self)),
               GraphQLField("authors", type: .list(.object(Author.selections))),
               GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
               GraphQLField("excerpt", type: .scalar(String.self)),
@@ -10434,8 +10468,8 @@ public final class GetSlateQuery: GraphQLQuery {
             self.resultMap = unsafeResultMap
           }
 
-          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
           }
 
           public var __typename: String {
@@ -10534,6 +10568,16 @@ public final class GetSlateQuery: GraphQLQuery {
             }
             set {
               resultMap.updateValue(newValue, forKey: "datePublished")
+            }
+          }
+
+          /// true if the item is an article
+          public var isArticle: Bool? {
+            get {
+              return resultMap["isArticle"] as? Bool
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "isArticle")
             }
           }
 
@@ -13200,8 +13244,8 @@ public struct SavedItemParts: GraphQLFragment {
       self.resultMap = unsafeResultMap
     }
 
-    public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-      return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+    public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+      return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
     }
 
     public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -13283,6 +13327,7 @@ public struct SavedItemParts: GraphQLFragment {
           GraphQLField("timeToRead", type: .scalar(Int.self)),
           GraphQLField("domain", type: .scalar(String.self)),
           GraphQLField("datePublished", type: .scalar(String.self)),
+          GraphQLField("isArticle", type: .scalar(Bool.self)),
           GraphQLField("authors", type: .list(.object(Author.selections))),
           GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
           GraphQLField("excerpt", type: .scalar(String.self)),
@@ -13297,8 +13342,8 @@ public struct SavedItemParts: GraphQLFragment {
         self.resultMap = unsafeResultMap
       }
 
-      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
       }
 
       public var __typename: String {
@@ -13397,6 +13442,16 @@ public struct SavedItemParts: GraphQLFragment {
         }
         set {
           resultMap.updateValue(newValue, forKey: "datePublished")
+        }
+      }
+
+      /// true if the item is an article
+      public var isArticle: Bool? {
+        get {
+          return resultMap["isArticle"] as? Bool
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "isArticle")
         }
       }
 
@@ -16043,6 +16098,7 @@ public struct ItemParts: GraphQLFragment {
       timeToRead
       domain
       datePublished
+      isArticle
       authors {
         __typename
         id
@@ -16091,6 +16147,7 @@ public struct ItemParts: GraphQLFragment {
       GraphQLField("timeToRead", type: .scalar(Int.self)),
       GraphQLField("domain", type: .scalar(String.self)),
       GraphQLField("datePublished", type: .scalar(String.self)),
+      GraphQLField("isArticle", type: .scalar(Bool.self)),
       GraphQLField("authors", type: .list(.object(Author.selections))),
       GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
       GraphQLField("excerpt", type: .scalar(String.self)),
@@ -16105,8 +16162,8 @@ public struct ItemParts: GraphQLFragment {
     self.resultMap = unsafeResultMap
   }
 
-  public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-    self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+  public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+    self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
   }
 
   public var __typename: String {
@@ -16205,6 +16262,16 @@ public struct ItemParts: GraphQLFragment {
     }
     set {
       resultMap.updateValue(newValue, forKey: "datePublished")
+    }
+  }
+
+  /// true if the item is an article
+  public var isArticle: Bool? {
+    get {
+      return resultMap["isArticle"] as? Bool
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "isArticle")
     }
   }
 
@@ -19001,6 +19068,7 @@ public struct SlateParts: GraphQLFragment {
           GraphQLField("timeToRead", type: .scalar(Int.self)),
           GraphQLField("domain", type: .scalar(String.self)),
           GraphQLField("datePublished", type: .scalar(String.self)),
+          GraphQLField("isArticle", type: .scalar(Bool.self)),
           GraphQLField("authors", type: .list(.object(Author.selections))),
           GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
           GraphQLField("excerpt", type: .scalar(String.self)),
@@ -19015,8 +19083,8 @@ public struct SlateParts: GraphQLFragment {
         self.resultMap = unsafeResultMap
       }
 
-      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
       }
 
       public var __typename: String {
@@ -19115,6 +19183,16 @@ public struct SlateParts: GraphQLFragment {
         }
         set {
           resultMap.updateValue(newValue, forKey: "datePublished")
+        }
+      }
+
+      /// true if the item is an article
+      public var isArticle: Bool? {
+        get {
+          return resultMap["isArticle"] as? Bool
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "isArticle")
         }
       }
 

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -306,6 +306,102 @@ public struct SavedItemUpsertInput: GraphQLMapConvertible {
   }
 }
 
+public enum Imageness: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+  public typealias RawValue = String
+  /// No images (v3 value is 0)
+  case noImages
+  /// Contains images (v3 value is 1)
+  case hasImages
+  /// Is an image (v3 value is 2)
+  case isImage
+  /// Auto generated constant for unknown enum values
+  case __unknown(RawValue)
+
+  public init?(rawValue: RawValue) {
+    switch rawValue {
+      case "NO_IMAGES": self = .noImages
+      case "HAS_IMAGES": self = .hasImages
+      case "IS_IMAGE": self = .isImage
+      default: self = .__unknown(rawValue)
+    }
+  }
+
+  public var rawValue: RawValue {
+    switch self {
+      case .noImages: return "NO_IMAGES"
+      case .hasImages: return "HAS_IMAGES"
+      case .isImage: return "IS_IMAGE"
+      case .__unknown(let value): return value
+    }
+  }
+
+  public static func == (lhs: Imageness, rhs: Imageness) -> Bool {
+    switch (lhs, rhs) {
+      case (.noImages, .noImages): return true
+      case (.hasImages, .hasImages): return true
+      case (.isImage, .isImage): return true
+      case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+      default: return false
+    }
+  }
+
+  public static var allCases: [Imageness] {
+    return [
+      .noImages,
+      .hasImages,
+      .isImage,
+    ]
+  }
+}
+
+public enum Videoness: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+  public typealias RawValue = String
+  /// No videos (v3 value is 0)
+  case noVideos
+  /// Contains videos (v3 value is 1)
+  case hasVideos
+  /// Is a video (v3 value is 2)
+  case isVideo
+  /// Auto generated constant for unknown enum values
+  case __unknown(RawValue)
+
+  public init?(rawValue: RawValue) {
+    switch rawValue {
+      case "NO_VIDEOS": self = .noVideos
+      case "HAS_VIDEOS": self = .hasVideos
+      case "IS_VIDEO": self = .isVideo
+      default: self = .__unknown(rawValue)
+    }
+  }
+
+  public var rawValue: RawValue {
+    switch self {
+      case .noVideos: return "NO_VIDEOS"
+      case .hasVideos: return "HAS_VIDEOS"
+      case .isVideo: return "IS_VIDEO"
+      case .__unknown(let value): return value
+    }
+  }
+
+  public static func == (lhs: Videoness, rhs: Videoness) -> Bool {
+    switch (lhs, rhs) {
+      case (.noVideos, .noVideos): return true
+      case (.hasVideos, .hasVideos): return true
+      case (.isVideo, .isVideo): return true
+      case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+      default: return false
+    }
+  }
+
+  public static var allCases: [Videoness] {
+    return [
+      .noVideos,
+      .hasVideos,
+      .isVideo,
+    ]
+  }
+}
+
 public enum PendingItemStatus: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   case resolved
@@ -857,8 +953,8 @@ public final class UserByTokenQuery: GraphQLQuery {
                 self.resultMap = unsafeResultMap
               }
 
-              public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-                return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+              public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+                return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
               }
 
               public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -941,6 +1037,8 @@ public final class UserByTokenQuery: GraphQLQuery {
                     GraphQLField("domain", type: .scalar(String.self)),
                     GraphQLField("datePublished", type: .scalar(String.self)),
                     GraphQLField("isArticle", type: .scalar(Bool.self)),
+                    GraphQLField("hasImage", type: .scalar(Imageness.self)),
+                    GraphQLField("hasVideo", type: .scalar(Videoness.self)),
                     GraphQLField("authors", type: .list(.object(Author.selections))),
                     GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
                     GraphQLField("excerpt", type: .scalar(String.self)),
@@ -955,8 +1053,8 @@ public final class UserByTokenQuery: GraphQLQuery {
                   self.resultMap = unsafeResultMap
                 }
 
-                public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-                  self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+                public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+                  self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
                 }
 
                 public var __typename: String {
@@ -1065,6 +1163,26 @@ public final class UserByTokenQuery: GraphQLQuery {
                   }
                   set {
                     resultMap.updateValue(newValue, forKey: "isArticle")
+                  }
+                }
+
+                /// 0=no images, 1=contains images, 2=is an image
+                public var hasImage: Imageness? {
+                  get {
+                    return resultMap["hasImage"] as? Imageness
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "hasImage")
+                  }
+                }
+
+                /// 0=no videos, 1=contains video, 2=is a video
+                public var hasVideo: Videoness? {
+                  get {
+                    return resultMap["hasVideo"] as? Videoness
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "hasVideo")
                   }
                 }
 
@@ -3926,8 +4044,8 @@ public final class SaveItemMutation: GraphQLMutation {
           self.resultMap = unsafeResultMap
         }
 
-        public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-          return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+        public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+          return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
         }
 
         public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -4010,6 +4128,8 @@ public final class SaveItemMutation: GraphQLMutation {
               GraphQLField("domain", type: .scalar(String.self)),
               GraphQLField("datePublished", type: .scalar(String.self)),
               GraphQLField("isArticle", type: .scalar(Bool.self)),
+              GraphQLField("hasImage", type: .scalar(Imageness.self)),
+              GraphQLField("hasVideo", type: .scalar(Videoness.self)),
               GraphQLField("authors", type: .list(.object(Author.selections))),
               GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
               GraphQLField("excerpt", type: .scalar(String.self)),
@@ -4024,8 +4144,8 @@ public final class SaveItemMutation: GraphQLMutation {
             self.resultMap = unsafeResultMap
           }
 
-          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
           }
 
           public var __typename: String {
@@ -4134,6 +4254,26 @@ public final class SaveItemMutation: GraphQLMutation {
             }
             set {
               resultMap.updateValue(newValue, forKey: "isArticle")
+            }
+          }
+
+          /// 0=no images, 1=contains images, 2=is an image
+          public var hasImage: Imageness? {
+            get {
+              return resultMap["hasImage"] as? Imageness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasImage")
+            }
+          }
+
+          /// 0=no videos, 1=contains video, 2=is a video
+          public var hasVideo: Videoness? {
+            get {
+              return resultMap["hasVideo"] as? Videoness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasVideo")
             }
           }
 
@@ -7545,6 +7685,8 @@ public final class GetSlateLineupQuery: GraphQLQuery {
                 GraphQLField("domain", type: .scalar(String.self)),
                 GraphQLField("datePublished", type: .scalar(String.self)),
                 GraphQLField("isArticle", type: .scalar(Bool.self)),
+                GraphQLField("hasImage", type: .scalar(Imageness.self)),
+                GraphQLField("hasVideo", type: .scalar(Videoness.self)),
                 GraphQLField("authors", type: .list(.object(Author.selections))),
                 GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
                 GraphQLField("excerpt", type: .scalar(String.self)),
@@ -7559,8 +7701,8 @@ public final class GetSlateLineupQuery: GraphQLQuery {
               self.resultMap = unsafeResultMap
             }
 
-            public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-              self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+            public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+              self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
             }
 
             public var __typename: String {
@@ -7669,6 +7811,26 @@ public final class GetSlateLineupQuery: GraphQLQuery {
               }
               set {
                 resultMap.updateValue(newValue, forKey: "isArticle")
+              }
+            }
+
+            /// 0=no images, 1=contains images, 2=is an image
+            public var hasImage: Imageness? {
+              get {
+                return resultMap["hasImage"] as? Imageness
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "hasImage")
+              }
+            }
+
+            /// 0=no videos, 1=contains video, 2=is a video
+            public var hasVideo: Videoness? {
+              get {
+                return resultMap["hasVideo"] as? Videoness
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "hasVideo")
               }
             }
 
@@ -10454,6 +10616,8 @@ public final class GetSlateQuery: GraphQLQuery {
               GraphQLField("domain", type: .scalar(String.self)),
               GraphQLField("datePublished", type: .scalar(String.self)),
               GraphQLField("isArticle", type: .scalar(Bool.self)),
+              GraphQLField("hasImage", type: .scalar(Imageness.self)),
+              GraphQLField("hasVideo", type: .scalar(Videoness.self)),
               GraphQLField("authors", type: .list(.object(Author.selections))),
               GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
               GraphQLField("excerpt", type: .scalar(String.self)),
@@ -10468,8 +10632,8 @@ public final class GetSlateQuery: GraphQLQuery {
             self.resultMap = unsafeResultMap
           }
 
-          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
           }
 
           public var __typename: String {
@@ -10578,6 +10742,26 @@ public final class GetSlateQuery: GraphQLQuery {
             }
             set {
               resultMap.updateValue(newValue, forKey: "isArticle")
+            }
+          }
+
+          /// 0=no images, 1=contains images, 2=is an image
+          public var hasImage: Imageness? {
+            get {
+              return resultMap["hasImage"] as? Imageness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasImage")
+            }
+          }
+
+          /// 0=no videos, 1=contains video, 2=is a video
+          public var hasVideo: Videoness? {
+            get {
+              return resultMap["hasVideo"] as? Videoness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasVideo")
             }
           }
 
@@ -13244,8 +13428,8 @@ public struct SavedItemParts: GraphQLFragment {
       self.resultMap = unsafeResultMap
     }
 
-    public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
-      return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+    public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+      return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
     }
 
     public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
@@ -13328,6 +13512,8 @@ public struct SavedItemParts: GraphQLFragment {
           GraphQLField("domain", type: .scalar(String.self)),
           GraphQLField("datePublished", type: .scalar(String.self)),
           GraphQLField("isArticle", type: .scalar(Bool.self)),
+          GraphQLField("hasImage", type: .scalar(Imageness.self)),
+          GraphQLField("hasVideo", type: .scalar(Videoness.self)),
           GraphQLField("authors", type: .list(.object(Author.selections))),
           GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
           GraphQLField("excerpt", type: .scalar(String.self)),
@@ -13342,8 +13528,8 @@ public struct SavedItemParts: GraphQLFragment {
         self.resultMap = unsafeResultMap
       }
 
-      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
       }
 
       public var __typename: String {
@@ -13452,6 +13638,26 @@ public struct SavedItemParts: GraphQLFragment {
         }
         set {
           resultMap.updateValue(newValue, forKey: "isArticle")
+        }
+      }
+
+      /// 0=no images, 1=contains images, 2=is an image
+      public var hasImage: Imageness? {
+        get {
+          return resultMap["hasImage"] as? Imageness
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "hasImage")
+        }
+      }
+
+      /// 0=no videos, 1=contains video, 2=is a video
+      public var hasVideo: Videoness? {
+        get {
+          return resultMap["hasVideo"] as? Videoness
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "hasVideo")
         }
       }
 
@@ -16099,6 +16305,8 @@ public struct ItemParts: GraphQLFragment {
       domain
       datePublished
       isArticle
+      hasImage
+      hasVideo
       authors {
         __typename
         id
@@ -16148,6 +16356,8 @@ public struct ItemParts: GraphQLFragment {
       GraphQLField("domain", type: .scalar(String.self)),
       GraphQLField("datePublished", type: .scalar(String.self)),
       GraphQLField("isArticle", type: .scalar(Bool.self)),
+      GraphQLField("hasImage", type: .scalar(Imageness.self)),
+      GraphQLField("hasVideo", type: .scalar(Videoness.self)),
       GraphQLField("authors", type: .list(.object(Author.selections))),
       GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
       GraphQLField("excerpt", type: .scalar(String.self)),
@@ -16162,8 +16372,8 @@ public struct ItemParts: GraphQLFragment {
     self.resultMap = unsafeResultMap
   }
 
-  public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-    self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+  public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+    self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
   }
 
   public var __typename: String {
@@ -16272,6 +16482,26 @@ public struct ItemParts: GraphQLFragment {
     }
     set {
       resultMap.updateValue(newValue, forKey: "isArticle")
+    }
+  }
+
+  /// 0=no images, 1=contains images, 2=is an image
+  public var hasImage: Imageness? {
+    get {
+      return resultMap["hasImage"] as? Imageness
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "hasImage")
+    }
+  }
+
+  /// 0=no videos, 1=contains video, 2=is a video
+  public var hasVideo: Videoness? {
+    get {
+      return resultMap["hasVideo"] as? Videoness
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "hasVideo")
     }
   }
 
@@ -19069,6 +19299,8 @@ public struct SlateParts: GraphQLFragment {
           GraphQLField("domain", type: .scalar(String.self)),
           GraphQLField("datePublished", type: .scalar(String.self)),
           GraphQLField("isArticle", type: .scalar(Bool.self)),
+          GraphQLField("hasImage", type: .scalar(Imageness.self)),
+          GraphQLField("hasVideo", type: .scalar(Videoness.self)),
           GraphQLField("authors", type: .list(.object(Author.selections))),
           GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
           GraphQLField("excerpt", type: .scalar(String.self)),
@@ -19083,8 +19315,8 @@ public struct SlateParts: GraphQLFragment {
         self.resultMap = unsafeResultMap
       }
 
-      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
-        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+      public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
       }
 
       public var __typename: String {
@@ -19193,6 +19425,26 @@ public struct SlateParts: GraphQLFragment {
         }
         set {
           resultMap.updateValue(newValue, forKey: "isArticle")
+        }
+      }
+
+      /// 0=no images, 1=contains images, 2=is an image
+      public var hasImage: Imageness? {
+        get {
+          return resultMap["hasImage"] as? Imageness
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "hasImage")
+        }
+      }
+
+      /// 0=no videos, 1=contains video, 2=is a video
+      public var hasVideo: Videoness? {
+        get {
+          return resultMap["hasVideo"] as? Videoness
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "hasVideo")
         }
       }
 

--- a/PocketKit/Sources/Sync/Item+extensions.swift
+++ b/PocketKit/Sources/Sync/Item+extensions.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+
+extension Item {
+    var hasImage: ItemImageness? {
+        imageness.flatMap(ItemImageness.init)
+    }
+
+    var hasVideo: ItemVideoness? {
+        videoness.flatMap(ItemVideoness.init)
+    }
+}

--- a/PocketKit/Sources/Sync/Item+extensions.swift
+++ b/PocketKit/Sources/Sync/Item+extensions.swift
@@ -2,11 +2,11 @@ import Foundation
 
 
 extension Item {
-    var hasImage: ItemImageness? {
+    public var hasImage: ItemImageness? {
         imageness.flatMap(ItemImageness.init)
     }
 
-    var hasVideo: ItemVideoness? {
+    public var hasVideo: ItemVideoness? {
         videoness.flatMap(ItemVideoness.init)
     }
 }

--- a/PocketKit/Sources/Sync/ItemImageness.swift
+++ b/PocketKit/Sources/Sync/ItemImageness.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+
+public enum ItemImageness: String, Equatable, Hashable {
+    case noImages
+    case hasImages
+    case isImage
+}
+
+extension ItemImageness {
+    typealias Remote = Imageness
+
+    init?(remote: Remote) {
+        switch remote {
+        case .noImages:
+            self = .noImages
+        case .hasImages:
+            self = .hasImages
+        case .isImage:
+            self = .isImage
+        default:
+            return nil
+        }
+    }
+}
+
+extension Imageness {
+    init(imageness: ItemImageness) {
+        switch imageness {
+        case .noImages:
+            self = .noImages
+        case .hasImages:
+            self = .hasImages
+        case .isImage:
+            self = .isImage
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/ItemImageness.swift
+++ b/PocketKit/Sources/Sync/ItemImageness.swift
@@ -2,26 +2,9 @@ import Foundation
 
 
 public enum ItemImageness: String, Equatable, Hashable {
-    case noImages
-    case hasImages
-    case isImage
-}
-
-extension ItemImageness {
-    typealias Remote = Imageness
-
-    init?(remote: Remote) {
-        switch remote {
-        case .noImages:
-            self = .noImages
-        case .hasImages:
-            self = .hasImages
-        case .isImage:
-            self = .isImage
-        default:
-            return nil
-        }
-    }
+    case noImages = "NO_IMAGES"
+    case hasImages = "HAS_IMAGES"
+    case isImage = "IS_IMAGE"
 }
 
 extension Imageness {

--- a/PocketKit/Sources/Sync/ItemVideoness.swift
+++ b/PocketKit/Sources/Sync/ItemVideoness.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+
+public enum ItemVideoness: String, Equatable, Hashable {
+    case noVideos
+    case hasVideos
+    case isVideo
+}
+
+extension ItemVideoness {
+    typealias Remote = Videoness
+
+    init?(remote: Remote) {
+        switch remote {
+        case .noVideos:
+            self = .noVideos
+        case .hasVideos:
+            self = .hasVideos
+        case .isVideo:
+            self = .isVideo
+        default:
+            return nil
+        }
+    }
+}
+
+extension Videoness {
+    init(videoness: ItemVideoness) {
+        switch videoness {
+        case .noVideos:
+            self = .noVideos
+        case .hasVideos:
+            self = .hasVideos
+        case .isVideo:
+            self = .isVideo
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/ItemVideoness.swift
+++ b/PocketKit/Sources/Sync/ItemVideoness.swift
@@ -2,26 +2,9 @@ import Foundation
 
 
 public enum ItemVideoness: String, Equatable, Hashable {
-    case noVideos
-    case hasVideos
-    case isVideo
-}
-
-extension ItemVideoness {
-    typealias Remote = Videoness
-
-    init?(remote: Remote) {
-        switch remote {
-        case .noVideos:
-            self = .noVideos
-        case .hasVideos:
-            self = .hasVideos
-        case .isVideo:
-            self = .isVideo
-        default:
-            return nil
-        }
-    }
+    case noVideos = "NO_VIDEOS"
+    case hasVideos = "HAS_VIDEOS"
+    case isVideo = "IS_VIDEO"
 }
 
 extension Videoness {

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -17,6 +17,7 @@
         <attribute name="domain" optional="YES" attributeType="String"/>
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="givenURL" optional="YES" attributeType="URI"/>
+        <attribute name="isArticle" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="language" optional="YES" attributeType="String"/>
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="resolvedURL" optional="YES" attributeType="URI"/>
@@ -44,8 +45,8 @@
     <elements>
         <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
-        <element name="Item" positionX="-45" positionY="99" width="128" height="239"/>
-        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="149"/>
+        <element name="Item" positionX="-45" positionY="99" width="128" height="254"/>
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
+        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="149"/>
     </elements>
 </model>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -17,6 +17,7 @@
         <attribute name="domain" optional="YES" attributeType="String"/>
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="givenURL" optional="YES" attributeType="URI"/>
+        <attribute name="imageness" optional="YES" attributeType="String"/>
         <attribute name="isArticle" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="language" optional="YES" attributeType="String"/>
         <attribute name="remoteID" optional="YES" attributeType="String"/>
@@ -24,6 +25,7 @@
         <attribute name="timeToRead" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="topImageURL" optional="YES" attributeType="URI"/>
+        <attribute name="videoness" optional="YES" attributeType="String"/>
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Author" inverseName="item" inverseEntity="Author"/>
         <relationship name="domainMetadata" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DomainMetadata" inverseName="item" inverseEntity="DomainMetadata"/>
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="item" inverseEntity="SavedItem"/>
@@ -45,7 +47,7 @@
     <elements>
         <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
-        <element name="Item" positionX="-45" positionY="99" width="128" height="254"/>
+        <element name="Item" positionX="-45" positionY="99" width="128" height="284"/>
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
         <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="149"/>
     </elements>

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -16,6 +16,7 @@ extension Item {
         timeToRead = remote.timeToRead.flatMap(Int32.init) ?? 0
         excerpt = remote.excerpt
         datePublished = remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) }
+        isArticle = remote.isArticle ?? false
 
         guard let context = managedObjectContext else {
             return

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -17,6 +17,8 @@ extension Item {
         excerpt = remote.excerpt
         datePublished = remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) }
         isArticle = remote.isArticle ?? false
+        imageness = remote.hasImage?.rawValue
+        videoness = remote.hasVideo?.rawValue
 
         guard let context = managedObjectContext else {
             return
@@ -56,6 +58,8 @@ extension Item {
         domain = unmanagedItem.domain
         article = unmanagedItem.article
         datePublished = unmanagedItem.datePublished
+        imageness = unmanagedItem.hasImage.flatMap(Imageness.init)?.rawValue
+        videoness = unmanagedItem.hasVideo.flatMap(Videoness.init)?.rawValue
 
         guard let context = managedObjectContext else {
             return

--- a/PocketKit/Sources/Sync/UnmanagedItem+extensions.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem+extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension UnmanagedItem {
+    public var bestURL: URL? {
+        resolvedURL ?? givenURL
+    }
+}

--- a/PocketKit/Sources/Sync/UnmanagedItem+extensions.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem+extensions.swift
@@ -4,4 +4,12 @@ extension UnmanagedItem {
     public var bestURL: URL? {
         resolvedURL ?? givenURL
     }
+
+    public var hasImage: ItemImageness? {
+        imageness.flatMap(ItemImageness.init)
+    }
+
+    public var hasVideo: ItemVideoness? {
+        videoness.flatMap(ItemVideoness.init)
+    }
 }

--- a/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
@@ -21,7 +21,8 @@ extension UnmanagedItem {
             domainMetadata: (remote.domainMetadata?.fragments.domainMetadataParts).flatMap(DomainMetadata.init),
             authors: remote.authors.flatMap { $0.compactMap { $0 }.map(Author.init) },
             datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) },
-            images: remote.images.flatMap { $0.compactMap { $0 }.map(Image.init) }
+            images: remote.images.flatMap { $0.compactMap { $0 }.map(Image.init) },
+            isArticle: remote.isArticle ?? false
         )
     }
 }

--- a/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem+remoteMapping.swift
@@ -22,7 +22,9 @@ extension UnmanagedItem {
             authors: remote.authors.flatMap { $0.compactMap { $0 }.map(Author.init) },
             datePublished: remote.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) },
             images: remote.images.flatMap { $0.compactMap { $0 }.map(Image.init) },
-            isArticle: remote.isArticle ?? false
+            isArticle: remote.isArticle ?? false,
+            imageness: remote.hasImage?.rawValue,
+            videoness: remote.hasVideo?.rawValue
         )
     }
 }

--- a/PocketKit/Sources/Sync/UnmanagedItem.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem.swift
@@ -17,6 +17,8 @@ public struct UnmanagedItem: Equatable, Hashable {
     public let datePublished: Date?
     public let images: [Image]?
     public let isArticle: Bool
+    public let imageness: String?
+    public let videoness: String?
 
     public struct DomainMetadata: Equatable, Hashable {
         public let name: String?

--- a/PocketKit/Sources/Sync/UnmanagedItem.swift
+++ b/PocketKit/Sources/Sync/UnmanagedItem.swift
@@ -16,6 +16,7 @@ public struct UnmanagedItem: Equatable, Hashable {
     public let authors: [Author]?
     public let datePublished: Date?
     public let images: [Image]?
+    public let isArticle: Bool
 
     public struct DomainMetadata: Equatable, Hashable {
         public let name: String?

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -22,6 +22,8 @@ fragment ItemParts on Item {
   domain
   datePublished
   isArticle
+  hasImage
+  hasVideo
   authors {
     id
     name

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -21,6 +21,7 @@ fragment ItemParts on Item {
   timeToRead
   domain
   datePublished
+  isArticle
   authors {
     id
     name

--- a/PocketKit/Tests/PocketKitTests/Support/SavedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/SavedItem+factories.swift
@@ -30,6 +30,7 @@ extension Item {
         let item = Item(context: space.context)
         item.remoteID = remoteID
         item.title = title
+        item.isArticle = true
 
         return item
     }

--- a/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
@@ -18,7 +18,9 @@ extension UnmanagedItem {
             authors: nil,
             datePublished: nil,
             images: nil,
-            isArticle: false
+            isArticle: false,
+            imageness: "HAS_IMAGES",
+            videoness: "HAS_VIDEOS"
         )
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/UnmanagedItem+factories.swift
@@ -17,7 +17,8 @@ extension UnmanagedItem {
             domainMetadata: nil,
             authors: nil,
             datePublished: nil,
-            images: nil
+            images: nil,
+            isArticle: false
         )
     }
 }

--- a/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
@@ -61,7 +61,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -92,7 +94,9 @@
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/archived-items.json
@@ -60,7 +60,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -90,7 +91,8 @@
                                 "authors": [],
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -90,7 +91,8 @@
                                         "src": "http://example.com/item-1",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -92,7 +94,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-3/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -55,7 +55,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -97,7 +98,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -56,7 +56,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -99,7 +101,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/save-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/save-item.json
@@ -36,7 +36,9 @@
                         "imageId": 1
                     }
                 ],
-                "isArticle": true
+                "isArticle": true,
+                "hasImage": "HAS_IMAGES",
+                "hasVideo": "HAS_VIDEOS",
             }
         }
     }

--- a/PocketKit/Tests/SyncTests/Fixtures/save-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/save-item.json
@@ -35,7 +35,8 @@
                         "src": "http://example.com/item-1/image-1.jpg",
                         "imageId": 1
                     }
-                ]
+                ],
+                "isArticle": true
             }
         }
     }

--- a/PocketKit/Tests/SyncTests/Fixtures/slate-detail.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slate-detail.json
@@ -31,7 +31,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-1.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 },
                 {
@@ -57,7 +59,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-2.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 },
                 {
@@ -83,7 +87,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-3.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 }
             ]

--- a/PocketKit/Tests/SyncTests/Fixtures/slate-detail.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slate-detail.json
@@ -30,7 +30,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-1.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 },
                 {
@@ -55,7 +56,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-2.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 },
                 {
@@ -80,7 +82,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-3.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 }
             ]

--- a/PocketKit/Tests/SyncTests/Fixtures/slates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slates.json
@@ -36,7 +36,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         },
                         {
@@ -61,7 +62,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],
@@ -116,7 +118,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],

--- a/PocketKit/Tests/SyncTests/Fixtures/slates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slates.json
@@ -37,7 +37,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         },
                         {
@@ -63,7 +65,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],
@@ -119,7 +123,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],

--- a/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -228,7 +228,9 @@ class PocketSourceTests: XCTestCase {
                 ],
                 datePublished: Date(),
                 images: [],
-                isArticle: false
+                isArticle: false,
+                imageness: "HAS_IMAGES",
+                videoness: "HAS_VIDEOS"
             )
         )
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -227,7 +227,8 @@ class PocketSourceTests: XCTestCase {
                     )
                 ],
                 datePublished: Date(),
-                images: []
+                images: [],
+                isArticle: false
             )
         )
 

--- a/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
@@ -18,7 +18,9 @@ extension UnmanagedItem {
             authors: nil,
             datePublished: nil,
             images: nil,
-            isArticle: false
+            isArticle: false,
+            imageness: "HAS_IMAGES",
+            videoness: "HAS_VIDEOS"
         )
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/UnmanagedItem+factories.swift
@@ -17,7 +17,8 @@ extension UnmanagedItem {
             domainMetadata: nil,
             authors: nil,
             datePublished: nil,
-            images: nil
+            images: nil,
+            isArticle: false
         )
     }
 }

--- a/Tests iOS/Fixtures/archived-favorite-items.json
+++ b/Tests iOS/Fixtures/archived-favorite-items.json
@@ -43,7 +43,8 @@
                                     }
                                 ],
                                 "domainMetadata": null,
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     },
@@ -73,7 +74,8 @@
                                 "authors": [],
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/archived-favorite-items.json
+++ b/Tests iOS/Fixtures/archived-favorite-items.json
@@ -44,7 +44,9 @@
                                 ],
                                 "domainMetadata": null,
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -75,7 +77,9 @@
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/archived-items.json
+++ b/Tests iOS/Fixtures/archived-items.json
@@ -43,7 +43,8 @@
                                     }
                                 ],
                                 "domainMetadata": null,
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     },
@@ -73,7 +74,8 @@
                                 "authors": [],
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/archived-items.json
+++ b/Tests iOS/Fixtures/archived-items.json
@@ -44,7 +44,9 @@
                                 ],
                                 "domainMetadata": null,
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -75,7 +77,9 @@
                                 "datePublished": "1999-01-01 12:01:01",
                                 "excerpt": "Vehicula Nibh Ligula Porta Magna",
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/archived-web-view.json
+++ b/Tests iOS/Fixtures/archived-web-view.json
@@ -1,0 +1,123 @@
+{
+    "data": {
+        "userByToken": {
+            "__typename": "[type-name-here]",
+            "savedItems": {
+                "__typename": "[type-name-here]",
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "hasNextPage": false,
+                    "endCursor": "cursor-3"
+                },
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-item-1",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-1",
+                                "title": "Archived Item 1",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "topImageUrl": "https://example.com/archived-item-1/top-image.jpg",
+                                "domain": null,
+                                "language": "en",
+                                "timeToRead": 6,
+                                "marticle": #MARTICLE#,
+                                "excerpt": "Risus Aenean Ultricies Nullam Vehicula",
+                                "datePublished": "2001-01-01 12:01:01",
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "archived-author-1",
+                                        "name": "Socrates",
+                                        "url": "https://example.com/authors/socrates"
+                                    }
+                                ],
+                                "domainMetadata": null,
+                                "images": [],
+                                "isArticle": true,
+                                "hasImage": "IS_IMAGE",
+                                "hasVideo": "",
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-item-2",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": true,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-2",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Archived Item 2",
+                                "topImageUrl": "https://example.com/items/archived-item-2/images/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "1999-01-01 12:01:01",
+                                "excerpt": "Vehicula Nibh Ligula Porta Magna",
+                                "images": [],
+                                "isArticle": true,
+                                "hasImage": "",
+                                "hasVideo": "IS_VIDEO",
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-3",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "archived-item-3",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": true,
+                            "isFavorite": true,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "archived-item-3",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Archived Item 3",
+                                "topImageUrl": "https://example.com/items/archived-item-3/images/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "1999-01-01 12:01:01",
+                                "excerpt": "Vehicula Nibh Ligula Porta Magna",
+                                "images": [],
+                                "isArticle": true,
+                                "hasImage": "",
+                                "hasVideo": "IS_VIDEO",
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -61,7 +61,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -99,7 +100,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -62,7 +62,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -101,7 +103,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/list-for-web-view.json
+++ b/Tests iOS/Fixtures/list-for-web-view.json
@@ -1,0 +1,157 @@
+{
+    "data": {
+        "userByToken": {
+            "__typename": "[type-name-here]",
+            "savedItems": {
+                "__typename": "[type-name-here]",
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "hasNextPage": false,
+                    "endCursor": "cursor-3"
+                },
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "saved-item-1",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": false,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "item-1",
+                                "title": "Item 1",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "topImageUrl": "https://example.com/item-1/top-image.jpg",
+                                "domain": null,
+                                "language": "en",
+                                "timeToRead": 6,
+                                "marticle": #MARTICLE#,
+                                "excerpt": "Cursus Aenean Elit",
+                                "datePublished": "2021-01-01 12:01:01",
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "author-1",
+                                        "name": "Jacob",
+                                        "url": "https://example.com/authors/jacob"
+                                    },
+                                    {
+                                        "__typename": "Author",
+                                        "id": "author-2",
+                                        "name": "David",
+                                        "url": "https://example.com/authors/david"
+                                    }
+                                ],
+                                "domainMetadata": {
+                                    "__typename": "[type-name-here]",
+                                    "name": "WIRED",
+                                    "logo": "http://example.com/item-1/domain-logo.jpg"
+                                },
+                                "images": [
+                                    {
+                                        "__typename": "[type-name-here]",
+                                        "height": 1,
+                                        "width": 2,
+                                        "src": "http://example.com/item-1/image-1.jpg",
+                                        "imageId": 1
+                                    }
+                                ],
+                                "isArticle": true,
+                                "hasImage": "IS_IMAGE",
+                                "hasVideo": "",
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "saved-item-2",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": false,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "item-2",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Item 2",
+                                "topImageUrl": "https://example.com/item-2/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "excerpt": "Cursus Aenean Elit",
+                                "images": [
+                                    {
+                                        "__typename": "[type-name-here]",
+                                        "height": 1,
+                                        "width": 2,
+                                        "src": "http://example.com/item-2/image-1.jpg",
+                                        "imageId": 1
+                                    }
+                                ],
+                                "isArticle": true,
+                                "hasImage": "",
+                                "hasVideo": "IS_VIDEO",
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-3",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "remoteID": "saved-item-3",
+                            "url": "http://localhost:8080/hello",
+                            "_createdAt": 0,
+                            "_deletedAt": null,
+                            "isArchived": false,
+                            "isFavorite": false,
+                            "item": {
+                                "__typename": "Item",
+                                "remoteID": "item-2",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Item 3",
+                                "topImageUrl": "https://example.com/item-3/top-image.jpg",
+                                "domain": "wired.com",
+                                "language": "en",
+                                "timeToRead": 6,
+                                "domainMetadata": null,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "excerpt": "Cursus Aenean Elit",
+                                "images": [
+                                    {
+                                        "__typename": "[type-name-here]",
+                                        "height": 1,
+                                        "width": 2,
+                                        "src": "http://example.com/item-2/image-1.jpg",
+                                        "imageId": 1
+                                    }
+                                ],
+                                "isArticle": false,
+                                "hasImage": "",
+                                "hasVideo": "",
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Tests iOS/Fixtures/list-with-archived-item.json
+++ b/Tests iOS/Fixtures/list-with-archived-item.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -88,7 +90,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -127,7 +131,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/list-with-archived-item.json
+++ b/Tests iOS/Fixtures/list-with-archived-item.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -86,7 +87,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -124,7 +126,8 @@
                                         "src": "http://example.com/item-3/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/list-with-unarchived-item.json
+++ b/Tests iOS/Fixtures/list-with-unarchived-item.json
@@ -44,7 +44,9 @@
                                 ],
                                 "domainMetadata": null,
                                 "images": [],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/list-with-unarchived-item.json
+++ b/Tests iOS/Fixtures/list-with-unarchived-item.json
@@ -43,7 +43,8 @@
                                     }
                                 ],
                                 "domainMetadata": null,
-                                "images": []
+                                "images": [],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/save-item.json
+++ b/Tests iOS/Fixtures/save-item.json
@@ -36,7 +36,9 @@
                         "imageId": 1
                     }
                 ],
-                "isArticle": true
+                "isArticle": true,
+                "hasImage": "HAS_IMAGES",
+                "hasVideo": "HAS_VIDEOS",
             }
         }
     }

--- a/Tests iOS/Fixtures/save-item.json
+++ b/Tests iOS/Fixtures/save-item.json
@@ -35,7 +35,8 @@
                         "src": "http://example.com/item-1/image-1.jpg",
                         "imageId": 1
                     }
-                ]
+                ],
+                "isArticle": true
             }
         }
     }

--- a/Tests iOS/Fixtures/slate-detail-web-view.json
+++ b/Tests iOS/Fixtures/slate-detail-web-view.json
@@ -1,0 +1,111 @@
+{
+    "data": {
+        "getSlate": {
+            "__typename": "[some-type-name]",
+            "id": "slate-1",
+            "requestId": "slate-1-request",
+            "experimentId": "slate-1-experiment",
+            "displayName": "Slate 1",
+            "description": "The description of slate 1",
+            "recommendations": [
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-1-rec-1",
+                    "item": {
+                        "__typename": "[some-type-name]",
+                        "remoteID": "recommended-item-1",
+                        "givenUrl": "http://localhost:8080/hello",
+                        "resolvedUrl": "http://localhost:8080/hello",
+                        "title": "Slate 1, Recommendation 1",
+                        "language": "en",
+                        "topImageUrl": "http://example.com/slate-1-rec-1/top-image.png",
+                        "timeToRead": 1,
+                        "marticle": [],
+                        "authors": [
+                            {
+                                "__typename": "Author",
+                                "id": "author-1",
+                                "name": "Jacob",
+                                "url": "http://example.com/authors/author-1"
+                            },
+                            {
+                                "__typename": "Author",
+                                "id": "author-2",
+                                "name": "David",
+                                "url": "http://example.com/authors/author-2"
+                            }
+                        ],
+                        "datePublished": "2021-01-01 12:01:01",
+                        "images": [],
+                        "excerpt": "Cursus Aenean Elit",
+                        "domain": "slate-1-rec-1.example.com",
+                        "domainMetadata": {
+                            "__typename": "[some-type-name]",
+                            "name": "Lifehacker",
+                            "logo": "https://slate-1-rec-1.example.com/logo.png"
+                        },
+                        "isArticle": true,
+                        "hasImage": "IS_IMAGE",
+                        "hasVideo": "",
+                    }
+                },
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-1-rec-2",
+                    "item": {
+                        "__typename": "[some-type-name]",
+                        "remoteID": "recommended-item-2",
+                        "givenUrl": "http://localhost:8080/hello",
+                        "resolvedUrl": "http://localhost:8080/hello",
+                        "title": "Slate 1, Recommendation 2",
+                        "language": "en",
+                        "topImageUrl": "http://example.com/slate-1-rec-2/top-image.png",
+                        "timeToRead": 2,
+                        "marticle": [],
+                        "authors": [],
+                        "datePublished": "2021-01-01 12:01:01",
+                        "images": [],
+                        "excerpt": "Cursus Aenean Elit",
+                        "domain": "slate-1-rec-2.example.com",
+                        "domainMetadata": {
+                            "__typename": "[some-type-name]",
+                            "name": "Lifehacker",
+                            "logo": "https://slate-1-rec-2.example.com/logo.png"
+                        },
+                        "isArticle": true,
+                        "hasImage": "",
+                        "hasVideo": "IS_VIDEO",
+                    }
+                },
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-1-rec-3",
+                    "item": {
+                        "__typename": "[some-type-name]",
+                        "remoteID": "recommended-item-3",
+                        "givenUrl": "http://localhost:8080/hello",
+                        "resolvedUrl": "http://localhost:8080/hello",
+                        "title": "Slate 1, Recommendation 3",
+                        "language": "en",
+                        "topImageUrl": "http://example.com/slate-1-rec-3/top-image.png",
+                        "timeToRead": 3,
+                        "marticle": [],
+                        "authors": [],
+                        "datePublished": "2021-01-01 12:01:01",
+                        "images": [],
+                        "excerpt": "Cursus Aenean Elit",
+                        "domain": "slate-1-rec-3.example.com",
+                        "domainMetadata": {
+                            "__typename": "[some-type-name]",
+                            "name": "Lifehacker",
+                            "logo": "https://slate-1-rec-3.example.com/logo.png"
+                        },
+                        "isArticle": false,
+                        "hasImage": "",
+                        "hasVideo": "",
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Tests iOS/Fixtures/slate-detail.json
+++ b/Tests iOS/Fixtures/slate-detail.json
@@ -43,7 +43,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-1.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 },
                 {
@@ -68,7 +69,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-2.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 },
                 {
@@ -93,7 +95,8 @@
                             "__typename": "[some-type-name]",
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-3.example.com/logo.png"
-                        }
+                        },
+                        "isArticle": true
                     }
                 }
             ]

--- a/Tests iOS/Fixtures/slate-detail.json
+++ b/Tests iOS/Fixtures/slate-detail.json
@@ -44,7 +44,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-1.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 },
                 {
@@ -70,7 +72,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-2.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 },
                 {
@@ -96,7 +100,9 @@
                             "name": "Lifehacker",
                             "logo": "https://slate-1-rec-3.example.com/logo.png"
                         },
-                        "isArticle": true
+                        "isArticle": true,
+                        "hasImage": "HAS_IMAGES",
+                        "hasVideo": "HAS_VIDEOS",
                     }
                 }
             ]

--- a/Tests iOS/Fixtures/slates-web-view.json
+++ b/Tests iOS/Fixtures/slates-web-view.json
@@ -1,0 +1,119 @@
+{
+    "data": {
+        "getSlateLineup": {
+            "id": "slate-lineup-1",
+            "requestId": "slate-lineup-1-request",
+            "experimentId": "slate-lineup-1-experiment",
+            "__typename": "[some-type-name]",
+            "slates": [
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-1",
+                    "requestId": "slate-1-request",
+                    "experimentId": "slate-1-experiment",
+                    "displayName": "Slate 1",
+                    "description": "The description of slate 1",
+                    "recommendations": [
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-1-rec-1",
+                            "item": {
+                                "__typename": "[some-type-name]",
+                                "remoteID": "recommended-item-1",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Slate 1, Recommendation 1",
+                                "language": "en",
+                                "topImageUrl": "http://example.com/slate-1-rec-1/top-image.png",
+                                "timeToRead": 1,
+                                "marticle": [],
+                                "authors": [
+                                    {
+                                        "__typename": "Author",
+                                        "id": "author-1",
+                                        "name": "Jacob",
+                                        "url": "http://example.com/authors/author-1"
+                                    },
+                                    {
+                                        "__typename": "Author",
+                                        "id": "author-2",
+                                        "name": "David",
+                                        "url": "http://example.com/authors/author-2"
+                                    }
+                                ],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "images": [],
+                                "excerpt": "Cursus Aenean Elit",
+                                "domain": "slate-1-rec-1.example.com",
+                                "domainMetadata": {
+                                    "__typename": "[some-type-name]",
+                                    "name": "Lifehacker",
+                                    "logo": "https://slate-1-rec-1.example.com/logo.png"
+                                },
+                                "isArticle": true,
+                                "hasImage": "IS_IMAGE",
+                                "hasVideo": "",
+                            }
+                        },
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-1-rec-2",
+                            "item": {
+                                "__typename": "[some-type-name]",
+                                "remoteID": "recommended-item-2",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Slate 1, Recommendation 2",
+                                "language": "en",
+                                "topImageUrl": "http://example.com/slate-1-rec-2/top-image.png",
+                                "timeToRead": 2,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "images": [],
+                                "excerpt": "Cursus Aenean Elit",
+                                "domain": "slate-1-rec-2.example.com",
+                                "domainMetadata": {
+                                    "__typename": "[some-type-name]",
+                                    "name": "Lifehacker",
+                                    "logo": "https://slate-1-rec-2.example.com/logo.png"
+                                },
+                                "isArticle": true,
+                                "hasImage": "",
+                                "hasVideo": "IS_VIDEO",
+                            }
+                        },
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-1-rec-3",
+                            "item": {
+                                "__typename": "[some-type-name]",
+                                "remoteID": "recommended-item-3",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "title": "Slate 1, Recommendation 3",
+                                "language": "en",
+                                "topImageUrl": "http://example.com/slate-1-rec-3/top-image.png",
+                                "timeToRead": 2,
+                                "marticle": [],
+                                "authors": [],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "images": [],
+                                "excerpt": "Cursus Aenean Elit",
+                                "domain": "slate-1-rec-3.example.com",
+                                "domainMetadata": {
+                                    "__typename": "[some-type-name]",
+                                    "name": "Lifehacker",
+                                    "logo": "https://slate-1-rec-3.example.com/logo.png"
+                                },
+                                "isArticle": false,
+                                "hasImage": "",
+                                "hasVideo": "",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Tests iOS/Fixtures/slates.json
+++ b/Tests iOS/Fixtures/slates.json
@@ -49,7 +49,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         },
                         {
@@ -74,7 +75,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],
@@ -109,7 +111,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         },
                         {
@@ -134,7 +137,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-2.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],

--- a/Tests iOS/Fixtures/slates.json
+++ b/Tests iOS/Fixtures/slates.json
@@ -50,7 +50,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         },
                         {
@@ -76,7 +78,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],
@@ -112,7 +116,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         },
                         {
@@ -138,7 +144,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-2.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],

--- a/Tests iOS/Fixtures/updated-list.json
+++ b/Tests iOS/Fixtures/updated-list.json
@@ -49,7 +49,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     },
@@ -92,7 +94,9 @@
                                         "imageId": 1
                                     }
                                 ],
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/updated-list.json
+++ b/Tests iOS/Fixtures/updated-list.json
@@ -48,7 +48,8 @@
                                         "src": "http://example.com/item-1/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     },
@@ -90,7 +91,8 @@
                                         "src": "http://example.com/item-2/image-1.jpg",
                                         "imageId": 1
                                     }
-                                ]
+                                ],
+                                "isArticle": true
                             }
                         }
                     }

--- a/Tests iOS/Fixtures/updated-slates.json
+++ b/Tests iOS/Fixtures/updated-slates.json
@@ -37,7 +37,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         },
                         {
@@ -63,7 +65,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],
@@ -99,7 +103,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         },
                         {
@@ -125,7 +131,9 @@
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-2.example.com/logo.png"
                                 },
-                                "isArticle": true
+                                "isArticle": true,
+                                "hasImage": "HAS_IMAGES",
+                                "hasVideo": "HAS_VIDEOS",
                             }
                         }
                     ],

--- a/Tests iOS/Fixtures/updated-slates.json
+++ b/Tests iOS/Fixtures/updated-slates.json
@@ -36,7 +36,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         },
                         {
@@ -61,7 +62,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-1-rec-2.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],
@@ -96,7 +98,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-1.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         },
                         {
@@ -121,7 +124,8 @@
                                     "__typename": "[some-type-name]",
                                     "name": "Lifehacker",
                                     "logo": "https://slate-2-rec-2.example.com/logo.png"
-                                }
+                                },
+                                "isArticle": true
                             }
                         }
                     ],

--- a/Tests iOS/HomeWebViewTests.swift
+++ b/Tests iOS/HomeWebViewTests.swift
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sails
+import NIO
+
+
+class HomeWebViewTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let uiApp = XCUIApplication()
+        app = PocketAppElement(app: uiApp)
+
+        server = Application()
+
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup("slates-web-view")
+            } else if apiRequest.isForSlateDetail {
+                return Response.slateLineup("slate-detail-web-view")
+            } else if apiRequest.isForMyListContent {
+                return Response.myList()
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else if apiRequest.isToSaveAnItem {
+                return Response.saveItem()
+            } else if apiRequest.isToArchiveAnItem {
+                return Response.archive()
+            } else {
+                fatalError("Unexpected request")
+            }
+        }
+
+        server.routes.get("/hello") { _, _ in
+            Response {
+                Status.ok
+                Fixture.data(name: "hello", ext: "html")
+            }
+        }
+
+        try server.start()
+
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    func test_home_showsWebViewWhenItemIsImage() {
+        test_home_showsWebView(from: "Slate 1, Recommendation 1")
+    }
+
+    func test_home_showsWebViewWhenItemIsVideo() {
+        test_home_showsWebView(from: "Slate 1, Recommendation 2")
+    }
+
+    func test_home_showsWebViewWhenItemIsNotAnArticle() {
+        test_home_showsWebView(from: "Slate 1, Recommendation 3")
+    }
+
+    func test_home_showsWebView(from name: String) {
+        app.homeView.slateHeader("Slate 1").wait()
+        app.homeView.recommendationCell(name).wait().tap()
+
+        app
+            .webReaderView
+            .staticText(matching: "Hello, world")
+            .wait()
+    }
+}
+
+// MARK: - Slate Detail
+extension HomeWebViewTests {
+    func test_slateDetail_showsWebViewWhenItemIsImage() {
+        test_slateDetail_showsWebView(from: "Slate 1, Recommendation 1")
+    }
+
+    func test_slateDetail_showsWebViewWhenItemIsVideo() {
+        test_slateDetail_showsWebView(from: "Slate 1, Recommendation 2")
+    }
+
+    func test_slateDetail_showsWebViewWhenItemIsNotAnArticle() {
+        test_slateDetail_showsWebView(from: "Slate 1, Recommendation 3")
+    }
+
+    func test_slateDetail_showsWebView(from name: String) {
+        app.homeView.topicChip("Slate 1").wait().tap()
+        app.slateDetailView.recommendationCell(name).wait().tap()
+
+        app
+            .webReaderView
+            .staticText(matching: "Hello, world")
+            .wait()
+    }
+}

--- a/Tests iOS/MyList/MyListTests.swift
+++ b/Tests iOS/MyList/MyListTests.swift
@@ -223,4 +223,51 @@ class MyListTests: XCTestCase {
         XCTAssertEqual(listView.itemCount, 1)
         XCTAssertTrue(listView.itemView(at: 0).contains(string: "Item 2"))
     }
+
+
+}
+
+// MARK: - Web View
+
+extension MyListTests {
+    func test_list_showsWebViewWhenItemIsImage() {
+        test_list_showsWebView(at: 0)
+    }
+
+    func test_list_showsWebViewWhenItemIsVideo() {
+        test_list_showsWebView(at: 1)
+    }
+
+    func test_list_showsWebViewWhenItemIsNotAnArticle() {
+        test_list_showsWebView(at: 2)
+    }
+
+    func test_list_showsWebView(at index: Int) {
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList("list-for-web-view")
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else {
+                fatalError("Unexpected request")
+            }
+        }
+
+        app.launch().tabBar.myListButton.wait().tap()
+
+        app
+            .myListView
+            .itemView(at: index)
+            .wait()
+            .tap()
+
+        app
+            .webReaderView
+            .staticText(matching: "Hello, world")
+            .wait()
+    }
 }


### PR DESCRIPTION
TL;DR - If an article is an article (that may or may not contain images or videos), then present it in the reader. For all other cases, present the web view.

## Cases

1. `isArticle` == false (source of truth: parser), then present the web view upon selection
2. `hasImage` == `IS_IMAGE`, then present the web view upon selection
3. `hasVideo` == `IS_VIDEO`, then present the web view upon selection
4. Present the reader as normal

### Rationale 
The rationale behind points 1 and 2 above is that the "standard" web view will present more options than we currently do. For example, a YouTube video will present the entire YouTube page, which provides more valuable information than just the video itself (especially since we do not provide an offline option for the video). Another example is an image - web views handle image interaction (tap & hold, drag gestures) more than we currently do now as well.

## Additions

### `Item`

+ `isArticle` (Core Data)
+ `imageness` (Core Data)
+ `videoness` (Core Data)
+ `hasImage` (to match the backend property; computed based on `imageness`)
+ `hasVideo` (to match the backend property; computed based on `videoness`)

### `UnmanagedItem`

+ `isArticle` (in-memory)
+ `imageness` (in-memory)
+ `videoness` (in-memory)
+ `hasImage` (to match the backend property; computed based on `imageness`)
+ `hasVideo` (to match the backend property; computed based on `videoness`)


### `ItemParts` (`list.graphql`)
+ `isArticle`
+ `hasImage`
+ `hasVideo`

### UI Tests

UI tests were added across the UI test suite to verify that under three conditions (1-3 above), the web view is presented on tap.