### PR TITLE
IN-591: Constrain Logout Screen to Portrait View

### DIFF
--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -7,6 +7,11 @@ class LoggedOutViewController: UIHostingController<LoggedOutView> {
     convenience init(viewModel: LoggedOutViewModel) {
         self.init(rootView: LoggedOutView(viewModel: viewModel))
     }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
 }
 
 struct LoggedOutView: View {


### PR DESCRIPTION
# IN-591

**Issue:** Progress indicator for the Login slideshow onboarding overlaps the readable text in Landscape view for iPhone
**Fix:** Disabled landscape view for iPhone and leave iPad view as is