### PR TITLE
ShareTo: Support saving items while offline

### DIFF
--- a/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
@@ -35,6 +35,7 @@ class RefreshCoordinator {
 
         notificationCenter.publisher(for: UIScene.willEnterForegroundNotification, object: nil).sink { [weak self] _ in
             self?.source.refresh()
+            self?.source.resolveUnresolvedSavedItems()
         }.store(in: &subscriptions)
     }
 

--- a/PocketKit/Sources/Sync/OSNotificationCenter.swift
+++ b/PocketKit/Sources/Sync/OSNotificationCenter.swift
@@ -111,8 +111,3 @@ public class OSNotificationCenter {
         }
     }
 }
-
-public extension CFNotificationName {
-    static let savedItemCreated = CFNotificationName("com.mozilla.pocket.savedItemCreated" as CFString)
-    static let savedItemUpdated = CFNotificationName("com.mozilla.pocket.savedItemUpdated" as CFString)
-}

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -47,6 +47,9 @@
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
     </entity>
+    <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES" codeGenerationType="class">
+        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
+    </entity>
     <elements>
         <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
@@ -54,5 +57,6 @@
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
         <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="149"/>
         <element name="SavedItemUpdatedNotification" positionX="-36" positionY="144" width="128" height="44"/>
+        <element name="UnresolvedSavedItem" positionX="-36" positionY="144" width="128" height="44"/>
     </elements>
 </model>

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -90,12 +90,17 @@ public class PocketSource: Source {
             self?.handleSavedItemsUpdatedNotification()
         }
 
+        osNotificationCenter.add(observer: notificationObserver, name: .unresolvedSavedItemCreated) { [weak self] in
+            self?.handleUnresolvedSavedItemCreatedNotification()
+        }
+
         observeNetworkStatus()
     }
 
     deinit {
         osNotificationCenter.remove(observer: notificationObserver, name: .savedItemCreated)
         osNotificationCenter.remove(observer: notificationObserver, name: .savedItemUpdated)
+        osNotificationCenter.remove(observer: notificationObserver, name:.unresolvedSavedItemCreated)
     }
 
     public var mainContext: NSManagedObjectContext {
@@ -248,6 +253,21 @@ extension PocketSource {
         )
 
         enqueue(operation: operation, task: .unarchive(remoteID: remoteID))
+    }
+
+    public func save(item: SavedItem) {
+        guard let url = item.url else {
+            return
+        }
+
+        let operation = operations.saveItemOperation(
+            managedItemID: item.objectID,
+            url: url,
+            events: _events,
+            apollo: apollo,
+            space: space
+        )
+        enqueue(operation: operation, task: .save(localID: item.objectID.uriRepresentation(), url: url))
     }
 }
 
@@ -426,6 +446,15 @@ extension PocketSource {
             }
         }
     }
+
+    public func resolveUnresolvedSavedItems() {
+        guard let unresolved = try? space.fetchUnresolvedSavedItems() else {
+            return
+        }
+
+        unresolved.compactMap(\.savedItem).forEach(save(item:))
+        space.delete(unresolved)
+    }
 }
 
 // MARK: - Interprocess notifications
@@ -444,5 +473,9 @@ extension PocketSource {
 
     func handleSavedItemCreatedNotification() {
         _events.send(.savedItemCreated)
+    }
+
+    func handleUnresolvedSavedItemCreatedNotification() {
+        resolveUnresolvedSavedItems()
     }
 }

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -62,6 +62,10 @@ public enum Requests {
     public static func fetchSavedItemUpdatedNotifications() -> NSFetchRequest<SavedItemUpdatedNotification> {
         return SavedItemUpdatedNotification.fetchRequest()
     }
+
+    public static func fetchUnresolvedSavedItems() -> NSFetchRequest<UnresolvedSavedItem> {
+        UnresolvedSavedItem.fetchRequest()
+    }
 }
 
 public enum Predicates {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -41,6 +41,8 @@ public protocol Source {
     func restore()
 
     func refresh(_ object: NSManagedObject, mergeChanges: Bool)
+
+    func resolveUnresolvedSavedItems()
 }
 
 public extension Source {

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -41,12 +41,11 @@ class Space {
     }
 
     func fetchArchivedItems() throws -> [SavedItem] {
-        let request = Requests.fetchArchivedItems()
-        return try context.fetch(request)
+        return try fetch(Requests.fetchArchivedItems())
     }
 
     func fetchAllSavedItems() throws -> [SavedItem] {
-        return try context.fetch(Requests.fetchAllSavedItems())
+        return try fetch(Requests.fetchAllSavedItems())
     }
     
     func fetchOrCreateSavedItem(byRemoteID itemID: String) throws -> SavedItem {
@@ -54,11 +53,19 @@ class Space {
     }
 
     func fetchPersistentSyncTasks() throws -> [PersistentSyncTask] {
-        return try context.fetch(Requests.fetchPersistentSyncTasks())
+        return try fetch(Requests.fetchPersistentSyncTasks())
     }
 
     func fetchSavedItemUpdatedNotifications() throws -> [SavedItemUpdatedNotification] {
-        return try context.fetch(Requests.fetchSavedItemUpdatedNotifications())
+        return try fetch(Requests.fetchSavedItemUpdatedNotifications())
+    }
+
+    func fetchUnresolvedSavedItems() throws -> [UnresolvedSavedItem] {
+        return try fetch(Requests.fetchUnresolvedSavedItems())
+    }
+
+    func fetch<T>(_ request: NSFetchRequest<T>) throws -> [T] {
+        try context.fetch(request)
     }
 
     func new<T: NSManagedObject>() -> T {

--- a/PocketKit/Tests/PocketKitTests/Refresh/RefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/RefreshCoordinatorTests.swift
@@ -100,9 +100,10 @@ class RefreshCoordinatorTests: XCTestCase {
         XCTAssertEqual(task.setTaskCompletedCall(at:0)?.success, false)
     }
 
-    func test_receivingAppWillEnterForegroundNotification() {
+    func test_receivingAppWillEnterForegroundNotification_refreshesSource_andResolvesUnresolvedSavedItems() {
         taskScheduler.stubRegisterHandler { _, _, _ in true }
         source.stubRefresh { _, _ in }
+        source.stubResolveUnresolvedSavedItems { }
 
         let coordinator = subject()
         coordinator.initialize()
@@ -110,5 +111,6 @@ class RefreshCoordinatorTests: XCTestCase {
         notificationCenter?.post(name: UIScene.willEnterForegroundNotification, object: nil)
 
         XCTAssertNotNil(source.refreshCall(at:0))
+        XCTAssertNotNil(source.resolveUnresolvedSavedItemsCall(at:0))
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -340,3 +340,35 @@ extension MockSource {
         return calls[index] as? RefreshObjectCall
     }
 }
+
+// MARK: - Resolved unresolved saved items
+extension MockSource {
+    static let resolveUnresolvedSavedItems = "resolveUnresolvedSavedItems"
+    typealias ResolveUnresolvedSavedItemsImpl = () -> Void
+    struct ResolveUnresolvedSavedItemsCall { }
+
+    func stubResolveUnresolvedSavedItems(impl: @escaping ResolveUnresolvedSavedItemsImpl) {
+        implementations[Self.resolveUnresolvedSavedItems] = impl
+    }
+
+    func resolveUnresolvedSavedItems() {
+        guard let impl = implementations[Self.resolveUnresolvedSavedItems] as? ResolveUnresolvedSavedItemsImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.resolveUnresolvedSavedItems] = (calls[Self.resolveUnresolvedSavedItems] ?? []) + [
+            ResolveUnresolvedSavedItemsCall()
+        ]
+
+        impl()
+    }
+
+    func resolveUnresolvedSavedItemsCall(at index: Int) -> ResolveUnresolvedSavedItemsCall? {
+        guard let calls = calls[Self.resolveUnresolvedSavedItems],
+              calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? ResolveUnresolvedSavedItemsCall
+    }
+}


### PR DESCRIPTION
# Source
- Listen for "unresolvedSavedItemCreated" notification
  When this notification is recieved, we enqueue a `saveItem` sync task
  that will be executed the next time a network connection becomes
  available.
- Add `resolveUnresolvedSavedItems` method that can be called from
  higher level code (such as PocketKit.RefreshCoordinator when the app
  enters foreground)

# PocketSaveService
- Send `.unresolvedSavedItemCreated` notification when:
  - the expiring activity expires
  - the request to client-api fails for any reason (such as a network timeout
    or airplane mode being enabled)

# RefreshCoordinator
- tell `source` to `resolveUnresolvedSavedItems` when app enters
  foreground