### PR TITLE
Log errors when aborting retriable operations

### DIFF
--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -36,11 +36,11 @@ class FetchList: SyncOperation {
         } catch {
             switch error {
             case is URLSessionClient.URLSessionClientError:
-                return .retry
+                return .retry(error)
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
-                    return .retry
+                    return .retry(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -37,7 +37,7 @@ class SaveItemOperation: SyncOperation {
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
-                    return .retry
+                    return .retry(error)
                 default:
                     return .failure(error)
                 }
@@ -45,7 +45,7 @@ class SaveItemOperation: SyncOperation {
                 // An error occurred with the client-side networking stack
                 // either the request timed out or it couldn't be sent for some other reason
                 // retry
-                return .retry
+                return .retry(error)
             default:
                 events.send(.error(error))
                 return .failure(error)

--- a/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
@@ -24,11 +24,11 @@ class SavedItemMutationOperation<Mutation: GraphQLMutation>: SyncOperation {
         } catch {
             switch error {
             case is URLSessionClient.URLSessionClientError:
-                return .retry
+                return .retry(error)
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
-                    return .retry
+                    return .retry(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -39,7 +39,7 @@ class RetriableOperationTests: XCTestCase {
             switch calls {
             case 0:
                 firstAttempt.fulfill()
-                return .retry
+                return .retry(TestError.anError)
             case 1:
                 secondAttempt.fulfill()
                 return .success
@@ -80,7 +80,7 @@ class RetriableOperationTests: XCTestCase {
 
             expectations[calls].fulfill()
             calls += 1
-            return .retry
+            return .retry(TestError.anError)
         }
 
         let executor = subject(operation: operation)

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -63,7 +63,7 @@ extension PocketSourceTests {
                 switch attempts {
                 case 0:
                     firstAttempt.fulfill()
-                    return .retry
+                    return .retry(TestError.anError)
                 case 1:
                     retrySignalSent.fulfill()
                     return .success
@@ -96,7 +96,7 @@ extension PocketSourceTests {
                 switch attempts {
                 case 0:
                     firstAttempt.fulfill()
-                    return .retry
+                    return .retry(TestError.anError)
                 case 1:
                     retrySignalSent.fulfill()
                     return .success
@@ -135,7 +135,7 @@ extension PocketSourceTests {
                 switch attempts {
                 case 0:
                     firstAttempt.fulfill()
-                    return .retry
+                    return .retry(TestError.anError)
                 default:
                     XCTFail("Unexpected number of attempts: \(attempts)")
                     return .failure(TestError.anError)


### PR DESCRIPTION
## Summary
It's technically possible for network operations to fail enough time to exceed our maximum number of allowed retries, but we don't actually know how often (if ever) this actually happens in practice. In order to get some more information about when/why/how this might happen, we add some logging (via Sentry).

## References 
https://getpocket.atlassian.net/browse/IN-709