### PR TITLE
Show loading indicator when loading slate detail content

### DIFF
--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -108,6 +108,8 @@ class SlateDetailViewModelTests: XCTestCase {
         viewModel.$snapshot.dropFirst().sink { snapshot in
             let reloaded = snapshot.reloadedItemIdentifiers.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
+                case .loading:
+                    return nil
                 case .recommendation(let objectID):
                     return objectID
                 }


### PR DESCRIPTION
## Summary

Adds an activity indicator when first loading a selected slate.

## References 

IN-692

Similar to pull request #196 

## Implementation Details

`SlateDetailViewModel.Section` and `SlateDetailViewModel.Cell` each have a new `loading` case. When `SlateDetailViewModel` is first initialized, it sets its initial snapshot to that of a "loading" snapshot - a snapshot that only contains a single `loading` section with a single `loading` item. `SlateDetailViewController` returns a single section/group/item, which is then used to return a single `LoadingCell`. This cell is simple - it's a `UICollectionViewCell` subclass that houses a `UIActivityIndicatorView` that is always animating (since the loading cell is only ever present for a "loading" section and is not reused otherwise). 

## Test Steps

- [x] Given I have opened the Pocket app,
when I view the Home tab and tap on a slate topic and data has not yet been loaded,
then I should see a spinner in the middle of the screen.

- [x] Given I viewed the Home tab and viewing a slate topic,
when data has been loaded,
then the spinner should disappear and the Home content should be visible.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

### Light Mode

![Simulator Screen Shot - iPhone 13 - 2022-07-11 at 13 32 35](https://user-images.githubusercontent.com/1158092/178334015-f201718d-0fb9-4da3-915c-46c9b4a45b3a.png)

### Dark Mode

![Simulator Screen Shot - iPhone 13 - 2022-07-11 at 13 32 58](https://user-images.githubusercontent.com/1158092/178334039-7e74c42f-6038-4909-b0c6-41c4a1b817e4.png)

