### PR TITLE
SaveToPocket: Support automatic dismissal

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
+++ b/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
@@ -3,6 +3,8 @@ import Foundation
 
 protocol ExtensionContext {
     var extensionItems: [ExtensionItem] { get }
+
+    func completeRequest(returningItems items: [Any]?, completionHandler: ((Bool) -> Void)?)
 }
 extension NSExtensionContext: ExtensionContext {
     var extensionItems: [ExtensionItem] {

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -29,7 +29,8 @@ class MainViewController: UIViewController {
                     ),
                     backgroundActivityPerformer: ProcessInfo.processInfo,
                     space: Space(container: .init(storage: .shared))
-                )
+                ),
+                dismissTimer: Timer.TimerPublisher(interval: 2, runLoop: .main, mode: .default)
             )
         )
     }
@@ -86,6 +87,10 @@ class MainViewController: UIViewController {
         view.addGestureRecognizer(tap)
 
         updateUI()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         Task {
             await viewModel.save(from: extensionContext)
@@ -100,7 +105,7 @@ class MainViewController: UIViewController {
 
     @objc
     private func finish() {
-        extensionContext?.completeRequest(returningItems: nil)
+        viewModel.finish(context: extensionContext)
     }
 }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/MainViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/MainViewModelTests.swift
@@ -1,35 +1,169 @@
 import XCTest
 @testable import SaveToPocketKit
+import SharedPocketKit
 
 
 class MainViewModelTests: XCTestCase {
+    private var appSession: AppSession!
     private var saveService: MockSaveService!
+    private var timer: Timer.TimerPublisher!
 
-    private func subject(saveService: SaveService? = nil) -> MainViewModel {
-        MainViewModel(saveService: saveService ?? self.saveService)
+    private func subject(
+        appSession: AppSession? = nil,
+        saveService: SaveService? = nil,
+        timer: Timer.TimerPublisher? = nil
+    ) -> MainViewModel {
+        MainViewModel(
+            appSession: appSession ?? self.appSession,
+            saveService: saveService ?? self.saveService,
+            timer: timer ?? self.timer
+        )
     }
 
     override func setUp() {
+        appSession = AppSession()
         saveService = MockSaveService()
+        timer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
+
         saveService.stubSave { _ in }
     }
+}
 
-    func test_save_sendsCorrectURLToService() async {
+// MARK: - No session
+extension MainViewModelTests {
+    func test_save_ifNoCurrentSession_doesNotCallSave() async {
+        let viewModel = subject()
+
         let provider = MockItemProvider()
-
         provider.stubHasItemConformingToTypeIdentifier { _ in
             return true
         }
-
         provider.stubLoadItem { _, _ in
             URL(string: "https://getpocket.com")! as NSSecureCoding
         }
 
         let extensionItem = MockExtensionItem(itemProviders: [provider])
-        let context = MockExtensionContext(extensionItems: [extensionItem])
 
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
+        await viewModel.save(from: context)
+        XCTAssertNil(saveService.saveCall(at: 0))
+    }
+
+    func test_save_ifNoValidSession_automaticallyCompletesRequest() async {
+        let context = MockExtensionContext(extensionItems: [])
         let viewModel = subject()
+
+        let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
+        context.stubCompleteRequest { _, _ in
+            completeRequestExpectation.fulfill()
+        }
+
+        await viewModel.save(from: context)
+
+        wait(for: [completeRequestExpectation], timeout: 1)
+    }
+}
+
+// MARK: - Session, no URL
+extension MainViewModelTests {
+    func test_save_ifValidSessionAndNoURL_doesNotCallSave() async {
+        let appSession = AppSession(keychain: MockKeychain())
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+        let viewModel = subject(appSession: appSession)
+
+        let extensionItem = MockExtensionItem(itemProviders: [])
+
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
+        await viewModel.save(from: context)
+        XCTAssertNil(saveService.saveCall(at: 0))
+    }
+
+
+    func test_save_ifValidSessionAndNoURL_automaticallyCompletesRequest() async {
+        let appSession = AppSession(keychain: MockKeychain())
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+        let viewModel = subject(appSession: appSession)
+
+        let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
+
+        let context = MockExtensionContext(extensionItems: [])
+        context.stubCompleteRequest { _, _ in
+            completeRequestExpectation.fulfill()
+        }
+
+        await viewModel.save(from: context)
+
+        wait(for: [completeRequestExpectation], timeout: 1)
+    }
+}
+
+// MARK: - Session, URL
+extension MainViewModelTests {
+    func test_save_ifValidSessionAndURL_sendsCorrectURLToService() async {
+        let appSession = AppSession(keychain: MockKeychain())
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+        let viewModel = subject(appSession: appSession)
+
+        let provider = MockItemProvider()
+        provider.stubHasItemConformingToTypeIdentifier { _ in
+            return true
+        }
+        provider.stubLoadItem { _, _ in
+            URL(string: "https://getpocket.com")! as NSSecureCoding
+        }
+
+        let extensionItem = MockExtensionItem(itemProviders: [provider])
+
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
         await viewModel.save(from: context)
         XCTAssertEqual(saveService.saveCall(at: 0)?.url, URL(string: "https://getpocket.com")!)
+    }
+
+    func test_save_ifValidSessionAndURL_automaticallyCompletesRequest() async {
+        let appSession = AppSession(keychain: MockKeychain())
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+        let viewModel = subject(appSession: appSession)
+
+        let provider = MockItemProvider()
+        provider.stubHasItemConformingToTypeIdentifier { _ in
+            return true
+        }
+        provider.stubLoadItem { _, _ in
+            URL(string: "https://getpocket.com")! as NSSecureCoding
+        }
+
+        let extensionItem = MockExtensionItem(itemProviders: [provider])
+
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
+        context.stubCompleteRequest { _, _ in
+            completeRequestExpectation.fulfill()
+        }
+
+        await viewModel.save(from: context)
+
+        wait(for: [completeRequestExpectation], timeout: 1)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Calls.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Calls.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+struct Calls<T> {
+    private var calls: [T] = []
+
+    mutating func add(_ call: T) {
+        calls.append(call)
+    }
+
+    var wasCalled: Bool {
+        !calls.isEmpty
+    }
+
+    var last: T? {
+        return calls.last
+    }
+
+    var count: Int {
+        return calls.count
+    }
+
+    subscript(index: Int) -> T {
+        calls[index]
+    }
+}
+

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
@@ -3,10 +3,30 @@ import Foundation
 
 
 class MockExtensionContext: ExtensionContext {
+    private var implementations: [String: Any] = [:]
+
     let extensionItems: [ExtensionItem]
 
     init(extensionItems: [ExtensionItem]) {
         self.extensionItems = extensionItems
+    }
+}
+
+extension MockExtensionContext {
+    static let completeRequestImpl = "completeRequestImpl"
+
+    typealias CompleteRequestImpl = ([Any]?, ((Bool) -> Void)?) -> Void
+
+    func stubCompleteRequest(_ impl: @escaping CompleteRequestImpl) {
+        implementations[Self.completeRequestImpl] = impl
+    }
+
+    func completeRequest(returningItems items: [Any]?, completionHandler: ((Bool) -> Void)?) {
+        guard let impl = implementations[Self.completeRequestImpl] as? CompleteRequestImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        impl(items, completionHandler)
     }
 }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockKeychain.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockKeychain.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import SharedPocketKit
+
+
+class MockKeychain: Keychain {
+    struct AddCall {
+        let query: CFDictionary
+        let result: UnsafeMutablePointer<CFTypeRef?>?
+    }
+
+    struct UpdateCall {
+        let query: CFDictionary
+        let attributes: CFDictionary
+    }
+
+    struct DeleteCall {
+        let query: CFDictionary
+    }
+
+    struct CopyMatchingCall {
+        let query: CFDictionary
+        let result: UnsafeMutablePointer<CFTypeRef?>?
+    }
+
+    private(set) var addCalls = Calls<AddCall>()
+    private(set) var updateCalls = Calls<UpdateCall>()
+    private(set) var deleteCalls = Calls<DeleteCall>()
+    private(set) var copyMatchingCalls = Calls<CopyMatchingCall>()
+
+    var addReturnVal: OSStatus = 0
+    func add(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        addCalls.add(AddCall(query: query, result: result))
+        return addReturnVal
+    }
+
+    var updateReturnVal: OSStatus = 0
+    func update(query: CFDictionary, attributes: CFDictionary) -> OSStatus {
+        updateCalls.add(UpdateCall(query: query, attributes: attributes))
+        return updateReturnVal
+    }
+
+    var copyMatchingReturnVal: OSStatus = 0
+    var copyMatchingResult: CFTypeRef?
+    func copyMatching(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        copyMatchingCalls.add(CopyMatchingCall(query: query, result: result))
+        result?.pointee = copyMatchingResult
+        return copyMatchingReturnVal
+    }
+
+    var deleteReturnVal: OSStatus = 0
+    func delete(query: CFDictionary) -> OSStatus {
+        deleteCalls.add(DeleteCall(query: query))
+        return deleteReturnVal
+    }
+}
+


### PR DESCRIPTION
This pull request introduces automatic dismissal of the `SaveToPocket` extension after `n` number of seconds. For the app implementation, this interval is 2 seconds, which is consistent with the legacy app. For tests, this interval is 0 seconds.

There are primary cases at this time:
1. The user is not logged in
2. The user is logged in, but there is no URL to share
3. The user is logged in, and there is a URL to share

All three of these cases will result in the view being automatically dismissed.