### PR TITLE
Home: show activity indicator on initial load

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -3,6 +3,25 @@ import Sync
 
 
 class HomeViewControllerSectionProvider {
+    func loadingSection() -> NSCollectionLayoutSection {
+        let item = NSCollectionLayoutItem(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .fractionalHeight(1)
+            )
+        )
+
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .fractionalHeight(0.65)
+            ),
+            subitems: [item]
+        )
+
+        return NSCollectionLayoutSection(group: group)
+    }
+
     func topicCarouselSection(slates: [Slate]?) -> NSCollectionLayoutSection {
         guard let slates = slates, !slates.isEmpty else {
             return NSCollectionLayoutSection(
@@ -143,8 +162,10 @@ class HomeViewControllerSectionProvider {
 
         return section
     }
+}
 
-    func twoUpGroup(
+extension HomeViewControllerSectionProvider {
+    private func twoUpGroup(
         slate: Slate,
         viewModel: HomeViewModel,
         width: CGFloat,
@@ -223,4 +244,5 @@ class HomeViewControllerSectionProvider {
             height: miniCardHeight
         )
     }
+
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -27,6 +27,8 @@ class HomeViewController: UIViewController {
               }
 
         switch section {
+        case .loading:
+            return self.sectionProvider.loadingSection()
         case .topics:
             let slates = self.dataSource.snapshot(for: section).items.compactMap { cell -> Slate? in
                 guard case .topic(let slate) = cell else {
@@ -81,6 +83,7 @@ class HomeViewController: UIViewController {
         }
 
         collectionView.backgroundColor = UIColor(.ui.white1)
+        collectionView.register(cellClass: LoadingCell.self)
         collectionView.register(cellClass: RecommendationCell.self)
         collectionView.register(cellClass: TopicChipCell.self)
         collectionView.register(viewClass: SlateHeaderView.self, forSupplementaryViewOfKind: SlateHeaderView.kind)
@@ -160,6 +163,9 @@ class HomeViewController: UIViewController {
 extension HomeViewController {
     func cellFor(_ item: HomeViewModel.Cell, at indexPath: IndexPath) -> UICollectionViewCell {
         switch item {
+        case .loading:
+            let cell: LoadingCell = collectionView.dequeueCell(for: indexPath)
+            return cell
         case .topic(let slate):
             let cell: TopicChipCell = collectionView.dequeueCell(for: indexPath)
             cell.configure(model: TopicChipPresenter(title: slate.name, image: nil))

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -15,7 +15,7 @@ class HomeViewModel {
     private let tracker: Tracker
 
     @Published
-    var snapshot = Snapshot()
+    var snapshot: Snapshot
 
     @Published
     var selectedReadableViewModel: RecommendationViewModel? = nil
@@ -39,6 +39,7 @@ class HomeViewModel {
         self.source = source
         self.tracker = tracker
         self.slateLineupController = source.makeSlateLineupController()
+        self.snapshot = Self.loadingSnapshot()
 
         self.slateLineupController.delegate = self
     }
@@ -56,6 +57,8 @@ class HomeViewModel {
 
     func select(cell: HomeViewModel.Cell, at indexPath: IndexPath) {
         switch cell {
+        case .loading:
+            return
         case .topic:
             select(topic: cell)
         case .recommendation:
@@ -86,6 +89,8 @@ class HomeViewModel {
 
     func willDisplay(_ cell: HomeViewModel.Cell, at indexPath: IndexPath) {
         switch cell {
+        case .loading:
+            return
         case .topic:
             return
         case .recommendation:
@@ -102,6 +107,13 @@ class HomeViewModel {
 }
 
 extension HomeViewModel {
+    private static func loadingSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.loading])
+        snapshot.appendItems([.loading], toSection: .loading)
+        return snapshot
+    }
+
     private func buildSnapshot() -> Snapshot {
         viewModels = [:]
         viewModelSubscriptions = []
@@ -236,6 +248,8 @@ extension HomeViewModel {
 
     private func contexts(for cell: HomeViewModel.Cell, at indexPath: IndexPath) -> [Context] {
         switch cell {
+        case .loading:
+            return []
         case .topic:
             return []
         case .recommendation(let objectID):
@@ -275,11 +289,13 @@ extension HomeViewModel {
 
 extension HomeViewModel {
     enum Section: Hashable {
+        case loading
         case topics
         case slate(Slate)
     }
 
     enum Cell: Hashable {
+        case loading
         case topic(Slate)
         case recommendation(NSManagedObjectID)
     }

--- a/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
@@ -1,0 +1,32 @@
+import UIKit
+import Textile
+
+
+class LoadingCell: UICollectionViewCell {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupContentView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension LoadingCell {
+    private func setupContentView() {
+        contentView.backgroundColor = .clear
+
+        let activityIndicator = UIActivityIndicatorView(style: .large)
+        activityIndicator.color = UIColor(.ui.grey1)
+        contentView.addSubview(activityIndicator)
+
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+
+        activityIndicator.startAnimating()
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -46,6 +46,21 @@ class HomeViewModelTests: XCTestCase {
         )
     }
 
+    func test_init_createsLoadingSnapshot() {
+        source.stubFetchSlateLineup { _ in }
+
+        let viewModel = subject()
+
+        let snapshotExpectation = expectation(description: "expected to receive updated snapshot")
+        viewModel.$snapshot.sink { snapshot in
+            XCTAssertEqual(snapshot.sectionIdentifiers, [.loading])
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
+            snapshotExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        wait(for: [snapshotExpectation], timeout: 1)
+    }
+
     func test_refresh_delegatesToSource() {
         let fetchExpectation = expectation(description: "expected to fetch slate lineup")
         source.stubFetchSlateLineup { _ in fetchExpectation.fulfill() }
@@ -100,7 +115,7 @@ class HomeViewModelTests: XCTestCase {
             let firstSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[1])
             let firstSlateRecommendations = firstSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
-                case .topic:
+                case .topic, .loading:
                     return nil
                 case .recommendation(let objectID):
                     return objectID
@@ -114,7 +129,7 @@ class HomeViewModelTests: XCTestCase {
             let secondSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[2])
             let secondSlateRecommendations = secondSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
-                case .topic:
+                case .topic, .loading:
                     return nil
                 case .recommendation(let objectID):
                     return objectID
@@ -128,7 +143,7 @@ class HomeViewModelTests: XCTestCase {
             let thirdSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[3])
             let thirdSlateRecommendations = thirdSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
-                case .topic:
+                case .topic, .loading:
                     return nil
                 case .recommendation(let objectID):
                     return objectID
@@ -163,7 +178,7 @@ class HomeViewModelTests: XCTestCase {
         viewModel.$snapshot.dropFirst().sink { snapshot in
             let reloaded = snapshot.reloadedItemIdentifiers.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
-                case .topic:
+                case .topic, .loading:
                     return nil
                 case .recommendation(let objectID):
                     return objectID


### PR DESCRIPTION
## Summary

Adds an activity indicator when first loading the Home feed.

## References 

IN-672

## Implementation Details

`HomeViewModel.Section` and `HomeViewModel.Cell` each have a new `loading` case. When `HomeViewModel` is first initialized, it sets its initial snapshot to that of a "loading" snapshot - a snapshot that only contains a single `loading` section with a single `loading` item. `HomeViewControllerSectionProvider` returns a single section/group/item, which is then used to return a single `LoadingCell`. This cell is simple - it's a `UICollectionViewCell` subclass that houses a `UIActivityIndicatorView` that is always animating (since the loading cell is only ever present for a "loading" section and is not reused otherwise). 

## Test Steps

- [ ] Given the app is closed, when the app opens to the Home feed, an activity indicator should be visible in the middle of the screen.
- [ ] Given the app is open and the Home feed is visible, when the Home feed loads, the activity indicator should disappear.
- [ ] Given the app is open and the Home feed is visible, when the Home feed has been pull-to-refresh'd, then only the activity indicator at the top of the Home feed should appear.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

### Light Mode

![image](https://user-images.githubusercontent.com/1158092/176270244-71f4a194-a0e9-4d9c-93af-637554e9d6e3.png)

### Dark Mode

![image](https://user-images.githubusercontent.com/1158092/176270079-61676a76-11ce-4de2-9297-13176097c9ee.png)
