### PR TITLE
Add authentication safeguards against multiple attempts

### DIFF
--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -68,6 +68,10 @@ class LoggedOutViewModel: ObservableObject {
 
     @MainActor
     func logIn() {
+        guard appSession.currentSession == nil else {
+            return
+        }
+
         lastAction = .logIn
 
         tracker.track(
@@ -88,6 +92,10 @@ class LoggedOutViewModel: ObservableObject {
 
     @MainActor
     func signUp() {
+        guard appSession.currentSession == nil else {
+            return
+        }
+
         lastAction = .signUp
 
         tracker.track(
@@ -141,6 +149,8 @@ class LoggedOutViewModel: ObservableObject {
                 presentedAlert = PocketAlert(error) { [weak self] in
                     self?.presentedAlert = nil
                 }
+                Crashlogger.capture(error: error)
+            case .alreadyAuthenticating:
                 Crashlogger.capture(error: error)
             case .other(let nested):
                 // All other errors will be throws by the AuthenticationSession,

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -25,6 +25,14 @@ class LoggedOutViewModelTests: XCTestCase {
         tracker = MockTracker()
         mockAuthenticationSession = MockAuthenticationSession()
         subscriptions = []
+
+        mockAuthenticationSession.stubStart {
+            self.mockAuthenticationSession.completionHandler?(
+                self.mockAuthenticationSession.url,
+                self.mockAuthenticationSession.error
+            )
+            return true
+        }
     }
 
     override func tearDown() {
@@ -49,6 +57,26 @@ class LoggedOutViewModelTests: XCTestCase {
 }
 
 extension LoggedOutViewModelTests {
+    func test_logIn_withExistingSession_doesNotAttemptAuthentication() async {
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+
+        let startExpectation = expectation(description: "expected start to not be called")
+        startExpectation.isInverted = true
+        mockAuthenticationSession.stubStart {
+            startExpectation.fulfill()
+            return true
+        }
+
+        let viewModel = subject()
+        await viewModel.logIn()
+
+        wait(for: [startExpectation], timeout: 1)
+    }
+
     func test_logIn_onFxAError_setsPresentedAlert() async {
         mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()
@@ -82,6 +110,26 @@ extension LoggedOutViewModelTests {
 }
 
 extension LoggedOutViewModelTests {
+    func test_signUp_withExistingSession_doesNotAttemptAuthentication() async {
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+
+        let startExpectation = expectation(description: "expected start to not be called")
+        startExpectation.isInverted = true
+        mockAuthenticationSession.stubStart {
+            startExpectation.fulfill()
+            return true
+        }
+
+        let viewModel = subject()
+        await viewModel.signUp()
+
+        wait(for: [startExpectation], timeout: 1)
+    }
+
     func test_signUp_onFxAError_setsPresentedAlert() async {
         mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()

--- a/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
@@ -3,6 +3,8 @@ import AuthenticationServices
 
 
 class MockAuthenticationSession: AuthenticationSession {
+    private var implementations: [String: Any] = [:]
+
     var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
 
     var prefersEphemeralWebBrowserSession = false
@@ -12,9 +14,23 @@ class MockAuthenticationSession: AuthenticationSession {
     var error: Error?
 
     required init() { }
+}
+
+extension MockAuthenticationSession {
+    static let start = "start"
+    typealias StartImpl = () -> Bool
+
+    struct StartCall { }
+
+    func stubStart(_ impl: @escaping StartImpl) {
+        implementations[Self.start] = impl
+    }
 
     func start() -> Bool {
-        completionHandler?(url, error)
-        return true
+        guard let impl = implementations[Self.start] as? StartImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        return impl()
     }
 }


### PR DESCRIPTION
## Summary

This pull request adds authentication safeguards to ensure there is only one active authentication session while the user is logged out

## References

IN-608

## Details

- Ensure the AuthorizationClient can only start one session at a time
- No-op LoggedOutViewModel.logIn and LoggedOutViewModel.signUp if the user is already logged in

## Testing

Unit tests have been added, and self-QA was performed to ensure on-device authentication still worked as intended.