### PR TITLE
IN-698: Fix Delete + Share Action for Recent Saves on iPad

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -162,6 +162,14 @@ class RegularMainCoordinator: NSObject {
         model.home.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
         }.store(in: &subscriptions)
+        
+        model.home.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &subscriptions)
+
+        model.home.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+            self?.share(activity)
+        }.store(in: &subscriptions)
 
         isResetting = false
     }


### PR DESCRIPTION
## Summary
Fix delete and share action in the overflow menu for a recent saves item (iPad)

## References 
IN-698

## Implementation Details
* Added presentation logic for the alert and share sheet for iPad via `RegularMainCoordinator` (similar to the logic that was added for iPhone via `CompactHomeCoordinator`)

## Test Steps
- [x] Given that user has recent saves item, When they tap on the overflow actions, Then they should be able to share, delete or archive the item.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-07-11 at 09 41 05](https://user-images.githubusercontent.com/6743397/178277713-53957169-0691-4ebf-b589-7e0ab88f06b5.png)
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-07-11 at 09 41 13](https://user-images.githubusercontent.com/6743397/178277733-2093a99c-eb1c-4a7c-a037-d063277fce43.png)