### PR TITLE
Fix list switcher layout issue after toggling lists

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -243,4 +243,12 @@ extension ItemsListViewController: SelectableViewController {
     var selectionItem: SelectionItem {
         return model.selectionItem
     }
+
+    func didBecomeSelected(by parent: MyListContainerViewController) {
+        // Fixes an issue where the navigation bar state could be out-of-sync
+        // with the expected state based on the current visible
+        // collection view's content offset after toggling list selection.
+        collectionView.contentOffset.y += 1
+        collectionView.contentOffset.y -= 1
+    }
 }

--- a/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
@@ -8,6 +8,8 @@ struct SelectionItem {
 
 protocol SelectableViewController: UIViewController {
     var selectionItem: SelectionItem { get }
+
+    func didBecomeSelected(by parent: MyListContainerViewController)
 }
 
 class MyListContainerViewController: UIViewController {
@@ -62,5 +64,7 @@ class MyListContainerViewController: UIViewController {
             child.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             child.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+
+        child.didBecomeSelected(by: self)
     }
 }


### PR DESCRIPTION
Fixes an issue where the navigation bar state could be out-of-sync with the expected state based on the current visible collection view's content offset after toggling list selection.

## Example Issue

![image](https://user-images.githubusercontent.com/1158092/162065578-bbd34553-4298-4c32-927f-32dc4ace052e.png)
