### PR TITLE
SaveTo: UI fixes and improved URL support

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/InfoView.swift
+++ b/PocketKit/Sources/SaveToPocketKit/InfoView.swift
@@ -98,8 +98,8 @@ private class CapsuleView: UIView {
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: 1),
 
-            textLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
-            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24),
+            textLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 28),
+            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
 
             textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
             textLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
@@ -50,13 +50,22 @@ class LoggedOutViewController: UIViewController {
             imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 36),
 
             capsuleTopConstraint,
-            infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
-            infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
 
             dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16)
         ])
+
+        if traitCollection.userInterfaceIdiom == .pad {
+            NSLayoutConstraint.activate([
+                infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                infoView.widthAnchor.constraint(equalToConstant: 379)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+                infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24)
+            ])
+        }
 
         infoView.model = viewModel.infoViewModel
         dismissLabel.attributedText = viewModel.dismissAttributedText

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -56,13 +56,22 @@ class SavedItemViewController: UIViewController {
             imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 36),
 
             capsuleTopConstraint,
-            infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
-            infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
 
             dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16)
         ])
+
+        if traitCollection.userInterfaceIdiom == .pad {
+            NSLayoutConstraint.activate([
+                infoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                infoView.widthAnchor.constraint(equalToConstant: 379)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                infoView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+                infoView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24)
+            ])
+        }
 
         dismissLabel.attributedText = viewModel.dismissAttributedText
 

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -84,11 +84,11 @@ private extension InfoView.Model {
     static let existingItem = InfoView.Model(
         style: .default,
         attributedText: NSAttributedString(
-            string: "You’ve already saved this before",
+            string: "Saved to Pocket",
             style: .mainText
         ),
         attributedDetailText: NSAttributedString(
-            string: "We’ll move it to the top of your list.",
+            string: "You've already saved this before. We'll move it to the top of your list.",
             style: .detailText
         )
     )

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -32,7 +32,7 @@ class SavedItemViewModel {
 
         for item in extensionItems {
             guard let url = try? await url(from: item) else {
-                // TODO: Throw an error?
+                infoViewModel = .error
                 break
             }
 
@@ -118,5 +118,14 @@ private extension InfoView.Model {
             string: "You've already saved this before. We'll move it to the top of your list.",
             style: .detailText
         )
+    )
+
+    static let error = InfoView.Model(
+        style: .error,
+        attributedText: NSAttributedString(
+            string: "Pocket couldn't save this link",
+            style: .mainTextError
+        ),
+        attributedDetailText: nil
     )
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -156,8 +156,8 @@ extension SavedItemViewModelTests {
         let infoViewModelChanged = expectation(description: "infoViewModelChanged")
         let subscription = viewModel.$infoViewModel.dropFirst().sink { model in
             defer { infoViewModelChanged.fulfill() }
-            XCTAssertEqual(model.attributedText.string, "You’ve already saved this before")
-            XCTAssertEqual(model.attributedDetailText?.string, "We’ll move it to the top of your list.")
+            XCTAssertEqual(model.attributedText.string, "Saved to Pocket")
+            XCTAssertEqual(model.attributedDetailText?.string, "You've already saved this before. We'll move it to the top of your list.")
         }
 
         let extensionItem = MockExtensionItem(itemProviders: [provider])


### PR DESCRIPTION
## Issues
IN-586
IN-587

## Fixes
1. Fix incorrect text when saving pre-existing item
2. Add whitespace under dismiss label
3. Set explicit width of capsule on iPad
4. Fix padding between capsule icon and text
5. Add error state
6. Add support for saving items that conform to `public.plain-text` UTI (e.g Medium)

## Screenshots

![image](https://user-images.githubusercontent.com/1158092/166565644-326b295e-8654-48a0-b6f9-915bc4f5a1ff.png)

![image](https://user-images.githubusercontent.com/1158092/166565679-0eb2e8e9-0d90-4ad7-b425-4719e4853266.png)
