### PR TITLE
Save extension service

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */; };
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
+		F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */; };
 		F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */; };
 		F2687E7327E28F0F00E43F09 /* SaveToPocketKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2687E7227E28F0F00E43F09 /* SaveToPocketKit */; };
 		F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */; };
@@ -154,6 +155,7 @@
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
 		F227F0C3265E96290031F985 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/System/Library/Frameworks/CoreText.framework; sourceTree = DEVELOPER_DIR; };
+		F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveToPocket.swift; sourceTree = "<group>"; };
 		F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeWebViewTests.swift; sourceTree = "<group>"; };
 		F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportARecommendationTests.swift; sourceTree = "<group>"; };
 		F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewElement.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 		F204A76127E22EC50010E155 /* SaveToPocket */ = {
 			isa = PBXGroup;
 			children = (
+				F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */,
 				166DF27927E9173500C03BF4 /* SaveToPocket.entitlements */,
 				F204A76727E22EC50010E155 /* Info.plist */,
 			);
@@ -400,6 +403,7 @@
 					};
 					F204A75F27E22EC50010E155 = {
 						CreatedOnToolsVersion = 13.3;
+						LastSwiftMigration = 1330;
 					};
 				};
 			};
@@ -534,6 +538,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -669,6 +674,7 @@
 		166A81DB2637406C0015AA1D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -696,6 +702,7 @@
 		166A81DC2637406C0015AA1D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -779,6 +786,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Mozilla Release Engineering (2FA397B66F)";
 				CODE_SIGN_STYLE = Manual;
@@ -801,6 +809,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -810,6 +819,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Mozilla Corporation (43AQ936H96)";
 				CODE_SIGN_STYLE = Manual;

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -39,11 +39,12 @@ let package = Package(
 
         .target(
             name: "SaveToPocketKit",
-            dependencies: ["SharedPocketKit", "Textile"]
+            dependencies: ["SharedPocketKit", "Textile", "Sync"]
         ),
         .testTarget(
             name: "SaveToPocketKitTests",
-            dependencies: ["SaveToPocketKit"]
+            dependencies: ["SaveToPocketKit"],
+            resources: [.copy("Fixtures")]
         ),
 
         .target(

--- a/PocketKit/Sources/SaveToPocketKit/AppSession+Sync.swift
+++ b/PocketKit/Sources/SaveToPocketKit/AppSession+Sync.swift
@@ -1,0 +1,11 @@
+import SharedPocketKit
+import Sync
+
+
+extension AppSession: SessionProvider {
+    public var session: Sync.Session? {
+        currentSession
+    }
+}
+
+extension SharedPocketKit.Session: Sync.Session { }

--- a/PocketKit/Sources/SaveToPocketKit/ExpiringActivityPerformer.swift
+++ b/PocketKit/Sources/SaveToPocketKit/ExpiringActivityPerformer.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+
+protocol ExpiringActivityPerformer {
+    func performExpiringActivity(withReason reason: String, using block: @escaping (Bool) -> Void)
+}
+
+extension ProcessInfo: ExpiringActivityPerformer { }

--- a/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
+++ b/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+
+protocol ExtensionContext {
+    var extensionItems: [ExtensionItem] { get }
+}
+extension NSExtensionContext: ExtensionContext {
+    var extensionItems: [ExtensionItem] {
+        inputItems.compactMap { $0 as? ExtensionItem }
+    }
+}
+
+protocol ExtensionItem {
+    var itemProviders: [ItemProvider]? { get }
+}
+extension NSExtensionItem: ExtensionItem {
+    var itemProviders: [ItemProvider]? {
+        attachments?.compactMap { $0 as ItemProvider }
+    }
+}
+
+protocol ItemProvider {
+    func hasItemConformingToTypeIdentifier(_ typeIdentifier: String) -> Bool
+
+    func loadItem(
+        forTypeIdentifier typeIdentifier: String,
+        options: [AnyHashable : Any]?
+    ) async throws -> NSSecureCoding
+}
+extension NSItemProvider: ItemProvider { }

--- a/PocketKit/Sources/SaveToPocketKit/Keys.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Keys.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+
+struct Keys {
+    static let shared = Keys()
+
+    let pocketApiConsumerKey: String
+
+    private init() {
+        guard let info = Bundle.main.infoDictionary else {
+            fatalError("Unable to load info dictionary for main bundle")
+        }
+
+        guard let pocketApiConsumerKey = info["PocketAPIConsumerKey"] as? String else {
+            fatalError("Unable to extract PocketApiConsumerKey from main bundle")
+        }
+
+        self.pocketApiConsumerKey = pocketApiConsumerKey
+    }
+}
+

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -9,8 +9,14 @@ class MainViewController: UIViewController {
 
     private let dismissLabel = UILabel()
 
+    private let viewModel: MainViewModel
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         Textiles.initialize()
+
+        let saveService = PocketSaveService()
+        self.viewModel = MainViewModel(saveService: saveService)
+
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -24,7 +24,8 @@ class MainViewController: UIViewController {
                         sessionProvider: AppSession(),
                         consumerKey: Keys.shared.pocketApiConsumerKey
                     ),
-                    backgroundActivityPerformer: ProcessInfo.processInfo
+                    backgroundActivityPerformer: ProcessInfo.processInfo,
+                    space: Space(container: .init(storage: .shared))
                 )
             )
         )

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -101,7 +101,7 @@ private class MainCapsuleView: UIView {
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [imageView, textLabel])
-        stackView.spacing = 28
+        stackView.spacing = 12
         stackView.axis = .horizontal
         return stackView
     }()
@@ -118,6 +118,9 @@ private class MainCapsuleView: UIView {
 
         addSubview(stackView)
 
+        imageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        imageView.setContentCompressionResistancePriority(.required, for: .vertical)
+        textLabel.adjustsFontSizeToFitWidth = true
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 5),

--- a/PocketKit/Sources/SaveToPocketKit/MainViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+
+class MainViewModel {
+    private let saveService: SaveService
+
+    init(saveService: SaveService) {
+        self.saveService = saveService
+    }
+
+    func save(from context: ExtensionContext?) async {
+        guard let context = context, !context.extensionItems.isEmpty else {
+            return
+        }
+
+
+        for item in context.extensionItems {
+            let urlUTI = "public.url"
+            guard let url = try? await item.itemProviders?
+                .first(where: { $0.hasItemConformingToTypeIdentifier(urlUTI) })?
+                .loadItem(forTypeIdentifier: urlUTI, options: nil) as? URL else {
+                // TODO: Throw an error?
+                break
+            }
+
+            await saveService.save(url: url)
+            break
+        }
+
+        return
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/MainViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewModel.swift
@@ -23,7 +23,7 @@ class MainViewModel {
                 break
             }
 
-            await saveService.save(url: url)
+            saveService.save(url: url)
             break
         }
 

--- a/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
@@ -6,20 +6,89 @@ import Sync
 class PocketSaveService: SaveService {
     private let apollo: ApolloClientProtocol
     private let backgroundActivityPerformer: ExpiringActivityPerformer
+    private let queue: OperationQueue
+    private let space: Space
 
-    init(apollo: ApolloClientProtocol, backgroundActivityPerformer: ExpiringActivityPerformer) {
+    init(
+        apollo: ApolloClientProtocol,
+        backgroundActivityPerformer: ExpiringActivityPerformer,
+        space: Space
+    ) {
         self.apollo = apollo
         self.backgroundActivityPerformer = backgroundActivityPerformer
+        self.space = space
+
+        self.queue = OperationQueue()
     }
 
     func save(url: URL) {
-        backgroundActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.save") { expiring in
-            if !expiring {
-                let mutation = SaveItemMutation(input: SavedItemUpsertInput(url: url.absoluteString))
-                Task {
-                    _ = try? await self.apollo.perform(mutation: mutation)
-                }
-            }
+        backgroundActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.save") { [weak self] expiring in
+            self?._save(expiring: expiring, url: url)
         }
+    }
+
+    private func _save(expiring: Bool, url: URL) {
+        guard !expiring else {
+            queue.cancelAllOperations()
+            queue.waitUntilAllOperationsAreFinished()
+            return
+        }
+
+        queue.addOperation(SaveOperation(apollo: apollo, space: space, url: url))
+        queue.waitUntilAllOperationsAreFinished()
+    }
+}
+
+class SaveOperation: AsyncOperation {
+    private let apollo: ApolloClientProtocol
+    private let space: Space
+    private let url: URL
+
+    private var task: Cancellable?
+    private var savedItem: SavedItem?
+
+    init(apollo: ApolloClientProtocol, space: Space, url: URL) {
+        self.apollo = apollo
+        self.space = space
+        self.url = url
+    }
+
+    override func start() {
+        guard !isCancelled else { return }
+
+        storeLocalSkeletonItem()
+        performMutation()
+    }
+
+    override func cancel() {
+        task?.cancel()
+        finishOperation()
+
+        super.cancel()
+    }
+
+    private func storeLocalSkeletonItem() {
+        savedItem = space.new()
+        savedItem?.url = url
+        try? space.save()
+    }
+
+    private func performMutation() {
+        let mutation = SaveItemMutation(input: SavedItemUpsertInput(url: url.absoluteString))
+        task = apollo.perform(mutation: mutation, publishResultToStore: false, queue: .main) { [weak self] result in
+            self?.handle(result: result)
+        }
+    }
+
+    private func handle(result: Result<GraphQLResult<SaveItemMutation.Data>, Error>) {
+        guard case .success(let graphQLResult) = result,
+              let savedItemParts = graphQLResult.data?.upsertSavedItem.fragments.savedItemParts else {
+            finishOperation()
+            return
+        }
+
+        savedItem?.update(from: savedItemParts)
+        try? space.save()
+        finishOperation()
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+
+class PocketSaveService: SaveService {
+    func save(url: URL) async {
+        
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/PocketSaveService.swift
@@ -1,8 +1,25 @@
 import Foundation
+import Apollo
+import Sync
 
 
 class PocketSaveService: SaveService {
-    func save(url: URL) async {
-        
+    private let apollo: ApolloClientProtocol
+    private let backgroundActivityPerformer: ExpiringActivityPerformer
+
+    init(apollo: ApolloClientProtocol, backgroundActivityPerformer: ExpiringActivityPerformer) {
+        self.apollo = apollo
+        self.backgroundActivityPerformer = backgroundActivityPerformer
+    }
+
+    func save(url: URL) {
+        backgroundActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.save") { expiring in
+            if !expiring {
+                let mutation = SaveItemMutation(input: SavedItemUpsertInput(url: url.absoluteString))
+                Task {
+                    _ = try? await self.apollo.perform(mutation: mutation)
+                }
+            }
+        }
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/SaveService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveService.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol SaveService {
+    func save(url: URL) async
+}

--- a/PocketKit/Sources/SaveToPocketKit/SaveService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveService.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 protocol SaveService {
-    func save(url: URL) async
+    func save(url: URL)
 }

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -5,7 +5,7 @@
 import Apollo
 
 
-extension ApolloClientProtocol {
+public extension ApolloClientProtocol {
     func fetch<Query: GraphQLQuery>(query: Query, resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
         return fetch(
             query: query,

--- a/PocketKit/Sources/Sync/Bundle+sync.swift
+++ b/PocketKit/Sources/Sync/Bundle+sync.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension Bundle {
-    static var sync: Bundle {
-        return .module
-    }
-}

--- a/PocketKit/Sources/Sync/NSPersistentContainer+Extensions.swift
+++ b/PocketKit/Sources/Sync/NSPersistentContainer+Extensions.swift
@@ -5,8 +5,8 @@
 import CoreData
 
 
-class PersistentContainer: NSPersistentContainer {
-    enum Storage {
+public class PersistentContainer: NSPersistentContainer {
+    public enum Storage {
         case inMemory
         case shared
     }

--- a/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 
-class AsyncOperation: Operation {
-    override var isAsynchronous: Bool {
+open class AsyncOperation: Operation {
+    override public var isAsynchronous: Bool {
         true
     }
 
     private var _isFinished = false
-    override var isFinished: Bool {
+    override public var isFinished: Bool {
         get {
             return _isFinished
         }
@@ -23,7 +23,7 @@ class AsyncOperation: Operation {
     }
 
     private var _isExecuting = false
-    override var isExecuting: Bool {
+    override public  var isExecuting: Bool {
         get {
             return _isExecuting
         }
@@ -38,7 +38,7 @@ class AsyncOperation: Operation {
         }
     }
 
-    func finishOperation() {
+    public func finishOperation() {
         isExecuting = false
         isFinished = true
     }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -44,7 +44,7 @@ public class PocketSource: Source {
         )
 
         self.init(
-            space: Space(container: .createDefault()),
+            space: Space(container: .init()),
             apollo: apollo,
             operations: OperationFactory(),
             lastRefresh: UserDefaultsLastRefresh(defaults: defaults),

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -8,7 +8,7 @@ import CoreData
 
 extension SavedItem {
     typealias SavedItemEdge = UserByTokenQuery.Data.UserByToken.SavedItem.Edge
-    typealias RemoteSavedItem = SavedItemParts
+    public typealias RemoteSavedItem = SavedItemParts
     typealias RemoteItem = ItemParts
 
     func update(from edge: SavedItemEdge) {
@@ -21,7 +21,7 @@ extension SavedItem {
         update(from: savedItemParts)
     }
 
-    func update(from remote: RemoteSavedItem) {
+    public func update(from remote: RemoteSavedItem) {
         remoteID = remote.remoteId
         url = URL(string: remote.url)
         createdAt = Date(timeIntervalSince1970: TimeInterval(remote._createdAt))

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -45,6 +45,13 @@ public enum Requests {
         return request
     }
 
+    public static func fetchSavedItem(byURL url: URL) -> NSFetchRequest<SavedItem> {
+        let request = SavedItem.fetchRequest()
+        request.predicate = NSPredicate(format: "url.absoluteString = %@", url.absoluteString)
+        request.fetchLimit = 1
+        return request
+    }
+
     public static func fetchPersistentSyncTasks() -> NSFetchRequest<PersistentSyncTask> {
         let request = PersistentSyncTask.fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(keyPath: \PersistentSyncTask.createdAt, ascending: true)]

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -5,13 +5,13 @@
 import CoreData
 
 class Space {
-    private let container: NSPersistentContainer
+    private let container: PersistentContainer
 
     var context: NSManagedObjectContext {
         container.viewContext
     }
     
-    required init(container: NSPersistentContainer) {
+    required init(container: PersistentContainer) {
         self.container = container
     }
 

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -4,14 +4,14 @@
 
 import CoreData
 
-class Space {
+public class Space {
     private let container: PersistentContainer
 
     var context: NSManagedObjectContext {
         container.viewContext
     }
     
-    required init(container: PersistentContainer) {
+    public required init(container: PersistentContainer) {
         self.container = container
     }
 
@@ -26,6 +26,11 @@ class Space {
 
     func fetchSavedItem(byRemoteItemID remoteItemID: String) throws -> SavedItem? {
         let request = Requests.fetchSavedItem(byRemoteItemID: remoteItemID)
+        return try context.fetch(request).first
+    }
+
+    func fetchSavedItem(byURL url: URL) throws -> SavedItem? {
+        let request = Requests.fetchSavedItem(byURL: url)
         return try context.fetch(request).first
     }
 
@@ -52,7 +57,7 @@ class Space {
         return try context.fetch(Requests.fetchPersistentSyncTasks())
     }
 
-    func new<T: NSManagedObject>() -> T {
+    public func new<T: NSManagedObject>() -> T {
         return T(context: context)
     }
 
@@ -60,7 +65,7 @@ class Space {
         context.delete(object)
     }
 
-    func save() throws {
+    public func save() throws {
         try context.obtainPermanentIDs(for: Array(context.insertedObjects))
         try context.save()
     }

--- a/PocketKit/Tests/PocketKitTests/Support/NSPersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/NSPersistentContainer+testContainer.swift
@@ -2,23 +2,6 @@ import CoreData
 
 @testable import Sync
 
-extension NSPersistentContainer {
-    static let testContainer: NSPersistentContainer = {
-        ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
-        ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
-
-        let url = Bundle.sync.url(forResource: "PocketModel", withExtension: "momd")!
-        let model = NSManagedObjectModel(contentsOf: url)!
-        let container = NSPersistentContainer(name: "PocketModel", managedObjectModel: model)
-        let description = NSPersistentStoreDescription(url: URL(fileURLWithPath: "/dev/null"))
-        container.persistentStoreDescriptions = [description]
-
-        container.loadPersistentStores { storeDescription, error in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        }
-
-        return container
-    }()
+extension PersistentContainer {
+    static let testContainer = PersistentContainer(storage: .inMemory)
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Fixtures/save-item.json
+++ b/PocketKit/Tests/SaveToPocketKitTests/Fixtures/save-item.json
@@ -1,0 +1,45 @@
+{
+    "data": {
+        "upsertSavedItem": {
+            "__typename": "[type-name-here]",
+            "remoteID": "saved-item-1",
+            "url": "https://example.com/item-1",
+            "_createdAt": 0,
+            "_deletedAt": null,
+            "isArchived": false,
+            "isFavorite": false,
+            "item": {
+                "__typename": "Item",
+                "remoteID": "item-1",
+                "givenUrl": "https://given.example.com/item-1",
+                "resolvedUrl": "https://resolved.example.com/item-1",
+                "title": "Item 1",
+                "topImageUrl": "https://example.com/item-1/top-image.jpg",
+                "domain": null,
+                "language": "en",
+                "timeToRead": 6,
+                "marticle": [],
+                "excerpt": "Cursus Aenean Elit",
+                "datePublished": "2021-01-01 12:01:01",
+                "authors": [],
+                "domainMetadata": {
+                    "__typename": "[type-name-here]",
+                    "name": "WIRED",
+                    "logo": "http://example.com/item-1/domain-logo.jpg"
+                },
+                "images": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "height": 1,
+                        "width": 2,
+                        "src": "http://example.com/item-1/image-1.jpg",
+                        "imageId": 1
+                    }
+                ],
+                "isArticle": true,
+                "hasImage": "HAS_IMAGES",
+                "hasVideo": "HAS_VIDEOS",
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/MainViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/MainViewModelTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SaveToPocketKit
+
+
+class MainViewModelTests: XCTestCase {
+    private var saveService: MockSaveService!
+
+    private func subject(saveService: SaveService? = nil) -> MainViewModel {
+        MainViewModel(saveService: saveService ?? self.saveService)
+    }
+
+    override func setUp() {
+        saveService = MockSaveService()
+        saveService.stubSave { _ in }
+    }
+
+    func test_save_sendsCorrectURLToService() async {
+        let provider = MockItemProvider()
+
+        provider.stubHasItemConformingToTypeIdentifier { _ in
+            return true
+        }
+
+        provider.stubLoadItem { _, _ in
+            URL(string: "https://getpocket.com")! as NSSecureCoding
+        }
+
+        let extensionItem = MockExtensionItem(itemProviders: [provider])
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+
+        let viewModel = subject()
+        await viewModel.save(from: context)
+        XCTAssertEqual(saveService.saveCall(at: 0)?.url, URL(string: "https://getpocket.com")!)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/PocketSaveServiceTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Apollo
+import Sync
+@testable import SaveToPocketKit
+
+
+class PocketSaveServiceTests: XCTestCase {
+    private var client: MockApolloClient!
+    private var backgroundActivityPerformer: MockExpiringActivityPerformer!
+
+    func subject(
+        client: ApolloClientProtocol? = nil,
+        backgroundActivityPerformer: ExpiringActivityPerformer? = nil
+    ) -> PocketSaveService {
+        PocketSaveService(
+            apollo: client ?? self.client,
+            backgroundActivityPerformer: backgroundActivityPerformer ?? self.backgroundActivityPerformer
+        )
+    }
+
+    override func setUp() async throws {
+        backgroundActivityPerformer = MockExpiringActivityPerformer()
+
+        client = MockApolloClient()
+        client.stubPerform(toReturnFixtureNamed: "save-item", asResultType: SaveItemMutation.self)
+    }
+
+    func test_save_beginsBackgroundActivity_andPerformsSaveItemMutationWithCorrectURL() {
+        backgroundActivityPerformer.stubPerformExpiringActivity { _, block in
+            block(false)
+        }
+
+        let service = subject()
+        service.save(url: URL(string: "https://getpocket.com")!)
+
+        XCTAssertNotNil(backgroundActivityPerformer.performCall(at:0))
+
+        let performCall: MockApolloClient.PerformCall<SaveItemMutation>? = client.performCall(at: 0)
+        XCTAssertEqual(performCall?.mutation.input.url, "https://getpocket.com")
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/PocketSaveServiceTests.swift
@@ -1,33 +1,44 @@
 import XCTest
 import Apollo
 import Sync
+
 @testable import SaveToPocketKit
+@testable import Sync
 
 
 class PocketSaveServiceTests: XCTestCase {
     private var client: MockApolloClient!
     private var backgroundActivityPerformer: MockExpiringActivityPerformer!
-
-    func subject(
-        client: ApolloClientProtocol? = nil,
-        backgroundActivityPerformer: ExpiringActivityPerformer? = nil
-    ) -> PocketSaveService {
-        PocketSaveService(
-            apollo: client ?? self.client,
-            backgroundActivityPerformer: backgroundActivityPerformer ?? self.backgroundActivityPerformer
-        )
-    }
+    private var space: Space!
 
     override func setUp() async throws {
         backgroundActivityPerformer = MockExpiringActivityPerformer()
-
         client = MockApolloClient()
-        client.stubPerform(toReturnFixtureNamed: "save-item", asResultType: SaveItemMutation.self)
+        space = Space(container: .testContainer)
+    }
+
+    func subject(
+        client: ApolloClientProtocol? = nil,
+        backgroundActivityPerformer: ExpiringActivityPerformer? = nil,
+        space: Space? = nil
+    ) -> PocketSaveService {
+        PocketSaveService(
+            apollo: client ?? self.client,
+            backgroundActivityPerformer: backgroundActivityPerformer ?? self.backgroundActivityPerformer,
+            space: space ?? self.space
+        )
     }
 
     func test_save_beginsBackgroundActivity_andPerformsSaveItemMutationWithCorrectURL() {
         backgroundActivityPerformer.stubPerformExpiringActivity { _, block in
-            block(false)
+            DispatchQueue.global(qos: .background).async {
+                block(false)
+            }
+        }
+
+        let performCalled = expectation(description: "perform called")
+        client.stubPerform(toReturnFixtureNamed: "save-item", asResultType: SaveItemMutation.self) {
+            performCalled.fulfill()
         }
 
         let service = subject()
@@ -35,7 +46,84 @@ class PocketSaveServiceTests: XCTestCase {
 
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at:0))
 
+        wait(for: [performCalled], timeout: 1)
         let performCall: MockApolloClient.PerformCall<SaveItemMutation>? = client.performCall(at: 0)
         XCTAssertEqual(performCall?.mutation.input.url, "https://getpocket.com")
     }
+
+    func test_save_createsAnEmptyItemLocally_andUpdatesFromResponse() throws {
+        backgroundActivityPerformer.stubPerformExpiringActivity { _, block in
+            DispatchQueue.global(qos: .background).async {
+                block(false)
+            }
+        }
+
+        let performMutationWasCalled = expectation(description: "perform mutation was called")
+        let performMutationCompleted = expectation(description: "perform mutation completed")
+        client.stubPerform { (operation: SaveItemMutation, _, _, handler) in
+            performMutationWasCalled.fulfill()
+
+            DispatchQueue.global(qos: .background).async {
+                let result = Fixture.load(name: "save-item").asGraphQLResult(from: operation)
+                handler?(.success(result))
+
+                performMutationCompleted.fulfill()
+            }
+
+            return MockCancellable()
+        }
+
+        let url = URL(string: "https://example.com/a-new-item")!
+        let service = subject()
+        service.save(url: url)
+
+        do {
+            wait(for: [performMutationWasCalled], timeout: 1)
+            let savedItem = try space.fetchSavedItem(byURL: url)
+            XCTAssertNotNil(savedItem)
+        }
+
+        do {
+            wait(for: [performMutationCompleted], timeout: 1)
+            let savedItem = try space.fetchSavedItem(byRemoteID: "saved-item-1")
+            XCTAssertNotNil(savedItem?.item)
+        }
+    }
+
+    func test_cancellationOfExpiringActivity_cancelsAllOperationsAndReturnsImmediately() {
+        var expiringActivity: ((Bool) -> Void)?
+        backgroundActivityPerformer.stubPerformExpiringActivity { _, _expiringActivity in
+            expiringActivity = _expiringActivity
+        }
+
+        let queue = DispatchQueue.global(qos: .background)
+        let cancellable = MockCancellable()
+        let performMutationCalled = expectation(description: "perform called")
+        client.stubPerform { (_: SaveItemMutation, _, _, _) in
+            queue.async { performMutationCalled.fulfill() }
+            return cancellable
+        }
+
+        let service = self.subject()
+        service.save(url: URL(string: "https://getpocket.com")!)
+
+        let finishedActivity = expectation(description: "finished the original call to perform an activity")
+        queue.async {
+            expiringActivity?(false)
+            finishedActivity.fulfill()
+        }
+
+        wait(for: [performMutationCalled], timeout: 1)
+
+        let finishedCancellingActivity = expectation(description: "finished cancelling the activity")
+        queue.async {
+            expiringActivity?(true)
+            XCTAssertNotNil(cancellable.cancelCall(at: 0))
+            finishedCancellingActivity.fulfill()
+        }
+
+        wait(for: [finishedActivity, finishedCancellingActivity], timeout: 1)
+    }
+
+
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Fixture.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Fixture.swift
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Apollo
+import Sync
+
+@testable import Sync
+
+class Fixture {
+    enum ReplacementEscapeStrategy {
+        case none
+        case encodeJSON
+    }
+
+    private enum DecodeError: Error {
+        case invalidJSON
+    }
+
+    let data: Data
+    let name: String
+    let ext: String
+
+    var string: String {
+        guard let string = String(data: data, encoding: .utf8) else {
+            fatalError("Could not decode string from fixture")
+        }
+
+        return string
+    }
+
+    init(name: String, ext: String, data: Data) {
+        self.name = name
+        self.ext = ext
+        self.data = data
+    }
+
+    static func load(name: String, ext: String = "json") -> Fixture {
+        let bundle = Bundle.module
+        guard let url = bundle.url(forResource: "Fixtures/\(name)", withExtension: ext) else {
+            fatalError("Could not find fixture named \(name) in \(bundle)")
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            return Fixture(name: name, ext: ext, data: data)
+        } catch {
+            fatalError("Could not load data from fixture named \(name) at url: \(url). Error: \(error)")
+        }
+    }
+
+    static func data(name: String, ext: String = "json") -> Data {
+        return load(name: name, ext: ext).data
+    }
+
+    static func decode<T: Decodable>(name: String, ext: String = "json") -> T {
+        let fixture = load(name: name, ext: ext)
+        return fixture.decode()
+    }
+
+    func replacing(
+        _ placeholder: String,
+        withFixtureNamed fixtureName: String,
+        escape: ReplacementEscapeStrategy = .none
+    ) -> Fixture {
+        let replacement = Fixture.load(name: fixtureName)
+        return replacing(placeholder, with: replacement, escape: escape)
+    }
+
+    func replacing(
+        _ placeholder: String,
+        with fixture: Fixture,
+        escape: ReplacementEscapeStrategy = .none
+    ) -> Fixture {
+        let replacement: String
+
+        switch escape {
+        case .none:
+            replacement = fixture.string
+        case .encodeJSON:
+            let encoder = JSONEncoder()
+            let data = try! encoder.encode(fixture.string)
+
+            replacement = String(data: data, encoding: .utf8)!
+        }
+
+        let data = string
+            .replacingOccurrences(of: "#\(placeholder)#", with: replacement)
+            .data(using: .utf8)
+
+        let newName = [name, fixture.name].joined(separator: "+")
+        guard let data = data else {
+            fatalError("Unable to encode \(newName) as utf8")
+        }
+
+        return Fixture(
+            name: newName,
+            ext: ext,
+            data: data
+        )
+    }
+
+    func asGraphQLResult<Operation: GraphQLOperation>(from operation: Operation) -> GraphQLResult<Operation.Data> {
+        do {
+            let anyJSON = try JSONSerialization.jsonObject(with: data, options: [])
+
+            guard let jsonObject = anyJSON as? JSONObject else {
+                throw DecodeError.invalidJSON
+            }
+
+            let response = GraphQLResponse(operation: operation, body: jsonObject)
+            return try response.parseResultFast()
+        } catch {
+            fatalError("Could not decode graphQL result: \(error)")
+        }
+    }
+
+    func decode<T: Decodable>(using decoder: JSONDecoder = JSONDecoder()) -> T {
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            fatalError("\(error)")
+        }
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockApolloClient+stubs.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockApolloClient+stubs.swift
@@ -1,0 +1,81 @@
+import XCTest
+import Apollo
+
+
+extension MockApolloClient {
+    func stubPerform<T: GraphQLMutation>(
+        toReturnFixtureNamed fixtureName: String,
+        asResultType: T.Type,
+        handler: (() -> ())? = nil
+    ) {
+        stubPerform { (mutation: T, _, queue, completion) in
+            queue.async {
+                let data = Fixture
+                    .load(name: fixtureName)
+                    .asGraphQLResult(from: mutation)
+
+                completion?(.success(data))
+                handler?()
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubPerform<T: GraphQLMutation>(
+        ofMutationType: T.Type,
+        toReturnError error: Error,
+        handler: (() -> ())? = nil
+    ) {
+        stubPerform { (mutation: T, _, queue, completion) -> Apollo.Cancellable in
+            queue.async {
+                completion?(.failure(error))
+                handler?()
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubFetch<T: GraphQLQuery>(
+        toReturnFixturedNamed fixtureName: String,
+        asResultType resultType: T.Type,
+        handler: (() -> ())? = nil
+    ) {
+        stubFetch(
+            toReturnFixture: Fixture.load(name: fixtureName),
+            asResultType: resultType,
+            handler: handler
+        )
+    }
+
+    func stubFetch<T: GraphQLQuery>(
+        toReturnFixture fixture: Fixture,
+        asResultType: T.Type,
+        handler: (() -> ())? = nil
+    ) {
+        stubFetch { (query: T, _, _, queue, completion) -> Apollo.Cancellable in
+            queue.async {
+                completion?(.success(fixture.asGraphQLResult(from: query)))
+                handler?()
+            }
+
+            return MockCancellable()
+        }
+    }
+
+    func stubFetch<T: GraphQLQuery>(
+        ofQueryType: T.Type,
+        toReturnError error: Error,
+        handler: (() -> ())? = nil
+    ) {
+        stubFetch { (query: T, _, _, queue, completion) -> Apollo.Cancellable in
+            queue.async {
+                completion?(.failure(error))
+                handler?()
+            }
+
+            return MockCancellable()
+        }
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockApolloClient.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockApolloClient.swift
@@ -1,0 +1,190 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Apollo
+@testable import Sync
+
+class MockApolloClient: ApolloClientProtocol {
+    var store: ApolloStore {
+        fatalError("\(Self.self).\(#function) is not implemented")
+    }
+    
+    var cacheKeyForObject: CacheKeyForObject? {
+        get { fatalError("\(Self.self).\(#function) is not implemented") }
+        set { fatalError("\(Self.self).\(#function) is not implemented") }
+    }
+
+    // MARK: - fetch
+
+    struct FetchCall<Query: GraphQLQuery> {
+        let query: Query
+        let cachePolicy: CachePolicy
+        let contextIdentifier: UUID?
+        let queue: DispatchQueue
+    }
+
+    typealias FetchImpl<Query: GraphQLQuery> = (
+        Query,
+        CachePolicy,
+        UUID?,
+        DispatchQueue,
+        GraphQLResultHandler<Query.Data>?
+    ) -> Cancellable
+
+    var fetchCalls: [Any] = []
+    var fetchImpl: Any?
+    @discardableResult
+    func fetch<Query: GraphQLQuery>(
+        query: Query,
+        cachePolicy: CachePolicy,
+        contextIdentifier: UUID?,
+        queue: DispatchQueue,
+        resultHandler: GraphQLResultHandler<Query.Data>? = nil
+    ) -> Cancellable {
+        let call = FetchCall(
+            query: query,
+            cachePolicy: cachePolicy,
+            contextIdentifier: contextIdentifier,
+            queue: queue
+        )
+        fetchCalls.append(call)
+
+        guard let anyImpl = fetchImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        guard let impl = anyImpl as? FetchImpl<Query> else {
+            fatalError("Stub implementation for \(Self.self).\(#function) is incorrect type")
+        }
+
+        return impl(query, cachePolicy, contextIdentifier, queue, resultHandler)
+    }
+
+    func stubFetch<Query: GraphQLQuery>(impl: @escaping FetchImpl<Query>) {
+        fetchImpl = impl
+    }
+
+    func fetchCall<Query: GraphQLQuery>(at index: Int) -> FetchCall<Query>? {
+        guard index < fetchCalls.count else {
+            return nil
+        }
+
+        let anyCall = fetchCalls[index]
+        guard let call = anyCall as? MockApolloClient.FetchCall<Query> else {
+            fatalError("Call is incorrect type: \(anyCall)")
+        }
+
+        return call
+    }
+
+    func fetchCall<Query: GraphQLQuery>(
+        withQueryType queryType: Query.Type,
+        at index: Int
+    ) -> FetchCall<Query>? {
+        return fetchCall(at: index)
+    }
+
+    // MARK: - perform
+
+    struct PerformCall<Mutation: GraphQLMutation> {
+        let mutation: Mutation
+        let publishResultToStore: Bool
+        let queue: DispatchQueue
+        let resultHandler: GraphQLResultHandler<Mutation.Data>?
+    }
+
+    typealias PerformImpl<Mutation: GraphQLMutation> = (
+        Mutation,
+        Bool,
+        DispatchQueue,
+        GraphQLResultHandler<Mutation.Data>?
+    ) -> Cancellable
+
+    private(set) var performCalls: [Any] = []
+    private var performImpl: Any?
+    @discardableResult
+    func perform<Mutation: GraphQLMutation>(
+        mutation: Mutation,
+        publishResultToStore: Bool,
+        queue: DispatchQueue,
+        resultHandler: GraphQLResultHandler<Mutation.Data>?
+    ) -> Cancellable {
+        performCalls.append(PerformCall(
+            mutation: mutation,
+            publishResultToStore: publishResultToStore,
+            queue: queue,
+            resultHandler: resultHandler
+        ))
+
+        guard let anyImpl = performImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        guard let impl = anyImpl as? PerformImpl<Mutation> else {
+            fatalError("Stub implementation for \(Self.self).\(#function) is incorrect type")
+        }
+
+        return impl(mutation, publishResultToStore, queue, resultHandler)
+    }
+
+    func stubPerform<Mutation: GraphQLMutation>(impl: @escaping PerformImpl<Mutation>) {
+        performImpl = impl
+    }
+
+    func performCall<Mutation: GraphQLMutation>(at index: Int) -> PerformCall<Mutation>? {
+        guard index < performCalls.count else {
+            return nil
+        }
+
+        let anyCall = performCalls[index]
+        guard let call = anyCall as? MockApolloClient.PerformCall<Mutation> else {
+            fatalError("Call is incorrect type: \(anyCall)")
+        }
+
+        return call
+    }
+
+    func performCall<Mutation: GraphQLMutation>(
+        withMutationType mutationType: Mutation.Type,
+        at index: Int
+    ) -> PerformCall<Mutation>? {
+        return performCall(at: index)
+    }
+
+    // MARK: - not implemented
+
+    @discardableResult
+    func watch<Query: GraphQLQuery>(
+        query: Query,
+        cachePolicy: CachePolicy,
+        callbackQueue: DispatchQueue,
+        resultHandler: @escaping GraphQLResultHandler<Query.Data>
+    ) -> GraphQLQueryWatcher<Query> {
+        fatalError("\(Self.self).\(#function) is not implemented")
+    }
+
+    @discardableResult
+    func upload<Operation: GraphQLOperation>(
+        operation: Operation,
+        files: [GraphQLFile],
+        queue: DispatchQueue,
+        resultHandler: GraphQLResultHandler<Operation.Data>?
+    ) -> Cancellable {
+        fatalError("\(Self.self).\(#function) is not implemented")
+    }
+    
+    @discardableResult
+    func subscribe<Subscription: GraphQLSubscription>(
+        subscription: Subscription,
+        queue: DispatchQueue,
+        resultHandler: @escaping GraphQLResultHandler<Subscription.Data>
+    ) -> Cancellable {
+        fatalError("\(Self.self).\(#function) is not implemented")
+    }
+
+    func clearCache(callbackQueue: DispatchQueue, completion: ((Result<Void, Error>) -> Void)?) {
+        fatalError("\(Self.self).\(#function) is not implemented")
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockCancellable.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockCancellable.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Apollo
+
+public class MockCancellable: Cancellable {
+    public func cancel() { }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockCancellable.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockCancellable.swift
@@ -5,5 +5,35 @@
 import Apollo
 
 public class MockCancellable: Cancellable {
-    public func cancel() { }
+    private var implementations: [String: Any] = [:]
+    private var calls: [String: [Any]] = [:]
+}
+
+extension MockCancellable {
+    private static let cancel = "cancel"
+    public typealias CancelImpl = () -> Void
+    public struct CancelCall { }
+
+    public func stubCancel(impl: @escaping CancelImpl) {
+        implementations[Self.cancel] = impl
+    }
+
+    public func cancelCall(at index: Int) -> CancelCall? {
+        guard let calls = calls[Self.cancel],
+                calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? CancelCall
+    }
+
+    public func cancel() {
+        calls[Self.cancel] = (calls[Self.cancel] ?? []) + [CancelCall()]
+
+        guard let impl = implementations[Self.cancel] as? CancelImpl else {
+            return
+        }
+
+        impl()
+    }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExpiringActivityPerformer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExpiringActivityPerformer.swift
@@ -1,0 +1,33 @@
+@testable import SaveToPocketKit
+
+
+class MockExpiringActivityPerformer: ExpiringActivityPerformer {
+    private var implementations: [String: Any] = [:]
+    private var calls: [String: [Any]] = [:]
+}
+
+extension MockExpiringActivityPerformer {
+    static let performImpl = "performImpl"
+    typealias PerformImpl = (String, (Bool) -> Void) -> Void
+
+    struct PerformCall {
+        let reason: String
+    }
+
+    func stubPerformExpiringActivity(_ impl: @escaping PerformImpl) {
+        implementations[Self.performImpl] = impl
+    }
+
+    func performCall(at index: Int) -> PerformCall? {
+        calls[Self.performImpl]?[index] as? PerformCall
+    }
+
+    func performExpiringActivity(withReason reason: String, using block: @escaping (Bool) -> Void) {
+        guard let impl = implementations[Self.performImpl] as? PerformImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        calls[Self.performImpl] = (calls[Self.performImpl] ?? []) + [PerformCall(reason: reason)]
+        impl(reason, block)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExpiringActivityPerformer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExpiringActivityPerformer.swift
@@ -8,7 +8,7 @@ class MockExpiringActivityPerformer: ExpiringActivityPerformer {
 
 extension MockExpiringActivityPerformer {
     static let performImpl = "performImpl"
-    typealias PerformImpl = (String, (Bool) -> Void) -> Void
+    typealias PerformImpl = (String, @escaping (Bool) -> Void) -> Void
 
     struct PerformCall {
         let reason: String

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import SaveToPocketKit
+
+
+class MockExtensionContext: ExtensionContext {
+    let extensionItems: [ExtensionItem]
+
+    init(extensionItems: [ExtensionItem]) {
+        self.extensionItems = extensionItems
+    }
+}
+
+class MockExtensionItem: ExtensionItem {
+    let itemProviders: [ItemProvider]?
+
+    init(itemProviders: [ItemProvider]?) {
+        self.itemProviders = itemProviders
+    }
+}
+
+class MockItemProvider: ItemProvider {
+    private var implementations: [String: Any] = [:]
+}
+
+extension MockItemProvider {
+    static let hasItemImpl = "hasItemImpl"
+
+    typealias HasItemImpl = (String) -> Bool
+
+    func stubHasItemConformingToTypeIdentifier(_ impl: @escaping HasItemImpl) {
+        implementations[Self.hasItemImpl] = impl
+    }
+
+    func hasItemConformingToTypeIdentifier(_ typeIdentifier: String) -> Bool {
+        guard let impl = implementations[Self.hasItemImpl] as? HasItemImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        return impl(typeIdentifier)
+    }
+}
+
+extension MockItemProvider {
+    static let loadItemImpl = "loadItemImpl"
+
+    typealias LoadItemImpl = (String, [AnyHashable: Any]?) async throws -> NSSecureCoding
+
+    func stubLoadItem(_ impl: @escaping LoadItemImpl) {
+        implementations[Self.loadItemImpl] = impl
+    }
+
+    func loadItem(forTypeIdentifier typeIdentifier: String, options: [AnyHashable : Any]?) async throws -> NSSecureCoding {
+        guard let loadItemImpl = implementations[Self.loadItemImpl] as? LoadItemImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        return try await loadItemImpl(typeIdentifier, options)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
@@ -23,7 +23,7 @@ extension MockSaveService {
         calls[Self.saveImpl]?[index] as? SaveCall
     }
 
-    func save(url: URL) async {
+    func save(url: URL) {
         guard let impl = implementations[Self.saveImpl] as? SaveImpl else {
             fatalError("\(Self.self).\(#function) is not stubbed")
         }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import SaveToPocketKit
+
+
+class MockSaveService: SaveService {
+    private var calls: [String: [Any]] = [:]
+    private var implementations: [String: Any] = [:]
+}
+
+extension MockSaveService {
+    private static let saveImpl = "CallImpl"
+    typealias SaveImpl = (URL) -> Void
+
+    struct SaveCall {
+        let url: URL
+    }
+
+    func stubSave(_ impl: @escaping SaveImpl) {
+        implementations[Self.saveImpl] = impl
+    }
+
+    func saveCall(at index: Int) -> SaveCall? {
+        calls[Self.saveImpl]?[index] as? SaveCall
+    }
+
+    func save(url: URL) async {
+        guard let impl = implementations[Self.saveImpl] as? SaveImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        calls[Self.saveImpl] = (calls[Self.saveImpl] ?? []) + [SaveCall(url: url)]
+        impl(url)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,0 +1,7 @@
+import CoreData
+
+@testable import Sync
+
+extension PersistentContainer {
+    static let testContainer = PersistentContainer(storage: .inMemory)
+}

--- a/PocketKit/Tests/SyncTests/Support/NSPersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/NSPersistentContainer+testContainer.swift
@@ -2,23 +2,6 @@ import CoreData
 
 @testable import Sync
 
-extension NSPersistentContainer {
-    static let testContainer: NSPersistentContainer = {
-        ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
-        ValueTransformer.setValueTransformer(SyncTaskTransformer(), forName: .syncTaskTransformer)
-
-        let url = Bundle.sync.url(forResource: "PocketModel", withExtension: "momd")!
-        let model = NSManagedObjectModel(contentsOf: url)!
-        let container = NSPersistentContainer(name: "PocketModel", managedObjectModel: model)
-        let description = NSPersistentStoreDescription(url: URL(fileURLWithPath: "/dev/null"))
-        container.persistentStoreDescriptions = [description]
-
-        container.loadPersistentStores { storeDescription, error in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        }
-
-        return container
-    }()
+extension PersistentContainer {
+    static let testContainer = PersistentContainer(storage: .inMemory)
 }

--- a/SaveToPocket/Info.plist
+++ b/SaveToPocket/Info.plist
@@ -7,12 +7,14 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.url&quot; OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.plain-text&quot;) AND (NOT ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.file-url&quot;)).@count &gt; 0).@count &gt; 0</string>
+			<string>SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text") AND (NOT ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url")).@count &gt; 0).@count &gt; 0</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.share-services</string>
 		<key>NSExtensionPrincipalClass</key>
 		<string>SaveToPocketKit.MainViewController</string>
 	</dict>
+	<key>PocketAPIConsumerKey</key>
+	<string>$(POCKET_API_CONSUMER_KEY)</string>
 </dict>
 </plist>

--- a/SaveToPocket/SaveToPocket.swift
+++ b/SaveToPocket/SaveToPocket.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation


### PR DESCRIPTION
This is the same code that we wrote together with the addition of storing the `SavedItem` locally when saving the item and updating it via the graphQL response.

Also, I noticed a layout bug when testing out the extension. It looked wonky on my tiny iPhone mini ;). Added a few adjustments to the layout code but could probably be improved.

Screenshot of layout bug:
![IMG_1822](https://user-images.githubusercontent.com/323541/160216587-f35a4913-91d3-498d-937e-0c8c74880048.PNG)

