### PR TITLE
Do not publish duplicate KeychainStorage values

### DIFF
--- a/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
+++ b/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
@@ -3,7 +3,7 @@ import Combine
 
 
 @propertyWrapper
-public class KeychainStorage<T: Codable> {
+public class KeychainStorage<T: Codable & Equatable> {
     private let keychain: Keychain
     private let service: String
     private let account: String
@@ -30,7 +30,7 @@ public class KeychainStorage<T: Codable> {
     }
 
     public var projectedValue: AnyPublisher<T?, Never> {
-        subject.eraseToAnyPublisher()
+        subject.removeDuplicates().eraseToAnyPublisher()
     }
 
     init(

--- a/PocketKit/Sources/SharedPocketKit/Session/Session.swift
+++ b/PocketKit/Sources/SharedPocketKit/Session/Session.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-public struct Session: Codable {
+public struct Session: Codable, Equatable {
     public let guid: String
     public let accessToken: String
     public let userIdentifier: String


### PR DESCRIPTION
This pull request modifies `KeychainStorage` to remove duplicates when publishing value changes. One such scenario where this was causing issue was when a user was logged out, and multiple `currentSession` values would be published despite the fact that the user was (still) logged out. The user, in this case, would see flickering because the scene was being updated and re-set up multiple times.

Due to how caching in `KeychainStorage` is handled, when the cached value is `nil`, the next "get" attempts to read from the keychain. This new value is set as the cached value. However, it is possible for `nil` to be read first, followed by another `nil` when attempting to "get" again, which in turn updates the cached value (to the same value). Updating the cached value published a change each time, even if the two values were the same. With this change, only the first `nil` value would be published until the next read contains a truly updated value.