### PR TITLE
Home: implement actions for recommendations in reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -108,6 +108,10 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
+        recommendation.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert: alert)
+        }.store(in: &readerSubscriptions)
+
         recommendation.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readerSubscriptions)
@@ -181,6 +185,11 @@ class CompactHomeCoordinator: NSObject {
         readerSettingsVC.sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
 
         viewController.present(readerSettingsVC, animated: !isResetting)
+    }
+
+    private func present(alert: PocketAlert?) {
+        guard !isResetting, let alert = alert else { return }
+        viewController.present(UIAlertController(alert), animated: !isResetting)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -169,6 +169,7 @@ extension HomeViewModel {
         } else {
             selectedReadableViewModel = RecommendationViewModel(
                 recommendation: viewModel.recommendation,
+                source: source,
                 tracker: tracker.childTracker(hosting: .articleView.screen)
             )
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -159,6 +159,7 @@ private extension SlateDetailViewModel {
         } else {
             selectedReadableViewModel = RecommendationViewModel(
                 recommendation: viewModel.recommendation,
+                source: source,
                 tracker: tracker.childTracker(hosting: .articleView.screen)
             )
 

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -235,6 +235,10 @@ class RegularMainCoordinator: NSObject {
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
+        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &readerSubscriptions)
+
         readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -49,7 +49,7 @@
         <attribute name="isFavorite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
-        <relationship name="item" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
     </entity>
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -224,12 +224,19 @@ extension PocketSource {
         enqueue(operation: operation, task: .unfavorite(remoteID: remoteID))
     }
 
-    public func delete(item: SavedItem) {
-        guard let remoteID = item.remoteID else {
+    public func delete(item savedItem: SavedItem) {
+        guard let remoteID = savedItem.remoteID else {
             return
         }
 
-        space.delete(item)
+        let item = savedItem.item
+
+        space.delete(savedItem)
+
+        if let item = item, item.recommendation == nil {
+            space.delete(item)
+        }
+
         try? space.save()
 
         let operation = operations.savedItemMutationOperation(

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+import Sync
+import Analytics
+import Combine
+
+@testable import PocketKit
+
+
+class RecommendationViewModelTests: XCTestCase {
+    private var source: MockSource!
+    private var tracker: MockTracker!
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        source = MockSource()
+        tracker = MockTracker()
+
+        continueAfterFailure = false
+    }
+
+    override func tearDown() {
+        subscriptions = []
+    }
+
+    func subject(
+        recommendation: Recommendation,
+        source: Source? = nil,
+        tracker: Tracker? = nil
+    ) -> RecommendationViewModel {
+        RecommendationViewModel(
+            recommendation: recommendation,
+            source: source ?? self.source,
+            tracker: tracker ?? self.tracker
+        )
+    }
+
+    func test_init_buildsCorrectActions() {
+        // not-favorited, not-archived
+        do {
+            let item: Item = .build()
+            let savedItem: SavedItem = .build(isFavorite: false, isArchived: false, item: item)
+            savedItem.item = item
+            let recommendation: Recommendation = .build(item: item)
+            let viewModel = subject(recommendation: recommendation)
+            XCTAssertEqual(
+                viewModel._actions.map(\.title),
+                ["Display Settings", "Favorite", "Archive", "Delete", "Share"]
+            )
+        }
+
+        // favorited, archived
+        do {
+            let item: Item = .build()
+            let savedItem: SavedItem = .build(isFavorite: true, isArchived: true, item: item)
+            savedItem.item = item
+            let recommendation: Recommendation = .build(item: item)
+            let viewModel = subject(recommendation: recommendation)
+            XCTAssertEqual(
+                viewModel._actions.map(\.title),
+                ["Display Settings", "Unfavorite", "Move to My List", "Delete", "Share"]
+            )
+        }
+    }
+
+    func test_whenItemChanges_rebuildsActions() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(isFavorite: false, isArchived: true, item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+        let viewModel = subject(recommendation: recommendation)
+
+        savedItem.isFavorite = true
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Display Settings", "Unfavorite", "Move to My List", "Delete", "Share"]
+        )
+
+        savedItem.isArchived = false
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Display Settings", "Unfavorite", "Archive", "Delete", "Share"]
+        )
+    }
+
+    func test_displaySettings_updatesIsPresentingReaderSettings() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+        let viewModel = subject(recommendation: recommendation)
+
+        viewModel.invokeAction(title: "Display Settings")
+
+        XCTAssertEqual(viewModel.isPresentingReaderSettings, true)
+    }
+
+    func test_favorite_delegatesToSource() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(isFavorite: false, item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+
+        let expectFavorite = expectation(description: "expect source.favorite(_:)")
+        source.stubFavoriteSavedItem { favoritedItem in
+            defer { expectFavorite.fulfill() }
+            XCTAssertTrue(favoritedItem === savedItem)
+        }
+
+        let viewModel = subject(recommendation: recommendation)
+
+        viewModel.invokeAction(title: "Favorite")
+
+        wait(for: [expectFavorite], timeout: 1)
+    }
+
+    func test_unfavorite_delegatesToSource() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(isFavorite: true, item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+
+        let expectUnfavorite = expectation(description: "expect source.unfavorite(_:)")
+        source.stubUnfavoriteSavedItem { unfavoritedItem in
+            defer { expectUnfavorite.fulfill() }
+            XCTAssertTrue(unfavoritedItem === savedItem)
+        }
+
+        let viewModel = subject(recommendation: recommendation)
+
+        viewModel.invokeAction(title: "Unfavorite")
+
+        wait(for: [expectUnfavorite], timeout: 1)
+    }
+
+    func test_delete_delegatesToSource_andSendsDeleteEvent() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+        let viewModel = subject(recommendation: recommendation)
+
+        let expectDelete = expectation(description: "expect source.delete(_:)")
+        source.stubDeleteSavedItem { deletedItem in
+            defer { expectDelete.fulfill() }
+            XCTAssertTrue(deletedItem === savedItem)
+        }
+
+        let expectDeleteEvent = expectation(description: "expect delete event")
+        viewModel.events.sink { event in
+            guard case .delete = event else {
+                XCTFail("Received unexpected event: \(event)")
+                return
+            }
+
+            expectDeleteEvent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Delete")
+        viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
+
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
+    }
+
+    func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+        let viewModel = subject(recommendation: recommendation)
+
+        let expectArchive = expectation(description: "expect source.archive(_:)")
+        source.stubArchiveSavedItem { archivedItem in
+            defer { expectArchive.fulfill() }
+            XCTAssertTrue(archivedItem === savedItem)
+        }
+
+        let expectArchiveEvent = expectation(description: "expect archive event")
+        viewModel.events.sink { event in
+            guard case .archive = event else {
+                XCTFail("Received unexpected event: \(event)")
+                return
+            }
+
+            expectArchiveEvent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Archive")
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
+    }
+
+    func test_moveToMyList_sendsRequestToSource_AndRefreshes() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(isArchived: true, item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+
+        let expectUnarchive = expectation(description: "expect source.unarchive(_:)")
+        source.stubUnarchiveSavedItem { unarchivedItem in
+            defer { expectUnarchive.fulfill() }
+            XCTAssertTrue(unarchivedItem === savedItem)
+        }
+
+        let viewModel = subject(recommendation: recommendation)
+        viewModel.invokeAction(title: "Move to My List")
+
+        wait(for: [expectUnarchive], timeout: 1)
+    }
+
+    func test_share_updatesSharedActivity() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+
+        let viewModel = subject(recommendation: recommendation)
+        viewModel.invokeAction(title: "Share")
+
+        XCTAssertNotNil(viewModel.sharedActivity)
+    }
+
+    func test_showWebReader_updatesPresentedWebReaderURL() {
+        let item: Item = .build()
+        let savedItem: SavedItem = .build(item: item)
+        savedItem.item = item
+        let recommendation: Recommendation = .build(item: item)
+
+        let viewModel = subject(recommendation: recommendation)
+        viewModel.showWebReader()
+
+        XCTAssertEqual(viewModel.presentedWebReaderURL, item.bestURL)
+    }
+}
+
+extension RecommendationViewModel {
+    func invokeAction(title: String) {
+        _actions.first(where: { $0.title == title })?.handler?(nil)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -97,6 +97,18 @@ class RecommendationViewModelTests: XCTestCase {
             viewModel._actions.map(\.title),
             ["Display Settings", "Unfavorite", "Archive", "Delete", "Share"]
         )
+
+        item.savedItem = nil
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Display Settings", "Save", "Share"]
+        )
+
+        item.savedItem = savedItem
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Display Settings", "Unfavorite", "Archive", "Delete", "Share"]
+        )
     }
 
     func test_displaySettings_updatesIsPresentingReaderSettings() {

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -169,6 +169,41 @@ class PocketSourceTests: XCTestCase {
         wait(for: [expectationToRunOperation], timeout: 1)
     }
 
+    func test_delete_ifSavedItemItemHasRecommendation_doesNotDeleteSavedItemItem() throws {
+        operations.stubItemMutationOperation { (_, _ , _: DeleteItemMutation) in
+            TestSyncOperation { }
+        }
+
+        let savedItem = try space.seedSavedItem(item: .build())
+        let item = savedItem.item!
+        item.recommendation = .build()
+
+        let remoteItemID = item.remoteID!
+
+        let source = subject()
+        source.delete(item: savedItem)
+
+        let fetchedItem = try space.fetchItem(byRemoteID: remoteItemID)
+        XCTAssertNotNil(fetchedItem)
+    }
+
+    func test_delete_ifSavedItemItemHasNoRecommendation_doesNotDeleteSavedItemItem() throws {
+        operations.stubItemMutationOperation { (_, _ , _: DeleteItemMutation) in
+            TestSyncOperation { }
+        }
+
+        let savedItem = try space.seedSavedItem(item: .build())
+        let item = savedItem.item!
+
+        let remoteItemID = item.remoteID!
+
+        let source = subject()
+        source.delete(item: savedItem)
+
+        let fetchedItem = try space.fetchItem(byRemoteID: remoteItemID)
+        XCTAssertNil(fetchedItem)
+    }
+
     func test_archive_archivesLocally_andExecutesArchiveMutation_andUpdatesArchivedAt() throws {
         let item = try space.seedSavedItem(remoteID: "archive-me")
         let expectationToRunOperation = expectation(description: "Run operation")


### PR DESCRIPTION
This pull request adds support for actions for recommendations opened in the reader.

Recommendations have three states:
1. Unsaved (not in "My List" or "Archive")
2. Saved, but not archived
3. Saved, but archived

Each of these states have their own actions available to them (as reviewed in Slack with product).

Points 1. and 2. above share the same available actions:
1. Display Settings
2. Favorite / Unfavorite
3. Move to My List / Archive
4. Delete
5. Share

Point 3 has a much more simplified set of actions:
1. Display Settings
2. Save
3. Share

For point 3, upon saving, the available actions will update to the actions shared by points 1. and 2 (acting as a "saved item"). When deleting an item via action, the available actions will be updated to the actions for point 3.

A change to `PocketSource.delete(item:)` had to be made. First, the data model was updated to `nullify` the `item` relationship on delete. Second, the `SavedItem.item` is deleted _if not part of a recommendation_. Otherwise, it remains stored.