### PR TITLE
Fix display settings not dismissable in landscape

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -175,8 +175,14 @@ class CompactHomeCoordinator: NSObject {
             recommendation.isPresentingReaderSettings = false
         }
 
-        readerSettingsVC.modalPresentationStyle = .pageSheet
-        readerSettingsVC.sheetPresentationController?.detents = [.medium()]
+        // iPhone (Portrait): defaults to .medium(); iPhone (Landscape): defaults to .large(); iPad (All): Menu
+        // By setting `prefersEdgeAttachedInCompactHeight` and `widthFollowsPreferredContentSizeWhenEdgeAttached`,
+        // landscape (iPhone) provides a non-fullscreen view that is dismissable by the user.
+        let detents: [UISheetPresentationController.Detent] = [.medium(), .large()]
+        readerSettingsVC.sheetPresentationController?.detents = detents
+        readerSettingsVC.sheetPresentationController?.prefersGrabberVisible = true
+        readerSettingsVC.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
+        readerSettingsVC.sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
 
         viewController.present(readerSettingsVC, animated: !isResetting)
     }

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -153,8 +153,14 @@ class CompactMyListContainerCoordinator: NSObject {
             readable.isPresentingReaderSettings = false
         }
 
-        readerSettingsVC.modalPresentationStyle = .pageSheet
-        readerSettingsVC.sheetPresentationController?.detents = [.medium()]
+        // iPhone (Portrait): defaults to .medium(); iPhone (Landscape): defaults to .large()
+        // By setting `prefersEdgeAttachedInCompactHeight` and `widthFollowsPreferredContentSizeWhenEdgeAttached`,
+        // landscape (iPhone) provides a non-fullscreen view that is dismissable by the user.
+        let detents: [UISheetPresentationController.Detent] = [.medium(), .large()]
+        readerSettingsVC.sheetPresentationController?.detents = detents
+        readerSettingsVC.sheetPresentationController?.prefersGrabberVisible = true
+        readerSettingsVC.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
+        readerSettingsVC.sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
 
         viewController.present(readerSettingsVC, animated: !isResetting)
     }

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -30,9 +30,9 @@ struct ReaderSettingsView: View {
                         ForEach(Constants.allowedFontFamilies, id: \.name) { family in
                             Text(family.name)
                                 .tag(family)
-                        }
+                        }.navigationBarTitleDisplayMode(.inline)
                     }
-                    
+
                     Stepper(
                         "Font Size",
                         value: settings.$fontSizeAdjustment,
@@ -41,6 +41,7 @@ struct ReaderSettingsView: View {
                     )
                 }
             }
-        }.navigationViewStyle(.stack)
+            .navigationBarHidden(true)
+        }
     }
 }


### PR DESCRIPTION
There are a few extra properties we can set on `UISheetPresentationController` to ensure that the view controller is dismissable in landscape. One oddity here is that we have to set both `.medium()` and `.large()` detents to support autorotate, as if we only set `.medium()`, then the landscape presentation using the new properties causes an exception, where having both detents is the workaround 🙃 

This does not change the iPad implementation, which uses a menu.

## Preview

![image](https://user-images.githubusercontent.com/1158092/161587197-94e80437-0300-425c-b258-cf25a9607c3d.png)
