### PR TITLE
Fix crash when reloading Home tab with items to be deleted

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -17,6 +17,8 @@ class HomeRecommendationCellViewModel {
         isSaved = recommendation.item?.savedItem != nil
         || recommendation.item?.savedItem?.isArchived == false
 
+        // Triggered when an item is explicitly deleted by the user,
+        // or when SlateService.fetchSlateLineup(_:) is called
         recommendation.publisher(for: \.item?.savedItem)
             .removeDuplicates()
             .sink { [weak self] savedItem in


### PR DESCRIPTION
## Summary

Fix crash when reloading Home tab with items to be deleted due to SlateService.fetchSlateLineup(_:) deleting any unsaved items, which would publish changes upwards, resulting in erroneous snapshots being published.

## References 

IN-693

## Implementation Details

This one's a little… weird. The major change here is that we empty out `HomeViewModel.viewModels` and `HomeViewModel.viewModelSubscriptions` when refreshing the Home feed (with visible items saved). By emptying out these values, we ensure that we are (primarily) not observing changes to Core Data related to unsaved items being deleted from the database. Below is I _believe_ what was happening:

1. On first load (refresh), a new slate lineup is fetched and added to Core Data, resulting in a new snapshot being generated and applied for the slate lineup and its initial slates / recommendations.
2. On second load (pull-to-refresh), the initial slate lineup is deleted, along with any unsaved items, triggering a new snapshot being generated and applied.
3. While the snapshot from `2` is being applied, unsaved recommendations and items are being deleted from Core Data
4. Deleting unsaved items triggers cell view model refreshes, which publish _another_ (reloaded) snapshot (referencing a recommendation that no longer exists within the database)
5. These snapshots could potentially be applied rapidly enough where one snapshot was not yet completely applied before another snapshot was requested to be applied.
6. *_Crash_*

Emptying out the aforementioned values would mean that steps `4` and `5` do not occur (due to the subscription(s) in `HomeRecommendationCellViewModel` being cancelled), preventing `6`.

## Test Steps

- [x] Given I am on the home tab with the feed loaded, 
when I save the first available recommendation and pull to refresh,
then the list should refresh and the app should not crash.

- [x] Given I am on the home tab with the feed loaded, 
when I unsave the first available recommendation and pull to refresh,
then the list should refresh and the app should not crash.

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
