### PR TITLE
Add support for "Move to My List" via swipe in Archive

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -83,7 +83,7 @@ class SavedItemViewModel: ReadableViewModel {
         item.bestURL
     }
     
-    func unarchive() {
+    func moveToMyList() {
         source.unarchive(item: item)
     }
 
@@ -124,7 +124,7 @@ extension SavedItemViewModel {
 
         let archiveAction: ItemAction
         if item.isArchived {
-            archiveAction = .reAdd { [weak self] _ in self?.unarchive() }
+            archiveAction = .moveToMyList { [weak self] _ in self?.moveToMyList() }
         } else {
             archiveAction = .archive { [weak self] _ in self?.archive() }
         }

--- a/PocketKit/Sources/PocketKit/ItemAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemAction.swift
@@ -57,11 +57,11 @@ extension ItemAction {
         )
     }
 
-    static func reAdd(_ handler: @escaping (Any?) -> ()) -> ItemAction {
+    static func moveToMyList(_ handler: @escaping (Any?) -> ()) -> ItemAction {
         return ItemAction(
-            title: "Re-add",
-            identifier: .reAddItem,
-            accessibilityIdentifier: "item-action-re-add",
+            title: "Move to My List",
+            identifier: .moveToMyListItem,
+            accessibilityIdentifier: "item-action-move-to-my-list",
             image: UIImage(asset: .save),
             handler: handler
         )
@@ -115,7 +115,7 @@ extension UIAction.Identifier {
     static let saveItem = UIAction.Identifier(rawValue: "save-item")
     static let archiveItem = UIAction.Identifier(rawValue: "archive-item")
     static let deleteItem = UIAction.Identifier(rawValue: "delete-item")
-    static let reAddItem = UIAction.Identifier(rawValue: "re-add-item")
+    static let moveToMyListItem = UIAction.Identifier(rawValue: "move-to-my-list-item")
     static let favoriteItem = UIAction.Identifier(rawValue: "favorite-item")
     static let shareItem = UIAction.Identifier(rawValue: "share-item")
     static let displaySettings = UIAction.Identifier(rawValue: "display-settings")

--- a/PocketKit/Sources/PocketKit/ItemContextualAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemContextualAction.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Textile
+import UIKit
+
+
+struct ItemContextualAction {
+    let style: UIContextualAction.Style
+    let title: String
+    let image: UIImage?
+    let backgroundColor: UIColor?
+    let completion: (((Bool) -> Void) -> Void)?
+}
+
+extension ItemContextualAction {
+    static func moveToMyList(_ completion: @escaping ((Bool) -> Void) -> Void) -> ItemContextualAction {
+        ItemContextualAction(
+            style: .normal,
+            title: "Move to My List",
+            image: UIImage(asset: .save),
+            backgroundColor: UIColor(.ui.teal2),
+            completion: completion
+        )
+    }
+
+    static func archive(_ completion: @escaping ((Bool) -> Void) -> Void) -> ItemContextualAction {
+        ItemContextualAction(
+            style: .normal,
+            title: "Archive",
+            image: UIImage(asset: .archive),
+            backgroundColor: UIColor(.ui.teal2),
+            completion: completion
+        )
+    }
+}
+
+extension UIContextualAction {
+    convenience init?(_ itemContextualAction: ItemContextualAction?) {
+        guard let action = itemContextualAction else {
+            return nil
+        }
+
+        self.init(style: action.style, title: action.title) { _, _, completion in
+            action.completion?(completion)
+        }
+
+        self.backgroundColor = action.backgroundColor
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -189,7 +189,7 @@ extension ItemsListItemCell {
 
         let shareAction: ItemAction?
         let favoriteAction: ItemAction?
-        let overflowActions: [ItemAction]?
+        let overflowActions: [ItemAction]
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -217,7 +217,7 @@ extension ItemsListItemCell {
             shareButton.addAction(shareAction, for: .primaryActionTriggered)
         }
 
-        let menuActions = state.model.flatMap(\.overflowActions).flatMap { $0.compactMap(UIAction.init) } ?? []
+        let menuActions = state.model?.overflowActions.compactMap(UIAction.init) ?? []
         menuButton.menu = UIMenu(children: menuActions)
 
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -67,7 +67,10 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
                         return nil
                     }
 
-                    return UISwipeActionsConfiguration(actions: model.trailingSwipeActions(for: objectID))
+                    let actions = model.trailingSwipeActions(for: objectID)
+                    .compactMap(UIContextualAction.init)
+
+                    return UISwipeActionsConfiguration(actions: actions)
                 }
 
                 return NSCollectionLayoutSection.list(using: config, layoutEnvironment: env)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -41,8 +41,8 @@ protocol ItemsListViewModel: AnyObject {
 
     func shareAction(for objectID: ItemIdentifier) -> ItemAction?
     func favoriteAction(for objectID: ItemIdentifier) -> ItemAction?
-    func overflowActions(for objectID: ItemIdentifier) -> [ItemAction]?
-    func trailingSwipeActions(for objectID: ItemIdentifier) -> [UIContextualAction]
+    func overflowActions(for objectID: ItemIdentifier) -> [ItemAction]
+    func trailingSwipeActions(for objectID: ItemIdentifier) -> [ItemContextualAction]
 
     func willDisplay(_ cell: ItemsListCell<ItemIdentifier>)
 }

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -135,9 +135,9 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         sharedActivity = PocketItemActivity(url: item.url, sender: sender)
     }
 
-    func overflowActions(for objectID: NSManagedObjectID) -> [ItemAction]? {
+    func overflowActions(for objectID: NSManagedObjectID) -> [ItemAction] {
         guard let item = bareItem(with: objectID) else {
-            return nil
+            return []
         }
 
         return [
@@ -150,18 +150,17 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         ]
     }
 
-    func trailingSwipeActions(for objectID: NSManagedObjectID) -> [UIContextualAction] {
+    func trailingSwipeActions(for objectID: NSManagedObjectID) -> [ItemContextualAction] {
         guard let item = bareItem(with: objectID) else {
             return []
         }
 
-        let archiveAction = UIContextualAction(style: .normal, title: "Archive") { [weak self] _, _, completion in
-            self?._archive(item: item)
-            completion(true)
-        }
-        archiveAction.backgroundColor = UIColor(.ui.lapis1)
-
-        return [archiveAction]
+        return [
+            .archive { [weak self] completion in
+                self?._archive(item: item)
+                completion(true)
+            }
+        ]
     }
 
     private func _archive(item: SavedItem) {

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
@@ -140,7 +140,7 @@ class ArchivedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         // Tap delete button in overflow menu
-        viewModel.overflowActions(for: items[0].objectID)?
+        viewModel.overflowActions(for: items[0].objectID)
             .first { $0.title == "Delete" }?
             .handler?(nil)
 
@@ -261,8 +261,8 @@ class ArchivedItemsListViewModelTests: XCTestCase {
             )
         }.store(in: &subscriptions)
 
-        viewModel.overflowActions(for: items[0].objectID)?
-            .first { $0.title == "Re-add" }?
+        viewModel.overflowActions(for: items[0].objectID)
+            .first { $0.title == "Move to My List" }?
             .handler?(nil)
 
         wait(for: [expectUnarchiveCall, expectSnapshotWithItemRemoved], timeout: 1)

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -44,7 +44,7 @@ class SavedItemViewModelTests: XCTestCase {
             let viewModel = subject(item: .build(isFavorite: true, isArchived: true))
             XCTAssertEqual(
                 viewModel._actions.map(\.title),
-                ["Display Settings", "Unfavorite", "Re-add", "Delete", "Share"]
+                ["Display Settings", "Unfavorite", "Move to My List", "Delete", "Share"]
             )
         }
     }
@@ -56,7 +56,7 @@ class SavedItemViewModelTests: XCTestCase {
         item.isFavorite = true
         XCTAssertEqual(
             viewModel._actions.map(\.title),
-            ["Display Settings", "Unfavorite", "Re-add", "Delete", "Share"]
+            ["Display Settings", "Unfavorite", "Move to My List", "Delete", "Share"]
         )
 
         item.isArchived = false
@@ -163,7 +163,7 @@ class SavedItemViewModelTests: XCTestCase {
         }
 
         let viewModel = subject(item: item)
-        viewModel.invokeAction(title: "Re-add")
+        viewModel.invokeAction(title: "Move to My List")
 
         wait(for: [expectUnarchive], timeout: 1)
     }

--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -106,6 +106,32 @@ class ArchiveTests: XCTestCase {
         app.myListView.selectionSwitcher.myListButton.tap()
         itemCell.wait()
     }
+
+    func test_unarchivingAnItem_bySwiping_removesFromArchive_andAddsToMyList() {
+        app.launch().tabBar.myListButton.wait().tap()
+        app.myListView.selectionSwitcher.archiveButton.wait().tap()
+
+        let itemCell = app.myListView.itemView(matching: "Archived Item 1")
+        itemCell.element.swipeLeft()
+
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isToSaveAnItem {
+                return Response.myList("unarchive")
+            } else if apiRequest.isForMyListContent {
+                return Response.myList("list-with-unarchived-item")
+            }
+
+            fatalError("Unexpected request")
+        }
+
+        app.myListView.readdSwipeButton.wait().tap()
+        waitForDisappearance(of: itemCell)
+
+        app.myListView.selectionSwitcher.myListButton.tap()
+        itemCell.wait()
+    }
 }
 
 extension ArchiveTests {

--- a/Tests iOS/Support/Elements/MyListElement.swift
+++ b/Tests iOS/Support/Elements/MyListElement.swift
@@ -33,6 +33,14 @@ struct MyListElement: PocketUIElement {
         ).containing(.staticText, identifier: "Favorites").element(boundBy: 0)
     }
 
+    var archiveSwipeButton: XCUIElement {
+        collectionView.buttons["Archive"]
+    }
+
+    var readdSwipeButton: XCUIElement {
+        collectionView.buttons["Move to My List"]
+    }
+
     var itemCount: Int {
         itemCells.count
     }

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -73,7 +73,7 @@ struct PocketAppElement {
     }
 
     var reAddButton: XCUIElement {
-        app.buttons["item-action-re-add"]
+        app.buttons["item-action-move-to-my-list"]
     }
 
     var shareButton: XCUIElement {


### PR DESCRIPTION
This pull request adds support for the "Move to My List" action via swipe when viewing one's archive.

## Details

- `trailingSwipeActions(for objectID: ItemIdentifier)` now returns `[ItemAction]?` instead of `UIContextualAction`, following a similar pattern to overflow actions.
- `Re-add` has been renamed to `Move to My List`, and all occurrences have been replaced.
- Any APIs that utilize a `Move to My List` action have been renamed accordingly for consistency.
- `(Pocket)Source` APIs have not been updated, and maintain `unarchive` as a naming convention.
- UI tests have been added for both swiping to archive from "My List", and swiping to "Move to My List" when viewing "Archive"

## Preview

![Simulator Screen Shot - iPhone 13 Pro - 2022-04-07 at 10 51 46](https://user-images.githubusercontent.com/1158092/162245666-1f3ed2de-c894-45da-944f-175d14d4fc8c.png)

