### PR TITLE
SaveTo: do not autodismiss on error

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
@@ -85,12 +85,6 @@ class LoggedOutViewController: UIViewController {
 
         viewModel.viewWillAppear(context: extensionContext, origin: self)
     }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        viewModel.viewDidAppear(context: extensionContext)
-    }
 }
 
 private extension LoggedOutViewController {

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -4,10 +4,6 @@ import Combine
 
 
 class LoggedOutViewModel {
-    private let dismissTimer: Timer.TimerPublisher
-
-    private var dismissTimerCancellable: AnyCancellable? = nil
-
     let infoViewModel = InfoView.Model(
         style: .error,
         attributedText: NSAttributedString(
@@ -25,10 +21,6 @@ class LoggedOutViewModel {
     @Published
     var actionButtonConfiguration: UIButton.Configuration? = nil
 
-    init(dismissTimer: Timer.TimerPublisher) {
-        self.dismissTimer = dismissTimer
-    }
-
     func viewWillAppear(context: ExtensionContext?, origin: Any) {
         if responder(from: origin) != nil {
             var configuration: UIButton.Configuration = .filled()
@@ -38,10 +30,6 @@ class LoggedOutViewModel {
             configuration.attributedTitle = AttributedString(NSAttributedString(string: "Log in to Pocket", style: .logIn))
             actionButtonConfiguration = configuration
         }
-    }
-
-    func viewDidAppear(context: ExtensionContext?) {
-        autodismiss(from: context)
     }
 
     func finish(context: ExtensionContext?, completionHandler: ((Bool) -> Void)? = nil) {
@@ -77,12 +65,6 @@ extension LoggedOutViewModel {
     private func open(url: URL, using responder: UIResponder) {
         let selector = sel_registerName("openURL:")
         responder.perform(selector, with: url)
-    }
-
-    private func autodismiss(from context: ExtensionContext?) {
-        dismissTimerCancellable = dismissTimer.autoconnect().first().sink(receiveCompletion:{ [weak self] _ in
-            self?.finish(context: context)
-        }, receiveValue: { _ in })
     }
 
     private func handleLoggedOut(context: ExtensionContext?, origin: Any) {

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -16,9 +16,7 @@ class MainViewController: UIViewController {
 
         if appSession.currentSession == nil {
             child = LoggedOutViewController(
-                viewModel: LoggedOutViewModel(
-                    dismissTimer: Timer.TimerPublisher(interval: 2.1, runLoop: .main, mode: .default)
-                )
+                viewModel: LoggedOutViewModel()
             )
         } else {
             child = SavedItemViewController(

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -43,10 +43,9 @@ class SavedItemViewModel {
                 infoViewModel = .newItem
             }
 
+            autodismiss(from: context)
             break
         }
-
-        autodismiss(from: context)
     }
 
     func finish(context: ExtensionContext?, completionHandler: ((Bool) -> Void)? = nil) {

--- a/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
@@ -3,20 +3,8 @@ import XCTest
 
 
 class LoggedOutViewModelTests: XCTestCase {
-    private var dismissTimer: Timer.TimerPublisher!
-
-    private func subject(
-        dismissTimer: Timer.TimerPublisher? = nil
-    ) -> LoggedOutViewModel {
-        LoggedOutViewModel(
-            dismissTimer: dismissTimer ?? self.dismissTimer
-        )
-    }
-
-    override func setUp() {
-        self.continueAfterFailure = false
-
-        dismissTimer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
+    private func subject() -> LoggedOutViewModel {
+        LoggedOutViewModel()
     }
 }
 
@@ -27,11 +15,12 @@ extension LoggedOutViewModelTests {
         let viewModel = subject()
 
         let completeRequestExpectation = expectation(description: "expected completeRequest to be called")
+        completeRequestExpectation.isInverted = true
         context.stubCompleteRequest { _, _ in
             completeRequestExpectation.fulfill()
         }
 
-        viewModel.viewDidAppear(context: context)
+        viewModel.viewWillAppear(context: context, origin: self)
 
         wait(for: [completeRequestExpectation], timeout: 1)
     }


### PR DESCRIPTION
As mentioned in the title, this updates the save extension to not autodismiss when there is an error. An error occurs when (1) a user is logged out, or (2) there is no URL within the extension context to save.