### PR TITLE
Add PR template to repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+* Include short description of what this PR accomplishes
+
+## References 
+* Links to docs, tickets, designs if available
+
+## Implementation Details
+* Overview of work that was implemented and changes made to the codebase
+
+## Test Steps
+* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.
+
+## PR Checklist:
+- [ ] Added Unit / UI tests
+- [ ] Self Review (review, clean up, documentation, run tests)
+- [ ] Basic Self QA
+
+## Screenshots


### PR DESCRIPTION
## Summary
Adds template to repo for engineers to use when creating PRs

Reference: https://getpocket.atlassian.net/wiki/spaces/~625c9c3cd7f1b80069bcb183/pages/2720628737/iOS+Next+Templates