### PR TITLE
Transition Slate(Lineup) to Core Data

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -28,9 +28,9 @@ class RecommendationViewModel: ReadableViewModel {
     @Published
     var isPresentingReaderSettings: Bool?
     
-    private let recommendation: Slate.Recommendation
+    private let recommendation: UnmanagedSlate.UnmanagedRecommendation
 
-    init(recommendation: Slate.Recommendation, tracker: Tracker) {
+    init(recommendation: UnmanagedSlate.UnmanagedRecommendation, tracker: Tracker) {
         self.recommendation = recommendation
         self.tracker = tracker
 

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -125,7 +125,7 @@ class CompactHomeCoordinator: NSObject {
         }.store(in: &readerSubscriptions)
     }
 
-    func report(_ recommendation: Slate.Recommendation?) {
+    func report(_ recommendation: UnmanagedSlate.UnmanagedRecommendation?) {
         guard !isResetting, let recommendation = recommendation else {
             return
         }

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -3,7 +3,7 @@ import Sync
 
 
 class HomeViewControllerSectionProvider {
-    func topicCarouselSection(slates: [Slate]?) -> NSCollectionLayoutSection {
+    func topicCarouselSection(slates: [UnmanagedSlate]?) -> NSCollectionLayoutSection {
         guard let slates = slates, !slates.isEmpty else {
             return NSCollectionLayoutSection(
                 group: .horizontal(
@@ -52,7 +52,7 @@ class HomeViewControllerSectionProvider {
         return section
     }
 
-    func section(for slate: Slate?, width: CGFloat) -> NSCollectionLayoutSection {
+    func section(for slate: UnmanagedSlate?, width: CGFloat) -> NSCollectionLayoutSection {
         let dividerHeight: CGFloat = 17
         let margin: CGFloat = 8
         let spacing: CGFloat = margin * 2
@@ -132,7 +132,7 @@ class HomeViewControllerSectionProvider {
     }
 
     func twoUpGroup(
-        slate: Slate,
+        slate: UnmanagedSlate,
         width: CGFloat,
         spacing: CGFloat,
         dividerHeight: CGFloat

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -12,12 +12,12 @@ import Lottie
 
 enum HomeSection: Hashable {
     case topicCarousel
-    case slate(Slate)
+    case slate(UnmanagedSlate)
 }
 
 enum HomeItem: Hashable {
-    case topicChip(Slate)
-    case recommendation(Slate.Recommendation)
+    case topicChip(UnmanagedSlate)
+    case recommendation(UnmanagedSlate.UnmanagedRecommendation)
 }
 
 class HomeViewController: UIViewController {
@@ -33,14 +33,14 @@ class HomeViewController: UIViewController {
     private let savedRecommendationsService: SavedRecommendationsService
     private var subscriptions: [AnyCancellable] = []
 
-    private var slateLineup: SlateLineup? {
+    private var slateLineup: UnmanagedSlateLineup? {
         didSet {
             applySnapshot()
             savedRecommendationsService.slates = slates
         }
     }
     
-    private var slates: [Slate]? {
+    private var slates: [UnmanagedSlate]? {
         return slateLineup?.slates
     }
 
@@ -281,11 +281,11 @@ extension HomeViewController {
         }
     }
 
-    private func isRecommendationSaved(_ recommendation: Slate.Recommendation) -> Bool {
+    private func isRecommendationSaved(_ recommendation: UnmanagedSlate.UnmanagedRecommendation) -> Bool {
         return savedRecommendationsService.itemIDs.contains(recommendation.item.id)
     }
     
-    private func report(_ recommendation: Slate.Recommendation) {
+    private func report(_ recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         model.selectedRecommendationToReport = recommendation
     }
     

--- a/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationPresenter.swift
@@ -23,9 +23,9 @@ private extension Style {
 }
 
 struct RecommendationPresenter {
-    private let recommendation: Slate.Recommendation
+    private let recommendation: UnmanagedSlate.UnmanagedRecommendation
 
-    init(recommendation: Slate.Recommendation) {
+    init(recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         self.recommendation = recommendation
     }
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -32,8 +32,8 @@ class SlateDetailViewController: UIViewController {
         return layout
     }()
 
-    private lazy var dataSource: UICollectionViewDiffableDataSource<Slate, Slate.Recommendation> = {
-        let registration = UICollectionView.CellRegistration<RecommendationCell, Slate.Recommendation> { cell, indexPath, recommendation in
+    private lazy var dataSource: UICollectionViewDiffableDataSource<UnmanagedSlate, UnmanagedSlate.UnmanagedRecommendation> = {
+        let registration = UICollectionView.CellRegistration<RecommendationCell, UnmanagedSlate.UnmanagedRecommendation> { cell, indexPath, recommendation in
             cell.mode = .hero
             
             let presenter = RecommendationPresenter(recommendation: recommendation)
@@ -65,7 +65,7 @@ class SlateDetailViewController: UIViewController {
             cell.overflowButton.addAction(reportAction, for: .primaryActionTriggered)
         }
         
-        let dataSource = UICollectionViewDiffableDataSource<Slate, Slate.Recommendation>(
+        let dataSource = UICollectionViewDiffableDataSource<UnmanagedSlate, UnmanagedSlate.UnmanagedRecommendation>(
             collectionView: collectionView
         ) { (collectionView, indexPath, recommendation) -> UICollectionViewCell? in
             return collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: recommendation)
@@ -103,14 +103,14 @@ class SlateDetailViewController: UIViewController {
         model.slateID
     }
 
-    private var slate: Slate? {
+    private var slate: UnmanagedSlate? {
         didSet {
             guard let slate = slate else {
                 dataSource.apply(NSDiffableDataSourceSnapshot())
                 return
             }
             
-            var snapshot = NSDiffableDataSourceSnapshot<Slate, Slate.Recommendation>()
+            var snapshot = NSDiffableDataSourceSnapshot<UnmanagedSlate, UnmanagedSlate.UnmanagedRecommendation>()
             snapshot.appendSections([slate])
             snapshot.appendItems(slate.recommendations, toSection: slate)
             
@@ -208,11 +208,11 @@ class SlateDetailViewController: UIViewController {
         }
     }
 
-    private func isRecommendationSaved(_ recommendation: Slate.Recommendation) -> Bool {
+    private func isRecommendationSaved(_ recommendation: UnmanagedSlate.UnmanagedRecommendation) -> Bool {
         return savedRecommendationsService.itemIDs.contains(recommendation.item.id)
     }
     
-    private func report(_ recommendation: Slate.Recommendation) {
+    private func report(_ recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         model.selectedRecommendationToReport = recommendation
     }
     
@@ -311,7 +311,7 @@ extension SlateDetailViewController {
         return [context, content, snowplowSlate, snowplowRecommendation]
     }
     
-    private func url(for recommendation: Slate.Recommendation) -> URL? {
+    private func url(for recommendation: UnmanagedSlate.UnmanagedRecommendation) -> URL? {
         recommendation.item.resolvedURL ?? recommendation.item.givenURL
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SlateHeaderPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateHeaderPresenter.swift
@@ -8,9 +8,9 @@ private extension Style {
 }
 
 struct SlateHeaderPresenter {
-    private let slate: Slate
+    private let slate: UnmanagedSlate
 
-    init(slate: Slate) {
+    init(slate: UnmanagedSlate) {
         self.slate = slate
     }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -10,7 +10,7 @@ class HomeViewModel {
     var selectedReadableViewModel: RecommendationViewModel?
 
     @Published
-    var selectedRecommendationToReport: Slate.Recommendation?
+    var selectedRecommendationToReport: UnmanagedSlate.UnmanagedRecommendation?
 
     @Published
     var selectedSlateDetail: SlateDetailViewModel?
@@ -26,7 +26,7 @@ class SlateDetailViewModel {
     var selectedReadableViewModel: RecommendationViewModel?
 
     @Published
-    var selectedRecommendationToReport: Slate.Recommendation?
+    var selectedRecommendationToReport: UnmanagedSlate.UnmanagedRecommendation?
 
     @Published
     var presentedWebReaderURL: URL?

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -326,7 +326,7 @@ class RegularMainCoordinator: NSObject {
         splitController.present(activityVC, animated: !isResetting)
     }
 
-    private func report(_ recommendation: Slate.Recommendation?) {
+    private func report(_ recommendation: UnmanagedSlate.UnmanagedRecommendation?) {
         guard !isResetting, let recommendation = recommendation else {
             return
         }

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
@@ -5,7 +5,7 @@ import Sync
 
 class ReportRecommendationHostingController: OnDismissHostingController<ReportRecommendationView> {
     init(
-        recommendation: Slate.Recommendation,
+        recommendation: UnmanagedSlate.UnmanagedRecommendation,
         tracker: Tracker,
         onDismiss: @escaping () -> Void
     ) {

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -17,7 +17,7 @@ struct ReportRecommendationView: View {
         static let submitButtonBackgroundColor = Color(.ui.teal2)
     }
     
-    private let recommendation: Slate.Recommendation
+    private let recommendation: UnmanagedSlate.UnmanagedRecommendation
     private let tracker: Tracker
     
     private var submitAccessibilityIdentifier: String {
@@ -39,7 +39,7 @@ struct ReportRecommendationView: View {
     @FocusState
     private var isCommentFocused: Bool
 
-    init(recommendation: Slate.Recommendation, tracker: Tracker) {
+    init(recommendation: UnmanagedSlate.UnmanagedRecommendation, tracker: Tracker) {
         self.recommendation = recommendation
         self.tracker = tracker
     }
@@ -115,7 +115,7 @@ struct ReportRecommendationView: View {
         }
     }
     
-    private func url(for recommendation: Slate.Recommendation) -> URL? {
+    private func url(for recommendation: UnmanagedSlate.UnmanagedRecommendation) -> URL? {
         recommendation.item.resolvedURL ?? recommendation.item.givenURL
     }
     

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -38,7 +38,6 @@
     <entity name="Recommendation" representedClassName="Recommendation" syncable="YES" codeGenerationType="class">
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="recommendation" inverseEntity="Item"/>
-        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="recommendation" inverseEntity="SavedItem"/>
         <relationship name="slate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Slate" inverseName="recommendations" inverseEntity="Slate"/>
     </entity>
     <entity name="SavedItem" representedClassName="SavedItem" syncable="YES" codeGenerationType="class">
@@ -51,7 +50,6 @@
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
-        <relationship name="recommendation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recommendation" inverseName="savedItem" inverseEntity="Recommendation"/>
     </entity>
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
@@ -79,8 +77,8 @@
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
         <element name="Item" positionX="-45" positionY="99" width="128" height="299"/>
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
-        <element name="Recommendation" positionX="-18" positionY="162" width="128" height="89"/>
-        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="179"/>
+        <element name="Recommendation" positionX="-18" positionY="162" width="128" height="74"/>
+        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="164"/>
         <element name="SavedItemUpdatedNotification" positionX="-36" positionY="144" width="128" height="44"/>
         <element name="Slate" positionX="-27" positionY="153" width="128" height="134"/>
         <element name="SlateLineup" positionX="-36" positionY="144" width="128" height="89"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -28,6 +28,7 @@
         <attribute name="videoness" optional="YES" attributeType="String"/>
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Author" inverseName="item" inverseEntity="Author"/>
         <relationship name="domainMetadata" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DomainMetadata" inverseName="item" inverseEntity="DomainMetadata"/>
+        <relationship name="recommendation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recommendation" inverseName="item" inverseEntity="Recommendation"/>
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="item" inverseEntity="SavedItem"/>
     </entity>
     <entity name="PersistentSyncTask" representedClassName="PersistentSyncTask" syncable="YES" codeGenerationType="class">
@@ -35,8 +36,8 @@
         <attribute name="syncTaskContainer" attributeType="Transformable" valueTransformerName="SyncTaskTransformer" customClassName="SyncTaskContainer"/>
     </entity>
     <entity name="Recommendation" representedClassName="Recommendation" syncable="YES" codeGenerationType="class">
-        <attribute name="id" optional="YES" attributeType="String"/>
-        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="recommendation" inverseEntity="Item"/>
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="recommendation" inverseEntity="SavedItem"/>
         <relationship name="slate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Slate" inverseName="recommendations" inverseEntity="Slate"/>
     </entity>
@@ -57,8 +58,8 @@
     </entity>
     <entity name="Slate" representedClassName="Slate" syncable="YES" codeGenerationType="class">
         <attribute name="experimentID" optional="YES" attributeType="String"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="requestID" optional="YES" attributeType="String"/>
         <attribute name="slateDescription" optional="YES" attributeType="String"/>
         <relationship name="recommendations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Recommendation" inverseName="slate" inverseEntity="Recommendation"/>
@@ -66,7 +67,7 @@
     </entity>
     <entity name="SlateLineup" representedClassName="SlateLineup" syncable="YES" codeGenerationType="class">
         <attribute name="experimentID" optional="YES" attributeType="String"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="requestID" optional="YES" attributeType="String"/>
         <relationship name="slates" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Slate" inverseName="slateLineup" inverseEntity="Slate"/>
     </entity>
@@ -76,7 +77,7 @@
     <elements>
         <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
-        <element name="Item" positionX="-45" positionY="99" width="128" height="284"/>
+        <element name="Item" positionX="-45" positionY="99" width="128" height="299"/>
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
         <element name="Recommendation" positionX="-18" positionY="162" width="128" height="89"/>
         <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="179"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -34,6 +34,12 @@
         <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="666643260" usesScalarValueType="NO"/>
         <attribute name="syncTaskContainer" attributeType="Transformable" valueTransformerName="SyncTaskTransformer" customClassName="SyncTaskContainer"/>
     </entity>
+    <entity name="Recommendation" representedClassName="Recommendation" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item"/>
+        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="recommendation" inverseEntity="SavedItem"/>
+        <relationship name="slate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Slate" inverseName="recommendations" inverseEntity="Slate"/>
+    </entity>
     <entity name="SavedItem" representedClassName="SavedItem" syncable="YES" codeGenerationType="class">
         <attribute name="archivedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -44,9 +50,25 @@
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
+        <relationship name="recommendation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recommendation" inverseName="savedItem" inverseEntity="Recommendation"/>
     </entity>
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
+    </entity>
+    <entity name="Slate" representedClassName="Slate" syncable="YES" codeGenerationType="class">
+        <attribute name="experimentID" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="requestID" optional="YES" attributeType="String"/>
+        <attribute name="slateDescription" optional="YES" attributeType="String"/>
+        <relationship name="recommendations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Recommendation" inverseName="slate" inverseEntity="Recommendation"/>
+        <relationship name="slateLineup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SlateLineup" inverseName="slates" inverseEntity="SlateLineup"/>
+    </entity>
+    <entity name="SlateLineup" representedClassName="SlateLineup" syncable="YES" codeGenerationType="class">
+        <attribute name="experimentID" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="requestID" optional="YES" attributeType="String"/>
+        <relationship name="slates" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Slate" inverseName="slateLineup" inverseEntity="Slate"/>
     </entity>
     <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
@@ -54,10 +76,13 @@
     <elements>
         <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
         <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
-        <element name="Item" positionX="-45" positionY="99" width="128" height="239"/>
+        <element name="Item" positionX="-45" positionY="99" width="128" height="284"/>
         <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
-        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="149"/>
+        <element name="Recommendation" positionX="-18" positionY="162" width="128" height="89"/>
+        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="179"/>
         <element name="SavedItemUpdatedNotification" positionX="-36" positionY="144" width="128" height="44"/>
+        <element name="Slate" positionX="-27" positionY="153" width="128" height="134"/>
+        <element name="SlateLineup" positionX="-36" positionY="144" width="128" height="89"/>
         <element name="UnresolvedSavedItem" positionX="-36" positionY="144" width="128" height="44"/>
     </elements>
 </model>

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -39,7 +39,7 @@ extension SavedItem {
         item?.update(remote: itemParts)
     }
 
-    func update(from recommendation: Slate.Recommendation) {
+    func update(from recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         self.url = recommendation.item.resolvedURL ?? recommendation.item.givenURL
 
         guard let context = managedObjectContext else {

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -6,7 +6,7 @@ extension SlateLineup {
     public typealias RemoteSlateLineup = GetSlateLineupQuery.Data.GetSlateLineup
 
     func update(from remote: RemoteSlateLineup, in space: Space) {
-        id = remote.id
+        remoteID = remote.id
         requestID = remote.requestId
         experimentID = remote.experimentId
 
@@ -26,7 +26,7 @@ extension Slate {
 
     func update(from remote: RemoteSlate, in space: Space) {
         experimentID = remote.experimentId
-        id = remote.id
+        remoteID = remote.id
         name = remote.displayName
         requestID = remote.requestId
         slateDescription = remote.description
@@ -46,7 +46,7 @@ extension Recommendation {
     public typealias RemoteRecommendation = Slate.RemoteSlate.Recommendation
 
     func update(from remote: RemoteRecommendation, in space: Space) {
-        id = remote.id
+        remoteID = remote.id
 
         if item != nil {
             item = nil

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CoreData
+
+
+extension SlateLineup {
+    public typealias RemoteSlateLineup = GetSlateLineupQuery.Data.GetSlateLineup
+
+    func update(from remote: RemoteSlateLineup, in space: Space) {
+        id = remote.id
+        requestID = remote.requestId
+        experimentID = remote.experimentId
+
+        if let slates = slates {
+            removeFromSlates(slates)
+        }
+        remote.slates.forEach { remote in
+            let slate: Slate = space.new()
+            slate.update(from: remote, in: space)
+            addToSlates(slate)
+        }
+    }
+}
+
+extension Slate {
+    public typealias RemoteSlate = SlateLineup.RemoteSlateLineup.Slate
+
+    func update(from remote: RemoteSlate, in space: Space) {
+        experimentID = remote.experimentId
+        id = remote.id
+        name = remote.displayName
+        requestID = remote.requestId
+        slateDescription = remote.description
+
+        if let recommendations = recommendations {
+            removeFromRecommendations(recommendations)
+        }
+        remote.recommendations.forEach { remote in
+            let recommendation: Recommendation = space.new()
+            recommendation.update(from: remote, in: space)
+            addToRecommendations(recommendation)
+        }
+    }
+}
+
+extension Recommendation {
+    public typealias RemoteRecommendation = Slate.RemoteSlate.Recommendation
+
+    func update(from remote: RemoteRecommendation, in space: Space) {
+        id = remote.id
+
+        if item != nil {
+            item = nil
+        }
+
+        let recommendationItem = try? space.fetchOrCreateItem(byRemoteID: remote.item.remoteId)
+        recommendationItem?.update(remote: remote.item.fragments.itemParts)
+        item = recommendationItem
+    }
+}

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -15,14 +15,14 @@ extension SlateLineup {
         }
         remote.slates.forEach { remote in
             let slate: Slate = space.new()
-            slate.update(from: remote, in: space)
+            slate.update(from: remote.fragments.slateParts, in: space)
             addToSlates(slate)
         }
     }
 }
 
 extension Slate {
-    public typealias RemoteSlate = SlateLineup.RemoteSlateLineup.Slate
+    public typealias RemoteSlate = SlateParts
 
     func update(from remote: RemoteSlate, in space: Space) {
         experimentID = remote.experimentId
@@ -31,11 +31,10 @@ extension Slate {
         requestID = remote.requestId
         slateDescription = remote.description
 
-        if let recommendations = recommendations {
-            removeFromRecommendations(recommendations)
-        }
         remote.recommendations.forEach { remote in
-            let recommendation: Recommendation = space.new()
+            guard let recommendation = try? space.fetchOrCreateRecommendation(byRemoteID: remote.id!) else {
+                return
+            }
             recommendation.update(from: remote, in: space)
             addToRecommendations(recommendation)
         }
@@ -43,14 +42,10 @@ extension Slate {
 }
 
 extension Recommendation {
-    public typealias RemoteRecommendation = Slate.RemoteSlate.Recommendation
+    public typealias RemoteRecommendation = SlateParts.Recommendation
 
     func update(from remote: RemoteRecommendation, in space: Space) {
         remoteID = remote.id
-
-        if item != nil {
-            item = nil
-        }
 
         let recommendationItem = try? space.fetchOrCreateItem(byRemoteID: remote.item.remoteId)
         recommendationItem?.update(remote: remote.item.fragments.itemParts)

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -78,7 +78,7 @@ public enum Requests {
 
     public static func fetchSlateLineup(byID id: String) -> NSFetchRequest<SlateLineup> {
         let request = Self.fetchSlateLineups()
-        request.predicate = NSPredicate(format: "id = %@", id)
+        request.predicate = NSPredicate(format: "remoteID = %@", id)
         request.fetchLimit = 1
         return request
     }

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -71,6 +71,42 @@ public enum Requests {
     public static func fetchUnresolvedSavedItems() -> NSFetchRequest<UnresolvedSavedItem> {
         UnresolvedSavedItem.fetchRequest()
     }
+
+    public static func fetchSlateLineups() -> NSFetchRequest<SlateLineup> {
+        SlateLineup.fetchRequest()
+    }
+
+    public static func fetchSlateLineup(byID id: String) -> NSFetchRequest<SlateLineup> {
+        let request = Self.fetchSlateLineups()
+        request.predicate = NSPredicate(format: "id = %@", id)
+        request.fetchLimit = 1
+        return request
+    }
+
+    public static func fetchSlates() -> NSFetchRequest<Slate> {
+        Slate.fetchRequest()
+    }
+
+    public static func fetchRecommendations() -> NSFetchRequest<Recommendation> {
+        Recommendation.fetchRequest()
+    }
+
+    public static func fetchItems() -> NSFetchRequest<Item> {
+        Item.fetchRequest()
+    }
+
+    public static func fetchItem(byRemoteID id: String) -> NSFetchRequest<Item> {
+        let request = self.fetchItems()
+        request.predicate = NSPredicate(format: "remoteID = %@", id)
+        request.fetchLimit = 1
+        return request
+    }
+
+    public static func fetchUnsavedItems() -> NSFetchRequest<Item> {
+        let request = self.fetchItems()
+        request.predicate = NSPredicate(format: "savedItem = nil")
+        return request
+    }
 }
 
 public enum Predicates {

--- a/PocketKit/Sources/Sync/SavedRecommendationsService.swift
+++ b/PocketKit/Sources/Sync/SavedRecommendationsService.swift
@@ -7,7 +7,7 @@ public class SavedRecommendationsService {
     @Published
     private(set) public var itemIDs: [String] = []
 
-    public var slates: [Slate]? = [] {
+    public var slates: [UnmanagedSlate]? = [] {
         didSet {
             update()
         }

--- a/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/Slates/Slate+remoteMapping.swift
@@ -1,18 +1,18 @@
 import Foundation
 
 
-public extension SlateLineup {
+public extension UnmanagedSlateLineup {
     typealias Remote = GetSlateLineupQuery.Data.GetSlateLineup
     
     init(remote: Remote) {
         id = remote.id
         requestID = remote.requestId
         experimentID = remote.experimentId
-        slates = remote.slates.map { $0.fragments.slateParts }.map(Slate.init)
+        slates = remote.slates.map { $0.fragments.slateParts }.map(UnmanagedSlate.init)
     }
 }
 
-extension Slate {
+extension UnmanagedSlate {
     typealias Remote = SlateParts
 
     init(remote: Remote) {
@@ -22,12 +22,12 @@ extension Slate {
             experimentID: remote.experimentId,
             name: remote.displayName,
             description: remote.description,
-            recommendations: remote.recommendations.map(Slate.Recommendation.init)
+            recommendations: remote.recommendations.map(UnmanagedSlate.UnmanagedRecommendation.init)
         )
     }
 }
 
-extension Slate.Recommendation {
+extension UnmanagedSlate.UnmanagedRecommendation {
     typealias Remote = SlateParts.Recommendation
 
     init(remote: Remote) {

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -25,7 +25,7 @@ class APISlateService: SlateService {
             return
         }
 
-        if let existingSlateLineup = try space.fetchSlateLineup(byID: remote.id) {
+        if let existingSlateLineup = try space.fetchSlateLineup(byRemoteID: remote.id) {
             space.delete(existingSlateLineup)
         }
 
@@ -34,10 +34,24 @@ class APISlateService: SlateService {
         let slateLineup: SlateLineup = space.new()
         slateLineup.update(from: remote, in: space)
 
-        try space.save()
+        try self.space.save()
     }
 
     func fetchSlate(_ slateID: String) async throws {
-        
+        let query = GetSlateQuery(slateID: slateID, recommendationCount: 25)
+
+        guard let remote = try await apollo.fetch(query: query).data?.getSlate?.fragments.slateParts else {
+            return
+        }
+
+        let unsavedItems = try space.fetchUnsavedItems()
+        unsavedItems.forEach {
+            space.delete($0)
+        }
+
+        let slate: Slate = try space.fetchOrCreateSlate(byRemoteID: remote.id)
+        slate.update(from: remote, in: space)
+
+        try self.space.save()
     }
 }

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -2,31 +2,42 @@ import Apollo
 import Foundation
 
 protocol SlateService {
-    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup?
-    func fetchSlate(_ slateID: String) async throws -> Slate?
+    func fetchSlateLineup(_ identifier: String) async throws
+    func fetchSlate(_ slateID: String) async throws
 }
 
 class APISlateService: SlateService {
     private let apollo: ApolloClientProtocol
+    private let space: Space
 
-    init(apollo: ApolloClientProtocol) {
+    init(
+        apollo: ApolloClientProtocol,
+        space: Space
+    ) {
         self.apollo = apollo
+        self.space = space
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
+    func fetchSlateLineup(_ identifier: String) async throws {
         let query = GetSlateLineupQuery(lineupID: identifier, maxRecommendations: 5)
-        
-        return try await apollo
-            .fetch(query: query)
-            .data?.getSlateLineup
-            .flatMap { $0 }
-            .map(SlateLineup.init)
+
+        guard let remote = try await apollo.fetch(query: query).data?.getSlateLineup else {
+            return
+        }
+
+        if let existingSlateLineup = try space.fetchSlateLineup(byID: remote.id) {
+            space.delete(existingSlateLineup)
+        }
+
+        try space.deleteUnsavedItems()
+
+        let slateLineup: SlateLineup = space.new()
+        slateLineup.update(from: remote, in: space)
+
+        try space.save()
     }
 
-    func fetchSlate(_ slateID: String) async throws -> Slate? {
-        let query = GetSlateQuery(slateID: slateID, recommendationCount: 25)
-        let remote = try await apollo.fetch(query: query).data?.getSlate
-
-        return (remote?.fragments.slateParts).flatMap(Slate.init)
+    func fetchSlate(_ slateID: String) async throws {
+        
     }
 }

--- a/PocketKit/Sources/Sync/Slates/UnmanagedSlate.swift
+++ b/PocketKit/Sources/Sync/Slates/UnmanagedSlate.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 
-public struct Slate: Identifiable, Equatable, Hashable {
+public struct UnmanagedSlate: Identifiable, Equatable, Hashable {
     public let id: String
     public let requestID: String
     public let experimentID: String
     public let name: String?
     public let description: String?
-    public let recommendations: [Recommendation]
+    public let recommendations: [UnmanagedRecommendation]
 
-    public struct Recommendation: Identifiable, Equatable, Hashable {
+    public struct UnmanagedRecommendation: Identifiable, Equatable, Hashable {
         public let id: String?
         public let item: UnmanagedItem
     }
 }
 
-private extension Slate {
+private extension UnmanagedSlate {
     enum CodingKeys: String, CodingKey {
         case id
         case requestID = "requestId"
@@ -26,9 +26,9 @@ private extension Slate {
     }
 }
 
-public struct SlateLineup: Identifiable, Equatable, Hashable {
+public struct UnmanagedSlateLineup: Identifiable, Equatable, Hashable {
     public let id: String
     public let requestID: String
     public let experimentID: String
-    public let slates: [Slate]
+    public let slates: [UnmanagedSlate]
 }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -28,15 +28,15 @@ public protocol Source {
 
     func unarchive(item: SavedItem)
 
-    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup?
+    func fetchSlateLineup(_ identifier: String) async throws
 
-    func fetchSlate(_ slateID: String) async throws -> Slate?
+    func fetchSlate(_ slateID: String) async throws
 
     func savedRecommendationsService() -> SavedRecommendationsService
 
-    func save(recommendation: Slate.Recommendation)
+    func save(recommendation: UnmanagedSlate.UnmanagedRecommendation)
 
-    func archive(recommendation: Slate.Recommendation)
+    func archive(recommendation: UnmanagedSlate.UnmanagedRecommendation)
 
     func fetchArchivePage(cursor: String?, isFavorite: Bool?)
 

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -64,6 +64,42 @@ class Space {
         return try fetch(Requests.fetchUnresolvedSavedItems())
     }
 
+    func fetchSlateLineups() throws -> [SlateLineup] {
+        return try fetch(Requests.fetchSlateLineups())
+    }
+
+    func fetchSlateLineup(byID id: String) throws -> SlateLineup? {
+        return try fetch(Requests.fetchSlateLineup(byID: id)).first
+    }
+
+    func fetchOrCreateSlateLineup(byID id: String) throws -> SlateLineup {
+        try fetchSlateLineup(byID: id) ?? new()
+    }
+
+    func fetchSlates() throws -> [Slate] {
+        return try fetch(Requests.fetchSlates())
+    }
+
+    func fetchRecommendations() throws -> [Recommendation] {
+        return try fetch(Requests.fetchRecommendations())
+    }
+
+    func fetchItems() throws -> [Item] {
+        return try fetch(Requests.fetchItems())
+    }
+
+    func fetchItem(byRemoteID id: String) throws -> Item? {
+        return try fetch(Requests.fetchItem(byRemoteID: id)).first
+    }
+
+    func fetchOrCreateItem(byRemoteID id: String) throws -> Item {
+        return try fetchItem(byRemoteID: id) ?? new()
+    }
+
+    func fetchUnsavedItems() throws -> [Item] {
+        return try fetch(Requests.fetchUnsavedItems())
+    }
+
     func fetch<T>(_ request: NSFetchRequest<T>) throws -> [T] {
         try context.fetch(request)
     }
@@ -78,6 +114,10 @@ class Space {
 
     func delete(_ objects: [NSManagedObject]) {
         objects.forEach(context.delete(_:))
+    }
+
+    func deleteUnsavedItems() throws {
+        try delete(fetchUnsavedItems())
     }
 
     func save() throws {

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -68,20 +68,42 @@ class Space {
         return try fetch(Requests.fetchSlateLineups())
     }
 
-    func fetchSlateLineup(byID id: String) throws -> SlateLineup? {
+    func fetchSlateLineup(byRemoteID id: String) throws -> SlateLineup? {
         return try fetch(Requests.fetchSlateLineup(byID: id)).first
     }
 
-    func fetchOrCreateSlateLineup(byID id: String) throws -> SlateLineup {
-        try fetchSlateLineup(byID: id) ?? new()
+    func fetchOrCreateSlateLineup(byRemoteID id: String) throws -> SlateLineup {
+        try fetchSlateLineup(byRemoteID: id) ?? new()
     }
 
     func fetchSlates() throws -> [Slate] {
         return try fetch(Requests.fetchSlates())
     }
 
+    func fetchSlate(byRemoteID id: String) throws -> Slate? {
+        let request = Requests.fetchSlates()
+        request.predicate = NSPredicate(format: "remoteID = %@", id)
+        request.fetchLimit = 1
+        return try fetch(request).first
+    }
+
+    func fetchOrCreateSlate(byRemoteID id: String) throws -> Slate {
+        return try fetchSlate(byRemoteID: id) ?? new()
+    }
+
     func fetchRecommendations() throws -> [Recommendation] {
         return try fetch(Requests.fetchRecommendations())
+    }
+
+    func fetchRecommendation(byRemoteID id: String) throws -> Recommendation? {
+        let request = Requests.fetchRecommendations()
+        request.predicate = NSPredicate(format: "remoteID = %@", id)
+        request.fetchLimit = 1
+        return try fetch(request).first
+    }
+
+    func fetchOrCreateRecommendation(byRemoteID id: String) throws -> Recommendation {
+        return try fetchRecommendation(byRemoteID: id) ?? new()
     }
 
     func fetchItems() throws -> [Item] {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -21,11 +21,11 @@ class MockSource: Source {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
+    func fetchSlateLineup(_ identifier: String) async throws {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
-    func fetchSlate(_ slateID: String) async throws -> Slate? {
+    func fetchSlate(_ slateID: String) async throws {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
@@ -33,11 +33,11 @@ class MockSource: Source {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
-    func save(recommendation: Slate.Recommendation) {
+    func save(recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 
-    func archive(recommendation: Slate.Recommendation) {
+    func archive(recommendation: UnmanagedSlate.UnmanagedRecommendation) {
         fatalError("\(Self.self)#\(#function) is not implemented")
     }
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -51,7 +51,7 @@ extension APISlateServiceTests {
         XCTAssertEqual(lineups.count, 1)
 
         let lineup = lineups[0]
-        XCTAssertEqual(lineup.id, "slate-lineup-1")
+        XCTAssertEqual(lineup.remoteID, "slate-lineup-1")
         XCTAssertEqual(lineup.requestID, "slate-lineup-1-request")
         XCTAssertEqual(lineup.experimentID, "slate-lineup-1-experiment")
 
@@ -60,7 +60,7 @@ extension APISlateServiceTests {
 
         do {
             let slate = slates[0]
-            XCTAssertEqual(slate.id, "slate-1")
+            XCTAssertEqual(slate.remoteID, "slate-1")
             XCTAssertEqual(slate.requestID, "slate-1-request")
             XCTAssertEqual(slate.experimentID, "slate-1-experiment")
             XCTAssertEqual(slate.name, "Slate 1")
@@ -71,7 +71,7 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[0]
-                XCTAssertEqual(recommendation.id, "slate-1-rec-1")
+                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-1")
 
                 let item = recommendation.item
                 XCTAssertNotNil(item)
@@ -95,14 +95,14 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[1]
-                XCTAssertEqual(recommendation.id, "slate-1-rec-2")
+                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-2")
                 XCTAssertNotNil(recommendation.item)
             }
         }
 
         do {
             let slate = slates[1]
-            XCTAssertEqual(slate.id, "slate-2")
+            XCTAssertEqual(slate.remoteID, "slate-2")
             XCTAssertEqual(slate.requestID, "slate-2-request")
             XCTAssertEqual(slate.experimentID, "slate-2-experiment")
             XCTAssertEqual(slate.name, "Slate 2")
@@ -113,7 +113,7 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[0]
-                XCTAssertEqual(recommendation.id, "slate-2-rec-1")
+                XCTAssertEqual(recommendation.remoteID, "slate-2-rec-1")
             }
         }
     }
@@ -122,8 +122,8 @@ extension APISlateServiceTests {
         apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
 
         let item = Item.build(remoteID: "item-1-seed")
-        let recommendation = Recommendation.build(id: "slate-1-recommendation-1-seed", item: item)
-        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
+        let recommendation = Recommendation.build(remoteID: "slate-1-recommendation-1-seed", item: item)
+        let slate = Slate.build(remoteID: "slate-1-seed", recommendations: [recommendation])
         SlateLineup.build(slates: [slate])
         try await space.context.perform {
             try self.space.save()
@@ -138,14 +138,14 @@ extension APISlateServiceTests {
 
         // 2. Old slates should be deleted
         let fetchedSlates = try space.fetchSlates()
-        let fetchedSlateIDs = fetchedSlates.map { $0.id! }
+        let fetchedSlateIDs = fetchedSlates.map { $0.remoteID! }
         XCTAssertEqual(fetchedSlates.count, 2)
         XCTAssertEqual(Set(fetchedSlateIDs) , ["slate-1", "slate-2"])
 
         // 3. Old recommendations should be deleted
         let fetchedRecommendations = try space.fetchRecommendations()
         XCTAssertEqual(fetchedRecommendations.count, 3)
-        let fetchedRecommendationIDs = fetchedRecommendations.map { $0.id! }
+        let fetchedRecommendationIDs = fetchedRecommendations.map { $0.remoteID! }
         XCTAssertFalse(fetchedRecommendationIDs.contains("slate-1-recommendation-1-seed"))
 
         // 4. Old items should be removed
@@ -160,8 +160,8 @@ extension APISlateServiceTests {
 
         let item = Item.build(remoteID: "item-1-seed")
         SavedItem.build(item: item)
-        let recommendation = Recommendation.build(id: "slate-1-recommendation-seed", item: item)
-        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
+        let recommendation = Recommendation.build(remoteID: "slate-1-recommendation-seed", item: item)
+        let slate = Slate.build(remoteID: "slate-1-seed", recommendations: [recommendation])
         SlateLineup.build(slates: [slate])
         try await space.context.perform {
             try self.space.save()
@@ -177,15 +177,129 @@ extension APISlateServiceTests {
     func test_fetchSlateLineup_existingItem_updatesExistingItem() async throws {
         apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
 
-        let item = Item.build(remoteID: "item-1-seed")
-        let recommendation = Recommendation.build(id: "slate-1-recommendation-1-seed", item: item)
-        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
-        SlateLineup.build(slates: [slate])
-        try space.context.performAndWait {
-            try space.save()
+        // fetchSlateLineup "cleans" all unsaved items before fetching,
+        // so we have to fake a saved item for the item to update
+        let item = Item.build(title: "Item 1 Seed")
+        SavedItem.build(item: item)
+        try await space.context.perform {
+            try self.space.save()
         }
 
         let service = subject()
         try await service.fetchSlateLineup("slate-lineup-identifier")
+
+        XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
     }
+}
+
+extension APISlateServiceTests {
+    func test_fetchSlate_performsCorrectQuery() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slate-detail", asResultType: GetSlateQuery.self)
+
+        let service = subject()
+        try await service.fetchSlate("slate-identifier")
+
+        let fetchCall: MockApolloClient.FetchCall<GetSlateQuery>? = apollo.fetchCall(at: 0)
+        XCTAssertNotNil(fetchCall)
+        XCTAssertEqual(fetchCall?.query.slateID, "slate-identifier")
+        XCTAssertEqual(fetchCall?.query.recommendationCount, 25)
+    }
+
+    func test_fetchSlate_emptySpace_savesSlate() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slate-detail", asResultType: GetSlateQuery.self)
+
+        let service = subject()
+        try await service.fetchSlate("slate-identifier")
+
+        let slates = try space.fetchSlates()
+        XCTAssertEqual(slates.count, 1)
+
+        let slate = slates[0]
+        XCTAssertEqual(slate.remoteID, "slate-1")
+        XCTAssertEqual(slate.requestID, "slate-1-request")
+        XCTAssertEqual(slate.experimentID, "slate-1-experiment")
+        XCTAssertEqual(slate.name, "Slate 1")
+        XCTAssertEqual(slate.slateDescription, "The description of slate 1")
+
+        let recommendations = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
+        XCTAssertEqual(recommendations.count, 3)
+
+        do {
+            let recommendation = recommendations[0]
+            XCTAssertEqual(recommendation.remoteID, "1")
+
+            let item = recommendation.item
+            XCTAssertNotNil(item)
+            XCTAssertEqual(item!.remoteID, "item-1")
+            XCTAssertEqual(item!.givenURL?.absoluteString, "https://given.example.com/rec-1")
+            XCTAssertEqual(item!.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
+            XCTAssertEqual(item!.title, "Slate 1, Recommendation 1")
+            XCTAssertEqual(item!.language, "en")
+            XCTAssertEqual(item!.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
+            XCTAssertEqual(item!.timeToRead, 1)
+            XCTAssertEqual(item!.article?.components, [])
+            XCTAssertEqual(item!.excerpt, "Cursus Aenean Elit")
+            XCTAssertEqual(item!.datePublished?.timeIntervalSince1970, 1609502461)
+            XCTAssertEqual(item!.domain, "slate-1-rec-1.example.com")
+            XCTAssertEqual(item!.domainMetadata?.name, "Lifehacker")
+            XCTAssertEqual(item!.domainMetadata?.logo?.absoluteString, "https://slate-1-rec-1.example.com/logo.png")
+            XCTAssertEqual(item!.isArticle, true)
+            XCTAssertEqual(item!.hasImage, .hasImages)
+            XCTAssertEqual(item!.hasVideo, .hasVideos)
+        }
+
+        do {
+            let recommendation = recommendations[1]
+            XCTAssertEqual(recommendation.remoteID, "2")
+            XCTAssertNotNil(recommendation.item)
+        }
+
+        do {
+            let recommendation = recommendations[2]
+            XCTAssertEqual(recommendation.remoteID, "3")
+            XCTAssertNotNil(recommendation.item)
+        }
+    }
+
+
+//    func test_fetchSlate_existingSlate_updatesRecommendations_withNoDuplicates() async throws {
+//        apollo.stubFetch(toReturnFixturedNamed: "slate-detail", asResultType: GetSlateQuery.self)
+//
+//        Slate.build(
+//            remoteID: "slate-1",
+//            recommendations: [
+//                .build(remoteID: "seed-1"),
+//                .build(remoteID: "1")
+//            ]
+//        )
+//        try await space.context.perform {
+//            try self.space.save()
+//        }
+//
+//        let service = subject()
+//        try await service.fetchSlate("slate-lineup-identifier")
+//
+//        let slates = try space.fetchSlates()
+//        XCTAssertEqual(slates.count, 1)
+//
+//        let recommendations = slates[0].recommendations?.compactMap { $0 as? Recommendation } ?? []
+//        XCTAssertEqual(recommendations.count, 4)
+//    }
+
+//    func test_fetchSlate_existingItem_updatesExistingItem() async throws {
+//        apollo.stubFetch(toReturnFixturedNamed: "slate-detail", asResultType: GetSlateQuery.self)
+//
+//        let item = Item.build(title: "Item 1 Seed")
+//        let recommendation = Recommendation.build(remoteID: "slate-1-recommendation-1-seed", item: item)
+//        let slate = Slate.build(remoteID: "slate-1-seed", recommendations: [recommendation])
+//        SlateLineup.build(slates: [slate])
+//        try space.context.performAndWait {
+//            try space.save()
+//        }
+//
+//        let service = subject()
+//        try await service.fetchSlate("slate-lineup-identifier")
+//
+//        XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
+//    }
 }

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -7,124 +7,185 @@ import Apollo
 
 class APISlateServiceTests: XCTestCase {
     var apollo: MockApolloClient!
+    var space: Space!
 
     override func setUpWithError() throws {
+        continueAfterFailure = false
+
         apollo = MockApolloClient()
+        space = Space(container: .testContainer)
+        try space.clear()
     }
 
-    func subject(apollo: MockApolloClient? = nil) -> APISlateService {
-        APISlateService(apollo: apollo ?? self.apollo)
+    func subject(
+        apollo: MockApolloClient? = nil,
+        space: Space? = nil
+    ) -> APISlateService {
+        APISlateService(
+            apollo: apollo ?? self.apollo,
+            space: space ?? self.space
+        )
     }
+}
 
-    func test_fetchSlateLineup_returnsSlateLineup() async throws {
+extension APISlateServiceTests {
+    func test_fetchSlateLineup_performsCorrectQuery() async throws {
         apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
 
-        let lineup = try await subject().fetchSlateLineup("slate-lineup-1")
-        XCTAssertNotNil(lineup)
-        XCTAssertEqual(lineup!.id, "slate-lineup-1")
-        XCTAssertEqual(lineup!.requestID, "slate-lineup-1-request")
-        XCTAssertEqual(lineup!.experimentID, "slate-lineup-1-experiment")
+        let service = subject()
+        try await service.fetchSlateLineup("slate-lineup-identifier")
 
-        XCTAssertEqual(lineup?.slates.count, 2)
+        let fetchCall: MockApolloClient.FetchCall<GetSlateLineupQuery>? = apollo.fetchCall(at: 0)
+        XCTAssertNotNil(fetchCall)
+        XCTAssertEqual(fetchCall?.query.lineupID, "slate-lineup-identifier")
+        XCTAssertEqual(fetchCall?.query.maxRecommendations, 5)
+    }
+
+    func test_fetchSlateLineup_emptySpace_savesLineupInSpace() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
+
+        let service = subject()
+        try await service.fetchSlateLineup("slate-lineup-identifier")
+
+        let lineups = try space.fetchSlateLineups()
+        XCTAssertEqual(lineups.count, 1)
+
+        let lineup = lineups[0]
+        XCTAssertEqual(lineup.id, "slate-lineup-1")
+        XCTAssertEqual(lineup.requestID, "slate-lineup-1-request")
+        XCTAssertEqual(lineup.experimentID, "slate-lineup-1-experiment")
+
+        let slates = lineup.slates?.compactMap { $0 as? Slate } ?? []
+        XCTAssertEqual(slates.count, 2)
 
         do {
-            let slate = lineup!.slates[0]
+            let slate = slates[0]
             XCTAssertEqual(slate.id, "slate-1")
             XCTAssertEqual(slate.requestID, "slate-1-request")
             XCTAssertEqual(slate.experimentID, "slate-1-experiment")
             XCTAssertEqual(slate.name, "Slate 1")
-            XCTAssertEqual(slate.description, "The description of slate 1")
-            XCTAssertEqual(slate.recommendations.count, 2)
+            XCTAssertEqual(slate.slateDescription, "The description of slate 1")
 
-            let recommendations = slate.recommendations
+            let recommendations = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
+            XCTAssertEqual(recommendations.count, 2)
 
             do {
                 let recommendation = recommendations[0]
                 XCTAssertEqual(recommendation.id, "slate-1-rec-1")
+
+                let item = recommendation.item
+                XCTAssertNotNil(item)
+                XCTAssertEqual(item!.remoteID, "item-1")
+                XCTAssertEqual(item!.givenURL?.absoluteString, "https://given.example.com/rec-1")
+                XCTAssertEqual(item!.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
+                XCTAssertEqual(item!.title, "Slate 1, Recommendation 1")
+                XCTAssertEqual(item!.language, "en")
+                XCTAssertEqual(item!.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
+                XCTAssertEqual(item!.timeToRead, 1)
+                XCTAssertEqual(item!.article?.components, [])
+                XCTAssertEqual(item!.excerpt, "Cursus Aenean Elit")
+                XCTAssertEqual(item!.datePublished?.timeIntervalSince1970, 1609502461)
+                XCTAssertEqual(item!.domain, "slate-1-rec-1.example.com")
+                XCTAssertEqual(item!.domainMetadata?.name, "Lifehacker")
+                XCTAssertEqual(item!.domainMetadata?.logo?.absoluteString, "https://slate-1-rec-1.example.com/logo.png")
+                XCTAssertEqual(item!.isArticle, true)
+                XCTAssertEqual(item!.hasImage, .hasImages)
+                XCTAssertEqual(item!.hasVideo, .hasVideos)
             }
 
             do {
                 let recommendation = recommendations[1]
                 XCTAssertEqual(recommendation.id, "slate-1-rec-2")
+                XCTAssertNotNil(recommendation.item)
             }
         }
 
         do {
-            let slate = lineup!.slates[1]
+            let slate = slates[1]
             XCTAssertEqual(slate.id, "slate-2")
             XCTAssertEqual(slate.requestID, "slate-2-request")
             XCTAssertEqual(slate.experimentID, "slate-2-experiment")
             XCTAssertEqual(slate.name, "Slate 2")
-            XCTAssertEqual(slate.description, "The description of slate 2")
-            XCTAssertEqual(slate.recommendations.count, 1)
+            XCTAssertEqual(slate.slateDescription, "The description of slate 2")
 
-            let recommendation = slate.recommendations[0]
-            XCTAssertEqual(recommendation.id, "slate-2-rec-1")
+            let recommendations = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
+            XCTAssertEqual(recommendations.count, 1)
 
-            let item = recommendation.item
-            XCTAssertEqual(item.id, "item-3")
-            XCTAssertEqual(item.givenURL, URL(string: "https://given.example.com/rec-1")!)
-            XCTAssertEqual(item.resolvedURL, URL(string: "https://resolved.example.com/rec-1")!)
-            XCTAssertEqual(item.title, "Slate 2, Recommendation 1")
-            XCTAssertEqual(item.language, "en")
-            XCTAssertEqual(item.topImageURL, URL(string: "http://example.com/slate-2-rec-1/top-image.png"))
-            XCTAssertEqual(item.timeToRead, 3)
-            XCTAssertEqual(item.excerpt, "Cursus Aenean Elit")
-            XCTAssertEqual(item.domain, "slate-2-rec-1.example.com")
-            XCTAssertEqual(item.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
-
-            let image = item.images?[0]
-            XCTAssertEqual(image?.height, 0)
-            XCTAssertEqual(image?.width, 0)
-            XCTAssertEqual(image?.src, URL(string: "http://example.com/slate-2-rec-1/image-1.png")!)
-            XCTAssertEqual(image?.imageID, 1)
-
-            let domain = item.domainMetadata
-            XCTAssertNotNil(domain)
-            XCTAssertEqual(domain?.name, "Lifehacker")
-            XCTAssertEqual(domain?.logo, URL(string: "https://slate-2-rec-1.example.com/logo.png"))
-
-            let author = item.authors?[0]
-            XCTAssertEqual(author?.id, "eb-white")
-            XCTAssertEqual(author?.name, "E.B. White")
-            XCTAssertEqual(author?.url, URL(string: "http://example.com/authors/eb-white")!)
-
-            switch item.article?.components[0] {
-            case .blockquote(let blockquote):
-                XCTAssertEqual(blockquote.content, "Pellentesque Ridiculus Porta")
-            case .none:
-                XCTFail("Expected blockquote component, got nil")
-            case .some(let component):
-                XCTFail("Expected blockquote component, got \(component)")
+            do {
+                let recommendation = recommendations[0]
+                XCTAssertEqual(recommendation.id, "slate-2-rec-1")
             }
         }
     }
 
-    func test_fetchSlate_returnsSlateDetails() async throws {
-        apollo.stubFetch(toReturnFixturedNamed: "slate-detail", asResultType: GetSlateQuery.self)
+    func test_fetchSlateLineup_existingSlateLineup_updatesExistingSpace() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
 
-        let slate = try await subject().fetchSlate("the-slate-id")
-
-        XCTAssertEqual(slate?.id, "slate-1")
-        XCTAssertEqual(slate?.name, "Slate 1")
-        XCTAssertEqual(slate?.description, "The description of slate 1")
-        XCTAssertEqual(slate?.recommendations.count, 3)
-
-        let recommendations = slate?.recommendations
-
-        do {
-            let recommendation = recommendations?[0]
-            XCTAssertEqual(recommendation?.id, "1")
+        let item = Item.build(remoteID: "item-1-seed")
+        let recommendation = Recommendation.build(id: "slate-1-recommendation-1-seed", item: item)
+        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
+        SlateLineup.build(slates: [slate])
+        try await space.context.perform {
+            try self.space.save()
         }
 
-        do {
-            let recommendation = recommendations?[1]
-            XCTAssertEqual(recommendation?.id, "2")
+        let service = subject()
+        try await service.fetchSlateLineup("slate-lineup-identifier")
+
+        // 1. Update existing slate lineup
+        let lineups = try space.fetchSlateLineups()
+        XCTAssertEqual(lineups.count, 1)
+
+        // 2. Old slates should be deleted
+        let fetchedSlates = try space.fetchSlates()
+        let fetchedSlateIDs = fetchedSlates.map { $0.id! }
+        XCTAssertEqual(fetchedSlates.count, 2)
+        XCTAssertEqual(Set(fetchedSlateIDs) , ["slate-1", "slate-2"])
+
+        // 3. Old recommendations should be deleted
+        let fetchedRecommendations = try space.fetchRecommendations()
+        XCTAssertEqual(fetchedRecommendations.count, 3)
+        let fetchedRecommendationIDs = fetchedRecommendations.map { $0.id! }
+        XCTAssertFalse(fetchedRecommendationIDs.contains("slate-1-recommendation-1-seed"))
+
+        // 4. Old items should be removed
+        let items = try space.fetchItems()
+        XCTAssertEqual(items.count, 3)
+        let itemIDs = items.map { $0.remoteID! }
+        XCTAssertEqual(Set(itemIDs), ["item-1", "item-2", "item-3"])
+    }
+
+    func test_fetchSlateLineup_existingSlateLineup_hasSavedItems_keepsItems() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
+
+        let item = Item.build(remoteID: "item-1-seed")
+        SavedItem.build(item: item)
+        let recommendation = Recommendation.build(id: "slate-1-recommendation-seed", item: item)
+        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
+        SlateLineup.build(slates: [slate])
+        try await space.context.perform {
+            try self.space.save()
         }
 
-        do {
-            let recommendation = recommendations?[2]
-            XCTAssertEqual(recommendation?.id, "3")
+        let service = subject()
+        try await service.fetchSlateLineup("slate-lineup-identifier")
+
+        let items = try space.fetchItems()
+        XCTAssertEqual(items.count, 4)
+    }
+
+    func test_fetchSlateLineup_existingItem_updatesExistingItem() async throws {
+        apollo.stubFetch(toReturnFixturedNamed: "slates", asResultType: GetSlateLineupQuery.self)
+
+        let item = Item.build(remoteID: "item-1-seed")
+        let recommendation = Recommendation.build(id: "slate-1-recommendation-1-seed", item: item)
+        let slate = Slate.build(id: "slate-1-seed", recommendations: [recommendation])
+        SlateLineup.build(slates: [slate])
+        try space.context.performAndWait {
+            try space.save()
         }
+
+        let service = subject()
+        try await service.fetchSlateLineup("slate-lineup-identifier")
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -216,7 +216,7 @@ class PocketSourceTests: XCTestCase {
             }
         }
 
-        let recommendation = Slate.Recommendation(
+        let recommendation = UnmanagedSlate.UnmanagedRecommendation(
             id: "recommendation-1",
             item: UnmanagedItem(
                 id: "item-1",
@@ -299,7 +299,7 @@ class PocketSourceTests: XCTestCase {
             }
         }
 
-        let recommendation: Slate.Recommendation = .build(
+        let recommendation: UnmanagedSlate.UnmanagedRecommendation = .build(
             id: "recommendation-1",
             item: .build(id: "item-1")
         )

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -312,49 +312,20 @@ class PocketSourceTests: XCTestCase {
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 
-    @MainActor
-    func test_fetchSlates_returnsResultsFromSlateService() async throws {
-        let slate = Slate(
-            id: "my-slate",
-            requestID: "request-id",
-            experimentID: "experiment-id",
-            name: "My Slate",
-            description: "slate-description",
-            recommendations: []
-        )
-        
-        let expectedLineup = SlateLineup(
-            id: "lineup-id",
-            requestID: "lineup-request-id",
-            experimentID: "experiment-id",
-            slates: [slate]
-        )
-        
-        slateService.stubFetchSlateLineup {
-            expectedLineup
-        }
+    func test_fetchSlateLineup_forwardsToSlateService() async throws {
+        slateService.stubFetchSlateLineup { _ in }
 
-        let actualLineup = try await subject().fetchSlateLineup("")
-        XCTAssertEqual(actualLineup, expectedLineup)
+        let source = subject()
+        try await source.fetchSlateLineup("slate-lineup-identifier")
+        XCTAssertEqual(slateService.fetchSlateLineupCall(at: 0)?.identifier, "slate-lineup-identifier")
     }
 
-    @MainActor
-    func test_fetchSlate_returnsResultFromSlateService() async throws {
-        let expectedSlate = Slate(
-            id: "my-slate",
-            requestID: "request-id",
-            experimentID: "experiment-id",
-            name: "My Slate",
-            description: "slate-description",
-            recommendations: []
-        )
-        
-        slateService.stubFetchSlate { _ in
-            return expectedSlate
-        }
+    func test_fetchSlate_forwardsToSlateService() async throws {
+        slateService.stubFetchSlate { _ in }
 
-        let actualSlate = try await subject().fetchSlate("the-slate-id")
-        XCTAssertEqual(actualSlate, expectedSlate)
+        let source = subject()
+        try await source.fetchSlate("slate-identifier")
+        XCTAssertEqual(slateService.fetchSlateCall(at: 0)?.identifier, "slate-identifier")
     }
 
     func test_itemsController_returnsAFetchedResultsController() throws {

--- a/PocketKit/Tests/SyncTests/Support/Item+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Item+factories.swift
@@ -4,10 +4,12 @@
 extension Item {
     static func build(
         in space: Space = Space(container: .testContainer),
-        remoteID: String = "item-1"
+        remoteID: String? = "item-1",
+        title: String? = "Item 1 Title"
     ) -> Item {
         let item: Item = space.new()
         item.remoteID = remoteID
+        item.title = title
         return item
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/Item+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Item+factories.swift
@@ -1,0 +1,13 @@
+@testable import Sync
+
+
+extension Item {
+    static func build(
+        in space: Space = Space(container: .testContainer),
+        remoteID: String = "item-1"
+    ) -> Item {
+        let item: Item = space.new()
+        item.remoteID = remoteID
+        return item
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
@@ -2,31 +2,76 @@
 
 
 class MockSlateService: SlateService {
-    typealias FetchSlateLineupImpl = () async throws -> SlateLineup
-    private var fetchSlateLineupImpl: FetchSlateLineupImpl?
+    var implementations: [String: Any] = [:]
+    var calls: [String: [Any]] = [:]
+}
+
+extension MockSlateService {
+    static let fetchSlateLineup = "fetchSlateLineup"
+    typealias FetchSlateLineupImpl = (String) async throws -> Void
+
+    struct FetchSlateLineupCall {
+        let identifier: String
+    }
+
     func stubFetchSlateLineup(impl: @escaping FetchSlateLineupImpl) {
-        fetchSlateLineupImpl = impl
+        implementations[Self.fetchSlateLineup] = impl
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws -> SlateLineup? {
-        guard let impl = fetchSlateLineupImpl else {
+    func fetchSlateLineup(_ identifier: String) async throws {
+        guard let impl = implementations[Self.fetchSlateLineup] as? FetchSlateLineupImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        return try await impl()
+        calls[Self.fetchSlateLineup] = (calls[Self.fetchSlateLineup] ?? []) + [
+            FetchSlateLineupCall(identifier: identifier)
+        ]
+
+        try await impl(identifier)
     }
 
-    typealias FetchSlateImpl = (String) async throws -> Slate?
-    private var fetchSlateImpl: FetchSlateImpl?
+    func fetchSlateLineupCall(at index: Int) -> FetchSlateLineupCall? {
+        guard let calls = calls[Self.fetchSlateLineup],
+              calls.count > index,
+              let call = calls[index] as? FetchSlateLineupCall else {
+                  return nil
+              }
+
+        return call
+    }
+}
+
+extension MockSlateService {
+    static let fetchSlate = "fetchSlate"
+    typealias FetchSlateImpl = (String) async throws -> Void
+
+    struct FetchSlateCall {
+        let identifier: String
+    }
+
     func stubFetchSlate(impl: @escaping FetchSlateImpl) {
-        fetchSlateImpl = impl
+        implementations[Self.fetchSlate] = impl
     }
 
-    func fetchSlate(_ slateID: String) async throws -> Slate? {
-        guard let impl = fetchSlateImpl else {
+    func fetchSlate(_ slateID: String) async throws {
+        guard let impl = implementations[Self.fetchSlate] as? FetchSlateImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        return try await impl(slateID)
+        calls[Self.fetchSlate] = (calls[Self.fetchSlate] ?? []) + [
+            FetchSlateCall(identifier: slateID)
+        ]
+
+        try await impl(slateID)
+    }
+
+    func fetchSlateCall(at index: Int) -> FetchSlateCall? {
+        guard let calls = calls[Self.fetchSlate],
+              calls.count > index,
+              let call = calls[index] as? FetchSlateCall else {
+                  return nil
+              }
+
+        return call
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/SavedItem+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/SavedItem+factories.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import Sync
+
+
+extension SavedItem {
+    @discardableResult
+    static func build(
+        in space: Space = Space(container: .testContainer),
+        remoteID: String = "saved-item-1",
+        url: String = "http://example.com/item-1",
+        isFavorite: Bool = false,
+        isArchived: Bool = false,
+        cursor: String? = nil,
+        item: Item? = .build()
+    ) -> SavedItem {
+        let savedItem: SavedItem = SavedItem(context: space.context)
+        savedItem.cursor = cursor ?? "cursor-\(remoteID)"
+        savedItem.remoteID = remoteID
+        savedItem.isFavorite = isFavorite
+        savedItem.isArchived = isArchived
+        savedItem.url = URL(string: url)!
+        savedItem.item = item
+
+        return savedItem
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/SlateLineup+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/SlateLineup+factories.swift
@@ -1,0 +1,63 @@
+@testable import Sync
+
+
+extension SlateLineup {
+    @discardableResult
+    static func build(
+        in space: Space = Space(container: .testContainer),
+        id: String = "slate-lineup-1",
+        requestID: String = "slate-lineup-1-request",
+        experimentID: String = "slate-lineup-1-experiment",
+        slates: [Slate] = []
+    ) -> SlateLineup {
+        let lineup: SlateLineup = space.new()
+        lineup.id = id
+        lineup.requestID = requestID
+        lineup.experimentID = experimentID
+
+        slates.forEach {
+            lineup.addToSlates($0)
+        }
+
+        return lineup
+    }
+}
+
+extension Slate {
+    @discardableResult
+    static func build(
+        in space: Space = Space(container: .testContainer),
+        experimentID: String = "slate-1-experiment",
+        id: String = "slate-1",
+        name: String = "Slate 1",
+        requestID: String = "slate-1-request",
+        slateDescription: String = "The description of slate 1",
+        recommendations: [Recommendation] = []
+    ) -> Slate {
+        let slate: Slate = space.new()
+        slate.experimentID = experimentID
+        slate.id = id
+        slate.name = name
+        slate.requestID = requestID
+        slate.slateDescription = slateDescription
+
+        recommendations.forEach {
+            slate.addToRecommendations($0)
+        }
+
+        return slate
+    }
+}
+
+extension Recommendation {
+    @discardableResult
+    static func build(
+        in space: Space = Space(container: .testContainer),
+        id: String = "slate-1-rec-1",
+        item: Item? = nil
+    ) -> Recommendation {
+        let recommendation: Recommendation = space.new()
+        recommendation.item = item
+        return recommendation
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/SlateLineup+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/SlateLineup+factories.swift
@@ -5,13 +5,13 @@ extension SlateLineup {
     @discardableResult
     static func build(
         in space: Space = Space(container: .testContainer),
-        id: String = "slate-lineup-1",
+        remoteID: String = "slate-lineup-1",
         requestID: String = "slate-lineup-1-request",
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) -> SlateLineup {
         let lineup: SlateLineup = space.new()
-        lineup.id = id
+        lineup.remoteID = remoteID
         lineup.requestID = requestID
         lineup.experimentID = experimentID
 
@@ -28,7 +28,7 @@ extension Slate {
     static func build(
         in space: Space = Space(container: .testContainer),
         experimentID: String = "slate-1-experiment",
-        id: String = "slate-1",
+        remoteID: String = "slate-1",
         name: String = "Slate 1",
         requestID: String = "slate-1-request",
         slateDescription: String = "The description of slate 1",
@@ -36,7 +36,7 @@ extension Slate {
     ) -> Slate {
         let slate: Slate = space.new()
         slate.experimentID = experimentID
-        slate.id = id
+        slate.remoteID = remoteID
         slate.name = name
         slate.requestID = requestID
         slate.slateDescription = slateDescription
@@ -53,10 +53,11 @@ extension Recommendation {
     @discardableResult
     static func build(
         in space: Space = Space(container: .testContainer),
-        id: String = "slate-1-rec-1",
+        remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) -> Recommendation {
         let recommendation: Recommendation = space.new()
+        recommendation.remoteID = remoteID
         recommendation.item = item
         return recommendation
     }

--- a/PocketKit/Tests/SyncTests/Support/UnmanagedSlate+Factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/UnmanagedSlate+Factories.swift
@@ -1,16 +1,16 @@
 @testable import Sync
 
 
-extension Slate {
+extension UnmanagedSlate {
     static func build(
         id: String = "slate-1",
         requestID: String = "slate-1-request",
         experimentID: String = "slate-1-experiment",
         name: String = "A slate",
         description: String = "For use in tests",
-        recommendations: [Slate.Recommendation] = []
-    ) -> Slate {
-        Slate(
+        recommendations: [UnmanagedSlate.UnmanagedRecommendation] = []
+    ) -> UnmanagedSlate {
+        UnmanagedSlate(
             id: id,
             requestID: requestID,
             experimentID: experimentID,
@@ -21,11 +21,11 @@ extension Slate {
     }
 }
 
-extension Slate.Recommendation {
+extension UnmanagedSlate.UnmanagedRecommendation {
     static func build(
         id: String? = "recommendation-1",
         item: UnmanagedItem = .build()
-    ) -> Slate.Recommendation {
-        return Slate.Recommendation(id: id, item: item)
+    ) -> UnmanagedSlate.UnmanagedRecommendation {
+        return UnmanagedSlate.UnmanagedRecommendation(id: id, item: item)
     }
 }


### PR DESCRIPTION
- [x] Add `SlateLineup` entity to data model
- [x] Add `Slate` entity to data model
- [x] Add `Recommendation` entity to data model
- [x] Rename previous Slate(Lineup) types to UnmanagedSlate(Lineup) 
- [x] Update `(API)SlateService.fetchSlateLineup` to insert / update `space`
- [x] Update `(API)SlateService.fetchSlate` to insert / update `space`