### PR TITLE
Accessibility: calculate topic chip cell heights

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -16,14 +16,17 @@ class HomeViewControllerSectionProvider {
             )
         }
 
+        var maxHeight: CGFloat = 0
         let items = slates.map { slate -> (width: CGFloat, item: NSCollectionLayoutItem) in
             let chip = TopicChipPresenter(title: slate.name)
             let width = TopicChipCell.width(chip: chip)
+            let height = TopicChipCell.height(chip: chip)
+            maxHeight = max(height, maxHeight)
 
             return (width: width, item: NSCollectionLayoutItem(
                 layoutSize: NSCollectionLayoutSize(
                     widthDimension: .absolute(width),
-                    heightDimension: .absolute(TopicChipCell.height)
+                    heightDimension: .absolute(height)
                 )
             ))
         }
@@ -33,7 +36,7 @@ class HomeViewControllerSectionProvider {
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .absolute(totalWidth),
-                heightDimension: .absolute(TopicChipCell.height)
+                heightDimension: .absolute(maxHeight)
             ),
             subitems: items.map { $0.item }
         )

--- a/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
@@ -24,7 +24,7 @@ class TopicChipCell: UICollectionViewCell {
         contentView.addSubview(toggledBackground)
         contentView.addSubview(titleLabel)
 
-        let cornerRadius = TopicChipCell.height / 2
+        let cornerRadius = frame.size.height / 2
         selectedBackgroundView = UIView()
         selectedBackgroundView?.layer.cornerRadius = cornerRadius
         selectedBackgroundView?.backgroundColor = UIColor(.ui.grey1).withAlphaComponent(0.1)
@@ -64,15 +64,13 @@ class TopicChipCell: UICollectionViewCell {
 }
 
 extension TopicChipCell {
-    static let height: CGFloat = 40
+    static func height(chip: TopicChipPresenter) -> CGFloat {
+        let size = chip.attributedTitle?.sizeFitting() ?? .zero
+        return size.height.rounded(.up) + 20
+    }
 
     static func width(chip: TopicChipPresenter) -> CGFloat {
-        let rect = chip.attributedTitle?.boundingRect(
-            with: CGSize(width: .greatestFiniteMagnitude, height: Self.height),
-            options: [.usesLineFragmentOrigin],
-            context: nil
-        ) ?? .zero
-
-        return rect.width.rounded(.up) + 24
+        let size = chip.attributedTitle?.sizeFitting() ?? .zero
+        return size.width.rounded(.up) + 24
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -24,6 +24,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             switch section {
             case .filters:
                 var totalWidth: CGFloat = 0
+                var maxHeight: CGFloat = 0
                 let layoutItems = self.dataSource.snapshot(for: .filters).items.compactMap { cellID -> NSCollectionLayoutItem? in
                     guard case .filterButton(let filterID) = cellID else {
                         return nil
@@ -31,12 +32,14 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
 
                     let model = self.model.filterButton(with: filterID)
                     let width = TopicChipCell.width(chip: model)
+                    let height = TopicChipCell.height(chip: model)
+                    maxHeight = max(height, maxHeight)
 
                     totalWidth += width
                     return NSCollectionLayoutItem(
                         layoutSize: .init(
                             widthDimension: .absolute(width),
-                            heightDimension: .absolute(TopicChipCell.height)
+                            heightDimension: .absolute(height)
                         )
                     )
                 }
@@ -45,7 +48,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
                 let group = NSCollectionLayoutGroup.horizontal(
                     layoutSize: .init(
                         widthDimension: .absolute(totalWidth + ((CGFloat(layoutItems.count) - 1) * spacing)),
-                        heightDimension: .absolute(TopicChipCell.height)
+                        heightDimension: .absolute(maxHeight)
                     ),
                     subitems: layoutItems
                 )


### PR DESCRIPTION
This pull request fixes an issue where topic chip cells were a constant height, and not calculated based on the current font as updated by the user's accessibility settings.