### PR TITLE
Update SaveTo capsule styling and overall font styling

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
@@ -5,13 +5,19 @@ import Textile
 
 private extension Style {
     static func title(modifier: StylerModifier) -> Style {
-        .header
-        .serif
-        .title
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.925))
+        var style: Style = .header
+            .serif
+            .title
+            .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+                paragraph.with(lineHeight: .multiplier(0.925))
+            }
+            .modified(by: modifier)
+
+        if modifier.fontFamily == .graphik {
+            style = style.with(weight: .medium)
         }
-        .modified(by: modifier)
+
+        return style
     }
 
     static func byline(modifier: StylerModifier) -> Style {

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
@@ -12,6 +12,14 @@ class ReaderSettings: StylerModifier, ObservableObject {
     
     @AppStorage("readerFontFamily")
     var fontFamily: FontDescriptor.Family = .blanco
+
+    var currentStyling: FontStyling {
+        if fontFamily == .graphik {
+            return GraphikLCGStyling()
+        } else {
+            return BlancoOSFStyling()
+        }
+    }
 }
 
 extension FontDescriptor.Family: RawRepresentable {

--- a/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
@@ -5,7 +5,7 @@ extension Style {
     static let logIn: Self = .header.sansSerif.h8.with(color: .ui.white)
 
     static func coloredMainText(color: ColorAsset) -> Style {
-        .header.sansSerif.h2.with(color: color).with { $0.with(lineSpacing: 4) }
+        .header.sansSerif.h2.with(color: color).with { $0.with(lineHeight: .explicit(36)).with(verticalAlignment: .center) } 
     }
     static let mainText: Self = coloredMainText(color: .ui.teal2)
     static let mainTextError: Self = coloredMainText(color: .ui.coral2)

--- a/PocketKit/Sources/Textile/FontStyling/BlancoOSFStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/BlancoOSFStyling.swift
@@ -1,0 +1,80 @@
+public struct BlancoOSFStyling: FontStyling {
+    public let h1: Style
+    public let h2: Style
+    public let h3: Style
+    public let h4: Style
+    public let h5: Style
+    public let h6: Style
+    public let body: Style
+    public let monospace: Style
+
+    public init(
+        h1: Style = Self.defaultH1,
+        h2: Style = Self.defaultH2,
+        h3: Style = Self.defaultH3,
+        h4: Style = Self.defaultH4,
+        h5: Style = Self.defaultH5,
+        h6: Style = Self.defaultH6,
+        body: Style = Self.defaultBody,
+        monospace: Style = Self.defaultMonospace
+    ) {
+        self.h1 = h1
+        self.h2 = h2
+        self.h3 = h3
+        self.h4 = h4
+        self.h5 = h5
+        self.h6 = h6
+        self.body = body
+        self.monospace = monospace
+    }
+
+    public func bolding(style: Style) -> Style {
+        style.with(weight: .semibold)
+    }
+
+    public func with(body: Style) -> FontStyling {
+        BlancoOSFStyling(
+            h1: h1,
+            h2: h2,
+            h3: h3,
+            h4: h4,
+            h5: h5,
+            h6: h6,
+            body: body,
+            monospace: monospace
+        )
+    }
+}
+
+public extension BlancoOSFStyling {
+    static let defaultH1: Style = .header.serif.h1.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.97))
+    }
+
+    static let defaultH2: Style = .header.serif.h2.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.95))
+    }
+
+    static let defaultH3: Style = .header.serif.h3.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.95))
+    }
+
+    static let defaultH4: Style = .header.serif.h4.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.96))
+    }
+
+    static let defaultH5: Style = .header.serif.h5.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.89))
+    }
+
+    static let defaultH6: Style = .header.serif.h6.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.9))
+    }
+
+    static let defaultBody: Style = .body.serif.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(1.1))
+    }
+
+    static var defaultMonospace: Style = .body.monospace
+}
+

--- a/PocketKit/Sources/Textile/FontStyling/FontStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/FontStyling.swift
@@ -1,0 +1,14 @@
+public protocol FontStyling {
+    var h1: Style { get }
+    var h2: Style { get }
+    var h3: Style { get }
+    var h4: Style { get }
+    var h5: Style { get }
+    var h6: Style { get }
+    var body: Style { get }
+    var monospace: Style { get }
+
+    func bolding(style: Style) -> Style
+
+    func with(body: Style) -> FontStyling
+}

--- a/PocketKit/Sources/Textile/FontStyling/GraphikLCGStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/GraphikLCGStyling.swift
@@ -1,0 +1,80 @@
+public struct GraphikLCGStyling: FontStyling {
+    public let h1: Style
+    public let h2: Style
+    public let h3: Style
+    public let h4: Style
+    public let h5: Style
+    public let h6: Style
+    public let body: Style
+    public let monospace: Style
+
+    public init(
+        h1: Style = Self.defaultH1,
+        h2: Style = Self.defaultH2,
+        h3: Style = Self.defaultH3,
+        h4: Style = Self.defaultH4,
+        h5: Style = Self.defaultH5,
+        h6: Style = Self.defaultH6,
+        body: Style = Self.defaultBody,
+        monospace: Style = Self.defaultMonospace
+    ) {
+        self.h1 = h1
+        self.h2 = h2
+        self.h3 = h3
+        self.h4 = h4
+        self.h5 = h5
+        self.h6 = h6
+        self.body = body
+        self.monospace = monospace
+    }
+
+    public func bolding(style: Style) -> Style {
+        style.with(weight: .medium)
+    }
+
+    public func with(body: Style) -> FontStyling {
+        GraphikLCGStyling(
+            h1: h1,
+            h2: h2,
+            h3: h3,
+            h4: h4,
+            h5: h5,
+            h6: h6,
+            body: body,
+            monospace: monospace
+        )
+    }
+}
+
+public extension GraphikLCGStyling {
+    static let defaultH1: Style = .header.sansSerif.h1.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.97))
+    }
+
+    static let defaultH2: Style = .header.sansSerif.h2.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.95))
+    }
+
+    static let defaultH3: Style = .header.sansSerif.h3.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.95))
+    }
+
+    static let defaultH4: Style = .header.sansSerif.h4.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.96))
+    }
+
+    static let defaultH5: Style = .header.sansSerif.h5.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.89))
+    }
+
+    static let defaultH6: Style = .header.sansSerif.h6.with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(0.9))
+    }
+
+    static let defaultBody: Style = .body.sansSerif.with(size: .body.adjusting(by: -3)).with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+        paragraph.with(lineHeight: .multiplier(1.2))
+    }
+
+    static let defaultMonospace: Style = .body.monospace
+}
+

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -1,45 +1,6 @@
 import Foundation
 import Down
 
-private extension Style {
-    static let h1: Style = .header.serif.h1
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.97))
-        }
-
-    static let h2: Style = .header.serif.h2
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.99))
-        }
-
-    static let h3: Style = .header.serif.h3
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.95))
-        }
-
-    static let h4: Style = .header.serif.h4
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.96))
-        }
-
-    static let h5: Style = .header.serif.h5
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.89))
-        }
-
-    static let h6: Style = .header.serif.h6
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(0.9))
-        }
-
-    static let bodyText: Style = .body.serif
-        .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
-            paragraph.with(lineHeight: .multiplier(1.1))
-        }
-
-    static let monospace: Style = .body.monospace
-}
-
 public extension NSAttributedString {
     convenience init(string: String, style: Style) {
         self.init(string: string, attributes: style.textAttributes)
@@ -57,16 +18,17 @@ public extension NSAttributedString {
         return nil
     }
     
-    static func defaultStyler(with modifier: StylerModifier, bodyStyle: Style? = nil) -> Styler {
-        TextileStyler(
-            h1: .h1,
-            h2: .h2,
-            h3: .h3,
-            h4: .h4,
-            h5: .h5,
-            h6: .h6,
-            body: bodyStyle ?? .bodyText,
-            monospace: .monospace,
+    static func defaultStyler(
+        with modifier: StylerModifier,
+        bodyStyle: Style? = nil
+    ) -> Styler {
+        var styling = modifier.currentStyling
+        if let bodyStyle = bodyStyle {
+            styling = styling.with(body: bodyStyle)
+        }
+
+        return TextileStyler(
+            styling: styling,
             modifier: modifier
         )
     }

--- a/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
@@ -16,32 +16,39 @@ public struct ParagraphStyle {
     public let lineBreakMode: LineBreakMode
     public let lineSpacing: CGFloat?
     public let lineHeight: LineHeight?
+    public let verticalAlignment: VerticalTextAlignment
 
     public init(
         alignment: TextAlignment,
         lineBreakMode: LineBreakMode = .none,
         lineSpacing: CGFloat? = nil,
-        lineHeight: LineHeight? = nil
+        lineHeight: LineHeight? = nil,
+        verticalAlignment: VerticalTextAlignment = .default
     ) {
         self.alignment = alignment
         self.lineBreakMode = lineBreakMode
         self.lineSpacing = lineSpacing
         self.lineHeight = lineHeight
+        self.verticalAlignment = verticalAlignment
     }
 
     public func with(alignment: TextAlignment) -> ParagraphStyle {
-        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight)
+        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight, verticalAlignment: verticalAlignment)
     }
 
     public func with(lineBreakMode: LineBreakMode) -> ParagraphStyle {
-        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight)
+        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight, verticalAlignment: verticalAlignment)
     }
 
     public func with(lineSpacing: CGFloat?) -> ParagraphStyle {
-        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight)
+        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight, verticalAlignment: verticalAlignment)
     }
 
     public func with(lineHeight: LineHeight?) -> ParagraphStyle {
-        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight)
+        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight, verticalAlignment: verticalAlignment)
+    }
+
+    public func with(verticalAlignment: VerticalTextAlignment) -> ParagraphStyle {
+        return ParagraphStyle(alignment: alignment, lineBreakMode: lineBreakMode, lineSpacing: lineSpacing, lineHeight: lineHeight, verticalAlignment: verticalAlignment)
     }
 }

--- a/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
@@ -18,3 +18,8 @@ public enum TextAlignment {
         }
     }
 }
+
+public enum VerticalTextAlignment {
+    case `default`
+    case center
+}

--- a/PocketKit/Sources/Textile/Style/Style+Definitions.swift
+++ b/PocketKit/Sources/Textile/Style/Style+Definitions.swift
@@ -38,15 +38,15 @@ public extension Style {
         public let display = Display()
 
         public struct SansSerif {
-            public let title = Style(family: .graphik, size: .title, weight: .semibold)
-            public let h1 = Style(family: .graphik, size: .h1, weight: .semibold)
-            public let h2 = Style(family: .graphik, size: .h2, weight: .semibold)
-            public let h3 = Style(family: .graphik, size: .h3, weight: .semibold)
-            public let h4 = Style(family: .graphik, size: .h4, weight: .semibold)
-            public let h5 = Style(family: .graphik, size: .h5, weight: .semibold)
-            public let h6 = Style(family: .graphik, size: .h6, weight: .semibold)
-            public let h7 = Style(family: .graphik, size: .h7, weight: .semibold)
-            public let h8 = Style(family: .graphik, size: .h8, weight: .semibold)
+            public let title = Style(family: .graphik, size: .title, weight: .medium)
+            public let h1 = Style(family: .graphik, size: .h1, weight: .medium)
+            public let h2 = Style(family: .graphik, size: .h2, weight: .medium)
+            public let h3 = Style(family: .graphik, size: .h3, weight: .medium)
+            public let h4 = Style(family: .graphik, size: .h4, weight: .medium)
+            public let h5 = Style(family: .graphik, size: .h5, weight: .medium)
+            public let h6 = Style(family: .graphik, size: .h6, weight: .medium)
+            public let h7 = Style(family: .graphik, size: .h7, weight: .medium)
+            public let h8 = Style(family: .graphik, size: .h8, weight: .medium)
             public let p1 = Style(family: .graphik, size: .p1, weight: .regular)
             public let p2 = Style(family: .graphik, size: .p2, weight: .regular)
             public let p3 = Style(family: .graphik, size: .p3, weight: .regular)
@@ -55,7 +55,7 @@ public extension Style {
         }
 
         public struct Serif {
-            public let title = Style(family: .blanco, size: .title, weight: .semibold)
+            public let title = Style(family: .blanco, size: .title, weight: .bold)
             public let h1 = Style(family: .blanco, size: .h1, weight: .bold)
             public let h2 = Style(family: .blanco, size: .h2, weight: .bold)
             public let h3 = Style(family: .blanco, size: .h3, weight: .bold)

--- a/PocketKit/Sources/Textile/Style/Style+UIKit.swift
+++ b/PocketKit/Sources/Textile/Style/Style+UIKit.swift
@@ -155,6 +155,30 @@ public extension Style {
             attributes[.backgroundColor] = UIColor(backgroundColor)
         }
 
+        switch paragraph.verticalAlignment {
+        case .center:
+            guard let lineHeight = paragraph.lineHeight else {
+                break
+            }
+
+            // Thinking of a line of text as a container, NSAttributedStrings by default render their text
+            // against the bottom of the container. CSS's "line-height" property aligns the center of text
+            // to the center of the container. We can mimic this behavior by offsetting the baseline by
+            // a fraction of the difference between the font's line height and the requested line height.
+            let font = attributes[.font] as! UIFont
+            let styleLineHeight: CGFloat
+            switch lineHeight {
+            case .explicit(let value):
+                styleLineHeight = value
+            case .multiplier(let value):
+                styleLineHeight = font.lineHeight * value
+            }
+
+            attributes[.baselineOffset] = (styleLineHeight - font.lineHeight) / 4
+        default:
+            break
+        }
+
         return attributes
     }
 }

--- a/PocketKit/Sources/Textile/StylerModifier.swift
+++ b/PocketKit/Sources/Textile/StylerModifier.swift
@@ -1,6 +1,8 @@
 public protocol StylerModifier {
     var fontSizeAdjustment: Int { get }
     var fontFamily: FontDescriptor.Family { get }
+
+    var currentStyling: FontStyling { get }
 }
 
 public extension Style {

--- a/PocketKit/Sources/Textile/TextileStyler.swift
+++ b/PocketKit/Sources/Textile/TextileStyler.swift
@@ -3,34 +3,15 @@ import Down
 
 
 public class TextileStyler: Styler {
-    private let h1: Style
-    private let h2: Style
-    private let h3: Style
-    private let h4: Style
-    private let h5: Style
-    private let h6: Style
-    private let body: Style
-    private let monospace: Style
-    
+    private let styling: FontStyling
+    private let modifier: StylerModifier
+
     public init(
-        h1: Style,
-        h2: Style,
-        h3: Style,
-        h4: Style,
-        h5: Style,
-        h6: Style,
-        body: Style,
-        monospace: Style,
+        styling: FontStyling,
         modifier: StylerModifier
     ) {
-        self.h1 = h1.modified(by: modifier)
-        self.h2 = h2.modified(by: modifier)
-        self.h3 = h3.modified(by: modifier)
-        self.h4 = h4.modified(by: modifier)
-        self.h5 = h5.modified(by: modifier)
-        self.h6 = h6.modified(by: modifier)
-        self.body = body.modified(by: modifier)
-        self.monospace = monospace.adjustingSize(by: modifier.fontSizeAdjustment)
+        self.styling = styling
+        self.modifier = modifier
     }
     
     public func style(document str: NSMutableAttributedString) {
@@ -72,13 +53,13 @@ public class TextileStyler: Styler {
     public func style(heading str: NSMutableAttributedString, level: Int) {
         var headingStyle: Style
         switch level {
-        case 1: headingStyle = h1
-        case 2: headingStyle = h2
-        case 3: headingStyle = h3
-        case 4: headingStyle = h4
-        case 5: headingStyle = h5
-        case 6: headingStyle = h6
-        default: headingStyle = body
+        case 1: headingStyle = styling.h1
+        case 2: headingStyle = styling.h2
+        case 3: headingStyle = styling.h3
+        case 4: headingStyle = styling.h4
+        case 5: headingStyle = styling.h5
+        case 6: headingStyle = styling.h6
+        default: headingStyle = styling.bolding(style: styling.body)
         }
         
         str.updateStyle { existingStyle in
@@ -88,7 +69,7 @@ public class TextileStyler: Styler {
 
             headingStyle = headingStyle.with(slant: existingStyle.fontDescriptor.slant)
             
-            if existingStyle.fontDescriptor.family == monospace.fontDescriptor.family {
+            if existingStyle.fontDescriptor.family == styling.monospace.fontDescriptor.family {
                 headingStyle = headingStyle
                     .with(family: existingStyle.fontDescriptor.family)
                     .with(backgroundColor: .ui.grey6)
@@ -104,7 +85,7 @@ public class TextileStyler: Styler {
     
     public func style(text str: NSMutableAttributedString) {
         str.updateStyle { _ in
-            body
+            styling.body
         }
     }
     
@@ -118,7 +99,7 @@ public class TextileStyler: Styler {
     
     public func style(code str: NSMutableAttributedString) {
         str.updateStyle { existingStyle in
-            monospace.with(backgroundColor: .ui.grey6)
+            styling.monospace.with(backgroundColor: .ui.grey6)
         }
     }
     
@@ -132,19 +113,20 @@ public class TextileStyler: Styler {
     
     public func style(emphasis str: NSMutableAttributedString) {
         str.updateStyle { existingStyle in
-            (existingStyle ?? body).with(slant: .italic)
+            (existingStyle ?? styling.body).with(slant: .italic)
         }
     }
     
     public func style(strong str: NSMutableAttributedString) {
         str.updateStyle { existingStyle in
-            (existingStyle ?? body).with(weight: .bold)
+            let style = existingStyle ?? styling.body
+            return styling.bolding(style: style)
         }
     }
     
     public func style(link str: NSMutableAttributedString, title: String?, url: String?) {
         str.updateStyle { existingStyle in
-            (existingStyle ?? body).with(underlineStyle: .single)
+            (existingStyle ?? styling.body).with(underlineStyle: .single)
         }
         
         if let urlString = url, let url = URL(string: urlString) {


### PR DESCRIPTION
## Summary

This pull request updates the UI of the SaveTo extension, such as padding around capsule text, and the weight of the capsule font. Additionally, `TextileStyler` had to be updated to support the correct font weight (e.g semibold vs medium), based on the selected font family when reading an article.

### Note

In order for the updated font weights to be visible, the fonts that are included at build-time have to be updated. These fonts will be distributed async, as they are not licensed for inclusion in our open source repo.

## References

IN-628

## Implementation Details

During design review, the SaveTo extension had incorrect padding when multi-line text was visible in the capsule. It was determined that the difference is due to how Figma uses the CSS "line-height" property vs how iOS renders text. "line-height" will center text within the line height, whereas iOS will pin text to the bottom. We can mimic "line-height" behavior by calculating and setting a baseline offset for an attributed string, which allows us to better match Figma designs.

A new protocol, `FontStyling`, has been introduced and is used in conjunction with `NSAttributedString.defaultStyler`. Types conforming to this protocol provide the styles to use when rendering markdown for elements such as `h1`, `h2`, `body`, etc. An instance of this type is used in conjunction with `StyleModifier` in `TextileStyler` to update the styling for these elements. `FontStyling` was created because different fonts require different values for element styling (e.g Graphik's default font size is smaller than Blanco). This also prepares us for custom styling for other fonts that will be added as display settings. 

Figma was used to determine decisions (such as setting Graphik to use medium over semibold), as well as review with design.