### PR TITLE
Omit gray image background when caption is not present

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -1,6 +1,12 @@
 import UIKit
 import Kingfisher
 
+protocol ImageComponentCellModel {
+    var caption: NSAttributedString? { get }
+    var image: ImageComponentCell.ImageSpec? { get }
+    var shouldHideCaption: Bool { get }
+    func imageViewBackgroundColor(imageSize: CGSize) -> UIColor
+}
 
 class ImageComponentCell: UICollectionViewCell {
     enum Constants {
@@ -12,12 +18,7 @@ class ImageComponentCell: UICollectionViewCell {
         let source: URL
         let size: CGSize
     }
-
-    struct Model {
-        let caption: NSAttributedString?
-        let image: ImageSpec?
-    }
-
+    
     let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .center
@@ -57,9 +58,9 @@ class ImageComponentCell: UICollectionViewCell {
 }
 
 extension ImageComponentCell {
-    func configure(model: Model, imageLoaded: ((UIImage) -> Void)? = nil) {
+    func configure(model: ImageComponentCellModel, imageLoaded: ((UIImage) -> Void)? = nil) {
         captionTextView.attributedText = model.caption
-        captionTextView.isHidden = model.caption == nil || model.caption?.string.isEmpty == true
+        captionTextView.isHidden = model.shouldHideCaption
 
         imageView.image = nil
         guard let imageSpec = model.image else {
@@ -81,14 +82,7 @@ extension ImageComponentCell {
         ) { [weak self] result in
             switch result {
             case .success(let result):
-
-                if let idealWidth = model.image?.size.width,
-                   result.image.size.width >= idealWidth {
-                    self?.imageView.backgroundColor = UIColor(.clear)
-                } else {
-                    self?.imageView.backgroundColor = UIColor(.ui.grey7)
-                }
-
+                self?.imageView.backgroundColor = model.imageViewBackgroundColor(imageSize: result.image.size)
                 imageLoaded?(result.image)
             case .failure:
                 break

--- a/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+
+@testable import Sync
+@testable import PocketKit
+
+class ImageComponentPresenterTests: XCTestCase { }
+
+// MARK: - ImageComponentCell Model
+extension ImageComponentPresenterTests {
+
+    func test_model_withCaption_shouldShow() {
+        let component = ImageComponent(
+            caption: "a caption",
+            credit: "a credit",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        
+        XCTAssertEqual(presenter.shouldHideCaption, false)
+    }
+    
+    func test_model_withNoCaption_shouldHide() {
+        let component = ImageComponent(
+            caption: " ",
+            credit: " ",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        
+        XCTAssertEqual(presenter.shouldHideCaption, true)
+    }
+    
+    func test_model_imageViewBackgroundColor_withImageSizeAndCaption_returnsClearBackground() {
+        let component = ImageComponent(
+            caption: "a caption",
+            credit: "a credit",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: 0, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
+    }
+    
+    func test_model_imageViewBackgroundColor_withImageSizeAndNoCaption_returnsClearBackground() {
+        let component = ImageComponent(
+            caption: " ",
+            credit: " ",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: 0, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
+    }
+    
+    func test_model_imageViewBackgroundColor_withSmallImageSizeAndCaption_returnsGreyBackground() {
+        let component = ImageComponent(
+            caption: "a caption",
+            credit: "a credit",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: -1, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.ui.grey7))
+    }
+    
+    func test_model_imageViewBackgroundColor_withSmallImageSizeAndNoCaption_returnsClearBackground() {
+        let component = ImageComponent(
+            caption: " ",
+            credit: " ",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: URL(string: "http://example.com")!
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: -1, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
+    }
+    
+    func test_model_imageViewBackgroundColor_withNoImageAndCaption_returnsClearBackground() {
+        let component = ImageComponent(
+            caption: "a caption",
+            credit: "a credit",
+            height: 1,
+            width: 2,
+            id: 3,
+            source: nil
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: -1, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
+    }
+    
+    func test_model_imageViewBackgroundColor_withNoImageAndNoCaption_returnsClearBackground() {
+        let component = ImageComponent(
+            caption: nil,
+            credit: nil,
+            height: 1,
+            width: 2,
+            id: 3,
+            source: nil
+        )
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let imageSize = CGSize(width: -1, height: 0)
+        
+        XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
+    }
+}


### PR DESCRIPTION
# IN-559 
**Summary**
In our article reader view, we have images that have a grey background if the image does not span to the entire width of the screen. We only want the grey background to appear if there is an image with a small image size and has an associated caption. If there is no caption, then we want to set the background of the image view to `.clear` instead of grey.

**Testing Steps**
1. Navigate to Home tab on an iPad and tap on the following article: [Night Shifts, by Michael W. Clune](https://harpers.org/archive/2022/04/night-shifts-dream-incubation-technology-sleep-research/)
2. Scroll through the article and verify that images have a clear background
3. Navigate to this following article: [How to Train Your Brain to Get What You Want in 60 Days] (https://getpocket.com/explore/item/how-to-train-your-brain-to-get-what-you-want-in-60-days)
4. Scroll through the article and verify that images have a grey background with captions

**Screenshot**
Has no caption
![image](https://user-images.githubusercontent.com/6743397/164760022-223d5300-8977-48df-90ee-bb8681d2145f.png)

Has caption
![image](https://user-images.githubusercontent.com/6743397/164760034-de310ed5-5e51-4d5b-9141-1994de53d72e.png)
