### PR TITLE
IN-590: Fix Highlight For Item Selection

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -16,16 +16,13 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
     let selectionItem: SelectionItem = SelectionItem(title: "Archive", image: .init(asset: .archive))
 
     @Published
-    var selectedReadable: SavedItemViewModel?
-
-    @Published
     var sharedActivity: PocketActivity?
 
     @Published
     var presentedAlert: PocketAlert?
 
     @Published
-    var presentedWebReaderURL: URL?
+    var selectedItem: SelectedItem?
 
     private let source: Source
     private let tracker: Tracker
@@ -66,8 +63,8 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
             }
         }.store(in: &subscriptions)
 
-        $selectedReadable.sink { [weak self] readable in
-            guard readable == nil else { return }
+        $selectedItem.sink { [weak self] itemSelected in
+            guard itemSelected == nil else { return }
             self?._events.send(.selectionCleared)
         }.store(in: &subscriptions)
     }
@@ -284,12 +281,14 @@ extension ArchivedItemsListViewModel {
         if let isArticle = item.item?.isArticle, isArticle == false
             || item.item?.hasImage == .isImage
             || item.item?.hasVideo == .isVideo {
-            presentedWebReaderURL = item.bestURL
+            selectedItem = .webView(item.bestURL)
         } else {
-            selectedReadable = SavedItemViewModel(
-                item: item,
-                source: source,
-                tracker: tracker.childTracker(hosting: .articleView.screen)
+            selectedItem = .readable(
+                SavedItemViewModel(
+                    item: item,
+                    source: source,
+                    tracker: tracker.childTracker(hosting: .articleView.screen)
+                )
             )
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -1,6 +1,28 @@
 import Combine
 import UIKit
 
+enum SelectedItem {
+    case readable(SavedItemViewModel?)
+    case webView(URL?)
+    
+    func clearPresentedWebReaderURL() {
+        switch self {
+        case .readable(let viewModel):
+            viewModel?.presentedWebReaderURL = nil
+        default:
+            break
+        }
+    }
+    
+    func clearSharedActivity() {
+        switch self {
+        case .readable(let viewModel):
+            viewModel?.sharedActivity = nil
+        default:
+            break
+        }
+    }
+}
 
 enum ItemsListSection: Int, CaseIterable {
     case filters

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -17,10 +17,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     var presentedAlert: PocketAlert?
 
     @Published
-    var presentedWebReaderURL: URL?
-
-    @Published
-    var selectedReadable: SavedItemViewModel?
+    var selectedItem: SelectedItem?
 
     @Published
     var sharedActivity: PocketActivity?
@@ -44,8 +41,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
 
         itemsController.delegate = self
 
-        $selectedReadable.sink { [weak self] readable in
-            guard readable == nil else { return }
+        $selectedItem.sink { [weak self] itemSelected in
+            guard itemSelected == nil else { return }
             self?._events.send(.selectionCleared)
         }.store(in: &subscriptions)
 
@@ -298,15 +295,16 @@ extension SavedItemsListViewModel {
         if let isArticle = item.item?.isArticle, isArticle == false
             || item.item?.hasImage == .isImage
             || item.item?.hasVideo == .isVideo {
-            presentedWebReaderURL = item.bestURL
+            selectedItem = .webView(item.bestURL)
         } else {
-            selectedReadable = bareItem(with: itemID).flatMap {
+            let selectedReadable = bareItem(with: itemID).flatMap {
                 SavedItemViewModel(
                     item: $0,
                     source: source,
                     tracker: tracker.childTracker(hosting: .articleView.screen)
                 )
             }
+            selectedItem = .readable(selectedReadable)
         }
     }
 


### PR DESCRIPTION
## IN-590
This issue is not specific to only video content but is related to items that are using the `SFSafariViewController` as they were not calling the `selectionCleared` event to deselect the cell.

## Fixes
1. Fix issue where safari view items were not auto-deselecting (iPhone)
2. Fix issue where archived items in reader view were not highlighting (iPad)
3. Refactor to use enum as the selected item could either be readable view or web view

## Testing Steps (iPhone)
1. Save a youtube video
2. Open it in My List View
3. Select "Done" in the upper left
4. Verify that item auto-deselects (de-highlights) itself

## Testing Steps (iPad)
1. Save a YouTube video and archive it in My List View
2. Navigate to Archive View and tap on any of the items
3. Verify that the item does not deselect itself and is still highlighted (similar to the My List View)
