### PR TITLE
Items should appear at top of list when resaving

### DIFF
--- a/PocketKit/Sources/ApolloCodegen/FileStructure.swift
+++ b/PocketKit/Sources/ApolloCodegen/FileStructure.swift
@@ -9,7 +9,7 @@ struct FileStructure {
 
     static let operationsDir = syncRoot
 
-    static let schemaURL = URL(fileURLWithPath: "schema.json", relativeTo: syncRoot).absoluteURL
+    static let schemaURL = URL(fileURLWithPath: "schema.graphqls", relativeTo: syncRoot).absoluteURL
 
     static let schemaDir = schemaURL.deletingLastPathComponent()
 

--- a/PocketKit/Sources/Sync/Operations/SyncTask.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncTask.swift
@@ -6,7 +6,6 @@ enum SyncTask: Codable {
     case unfavorite(remoteID: String)
     case delete(remoteID: String)
     case archive(remoteID: String)
-    case unarchive(remoteID: String)
     case save(localID: URL, url: URL)
     case fetchArchivePage(cursor: String?, isFavorite: Bool?)
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -205,6 +205,7 @@ extension PocketSource {
         }
 
         item.isArchived = true
+        item.archivedAt = Date()
         try? space.save()
 
         let operation = operations.savedItemMutationOperation(

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -220,6 +220,7 @@ extension PocketSource {
         guard let url = item.url else { return }
 
         item.isArchived = false
+        item.createdAt = Date()
         try? space.save()
 
         let operation = operations.saveItemOperation(

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -217,20 +217,20 @@ extension PocketSource {
     }
 
     public func unarchive(item: SavedItem) {
-        guard let remoteID = item.remoteID else {
-            return
-        }
+        guard let url = item.url else { return }
 
         item.isArchived = false
         try? space.save()
 
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
+        let operation = operations.saveItemOperation(
+            managedItemID: item.objectID,
+            url: url,
             events: _events,
-            mutation: UnarchiveItemMutation(itemID: remoteID)
+            apollo: apollo,
+            space: space
         )
 
-        enqueue(operation: operation, task: .unarchive(remoteID: remoteID))
+        enqueue(operation: operation, task: .save(localID: item.objectID.uriRepresentation(), url: url))
     }
 }
 
@@ -361,13 +361,6 @@ extension PocketSource {
                     apollo: apollo,
                     events: _events,
                     mutation: ArchiveItemMutation(itemID: remoteID)
-                )
-                enqueue(operation: operation, persistentTask: persistentTask)
-            case .unarchive(let remoteID):
-                let operation = operations.savedItemMutationOperation(
-                    apollo: apollo,
-                    events: _events,
-                    mutation: UnarchiveItemMutation(itemID: remoteID)
                 )
                 enqueue(operation: operation, persistentTask: persistentTask)
             case .delete(let remoteID):

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -119,12 +119,6 @@ mutation ArchiveItem($itemID: ID!) {
   }
 }
 
-mutation UnarchiveItem($itemID: ID!) {
-    updateSavedItemUnArchive(id: $itemID) {
-      id
-    }
-}
-
 mutation DeleteItem($itemID: ID!) {
   deleteSavedItem(id: $itemID)
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -178,7 +178,7 @@ class PocketSourceTests: XCTestCase {
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 
-    func test_unarchive_executesSaveItemMutation() throws {
+    func test_unarchive_executesSaveItemMutation_andUpdatesCreatedAtField() throws {
         let item = try space.seedSavedItem(remoteID: "unarchive-me")
         item.isArchived = true
 
@@ -195,6 +195,7 @@ class PocketSourceTests: XCTestCase {
         let fetchedItem = try space.fetchSavedItem(byRemoteID: "archive-me")
         XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.isArchived)
+        XCTAssertNotNil(item.createdAt)
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -178,12 +178,12 @@ class PocketSourceTests: XCTestCase {
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 
-    func test_unarchive_executesUnarchiveMutation() throws {
+    func test_unarchive_executesSaveItemMutation() throws {
         let item = try space.seedSavedItem(remoteID: "unarchive-me")
         item.isArchived = true
 
         let expectationToRunOperation = expectation(description: "Run operation")
-        operations.stubItemMutationOperation { (_, _ , _: UnarchiveItemMutation) in
+        operations.stubSaveItemOperation { _, _, _, _, _ in
             TestSyncOperation {
                 expectationToRunOperation.fulfill()
             }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -161,7 +161,7 @@ class PocketSourceTests: XCTestCase {
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 
-    func test_archive_archivesLocally_andExecutesArchiveMutation() throws {
+    func test_archive_archivesLocally_andExecutesArchiveMutation_andUpdatesArchivedAt() throws {
         let item = try space.seedSavedItem(remoteID: "archive-me")
         let expectationToRunOperation = expectation(description: "Run operation")
         operations.stubItemMutationOperation { (_, _ , _: ArchiveItemMutation) in
@@ -175,6 +175,7 @@ class PocketSourceTests: XCTestCase {
 
         XCTAssertTrue(item.isArchived)
         XCTAssertFalse(item.hasChanges)
+        XCTAssertNotNil(item.archivedAt)
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 

--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -90,7 +90,7 @@ class ArchiveTests: XCTestCase {
         server.routes.post("/graphql") { request, _ in
             let apiRequest = ClientAPIRequest(request)
 
-            if apiRequest.isToUnarchiveAnItem {
+            if apiRequest.isToSaveAnItem {
                 return Response.myList("unarchive")
             } else if apiRequest.isForMyListContent {
                 return Response.myList("list-with-unarchived-item")

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -51,10 +51,6 @@ struct ClientAPIRequest {
         contains("updateSavedItemUnFavorite")
     }
 
-    var isToUnarchiveAnItem: Bool {
-        contains("updateSavedItemUnArchive")
-    }
-
     var isForSlateDetail: Bool {
         contains("getSlate(")
     }


### PR DESCRIPTION
When moving an item from archive back to my list, we need to use the `upsertSavedItem` mutation so that the backend updates the `_createdAt` property, which is what we sort my list by.

We were using the more specific `updateSavedItemUnArchive` mutation which only updates the `isArchived` property to true but does not update the `_createdAt` property.

This PR removes the `updateSavedItemUnArchive` mutation and changes `PocketSource.unarchive()` to use the correct mutation.

We also update the `createdAt` property locally before sending the mutation so that offline behavior is still correct.

Also: this builds on a couple of previous commits:

1. The Apollo codegen package needed to be updated to point to the new schema file

2. When archiving an item, we now update the local item's `archivedAt` property so that it is properly sorted while offline 

Additional info can be found in message for each commit. 

https://getpocket.atlassian.net/browse/IN-546