### PR TITLE
Present context menu when tapping and holding links in reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -6,6 +6,7 @@ import UIKit
 protocol ArticleComponentTextCellDelegate: AnyObject {
     func articleComponentTextCell(_ cell: ArticleComponentTextCell, didShareText: String?)
     func articleComponentTextCell(_ cell: ArticleComponentTextCell, shouldOpenURL url: URL) -> Bool
+    func articleComponentTextCell(_ cell: ArticleComponentTextCell, contextMenuConfigurationForURL url: URL) -> UIContextMenuConfiguration?
 }
 
 // An object that conforms to this protocol is capable of delegating actions
@@ -17,27 +18,34 @@ protocol ArticleComponentTextCell: ArticleComponentTextViewDelegate {
 // Apply default implementations of PocketTextViewDelegate callbacks
 // so that this code can be reused across conforming cells.
 extension ArticleComponentTextCell {
-    func pocketTextViewDidSelectShareAction(_ textView: ArticleComponentTextView) {
+    func articleComponentTextViewDidSelectShareAction(_ textView: ArticleComponentTextView) {
         let selectedText =  (textView.text as NSString).substring(with: textView.selectedRange)
         delegate?.articleComponentTextCell(self, didShareText: selectedText)
     }
     
-    func pocketTextView(_ textView: ArticleComponentTextView, shouldOpenURL url: URL) -> Bool {
+    func articleComponentTextView(_ textView: ArticleComponentTextView, shouldOpenURL url: URL) -> Bool {
         return delegate?.articleComponentTextCell(self, shouldOpenURL: url) ?? true
+    }
+
+    func articleComponentTextView(_ textView: ArticleComponentTextView, contextMenuConfigurationForURL url: URL) -> UIContextMenuConfiguration? {
+        return delegate?.articleComponentTextCell(self, contextMenuConfigurationForURL: url)
     }
 }
 
 // An object that conforms to this protocol is able to respond to (overridden)
 // events that occur within a PocketTextView.
 protocol ArticleComponentTextViewDelegate: AnyObject {
-    func pocketTextViewDidSelectShareAction(_ textView: ArticleComponentTextView)
-    func pocketTextView(_ textView: ArticleComponentTextView, shouldOpenURL url: URL) -> Bool
+    func articleComponentTextViewDidSelectShareAction(_ textView: ArticleComponentTextView)
+    func articleComponentTextView(_ textView: ArticleComponentTextView, shouldOpenURL url: URL) -> Bool
+    func articleComponentTextView(_ textView: ArticleComponentTextView, contextMenuConfigurationForURL url: URL) -> UIContextMenuConfiguration?
 }
 
 // A subclass of UITextView that overrides certain actions (e.g Share),
 // and delegates the response to these actions to its delegate.
 class ArticleComponentTextView: UITextView {
     var actionDelegate: ArticleComponentTextViewDelegate? = nil
+
+    private var urlTextRange: UITextRange? = nil
     
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
@@ -48,6 +56,11 @@ class ArticleComponentTextView: UITextView {
         isEditable = false
         isScrollEnabled = false
         delegate = self
+
+        interactions
+            .filter { $0 is UIContextMenuInteraction }
+            .forEach { removeInteraction($0) }
+        addInteraction(UIContextMenuInteraction(delegate: self))
     }
     
     required init?(coder: NSCoder) {
@@ -56,7 +69,7 @@ class ArticleComponentTextView: UITextView {
     
     @objc
     func _share(_ sender: Any?) {
-        actionDelegate?.pocketTextViewDidSelectShareAction(self)
+        actionDelegate?.articleComponentTextViewDidSelectShareAction(self)
     }
 }
 
@@ -67,6 +80,46 @@ extension ArticleComponentTextView: UITextViewDelegate {
         in characterRange: NSRange,
         interaction: UITextItemInteraction
     ) -> Bool {
-        return actionDelegate?.pocketTextView(self, shouldOpenURL: URL) ?? true
+        return actionDelegate?.articleComponentTextView(self, shouldOpenURL: URL) ?? true
+    }
+}
+
+extension ArticleComponentTextView: UIContextMenuInteractionDelegate {
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        let index = layoutManager.characterIndex(for: location, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
+        var range = NSRange()
+        let attributes = attributedText.attributes(at: index, effectiveRange: &range)
+        let start = position(from: beginningOfDocument, offset: range.location)!
+        let end = position(from: start, offset: range.length)!
+        urlTextRange = textRange(from: start, to: end)!
+
+        if let url = attributes[.link] as? URL {
+            return actionDelegate?.articleComponentTextView(self, contextMenuConfigurationForURL: url)
+        }
+
+        return nil
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        let previewParameters = UIPreviewParameters()
+        previewParameters.backgroundColor = .clear
+        let preview = UITargetedPreview(view: self, parameters: previewParameters)
+        return preview
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForDismissingMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        let previewParameters = UIPreviewParameters()
+        previewParameters.backgroundColor = .clear
+        let preview = UITargetedPreview(view: self, parameters: previewParameters)
+        return preview
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -4,6 +4,7 @@ import Textile
 import Combine
 import Analytics
 import Kingfisher
+import SafariServices
 
 
 protocol ReadableViewControllerDelegate: AnyObject {
@@ -198,6 +199,25 @@ extension ReadableViewController: ArticleComponentTextCellDelegate {
     ) -> Bool {
         delegate?.readableViewController(self, openURL: url)
         return false
+    }
+
+    func articleComponentTextCell(
+        _ cell: ArticleComponentTextCell,
+        contextMenuConfigurationForURL url: URL
+    ) -> UIContextMenuConfiguration? {
+        return UIContextMenuConfiguration(
+            identifier: nil,
+            previewProvider: {
+                SFSafariViewController(url: url)
+            }
+        ) { [weak self] _ in
+            let actions = self?.readableViewModel.externalActions(for: url).compactMap { UIAction($0) }
+            ?? []
+            return UIMenu(
+                title: url.host ?? "",
+                children: actions
+            )
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -31,6 +31,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     func delete()
     func showWebReader()
     func fetchDetailsIfNeeded()
+    func externalActions(for url: URL) -> [ItemAction]
 }
 
 // MARK: - ReadableViewControllerDelegate

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -87,39 +87,6 @@ class RecommendationViewModel: ReadableViewModel {
         source.unarchive(item: savedItem)
     }
 
-    private func favorite() {
-        guard let savedItem = recommendation.item?.savedItem else {
-            return
-        }
-
-        source.favorite(item: savedItem)
-        track(identifier: .itemFavorite)
-    }
-
-    private func unfavorite() {
-        guard let savedItem = recommendation.item?.savedItem else {
-            return
-        }
-
-        source.unfavorite(item: savedItem)
-        track(identifier: .itemUnfavorite)
-    }
-
-    private func archive() {
-        guard let savedItem = recommendation.item?.savedItem else {
-            return
-        }
-
-        source.archive(item: savedItem)
-        track(identifier: .itemArchive)
-        _events.send(.archive)
-    }
-
-    private func save() {
-        source.save(recommendation: recommendation)
-        track(identifier: .itemSave)
-    }
-
     func delete() {
         guard let savedItem = recommendation.item?.savedItem else {
             return
@@ -135,6 +102,15 @@ class RecommendationViewModel: ReadableViewModel {
 
     func fetchDetailsIfNeeded() {
         // no op
+    }
+    
+    func externalActions(for url: URL) -> [ItemAction] {
+        [
+            .save { [weak self] _ in self?.saveExternalURL(url) },
+            .open { [weak self] _ in self?.openExternalURL(url) },
+            .copyLink { [weak self] _ in self?.copyExternalURL(url) },
+            .share { [weak self] _ in self?.shareExternalURL(url) }
+        ]
     }
 }
 
@@ -195,5 +171,54 @@ extension RecommendationViewModel {
 
     private func report() {
         selectedRecommendationToReport = recommendation
+    }
+
+    private func favorite() {
+        guard let savedItem = recommendation.item?.savedItem else {
+            return
+        }
+
+        source.favorite(item: savedItem)
+        track(identifier: .itemFavorite)
+    }
+
+    private func unfavorite() {
+        guard let savedItem = recommendation.item?.savedItem else {
+            return
+        }
+
+        source.unfavorite(item: savedItem)
+        track(identifier: .itemUnfavorite)
+    }
+
+    private func archive() {
+        guard let savedItem = recommendation.item?.savedItem else {
+            return
+        }
+
+        source.archive(item: savedItem)
+        track(identifier: .itemArchive)
+        _events.send(.archive)
+    }
+
+    private func save() {
+        source.save(recommendation: recommendation)
+        track(identifier: .itemSave)
+    }
+
+    private func saveExternalURL(_ url: URL) {
+        source.save(url: url)
+    }
+
+    private func copyExternalURL(_ url: URL) {
+        UIPasteboard.general.url = url
+    }
+
+    private func shareExternalURL(_ url: URL) {
+        sharedActivity = PocketItemActivity(url: url)
+    }
+
+    private func openExternalURL(_ url: URL) {
+        presentedWebReaderURL = url
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -87,22 +87,6 @@ class SavedItemViewModel: ReadableViewModel {
         source.unarchive(item: item)
     }
 
-    private func favorite() {
-        source.favorite(item: item)
-        track(identifier: .itemFavorite)
-    }
-
-    private func unfavorite() {
-        source.unfavorite(item: item)
-        track(identifier: .itemUnfavorite)
-    }
-
-    private func archive() {
-        source.archive(item: item)
-        track(identifier: .itemArchive)
-        _events.send(.archive)
-    }
-
     func delete() {
         source.delete(item: item)
         _events.send(.delete)
@@ -119,6 +103,15 @@ class SavedItemViewModel: ReadableViewModel {
             try? await self.source.fetchDetails(for: self.item)
             _events.send(.contentUpdated)
         }
+    }
+    
+    func externalActions(for url: URL) -> [ItemAction] {
+        [
+            .save { [weak self] _ in self?.saveExternalURL(url) },
+            .open { [weak self] _ in self?.openExternalURL(url) },
+            .copyLink { [weak self] _ in self?.copyExternalURL(url) },
+            .share { [weak self] _ in self?.shareExternalURL(url) }
+        ]
     }
 }
 
@@ -145,5 +138,37 @@ extension SavedItemViewModel {
             .delete { [weak self] _ in self?.confirmDelete() },
             .share { [weak self] _ in self?.share() }
         ]
+    }
+
+    private func favorite() {
+        source.favorite(item: item)
+        track(identifier: .itemFavorite)
+    }
+
+    private func unfavorite() {
+        source.unfavorite(item: item)
+        track(identifier: .itemUnfavorite)
+    }
+
+    private func archive() {
+        source.archive(item: item)
+        track(identifier: .itemArchive)
+        _events.send(.archive)
+    }
+
+    private func saveExternalURL(_ url: URL) {
+        source.save(url: url)
+    }
+
+    private func copyExternalURL(_ url: URL) {
+        UIPasteboard.general.url = url
+    }
+
+    private func shareExternalURL(_ url: URL) {
+        sharedActivity = PocketItemActivity(url: url)
+    }
+
+    private func openExternalURL(_ url: URL) {
+        presentedWebReaderURL = url
     }
 }

--- a/PocketKit/Sources/PocketKit/ItemAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemAction.swift
@@ -130,6 +130,26 @@ extension ItemAction {
             handler: handler
         )
     }
+
+    static func copyLink(_ handler: @escaping (Any?) -> ()) -> ItemAction {
+        return ItemAction(
+            title: "Copy link",
+            identifier: .copyLink,
+            accessibilityIdentifier: "item-action-copy-link",
+            image: UIImage(systemName: "link"),
+            handler: handler
+        )
+    }
+
+    static func open(_ handler: @escaping (Any?) -> ()) -> ItemAction {
+        return ItemAction(
+            title: "Open",
+            identifier: .open,
+            accessibilityIdentifier: "item-action-open",
+            image: UIImage(systemName: "safari"),
+            handler: handler
+        )
+    }
 }
 
 extension UIAction.Identifier {
@@ -143,6 +163,8 @@ extension UIAction.Identifier {
     static let report = UIAction.Identifier(rawValue: "report")
     static let recommendationPrimary = UIAction.Identifier(rawValue: "recommendation-primary")
     static let seeAllPrimary = UIAction.Identifier(rawValue: "see-all-primary")
+    static let copyLink = UIAction.Identifier(rawValue: "copy-link")
+    static let open = UIAction.Identifier(rawValue: "open")
 }
 
 extension UIAction {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -499,3 +499,19 @@ extension PocketSource {
         try? space.save()
     }
 }
+
+// MARK: - URL
+extension PocketSource {
+    public func save(url: URL) {
+        if let savedItem = try? space.fetchSavedItem(byURL: url) {
+            unarchive(item: savedItem)
+        } else {
+            let savedItem: SavedItem = space.new()
+            savedItem.url = url
+            savedItem.createdAt = Date()
+            try? space.save()
+
+            save(item: savedItem)
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -55,6 +55,8 @@ public protocol Source {
     func download(images: [Image])
 
     func fetchDetails(for savedItem: SavedItem) async throws
+    
+    func save(url: URL)
 }
 
 public extension Source {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -699,3 +699,37 @@ extension MockSource {
         return calls[index] as? FetchDetailsCall
     }
 }
+
+extension MockSource {
+    private static let saveURL = "saveURL"
+    typealias SaveURLImpl = (URL) -> Void
+    struct SaveURLCall {
+        let url: URL
+    }
+
+    func stubSaveURL(_ impl: @escaping SaveURLImpl) {
+        implementations[Self.saveURL] = impl
+    }
+
+    func saveURLCall(at index: Int) -> SaveURLCall? {
+        guard let calls = calls[Self.saveURL],
+              index < calls.count,
+              let call = calls[index] as? SaveURLCall else {
+            return nil
+        }
+
+        return call
+    }
+
+    func save(url: URL) {
+        guard let impl = implementations[Self.saveURL] as? SaveURLImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.saveURL] = (calls[Self.saveURL] ?? []) + [
+            SaveURLCall(url: url)
+        ]
+
+        impl(url)
+    }
+}


### PR DESCRIPTION
## Summary

Presents a context menu to the user when tapping and holding links from text views in the reader.

## References 

IN-618

## Implementation Details

### Presentation

`ArticleComponentTextView` handles adding a `UIContextMenuInteraction` _to_ the text view, so that we can handle long presses. However, a `UITextView` adds its own context menu interaction upon initialization, so we have to filter out these existing context menu interactions and remove them, so we can handle our own. `ArticleComponentTextView` then handles the context menu interaction, only requesting a context menu when the location of the tap is _on_ a link. A request for the context menu to present is then requested up the delegate chain, finally reaching `ReadableViewController`. This view controller requests "external actions" (actions for links aside from the item url itself) from a `ReadableViewModel`, which provides 4 `ItemAction`s: save, open, copy, and share. These `ItemAction`s are used when presenting other context menus within the app, so it made sense (to me) to utilize them again. 

### Save

Save updates `PocketSource` to add a generic `save(url:)` function. This function will check if a `SavedItem` exists for the provided url, and if so, unarchive it (which will mark `isArchived` as false, and update `createdAt` to move the item to the top of the list). Unarchive performs a save operation on an item just as saving does, so it seemed fair to just call "unarchive" to capture both unarchive and move-to-the-top-of-the-list behaviors. If a `SavedItem` does _not_ exist, one will be created, and `save(item:)` will be called, which will perform a save operation, resolving the save via GraphQL query and updating Core Data (thus reflecting the change in My List).

### Open

The open item action piggybacks off of a `ReadableViewModel`'s `presentedWebReaderURL`, which is already subscribed to in a coordinator to appropriately present a `SFSafariViewController` for a provided url.

### Copy

The copy action simply uses `UIPasteboard.general` to set its current value to a url.

### Share

The share action piggybacks off of a `ReadableViewModel`'s `sharedActivity`, which is already subscribed to in a coordinator to appropriately present a share sheet.

## Test Steps

- [x] Given I am reading an article, when I tap and hold a link, a context menu should appear.
- [x] Given I have opened the context menu, when I look at the menu, I should see a preview of the link.
- [x] Given I have opened the context menu, when I tap "Save", the link should be saved to "My List"
- [x] Given I have opened the context menu, when I tap "Save" and the link had previously been saved, it should move to the top of My List
- [x] Given I have opened the context menu, when I tap "Save" and the link had been archived, it should move to the top of My List
- [x] Given I have opened the context menu, when I tap "Open", it should open the article in a browser view
- [x] Given I have opened the context menu, when I tap "Copy link", it should copy the link to the system clipboard
- [x] Given I have opened the context menu, when I tap "Share", it should open a share sheet for the link

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

![Simulator Screen Shot - iPhone 13 Pro - 2022-07-19 at 15 58 07](https://user-images.githubusercontent.com/1158092/180012713-ec01dc78-1f36-464c-9052-1b40d6143e78.png)

