### PR TITLE
Support reporting a recommendation from the reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -25,6 +25,9 @@ class RecommendationViewModel: ReadableViewModel {
 
     @Published
     var isPresentingReaderSettings: Bool?
+
+    @Published
+    var selectedRecommendationToReport: Recommendation?
     
     private let recommendation: Recommendation
     private let source: Source
@@ -137,7 +140,8 @@ extension RecommendationViewModel {
             _actions = [
                 .displaySettings { [weak self] _ in self?.displaySettings() },
                 .save { [weak self] _ in self?.save() },
-                .share { [weak self] _ in self?.share() }
+                .share { [weak self] _ in self?.share() },
+                .report { [weak self] _ in self?.report() }
             ]
 
             return
@@ -183,5 +187,9 @@ extension RecommendationViewModel {
 
         buildActions()
         subscribe(to: savedItem)
+    }
+
+    private func report() {
+        selectedRecommendationToReport = recommendation
     }
 }

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -42,7 +42,7 @@ class RecommendationViewModelTests: XCTestCase {
             let viewModel = subject(recommendation: recommendation)
             XCTAssertEqual(
                 viewModel._actions.map(\.title),
-                ["Display Settings", "Save", "Share"]
+                ["Display Settings", "Save", "Share", "Report"]
             )
         }
 
@@ -101,7 +101,7 @@ class RecommendationViewModelTests: XCTestCase {
         item.savedItem = nil
         XCTAssertEqual(
             viewModel._actions.map(\.title),
-            ["Display Settings", "Save", "Share"]
+            ["Display Settings", "Save", "Share", "Report"]
         )
 
         item.savedItem = savedItem
@@ -273,6 +273,21 @@ class RecommendationViewModelTests: XCTestCase {
         viewModel.invokeAction(title: "Save")
 
         wait(for: [expectSave], timeout: 1)
+    }
+
+    func test_report_updatesSelectedRecommendationToReport() {
+        let recommendation = Recommendation.build(item: .build())
+
+        let viewModel = subject(recommendation: recommendation)
+
+        let reportExpectation = expectation(description: "expected recommendation to be reported")
+        viewModel.$selectedRecommendationToReport.dropFirst().sink { recommendation in
+            XCTAssertNotNil(recommendation)
+            reportExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Report")
+        wait(for: [reportExpectation], timeout: 1)
     }
 }
 

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -92,4 +92,16 @@ class ReportARecommendationTests: XCTestCase {
         
         XCTAssertTrue(requestBody.contains("reason"))
     }
+
+    func test_reportingARecommendation_fromReader_showsReportView() {
+        app.homeView
+            .recommendationCell("Slate 1, Recommendation 1")
+            .wait()
+            .tap()
+
+        app.readerView.readerToolbar.moreButton.tap()
+        app.reportButton.wait().tap()
+
+        app.reportView.wait()
+    }
 }

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -79,6 +79,10 @@ struct PocketAppElement {
     var shareButton: XCUIElement {
         app.buttons["Share"]
     }
+
+    var reportButton: XCUIElement {
+        app.buttons["Report"]
+    }
     
     var alert: AlertElement {
         AlertElement(app.alerts.element(boundBy: 0))


### PR DESCRIPTION
## Summary

This pull request adds support for reporting an (unsaved) item from the Home feed, i.e a recommendation, from the reader when opening the action menu.

## References

IN-432

## Implementation Details

A new `ItemAction` has been added to `RecommendationViewModel`, which is the `ReadableViewModel` generated when an item from the Home feed is opened. This action has only been added when an item is unsaved (i.e not in "My List" or "Archive"). This introduces a new `selectedRecommendationToReport` property that mimics that of `HomeViewModel`. This property is them sinked to within both regular and compact coordinators, at which point the report modal is presented for the recommendation. Additionally, the `report` function in the coordinators has been refactored to accept a closure that will be called on dismissal of the report view. This cleans up the way in which the `selectedRecommendationToReport` properties are unset upon dismissal.

## Screenshots

![image](https://user-images.githubusercontent.com/1158092/175084787-00b0c465-d97b-46b9-93dc-75830f85e256.png)

## Test Steps

- [ ] Given I am on the Home tab and I have not previously saved or archived an item, when I open a recommendation in the reader and I tap the overflow menu, then I should see the report button.
- [ ] Given I am on the Home tab and I have previously saved or archived an item, when I open a recommendation in the reader and I tap the overflow menu, then I should not see the report button.
- [ ] Given I am on the Home tab and I have previously saved or archived an item, when I open a recommendation in the reader and I tap the overflow menu and delete the item and reopen the menu, then I should see the report button.