### PR TITLE
Add support for pending saved items

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -64,7 +64,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     var domain: String? {
-        recommendation.item.domainMetadata?.name ?? recommendation.item.domain
+        recommendation.item.domainMetadata?.name ?? recommendation.item.domain ?? recommendation.item.bestURL?.host
     }
 
     var publishDate: Date? {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -72,7 +72,7 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     var domain: String? {
-        item.item?.domainMetadata?.name ?? item.item?.domain
+        item.item?.domainMetadata?.name ?? item.item?.domain ?? item.host
     }
 
     var publishDate: Date? {

--- a/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
@@ -102,7 +102,7 @@ struct RecommendationPresenter {
     }
 
     private var domain: String? {
-        recommendation.item.domainMetadata?.name ?? recommendation.item.domain
+        recommendation.item.domainMetadata?.name ?? recommendation.item.domain ?? recommendation.item.bestURL?.host
     }
 
     private var timeToRead: String? {

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -12,6 +12,10 @@ public extension SavedItem {
     }
 
     var bestURL: URL? {
-        item?.resolvedURL ?? item?.givenURL ?? url
+        item?.bestURL ?? url
+    }
+
+    var isPending: Bool {
+        item == nil
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -163,15 +163,15 @@ extension ArchivedItemsListViewModel {
         )
     }
 
-    func item(with cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
+    func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
         guard case .item(let archivedItemID) = cellID else {
             return nil
         }
 
-        return item(with: archivedItemID)
+        return presenter(for: archivedItemID)
     }
 
-    func item(with itemID: ItemIdentifier) -> ItemsListItemPresenter? {
+    func presenter(for itemID: ItemIdentifier) -> ItemsListItemPresenter? {
         archivedItemsByID[itemID].flatMap(ItemsListItemPresenter.init)
     }
 }
@@ -248,6 +248,15 @@ extension ArchivedItemsListViewModel {
 
 // MARK: - Selecting cells
 extension ArchivedItemsListViewModel {
+    func shouldSelectCell(with cell: ItemsListCell<ItemIdentifier>) -> Bool {
+        switch cell {
+        case .filterButton: return true
+        case .item(let objectID): return !(archivedItemsByID[objectID]?.isPending ?? true)
+        case .nextPage: return false
+        case .offline: return false
+        }
+    }
+
     func selectCell(with cell: ItemsListCell<ItemIdentifier>) {
         switch cell {
         case .filterButton(let filter):

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItem.swift
@@ -7,9 +7,10 @@ protocol ItemsListItem {
     var bestURL: URL? { get }
     var topImageURL: URL? { get }
     var domain: String? { get }
-
     var domainMetadata: ItemsListItemDomainMetadata? { get }
     var timeToRead: Int? { get }
+    var isPending: Bool { get }
+    var host: String? { get }
 }
 
 protocol ItemsListItemDomainMetadata {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
@@ -20,6 +20,7 @@ private extension Style {
                 .with(lineSpacing: 4)
                 .with(lineBreakMode: .byTruncatingTail)
         }
+    static let pendingTitle: Style = title.with(color: .ui.grey5)
 
     static let detail: Style = .header.sansSerif.p4
         .with(color: .ui.grey4)
@@ -28,6 +29,7 @@ private extension Style {
                 .with(lineSpacing: 4)
                 .with(lineBreakMode: .byTruncatingTail)
         }
+    static let pendingDetail: Style = .detail.with(color: .ui.grey5)
 }
 
 class ItemsListItemPresenter {
@@ -38,11 +40,11 @@ class ItemsListItemPresenter {
     }
 
     var attributedTitle: NSAttributedString {
-        NSAttributedString(string: title, style: .title)
+        NSAttributedString(string: title, style: item.isPending ? .pendingTitle : .title)
     }
 
     var attributedDetail: NSAttributedString {
-        NSAttributedString(string: detail, style: .detail)
+        NSAttributedString(string: detail, style: item.isPending ? .pendingDetail : .detail)
     }
 
     var thumbnailURL: URL? {
@@ -65,7 +67,7 @@ class ItemsListItemPresenter {
     }
 
     private var domain: String? {
-        item.domainMetadata?.name ?? item.domain
+        item.domainMetadata?.name ?? item.domain ?? item.host
     }
 
     private var timeToRead: String? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -184,15 +184,15 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
     }
 
     private func configure(cell: ItemsListItemCell, indexPath: IndexPath, objectID: ViewModel.ItemIdentifier) {
-        guard let item = model.item(with: objectID) else {
+        guard let presenter = model.presenter(for: objectID) else {
             return
         }
 
         cell.backgroundConfiguration = .listPlainCell()
         cell.model = .init(
-            attributedTitle: item.attributedTitle,
-            attributedDetail: item.attributedDetail,
-            thumbnailURL: item.thumbnailURL,
+            attributedTitle: presenter.attributedTitle,
+            attributedDetail: presenter.attributedDetail,
+            thumbnailURL: presenter.thumbnailURL,
             shareAction: model.shareAction(for: objectID),
             favoriteAction: model.favoriteAction(for: objectID),
             overflowActions: model.overflowActions(for: objectID)
@@ -233,6 +233,14 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         }
 
         model.willDisplay(cell)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let cell = dataSource.itemIdentifier(for: indexPath) else {
+            return false
+        }
+
+        return model.shouldSelectCell(with: cell)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -34,9 +34,10 @@ protocol ItemsListViewModel: AnyObject {
     func fetch()
     func refresh(_ completion: (() -> ())?)
 
-    func item(with cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter?
-    func item(with itemID: ItemIdentifier) -> ItemsListItemPresenter?
+    func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter?
+    func presenter(for itemID: ItemIdentifier) -> ItemsListItemPresenter?
     func filterButton(with id: ItemsListFilter) -> TopicChipPresenter
+    func shouldSelectCell(with cell: ItemsListCell<ItemIdentifier>) -> Bool
     func selectCell(with: ItemsListCell<ItemIdentifier>)
 
     func shareAction(for objectID: ItemIdentifier) -> ItemAction?

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -22,6 +22,10 @@ extension SavedItem: ItemsListItem {
     var domainMetadata: ItemsListItemDomainMetadata? {
         return item?.domainMetadata
     }
+
+    var host: String? {
+        bestURL?.host
+    }
 }
 
 extension DomainMetadata: ItemsListItemDomainMetadata {

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -70,15 +70,15 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         source.refresh(completion: completion)
     }
 
-    func item(with cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
+    func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
         guard case .item(let objectID) = cellID else {
             return nil
         }
 
-        return item(with: objectID)
+        return presenter(for: objectID)
     }
 
-    func item(with itemID: ItemIdentifier) -> ItemsListItemPresenter? {
+    func presenter(for itemID: ItemIdentifier) -> ItemsListItemPresenter? {
         bareItem(with: itemID).flatMap(ItemsListItemPresenter.init)
     }
 
@@ -87,6 +87,15 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             title: filterID.rawValue,
             isSelected: selectedFilters.contains(filterID)
         )
+    }
+
+    func shouldSelectCell(with cell: ItemsListCell<ItemIdentifier>) -> Bool {
+        switch cell {
+        case .filterButton: return true
+        case .item(let objectID): return !(bareItem(with: objectID)?.isPending ?? true)
+        case .nextPage: return false
+        case .offline: return false
+        }
     }
 
     func selectCell(with cellID: ItemsListCell<ItemIdentifier>) {

--- a/PocketKit/Sources/PocketKit/URL+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/URL+Extensions.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+
+extension URL {
+    var host: String? {
+        guard let urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let host = urlComponents.host else {
+            return nil
+        }
+
+        let components = host.components(separatedBy: ".")
+        let endIndex = max(components.index(components.count, offsetBy: -2), 0)
+        let parsed = components[endIndex...]
+        return parsed.joined(separator: ".")
+    }
+}

--- a/PocketKit/Sources/Sync/Item+extensions.swift
+++ b/PocketKit/Sources/Sync/Item+extensions.swift
@@ -2,6 +2,10 @@ import Foundation
 
 
 extension Item {
+    public var bestURL: URL? {
+        resolvedURL ?? givenURL
+    }
+
     public var hasImage: ItemImageness? {
         imageness.flatMap(ItemImageness.init)
     }

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
@@ -109,7 +109,7 @@ class ArchivedItemsListViewModelTests: XCTestCase {
         itemsController.delegate?.controllerDidChangeContent(itemsController)
 
         wait(for: [expectSnapshot], timeout: 1)
-        XCTAssertNotNil(viewModel.item(with: items[0].objectID))
+        XCTAssertNotNil(viewModel.presenter(for: items[0].objectID))
     }
 
     func test_shareAction_setsSharedActivity() {

--- a/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import Textile
+@testable import PocketKit
+
+
+class ItemsListItemPresenterTests: XCTestCase { }
+
+// MARK: - Attributed Title
+extension ItemsListItemPresenterTests {
+    func test_attributedTitle_withItemTitle_usesTitle() {
+        let item = MockItemsListItem.build(title: "Test Title")
+        let presenter = ItemsListItemPresenter(item: item)
+
+        XCTAssertEqual(presenter.attributedTitle.string, "Test Title")
+    }
+
+    func test_attributedTitle_noItemTitle_usesBestURL() {
+        let item = MockItemsListItem.build(bestURL: URL(string: "https://getpocket.com")!)
+        let presenter = ItemsListItemPresenter(item: item)
+
+        XCTAssertEqual(presenter.attributedTitle.string, "https://getpocket.com")
+    }
+
+    func test_attributedTitle_whenItemIsNotPending_usesCorrectStyle() {
+        let item = MockItemsListItem.build(title: "Pocket")
+        let presenter = ItemsListItemPresenter(item: item)
+
+        let style = presenter.attributedTitle.attributes(at: 0, effectiveRange: nil)[.style] as! Style
+        XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey1))
+    }
+
+    func test_attributedTitle_whenItemIsPending_usesCorrectStyle() {
+        let item = MockItemsListItem.build(title: "Pocket", isPending: true)
+        let presenter = ItemsListItemPresenter(item: item)
+
+        let style = presenter.attributedTitle.attributes(at: 0, effectiveRange: nil)[.style] as! Style
+        XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey5))
+    }
+}
+
+// MARK: - Attributed Detail
+extension ItemsListItemPresenterTests {
+    func test_attributedDetail_withDomainMetadata_usesName() {
+        let item = MockItemsListItem.build(
+            domainMetadata: MockItemsListItemDomainMetadata(name: "Pocket Domain")
+        )
+        let presenter = ItemsListItemPresenter(item: item)
+
+        XCTAssertEqual(presenter.attributedDetail.string, "Pocket Domain")
+    }
+
+    func test_attributedDetail_noDomainMetatada_usesDomain() {
+        let item = MockItemsListItem.build(domain: "getpocket.com")
+        let presenter = ItemsListItemPresenter(item: item)
+
+        XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
+    }
+
+    func test_attributedDetail_noDomainMetadataOrName_usesHot() {
+        let item = MockItemsListItem.build(host: "getpocket.com")
+        let presenter = ItemsListItemPresenter(item: item)
+
+        XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
+    }
+
+    func test_attributedDetail_whenItemIsNotPending_usesCorrectStyle() {
+        let item = MockItemsListItem.build(domain: "Pocket")
+        let presenter = ItemsListItemPresenter(item: item)
+
+        let style = presenter.attributedDetail.attributes(at: 0, effectiveRange: nil)[.style] as! Style
+        XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey4))
+    }
+
+    func test_attributedDetail_whenItemIsPending_usesCorrectStyle() {
+        let item = MockItemsListItem.build(domain: "Pocket", isPending: true)
+        let presenter = ItemsListItemPresenter(item: item)
+
+        let style = presenter.attributedDetail.attributes(at: 0, effectiveRange: nil)[.style] as! Style
+        XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey5))
+    }
+}
+
+private extension Style {
+    static let title: Style = .header.sansSerif.h7
+        .with { paragraph in
+            paragraph
+                .with(lineSpacing: 4)
+                .with(lineBreakMode: .byTruncatingTail)
+        }
+    static let pendingTitle: Style = title.with(color: .ui.grey5)
+
+    static let detail: Style = .header.sansSerif.p4
+        .with(color: .ui.grey4)
+        .with { paragraph in
+            paragraph
+                .with(lineSpacing: 4)
+                .with(lineBreakMode: .byTruncatingTail)
+        }
+    static let pendingDetail: Style = .detail.with(color: .ui.grey5)
+}

--- a/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
@@ -56,7 +56,7 @@ extension ItemsListItemPresenterTests {
         XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
     }
 
-    func test_attributedDetail_noDomainMetadataOrName_usesHot() {
+    func test_attributedDetail_noDomainMetadataOrName_usesHost() {
         let item = MockItemsListItem.build(host: "getpocket.com")
         let presenter = ItemsListItemPresenter(item: item)
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import Analytics
+import Sync
+@testable import PocketKit
+
+
+class SavedItemsListViewModelTests: XCTestCase {
+    var source: MockSource!
+    var tracker: MockTracker!
+    var itemsController: MockSavedItemsController!
+
+    override func setUp() {
+        self.source = MockSource()
+        self.tracker = MockTracker()
+
+        self.itemsController = MockSavedItemsController()
+        self.itemsController.stubIndexPathForObject { _ in IndexPath(item: 0, section: 0) }
+        source.stubMakeItemsController { self.itemsController }
+    }
+
+    func subject(
+        source: Source? = nil,
+        tracker: Tracker? = nil
+    ) -> SavedItemsListViewModel {
+        SavedItemsListViewModel(
+            source: source ?? self.source,
+            tracker: tracker ?? self.tracker
+        )
+    }
+
+    func test_shouldSelectCell_whenItemIsPending_returnsFalse() {
+        let viewModel = subject()
+
+        let item = SavedItem.build(item: nil)
+
+        source.stubObject { _ in
+            item
+        }
+
+        XCTAssertFalse(viewModel.shouldSelectCell(with: .item(item.objectID)))
+    }
+
+    func test_shouldSelectCell_whenItemIsNotPending_returnsFalse() {
+        let viewModel = subject()
+
+        let item = SavedItem.build()
+
+        source.stubObject { _ in item }
+
+        XCTAssertTrue(viewModel.shouldSelectCell(with: .item(item.objectID)))
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import PocketKit
+
+
+struct MockItemsListItem: ItemsListItem {
+    let title: String?
+    let isFavorite: Bool
+    let bestURL: URL?
+    let topImageURL: URL?
+    let domain: String?
+    let domainMetadata: ItemsListItemDomainMetadata?
+    let timeToRead: Int?
+    let isPending: Bool
+    let host: String?
+
+    static func build(
+        title: String? = nil,
+        isFavorite: Bool = false,
+        bestURL: URL? = nil,
+        topImageURL: URL? = nil,
+        domain: String? = nil,
+        domainMetadata: ItemsListItemDomainMetadata? = nil,
+        timeToRead: Int? = nil,
+        isPending: Bool = false,
+        host: String? = nil
+    ) -> MockItemsListItem {
+        MockItemsListItem(
+            title: title,
+            isFavorite: isFavorite,
+            bestURL: bestURL,
+            topImageURL: topImageURL,
+            domain: domain,
+            domainMetadata: domainMetadata,
+            timeToRead: timeToRead,
+            isPending: isPending,
+            host: host
+        )
+    }
+}
+
+struct MockItemsListItemDomainMetadata: ItemsListItemDomainMetadata {
+    let name: String?
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -21,10 +21,6 @@ class MockSource: Source {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
-    func object<T>(id: NSManagedObjectID) -> T? where T : NSManagedObject {
-        fatalError("\(Self.self)#\(#function) is not implemented")
-    }
-
     func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
@@ -47,6 +43,23 @@ class MockSource: Source {
 
     func restore() {
         fatalError("\(Self.self).\(#function) is not implemented")
+    }
+}
+
+extension MockSource {
+    private static let object = "object"
+    typealias ObjectImpl<T> = (NSManagedObjectID) -> T
+
+    func stubObject<T: NSManagedObject>(_ impl: @escaping ObjectImpl<T>) {
+        implementations[Self.object] = impl
+    }
+
+    func object<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
+        guard let impl = implementations[Self.object] as? ObjectImpl<T> else {
+            fatalError("\(Self.self)#\(#function) is not implemented")
+        }
+
+        return impl(id)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Support/SavedItem+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/SavedItem+factories.swift
@@ -11,7 +11,7 @@ extension SavedItem {
         isFavorite: Bool = false,
         isArchived: Bool = false,
         cursor: String? = nil,
-        item: Item? = nil
+        item: Item? = .build()
     ) -> SavedItem {
         let savedItem: SavedItem = SavedItem(context: space.context)
         savedItem.cursor = cursor ?? "cursor-\(remoteID)"
@@ -19,7 +19,7 @@ extension SavedItem {
         savedItem.isFavorite = isFavorite
         savedItem.isArchived = isArchived
         savedItem.url = URL(string: url)!
-        savedItem.item = item ?? .build()
+        savedItem.item = item
 
         return savedItem
     }


### PR DESCRIPTION
This pull request adds support for pending saved items. A pending saved item is defined as a `SavedItem` where `item == nil`. In order to better support pending saved items, three things need to take place:

- [x] Disable the tapping of pending items
- [x] Parse the host from the saved URL as the domain
- [x]Grey-out the item title and domain within a user's list

Since we _are_ now able to parse the host our of the saved item's URL, I've also added support for using the URL's host as a fallback across archived and recommended items.

This pull request fulfills these three items, as well as adds tests for two types: 
1. `ItemsListItemPresenter` - verifies that the `attributedTitle` and `attributedDetail` return the correct strings and styles based on what values an item has present
2. `SavedItemsListViewModel` - verifies that `shouldSelectCell` returns the correct value for (non-)pending items