### PR TITLE
My List: Show skeleton cells during intial download

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemPlaceholderCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemPlaceholderCell.swift
@@ -5,25 +5,33 @@ import Textile
 class ItemPlaceholderCell: UICollectionViewListCell {
     private let actionsImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.tintColor = UIColor(.ui.grey6)
         imageView.image = UIImage(asset: .itemSkeletonActions)
+
         return imageView
     }()
 
     private let tagsImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.tintColor = UIColor(.ui.skeletonCellImageBackground)
         imageView.image = UIImage(asset: .itemSkeletonTags)
+
         return imageView
     }()
 
     private let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.tintColor = UIColor(.ui.skeletonCellImageBackground)
         imageView.image = UIImage(asset: .itemSkeletonThumbnail)
+
         return imageView
     }()
 
     private let titleImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.tintColor = UIColor(.ui.skeletonCellImageBackground)
         imageView.image = UIImage(asset: .itemSkeletonTitle)
+
         return imageView
     }()
 
@@ -31,6 +39,7 @@ class ItemPlaceholderCell: UICollectionViewListCell {
         super.init(frame: frame)
         accessibilityIdentifier = "my-list-item-skeleton"
 
+        contentView.backgroundColor = UIColor(.ui.white1)
         contentView.addSubview(actionsImageView)
         contentView.addSubview(tagsImageView)
         contentView.addSubview(thumbnailImageView)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemPlaceholderCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemPlaceholderCell.swift
@@ -29,7 +29,7 @@ class ItemPlaceholderCell: UICollectionViewListCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
+        accessibilityIdentifier = "my-list-item-skeleton"
 
         contentView.addSubview(actionsImageView)
         contentView.addSubview(tagsImageView)

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -1653,6 +1653,7 @@ public final class UserByTokenQuery: GraphQLQuery {
         __typename
         savedItems(pagination: $pagination, filter: $savedItemsFilter) {
           __typename
+          totalCount
           pageInfo {
             __typename
             hasNextPage
@@ -1780,6 +1781,7 @@ public final class UserByTokenQuery: GraphQLQuery {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("totalCount", type: .nonNull(.scalar(Int.self))),
             GraphQLField("pageInfo", type: .nonNull(.object(PageInfo.selections))),
             GraphQLField("edges", type: .list(.object(Edge.selections))),
           ]
@@ -1791,8 +1793,8 @@ public final class UserByTokenQuery: GraphQLQuery {
           self.resultMap = unsafeResultMap
         }
 
-        public init(pageInfo: PageInfo, edges: [Edge?]? = nil) {
-          self.init(unsafeResultMap: ["__typename": "SavedItemConnection", "pageInfo": pageInfo.resultMap, "edges": edges.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }])
+        public init(totalCount: Int, pageInfo: PageInfo, edges: [Edge?]? = nil) {
+          self.init(unsafeResultMap: ["__typename": "SavedItemConnection", "totalCount": totalCount, "pageInfo": pageInfo.resultMap, "edges": edges.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }])
         }
 
         public var __typename: String {
@@ -1801,6 +1803,16 @@ public final class UserByTokenQuery: GraphQLQuery {
           }
           set {
             resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// Identifies the total count of SavedItems in the connection.
+        public var totalCount: Int {
+          get {
+            return resultMap["totalCount"]! as! Int
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "totalCount")
           }
         }
 

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -10,6 +10,7 @@ protocol SyncOperationFactory {
         apollo: ApolloClientProtocol,
         space: Space,
         events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
         maxItems: Int,
         lastRefresh: LastRefresh
     ) -> SyncOperation
@@ -35,6 +36,7 @@ class OperationFactory: SyncOperationFactory {
         apollo: ApolloClientProtocol,
         space: Space,
         events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
         maxItems: Int,
         lastRefresh: LastRefresh
     ) -> SyncOperation {
@@ -43,6 +45,7 @@ class OperationFactory: SyncOperationFactory {
             apollo: apollo,
             space: space,
             events: events,
+            initialDownloadState: initialDownloadState,
             maxItems: maxItems,
             lastRefresh: lastRefresh
         )

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -2,11 +2,19 @@ import Combine
 import CoreData
 import Foundation
 
+public enum InitialDownloadState {
+    case unknown
+    case started
+    case paginating(totalCount: Int)
+    case completed
+}
 
 public protocol Source {
     var mainContext: NSManagedObjectContext { get }
 
     var events: AnyPublisher<SyncEvent, Never> { get }
+
+    var initialDownloadState: CurrentValueSubject<InitialDownloadState, Never> { get }
 
     func clear()
 

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -81,6 +81,7 @@ fragment SlateParts on Slate {
 query UserByToken($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
   userByToken(token: $token) {
     savedItems(pagination: $pagination, filter: $savedItemsFilter) {
+      totalCount
       pageInfo {
         hasNextPage
         endCursor

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/skeletonCellImageBackground.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/skeletonCellImageBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE7",
+          "green" : "0xE7",
+          "red" : "0xE7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4D",
+          "green" : "0x4D",
+          "red" : "0x4D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -33,6 +33,8 @@ public struct UIPalette {
     public let white1 = ColorAsset.ui("white1")
 
     public let black = ColorAsset.ui("black")
+
+    public let skeletonCellImageBackground = ColorAsset.ui("skeletonCellImageBackground")
 }
 
 public struct BrandingPalette {

--- a/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.actions.imageset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.actions.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.tags.imageset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.tags.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.thumbnail.imageset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.thumbnail.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.title.imageset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Images/Images.xcassets/item-skeleton/item-skeleton.title.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -10,6 +10,8 @@ class MockSource: Source {
         _events.eraseToAnyPublisher()
     }
 
+    var initialDownloadState: CurrentValueSubject<InitialDownloadState, Never> = .init(.unknown)
+
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
 

--- a/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 1,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/PocketKit/Tests/SyncTests/Fixtures/empty-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/empty-list.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 0,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 2,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 2,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 2,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 1,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -10,7 +10,7 @@ extension PocketSourceTests {
 
     func test_enqueueingOperations_whenNetworkPathIsUnsatisfied_doesNotExecuteOperations() {
         sessionProvider.session = MockSession()
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation {
                 XCTFail("Operation should not be executed while network path is unsatisfied")
             }
@@ -34,7 +34,7 @@ extension PocketSourceTests {
         }
 
         let expectFetchList = expectation(description: "execute the fetch list operation")
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation {
                 expectFetchList.fulfill()
             }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
@@ -7,7 +7,7 @@ extension PocketSourceTests {
         sessionProvider.session = MockSession()
 
         let fetchList = expectation(description: "fetchList operation executed")
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation { fetchList.fulfill() }
         }
 
@@ -41,7 +41,7 @@ extension PocketSourceTests {
         source.drain { done.fulfill() }
         wait(for: [done], timeout: 1)
 
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             XCTFail("Operation should not be re-created after succeeding")
             return TestSyncOperation { }
         }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -73,7 +73,7 @@ class PocketSourceTests: XCTestCase {
         let session = MockSession()
         sessionProvider.session = session
         let expectationToRunOperation = expectation(description: "Run operation")
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation {
                 expectationToRunOperation.fulfill()
             }
@@ -89,7 +89,7 @@ class PocketSourceTests: XCTestCase {
 
     func test_refreshWithCompletion_callsCompletionWhenFinished() {
         sessionProvider.session = MockSession()
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation { }
         }
 
@@ -105,7 +105,7 @@ class PocketSourceTests: XCTestCase {
 
     func test_refresh_whenTokenIsNil_callsCompletion() {
         sessionProvider.session = nil
-        operations.stubFetchList { _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _ in
             TestSyncOperation { }
         }
 

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -13,13 +13,21 @@ class MockOperationFactory: SyncOperationFactory {
 
 // MARK: - fetchList
 extension MockOperationFactory {
-    typealias FetchListImpl = (String, ApolloClientProtocol, Space, SyncEvents, Int) -> SyncOperation
+    typealias FetchListImpl = (
+        String,
+        ApolloClientProtocol,
+        Space,
+        SyncEvents,
+        CurrentValueSubject<InitialDownloadState, Never>,
+        Int
+    ) -> SyncOperation
 
     struct FetchListCall {
         let token: String
         let apollo: ApolloClientProtocol
         let space: Space
         let events: SyncEvents
+        let initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>
         let maxItems: Int
         let lastRefresh: LastRefresh
     }
@@ -33,6 +41,7 @@ extension MockOperationFactory {
         apollo: ApolloClientProtocol,
         space: Space,
         events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
         maxItems: Int,
         lastRefresh: LastRefresh
     ) -> SyncOperation {
@@ -46,12 +55,13 @@ extension MockOperationFactory {
                 apollo: apollo,
                 space: space,
                 events: events,
+                initialDownloadState: initialDownloadState,
                 maxItems: maxItems,
                 lastRefresh: lastRefresh
             )
         ]
 
-        return impl(token, apollo, space, events, maxItems)
+        return impl(token, apollo, space, events, initialDownloadState, maxItems)
     }
 
 

--- a/Tests iOS/Fixtures/initial-list-recent-saves.json
+++ b/Tests iOS/Fixtures/initial-list-recent-saves.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 2,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 2,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/Tests iOS/Fixtures/list-for-web-view.json
+++ b/Tests iOS/Fixtures/list-for-web-view.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/Tests iOS/Fixtures/list-with-archived-item.json
+++ b/Tests iOS/Fixtures/list-with-archived-item.json
@@ -4,6 +4,7 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,

--- a/Tests iOS/Fixtures/my-list-loading-page-1.json
+++ b/Tests iOS/Fixtures/my-list-loading-page-1.json
@@ -4,10 +4,10 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
-                "totalCount": 2,
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
-                    "hasNextPage": false,
+                    "hasNextPage": true,
                     "endCursor": "cursor-2"
                 },
                 "edges": [
@@ -26,31 +26,19 @@
                             "item": {
                                 "__typename": "Item",
                                 "remoteID": "item-1",
+                                "title": "Item 1",
                                 "givenUrl": "http://localhost:8080/hello",
                                 "resolvedUrl": "http://localhost:8080/hello",
-                                "title": "Updated Item 1",
                                 "topImageUrl": "https://example.com/item-1/top-image.jpg",
                                 "domain": null,
                                 "language": "en",
                                 "timeToRead": 6,
                                 "marticle": [],
-                                "authors": [],
-                                "datePublished": "2021-01-01 12:01:01",
                                 "excerpt": "Cursus Aenean Elit",
-                                "domainMetadata": {
-                                    "__typename": "[type-name-here]",
-                                    "name": "WIRED",
-                                    "logo": "http://example.com/item-1/domain-logo.jpg"
-                                },
-                                "images": [
-                                    {
-                                        "__typename": "[type-name-here]",
-                                        "height": 1,
-                                        "width": 2,
-                                        "src": "http://example.com/item-1/image-1.jpg",
-                                        "imageId": 1
-                                    }
-                                ],
+                                "datePublished": "2021-01-01 12:01:01",
+                                "authors": [],
+                                "domainMetadata": null,
+                                "images": [],
                                 "isArticle": true,
                                 "hasImage": "HAS_IMAGES",
                                 "hasVideo": "HAS_VIDEOS",
@@ -61,7 +49,7 @@
                         "__typename": "[type-name-here]",
                         "cursor": "cursor-2",
                         "node": {
-                            "__typename": "Item",
+                            "__typename": "[type-name-here]",
                             "remoteID": "saved-item-2",
                             "url": "https://example.com/item-2",
                             "_createdAt": 0,
@@ -74,29 +62,17 @@
                                 "remoteID": "item-2",
                                 "givenUrl": "https://example.com/item-2",
                                 "resolvedUrl": "https://example.com/item-2",
-                                "title": "Updated Item 2",
+                                "title": "Item 2",
                                 "topImageUrl": "https://example.com/item-2/top-image.jpg",
-                                "domain": null,
+                                "domain": "wired.com",
                                 "language": "en",
                                 "timeToRead": 6,
+                                "domainMetadata": null,
                                 "marticle": [],
                                 "authors": [],
                                 "datePublished": "2021-01-01 12:01:01",
                                 "excerpt": "Cursus Aenean Elit",
-                                "domainMetadata": {
-                                    "__typename": "[type-name-here]",
-                                    "name": "WIRED",
-                                    "logo": "http://example.com/item-2/domain-logo.jpg"
-                                },
-                                "images": [
-                                    {
-                                        "__typename": "[type-name-here]",
-                                        "height": 1,
-                                        "width": 2,
-                                        "src": "http://example.com/item-2/image-1.jpg",
-                                        "imageId": 1
-                                    }
-                                ],
+                                "images": [],
                                 "isArticle": true,
                                 "hasImage": "HAS_IMAGES",
                                 "hasVideo": "HAS_VIDEOS",

--- a/Tests iOS/Fixtures/my-list-loading-page-2.json
+++ b/Tests iOS/Fixtures/my-list-loading-page-2.json
@@ -4,20 +4,20 @@
             "__typename": "[type-name-here]",
             "savedItems": {
                 "__typename": "[type-name-here]",
-                "totalCount": 1,
+                "totalCount": 3,
                 "pageInfo": {
                     "__typename": "[type-name-here]",
                     "hasNextPage": false,
-                    "endCursor": "cursor-1"
+                    "endCursor": "cursor-3"
                 },
                 "edges": [
                     {
                         "__typename": "[type-name-here]",
-                        "cursor": "cursor-1",
+                        "cursor": "cursor-3",
                         "node": {
                             "__typename": "[type-name-here]",
-                            "remoteID": "archived-item-1",
-                            "url": "http://example.com/items/archived-item-1",
+                            "remoteID": "saved-item-3",
+                            "url": "http://localhost:8080/hello",
                             "_createdAt": 0,
                             "_deletedAt": null,
                             "archivedAt": null,
@@ -25,25 +25,18 @@
                             "isFavorite": false,
                             "item": {
                                 "__typename": "Item",
-                                "remoteID": "archived-item-1",
-                                "title": "Archived Item 1",
-                                "givenUrl": "http://example.com/items/archived-item-1",
-                                "resolvedUrl": "http://example.com/items/archived-item-1",
-                                "topImageUrl": "https://example.com/archived-item-1/top-image.jpg",
+                                "remoteID": "item-3",
+                                "title": "Item 3",
+                                "givenUrl": "http://localhost:8080/hello",
+                                "resolvedUrl": "http://localhost:8080/hello",
+                                "topImageUrl": "https://example.com/item-3/top-image.jpg",
                                 "domain": null,
                                 "language": "en",
                                 "timeToRead": 6,
                                 "marticle": #MARTICLE#,
-                                "excerpt": "Risus Aenean Ultricies Nullam Vehicula",
-                                "datePublished": "2001-01-01 12:01:01",
-                                "authors": [
-                                    {
-                                        "__typename": "Author",
-                                        "id": "archived-author-1",
-                                        "name": "Socrates",
-                                        "url": "https://example.com/authors/socrates"
-                                    }
-                                ],
+                                "excerpt": "Cursus Aenean Elit",
+                                "datePublished": "2021-01-01 12:01:01",
+                                "authors": [],
                                 "domainMetadata": null,
                                 "images": [],
                                 "isArticle": true,

--- a/Tests iOS/Support/Elements/MyListElement.swift
+++ b/Tests iOS/Support/Elements/MyListElement.swift
@@ -49,6 +49,10 @@ struct MyListElement: PocketUIElement {
         itemCells.count
     }
 
+    var skeletonCellCount: Int {
+        element.cells.matching(identifier: "my-list-item-skeleton").count
+    }
+
     func itemView(at index: Int) -> ItemRowElement {
         return ItemRowElement(itemCells.element(boundBy: index))
     }


### PR DESCRIPTION
## Summary
Show skeleton cells during intial download

## References 
https://getpocket.atlassian.net/browse/IN-570

## Implementation Details
In order to keep track of the current state of the initial download, we add a `initialDownloadState` property to `Source`. This property contains an instance of the enum `InitialDownloadState` that can be one of `.unknown`, `.started`, `paginating`, or `.completed`.
This allows us to respond appropriately when determining how to build a snapshot for My List. For example, when building the snapshot while the download state is `.started`, we know to simply include a few skeleton cells to signal to the user that content is being fetched. Once we start `paginating` we can use the `totalCount` associated value to determine the number of placeholder cells that need to be rendered alongside the actual content that has been loaded.

## Test Steps
1. Launch app for first time, navigate to "My List/My List"
2. Before any content has been loaded, you should see 4 placeholder/skeleton cells3. 
3. After content starts to load, scroll down quickly
4. Observe that there are placeholder cells that will transition to cells with actual content as the pagination process continues

## Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
### Initial load
![initial-load](https://user-images.githubusercontent.com/323541/179869237-63ec5505-e11b-4c4e-9231-23dc097db858.png)

### Paginating
![paginating](https://user-images.githubusercontent.com/323541/179869242-42980e58-263c-4af9-9279-0e0e90fd2ee1.png)

