### PR TITLE
SaveTo: Add "Log In to Pocket" button when logged out

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -22,6 +22,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.mozilla.pocket.next</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pocket-next</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		F2687E7327E28F0F00E43F09 /* SaveToPocketKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2687E7227E28F0F00E43F09 /* SaveToPocketKit */; };
 		F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */; };
 		F2843C202714D97000E03ED5 /* ReportViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */; };
+		F2A009EC27F61C8D004B5E71 /* SaveToPocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A009E927F61C81004B5E71 /* SaveToPocketTests.swift */; };
 		F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */; };
 		F2A5B6B6271E03C400FB8BF2 /* LaunchEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */; };
 		F2FC070327A9B749009F8D98 /* ArchiveFiltersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FC070227A9B749009F8D98 /* ArchiveFiltersTests.swift */; };
@@ -159,6 +160,7 @@
 		F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeWebViewTests.swift; sourceTree = "<group>"; };
 		F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportARecommendationTests.swift; sourceTree = "<group>"; };
 		F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewElement.swift; sourceTree = "<group>"; };
+		F2A009E927F61C81004B5E71 /* SaveToPocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveToPocketTests.swift; sourceTree = "<group>"; };
 		F2A5B6B3271E03B300FB8BF2 /* LaunchArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
 		F2A5B6B5271E03C400FB8BF2 /* LaunchEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchEnvironment.swift; sourceTree = "<group>"; };
 		F2FC070227A9B749009F8D98 /* ArchiveFiltersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveFiltersTests.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 				F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */,
 				F2843C1D2714D18200E03ED5 /* ReportARecommendationTests.swift */,
 				1613B2B02755696B0014F301 /* SignOutTests.swift */,
+				F2A009E927F61C81004B5E71 /* SaveToPocketTests.swift */,
 			);
 			path = "Tests iOS";
 			sourceTree = "<group>";
@@ -505,6 +508,7 @@
 				1605237E27A4627F00E09FD2 /* XCTestCase+extensions.swift in Sources */,
 				1648D5A727024C6400F67C4B /* SlateDetailElement.swift in Sources */,
 				166BAD0B2656E76B00E401F0 /* ReaderElement.swift in Sources */,
+				F2A009EC27F61C8D004B5E71 /* SaveToPocketTests.swift in Sources */,
 				166F8F2726D0488900F898E3 /* XCUIElement+wait.swift in Sources */,
 				F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */,
 				1606F21B26EBC1A200238111 /* HomeTests.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -35,6 +35,7 @@ struct LoggedOutView: View {
             LoggedOutOfflineView(isPresented: $viewModel.isPresentingOfflineView)
                 .onDisappear { viewModel.offlineViewDidDisappear() }
         }
+        .accessibilityIdentifier("logged-out")
     }
 }
 

--- a/PocketKit/Sources/SaveToPocketKit/InfoView.swift
+++ b/PocketKit/Sources/SaveToPocketKit/InfoView.swift
@@ -2,13 +2,13 @@ import UIKit
 import Textile
 
 
-enum MainViewStyle {
+enum InfoViewStyle {
     case `default`
     case error
 }
 
-class MainInfoView: UIView {
-    private let capsuleView = MainCapsuleView()
+class InfoView: UIView {
+    private let capsuleView = CapsuleView()
 
     private let detailTextLabel: UILabel = {
         let label = UILabel()
@@ -24,18 +24,26 @@ class MainInfoView: UIView {
         return stackView
     }()
 
-    var attributedText: NSAttributedString? {
+    private var attributedText: NSAttributedString? {
         get { capsuleView.attributedText }
         set { capsuleView.attributedText = newValue }
     }
 
-    var attributedDetailText: NSAttributedString? {
+    private var attributedDetailText: NSAttributedString? {
         get { detailTextLabel.attributedText }
         set { detailTextLabel.attributedText = newValue }
     }
 
-    var style: MainViewStyle = .default {
+    private var style: InfoViewStyle = .default {
         didSet { capsuleView.style = style }
+    }
+
+    var model: Model? = nil {
+        didSet {
+            style = model?.style ?? .default
+            attributedText = model?.attributedText ?? nil
+            attributedDetailText = model?.attributedDetailText ?? nil
+        }
     }
 
     init() {
@@ -57,7 +65,7 @@ class MainInfoView: UIView {
     }
 }
 
-private class MainCapsuleView: UIView {
+private class CapsuleView: UIView {
     private let imageView = UIImageView()
 
     private let textLabel: UILabel = {
@@ -71,7 +79,7 @@ private class MainCapsuleView: UIView {
         set { textLabel.attributedText = newValue }
     }
 
-    var style: MainViewStyle = .default {
+    var style: InfoViewStyle = .default {
         didSet { updateStyle() }
     }
 
@@ -118,5 +126,13 @@ private class MainCapsuleView: UIView {
             backgroundColor = UIColor(.ui.coral5)
             imageView.image = UIImage(asset: .error)
         }
+    }
+}
+
+extension InfoView {
+    struct Model {
+        let style: InfoViewStyle
+        let attributedText: NSAttributedString
+        let attributedDetailText: NSAttributedString?
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
@@ -1,0 +1,115 @@
+import UIKit
+import Combine
+
+
+class LoggedOutViewController: UIViewController {
+    private let imageView = UIImageView(image: UIImage(asset: .logo))
+
+    private let infoView = InfoView()
+
+    private let dismissLabel = UILabel()
+
+    private let viewModel: LoggedOutViewModel
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(viewModel: LoggedOutViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(.ui.white1)
+
+        view.addSubview(imageView)
+        view.addSubview(infoView)
+        view.addSubview(dismissLabel)
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        infoView.translatesAutoresizingMaskIntoConstraints = false
+        dismissLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let capsuleTopConstraint = NSLayoutConstraint(
+            item: infoView,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .bottom,
+            multiplier: 0.35,
+            constant: 0
+        )
+
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 36),
+
+            capsuleTopConstraint,
+            infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+
+            dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        infoView.model = viewModel.infoViewModel
+        dismissLabel.attributedText = viewModel.dismissAttributedText
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(finish))
+        view.addGestureRecognizer(tap)
+
+        viewModel.$actionButtonConfiguration.prefix(2).sink { [weak self] configuration in
+            if let configuration = configuration {
+                self?.createActionButton(configuration: configuration)
+            }
+        }.store(in: &subscriptions)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.viewWillAppear(context: extensionContext, origin: self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        viewModel.viewDidAppear(context: extensionContext)
+    }
+}
+
+private extension LoggedOutViewController {
+    @objc
+    private func finish() {
+        viewModel.finish(context: extensionContext)
+    }
+
+    private func logIn() {
+        viewModel.logIn(from: extensionContext, origin: self)
+    }
+
+    private func createActionButton(configuration: UIButton.Configuration) {
+        let actionButton = UIButton(
+            configuration: configuration,
+            primaryAction: UIAction { [weak self] _ in
+                self?.logIn()
+            }
+        )
+        actionButton.accessibilityIdentifier = "log-in"
+
+        view.addSubview(actionButton)
+
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            actionButton.bottomAnchor.constraint(equalTo: dismissLabel.topAnchor, constant: -16),
+            actionButton.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            actionButton.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+        ])
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -1,0 +1,91 @@
+import UIKit
+import SharedPocketKit
+import Combine
+
+
+class LoggedOutViewModel {
+    private let dismissTimer: Timer.TimerPublisher
+
+    private var dismissTimerCancellable: AnyCancellable? = nil
+
+    let infoViewModel = InfoView.Model(
+        style: .error,
+        attributedText: NSAttributedString(
+            string: "Log in to Pocket to save",
+            style: .mainTextError
+        ),
+        attributedDetailText: NSAttributedString(
+            string: "Pocket couldn't save the link. Log in to the Pocket app and try saving again.",
+            style: .detailText
+        )
+    )
+
+    let dismissAttributedText = NSAttributedString(string: "Tap to Dismiss", style: .dismiss)
+
+    @Published
+    var actionButtonConfiguration: UIButton.Configuration? = nil
+
+    init(dismissTimer: Timer.TimerPublisher) {
+        self.dismissTimer = dismissTimer
+    }
+
+    func viewWillAppear(context: ExtensionContext?, origin: Any) {
+        if responder(from: origin) != nil {
+            var configuration: UIButton.Configuration = .filled()
+            configuration.background.backgroundColor = UIColor(.ui.teal2)
+            configuration.background.cornerRadius = 13
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 13, leading: 0, bottom: 13, trailing: 0)
+            configuration.attributedTitle = AttributedString(NSAttributedString(string: "Log in to Pocket", style: .logIn))
+            actionButtonConfiguration = configuration
+        }
+    }
+
+    func viewDidAppear(context: ExtensionContext?) {
+        autodismiss(from: context)
+    }
+
+    func finish(context: ExtensionContext?, completionHandler: ((Bool) -> Void)? = nil) {
+        context?.completeRequest(returningItems: nil, completionHandler: completionHandler)
+    }
+
+    func logIn(from context: ExtensionContext?, origin: Any) {
+        guard let responder = responder(from: origin) else {
+            return
+        }
+
+        finish(context: context) { [weak self] _ in
+            self?.open(url: URL(string: "pocket-next:")!, using: responder)
+        }
+    }
+}
+
+extension LoggedOutViewModel {
+    private func responder(from origin: Any) -> UIResponder? {
+        guard let origin = origin as? UIResponder else {
+            return nil
+        }
+
+        let selector = sel_registerName("openURL:")
+        var responder: UIResponder? = origin
+        while let r = responder, !r.responds(to: selector) {
+            responder = r.next
+        }
+
+        return responder
+    }
+
+    private func open(url: URL, using responder: UIResponder) {
+        let selector = sel_registerName("openURL:")
+        responder.perform(selector, with: url)
+    }
+
+    private func autodismiss(from context: ExtensionContext?) {
+        dismissTimerCancellable = dismissTimer.autoconnect().first().sink(receiveCompletion:{ [weak self] _ in
+            self?.finish(context: context)
+        }, receiveValue: { _ in })
+    }
+
+    private func handleLoggedOut(context: ExtensionContext?, origin: Any) {
+        logIn(from: context, origin: origin)
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -6,35 +6,39 @@ import Sync
 
 
 class MainViewController: UIViewController {
-    private let imageView = UIImageView(image: UIImage(asset: .logo))
-
-    private let infoView = MainInfoView()
-
-    private let dismissLabel = UILabel()
-
-    private let viewModel: MainViewModel
+    private let childViewController: UIViewController
 
     convenience init() {
         Textiles.initialize()
 
         let appSession = AppSession()
+        let child: UIViewController
 
-        self.init(
-            viewModel: MainViewModel(
-                appSession: appSession,
-                saveService: PocketSaveService(
-                    sessionProvider: appSession,
-                    consumerKey: Keys.shared.pocketApiConsumerKey,
-                    expiringActivityPerformer: ProcessInfo.processInfo
-                ),
-                dismissTimer: Timer.TimerPublisher(interval: 2, runLoop: .main, mode: .default)
+        if appSession.currentSession == nil {
+            child = LoggedOutViewController(
+                viewModel: LoggedOutViewModel(
+                    dismissTimer: Timer.TimerPublisher(interval: 2, runLoop: .main, mode: .default)
+                )
             )
-        )
+        } else {
+            child = SavedItemViewController(
+                viewModel: SavedItemViewModel(
+                    appSession: appSession,
+                    saveService: PocketSaveService(
+                        sessionProvider: appSession,
+                        consumerKey: Keys.shared.pocketApiConsumerKey,
+                        expiringActivityPerformer: ProcessInfo.processInfo
+                    ),
+                    dismissTimer: Timer.TimerPublisher(interval: 2, runLoop: .main, mode: .default)
+                )
+            )
+        }
+
+        self.init(childViewController: child)
     }
 
-    init(viewModel: MainViewModel) {
-        self.viewModel = viewModel
-
+    init(childViewController: UIViewController) {
+        self.childViewController = childViewController
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -45,67 +49,16 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor(.ui.white1)
+        addChild(childViewController)
+        view.addSubview(childViewController.view)
+        childViewController.didMove(toParent: self)
 
-        view.addSubview(imageView)
-        view.addSubview(infoView)
-        view.addSubview(dismissLabel)
-
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        infoView.translatesAutoresizingMaskIntoConstraints = false
-        dismissLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        let capsuleTopConstraint = NSLayoutConstraint(
-            item: infoView,
-            attribute: .top,
-            relatedBy: .equal,
-            toItem: view,
-            attribute: .bottom,
-            multiplier: 0.35,
-            constant: 0
-        )
-
+        childViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 36),
-
-            capsuleTopConstraint,
-            infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            infoView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            infoView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-
-            dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            childViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            childViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            childViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            childViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
-
-        dismissLabel.attributedText = NSAttributedString(string: "Tap to Dismiss", style: .dismiss)
-
-        let tap = UITapGestureRecognizer(target: self, action: #selector(finish))
-        view.addGestureRecognizer(tap)
-
-        updateUI()
     }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        Task {
-            await viewModel.save(from: extensionContext)
-        }
-    }
-
-    private func updateUI() {
-        infoView.style = viewModel.style
-        infoView.attributedText = viewModel.attributedText
-        infoView.attributedDetailText = viewModel.attributedDetailText
-    }
-
-    @objc
-    private func finish() {
-        viewModel.finish(context: extensionContext)
-    }
-}
-
-private extension Style {
-    static let dismiss: Self = .header.sansSerif.p3.with(color: .ui.grey5).with { $0.with(lineHeight: .explicit(22)) }
 }

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -1,0 +1,78 @@
+import UIKit
+import Textile
+
+
+class SavedItemViewController: UIViewController {
+    private let imageView = UIImageView(image: UIImage(asset: .logo))
+
+    private let infoView = InfoView()
+
+    private let dismissLabel = UILabel()
+
+    private let viewModel: SavedItemViewModel
+
+    init(viewModel: SavedItemViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(.ui.white1)
+
+        view.addSubview(imageView)
+        view.addSubview(infoView)
+        view.addSubview(dismissLabel)
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        infoView.translatesAutoresizingMaskIntoConstraints = false
+        dismissLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let capsuleTopConstraint = NSLayoutConstraint(
+            item: infoView,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .bottom,
+            multiplier: 0.35,
+            constant: 0
+        )
+
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 36),
+
+            capsuleTopConstraint,
+            infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+
+            dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        infoView.model = viewModel.infoViewModel
+        dismissLabel.attributedText = viewModel.dismissAttributedText
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(finish))
+        view.addGestureRecognizer(tap)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        Task {
+            await viewModel.save(from: extensionContext)
+        }
+    }
+
+    @objc
+    private func finish() {
+        viewModel.finish(context: extensionContext)
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -1,35 +1,31 @@
 import Foundation
 import SharedPocketKit
 import Sync
-import Textile
 import Combine
 
 
-class MainViewModel {
+class SavedItemViewModel {
     private let appSession: AppSession
     private let saveService: SaveService
     private let dismissTimer: Timer.TimerPublisher
 
     private var dismissTimerCancellable: AnyCancellable? = nil
 
-    let style: MainViewStyle
-    let attributedText: NSAttributedString
-    let attributedDetailText: NSAttributedString?
+    let infoViewModel = InfoView.Model(
+        style: .default,
+        attributedText: NSAttributedString(
+            string: "Saved to Pocket",
+            style: .mainText
+        ),
+        attributedDetailText: nil
+    )
+
+    let dismissAttributedText = NSAttributedString(string: "Tap to Dismiss", style: .dismiss)
 
     init(appSession: AppSession, saveService: SaveService, dismissTimer: Timer.TimerPublisher) {
         self.appSession = appSession
         self.saveService = saveService
         self.dismissTimer = dismissTimer
-
-        if appSession.currentSession != nil {
-            style = .default
-            attributedText = NSAttributedString(string: "Saved to Pocket", style: .mainText)
-            attributedDetailText = nil
-        } else {
-            style = .error
-            attributedText = NSAttributedString(string: "Log in to Pocket to save", style: .mainTextError)
-            attributedDetailText = NSAttributedString(string: "Pocket couldn't save the link. Log in to the Pocket app and try saving again.", style: .detailText)
-        }
     }
 
     func save(from context: ExtensionContext?) async {
@@ -56,23 +52,15 @@ class MainViewModel {
         autodismiss(from: context)
     }
 
-    func finish(context: ExtensionContext?) {
-        context?.completeRequest(returningItems: nil, completionHandler: nil)
-    }
-
-    private func autodismiss(from context: ExtensionContext?) {
-        dismissTimerCancellable = dismissTimer.autoconnect().sink { [weak self] _ in
-            self?.finish(context: context)
-        }
+    func finish(context: ExtensionContext?, completionHandler: ((Bool) -> Void)? = nil) {
+        context?.completeRequest(returningItems: nil, completionHandler: completionHandler)
     }
 }
 
-private extension Style {
-    static func coloredMainText(color: ColorAsset) -> Style {
-        .header.sansSerif.h2.with(color: color).with { $0.with(lineSpacing: 4) }
+extension SavedItemViewModel {
+    private func autodismiss(from context: ExtensionContext?) {
+        dismissTimerCancellable = dismissTimer.autoconnect().first().sink { [weak self] _ in
+            self?.finish(context: context)
+        }
     }
-    static let mainText: Self = coloredMainText(color: .ui.teal2)
-    static let mainTextError: Self = coloredMainText(color: .ui.coral2)
-
-    static let detailText: Self = .header.sansSerif.p2.with { $0.with(lineHeight: .explicit(28)).with(alignment: .center) }
 }

--- a/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
@@ -1,0 +1,16 @@
+import Textile
+
+
+extension Style {
+    static let logIn: Self = .header.sansSerif.h7.with(color: .ui.white)
+
+    static func coloredMainText(color: ColorAsset) -> Style {
+        .header.sansSerif.h2.with(color: color).with { $0.with(lineSpacing: 4) }
+    }
+    static let mainText: Self = coloredMainText(color: .ui.teal2)
+    static let mainTextError: Self = coloredMainText(color: .ui.coral2)
+
+    static let detailText: Self = .header.sansSerif.p2.with { $0.with(lineHeight: .explicit(28)).with(alignment: .center) }
+
+    static let dismiss: Self = .header.sansSerif.p4.with(color: .ui.grey5).with { $0.with(lineHeight: .explicit(22)) }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import SaveToPocketKit
+
+
+class LoggedOutViewModelTests: XCTestCase {
+    private var dismissTimer: Timer.TimerPublisher!
+
+    private func subject(
+        dismissTimer: Timer.TimerPublisher? = nil
+    ) -> LoggedOutViewModel {
+        LoggedOutViewModel(
+            dismissTimer: dismissTimer ?? self.dismissTimer
+        )
+    }
+
+    override func setUp() {
+        self.continueAfterFailure = false
+
+        dismissTimer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
+    }
+}
+
+// MARK: - No session
+extension LoggedOutViewModelTests {
+    func test_viewWillAppear_automaticallyCompletesRequest() async {
+        let context = MockExtensionContext(extensionItems: [])
+        let viewModel = subject()
+
+        let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
+        context.stubCompleteRequest { _, _ in
+            completeRequestExpectation.fulfill()
+        }
+
+        viewModel.viewDidAppear(context: context)
+
+        wait(for: [completeRequestExpectation], timeout: 1)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -5,71 +5,36 @@ import Sync
 @testable import SaveToPocketKit
 
 
-class MainViewModelTests: XCTestCase {
+class SavedItemViewModelTests: XCTestCase {
     private var appSession: AppSession!
     private var saveService: MockSaveService!
-    private var timer: Timer.TimerPublisher!
+    private var dismissTimer: Timer.TimerPublisher!
 
     private func subject(
         appSession: AppSession? = nil,
         saveService: SaveService? = nil,
-        timer: Timer.TimerPublisher? = nil
-    ) -> MainViewModel {
-        MainViewModel(
+        dismissTimer: Timer.TimerPublisher? = nil
+    ) -> SavedItemViewModel {
+        SavedItemViewModel(
             appSession: appSession ?? self.appSession,
             saveService: saveService ?? self.saveService,
-            dismissTimer: timer ?? self.timer
+            dismissTimer: dismissTimer ?? self.dismissTimer
         )
     }
 
     override func setUp() {
+        self.continueAfterFailure = false
+
         appSession = AppSession()
         saveService = MockSaveService()
-        timer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
+        dismissTimer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
 
         saveService.stubSave { _ in }
     }
 }
 
-// MARK: - No session
-extension MainViewModelTests {
-    func test_save_ifNoCurrentSession_doesNotCallSave() async {
-        let viewModel = subject()
-
-        let provider = MockItemProvider()
-        provider.stubHasItemConformingToTypeIdentifier { _ in
-            return true
-        }
-        provider.stubLoadItem { _, _ in
-            URL(string: "https://getpocket.com")! as NSSecureCoding
-        }
-
-        let extensionItem = MockExtensionItem(itemProviders: [provider])
-
-        let context = MockExtensionContext(extensionItems: [extensionItem])
-        context.stubCompleteRequest { _, _ in }
-
-        await viewModel.save(from: context)
-        XCTAssertNil(saveService.saveCall(at: 0))
-    }
-
-    func test_save_ifNoValidSession_automaticallyCompletesRequest() async {
-        let context = MockExtensionContext(extensionItems: [])
-        let viewModel = subject()
-
-        let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
-        context.stubCompleteRequest { _, _ in
-            completeRequestExpectation.fulfill()
-        }
-
-        await viewModel.save(from: context)
-
-        wait(for: [completeRequestExpectation], timeout: 1)
-    }
-}
-
 // MARK: - Session, no URL
-extension MainViewModelTests {
+extension SavedItemViewModelTests {
     func test_save_ifValidSessionAndNoURL_doesNotCallSave() async {
         let appSession = AppSession(keychain: MockKeychain())
         appSession.currentSession = Session(
@@ -112,7 +77,7 @@ extension MainViewModelTests {
 }
 
 // MARK: - Session, URL
-extension MainViewModelTests {
+extension SavedItemViewModelTests {
     func test_save_ifValidSessionAndURL_sendsCorrectURLToService() async {
         let appSession = AppSession(keychain: MockKeychain())
         appSession.currentSession = Session(
@@ -169,3 +134,4 @@ extension MainViewModelTests {
         wait(for: [completeRequestExpectation], timeout: 1)
     }
 }
+

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
@@ -4,6 +4,7 @@ import Foundation
 
 class MockExtensionContext: ExtensionContext {
     private var implementations: [String: Any] = [:]
+    private var calls: [String: [Any]] = [:]
 
     let extensionItems: [ExtensionItem]
 

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import Sails
+
+class SaveToPocketTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+
+    override func setUpWithError() throws {
+        self.continueAfterFailure = false
+
+        server = Application()
+        app = PocketAppElement(app: XCUIApplication())
+
+        server.routes.get("/hello") { _, _ in
+            Response {
+                Status.ok
+                Fixture.data(name: "hello", ext: "html")
+            }
+        }
+
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    func test_whenLoggedOut_userTapsLogIn_opensApp() {
+        app.launch(arguments: .firstLaunch, environment: .noSession)
+
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        safari.launch()
+
+        safari.textFields["Address"].tap()
+        safari.typeText("http://localhost:8080/hello\n")
+        safari.staticTexts["Hello, world"].wait()
+        safari.toolbars.buttons["ShareButton"].tap()
+        let activityView = safari.descendants(matching: .other)["ActivityListView"].wait()
+
+        // Sadly this is the only way I could devise to find the Pocket Beta button
+        // This will likely be very brittle
+        activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 1).tap()
+        safari.buttons["log-in"].wait().tap()
+
+        app.loggedOutView.wait()
+    }
+}

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -16,8 +16,8 @@ struct PocketAppElement {
         app.state == .runningForeground
     }
 
-    var signInView: SignInFormElement {
-        return SignInFormElement(app)
+    var loggedOutView: XCUIElement {
+        return app.collectionViews["logged-out"]
     }
 
     var homeView: HomeViewElement {


### PR DESCRIPTION
This pull request adds support for presenting a "Log in to Pocket" button when opening the extension if the user is logged out. 

# TL;DR

## MainViewModel

This view model has been updated to return a presenter (type: `MainViewPresenter` based on state and origin. This presenter is then used to conditionally show (or not show) an additional view at the bottom of `MainViewController` based on the usability of the presenter. In a logged out state, this is based on whether there is a `UIResponder` in the chain that can handle opening URLs. 

## MainViewPresenter

This type has been added as a protocol with one required property: `view: UIView?`. This view is what is conditionally shown at the bottom of `MainViewController`. Currently, there are two presenters: `SavedViewPresenter` (for when an item has been saved) and `LoggedOutViewPresenter` (for when the user is logged out). These presenters are also used to update the state and text of the `MainInfoView` presented by the main view controller.

## URL Schemes

The `pocket-next` URL scheme has been registered with the main app so that it can be opened from the extension (by opening `pocket-next:`. 

## Preview

![image](https://user-images.githubusercontent.com/1158092/161768217-cd93df39-5e6d-4479-8ec7-10fac8172959.png)
