### PR TITLE
IN-569: Fix List Item Action Buttons Sizing

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -31,6 +31,7 @@ class ItemsListItemCell: UICollectionViewCell {
         static let textStackSpacing: CGFloat = 8
         static let topLevelStackSpacing: CGFloat = 14
         static let actionButtonHeight: CGFloat = 28
+        static let actionButtonImageSize = CGSize(width: 20, height: 20)
         static let mainStackSpacing: CGFloat = 8
         static let margins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
@@ -70,8 +71,9 @@ class ItemsListItemCell: UICollectionViewCell {
     private let shareButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.contentInsets = .zero
-        config.background.image = UIImage(asset: .share)
+        config.image = UIImage(asset: .share)
             .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
+            .resized(to: Constants.actionButtonImageSize)
 
         let button = UIButton(configuration: config, primaryAction: nil)
         button.accessibilityIdentifier = "share"
@@ -81,9 +83,10 @@ class ItemsListItemCell: UICollectionViewCell {
     private let menuButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.contentInsets = .zero
-        config.background.image = UIImage(asset: .overflow)
+        config.image = UIImage(asset: .overflow)
             .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
-
+            .resized(to: Constants.actionButtonImageSize)
+        
         let button = UIButton(configuration: config, primaryAction: nil)
         button.accessibilityIdentifier = "item-actions"
         button.showsMenuAsPrimaryAction = true
@@ -207,7 +210,7 @@ extension ItemsListItemCell {
 
         favoriteButton.accessibilityLabel = state.model?.favoriteAction?.title
         favoriteButton.accessibilityIdentifier = state.model?.favoriteAction?.accessibilityIdentifier
-        favoriteButton.configuration?.image = state.model?.favoriteAction?.image
+        favoriteButton.configuration?.image = state.model?.favoriteAction?.image?.resized(to: Constants.actionButtonImageSize)
 
         if let favoriteAction = UIAction(state.model?.favoriteAction) {
             favoriteButton.addAction(favoriteAction, for: .primaryActionTriggered)

--- a/PocketKit/Sources/Textile/Style/Style+UIKit.swift
+++ b/PocketKit/Sources/Textile/Style/Style+UIKit.swift
@@ -169,4 +169,10 @@ public extension UIImage {
     convenience init(asset: ImageAsset) {
         self.init(named: asset.name, in: .module, with: nil)!
     }
+    
+    func resized(to size: CGSize) -> UIImage {
+        return UIGraphicsImageRenderer(size: size).image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
 }


### PR DESCRIPTION
# IN-569
**Issue:** My List/Archive item action buttons sizing does not match designs. This is due to the image being set as the background image and not the foreground image of the button. Also, the image were not conforming to 20x20 as specified in the Figma file.
**Fix:** Add resizable function to adjust image size and set images to the foreground instead of background of the button.

Reference: https://nshipster.com/image-resizing/

## Testing Steps
1. Navigate to MyList
2. Verify action button items (favorite, share, more) resemble the sizes in Figma file for iPhone and iPad. 

## Screenshots
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-05-06 at 09 45 27](https://user-images.githubusercontent.com/6743397/167149897-a34fa4e3-a6ce-4d76-a7e2-b01f3524dea7.png)