### PR TITLE
IN-647: Use ".destructive" style for swipe actions that remove a cell

### DIFF
--- a/PocketKit/Sources/PocketKit/ItemContextualAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemContextualAction.swift
@@ -14,7 +14,7 @@ struct ItemContextualAction {
 extension ItemContextualAction {
     static func moveToMyList(_ completion: @escaping ((Bool) -> Void) -> Void) -> ItemContextualAction {
         ItemContextualAction(
-            style: .normal,
+            style: .destructive,
             title: "Move to My List",
             image: UIImage(asset: .save),
             backgroundColor: UIColor(.ui.teal2),
@@ -24,7 +24,7 @@ extension ItemContextualAction {
 
     static func archive(_ completion: @escaping ((Bool) -> Void) -> Void) -> ItemContextualAction {
         ItemContextualAction(
-            style: .normal,
+            style: .destructive,
             title: "Archive",
             image: UIImage(asset: .archive),
             backgroundColor: UIColor(.ui.teal2),


### PR DESCRIPTION
This creates a much smoother animation and fixes the bug described in
the linked ticket.

Co-authored-by: David Skuza <dskuza@getpocket.com>
Co-authored-by: Cyndi Chin <cchin@mozilla.com>
IN-647