### PR TITLE
Retry immediately on refresh

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -83,6 +83,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
 
     func refresh(_ completion: (() -> ())? = nil) {
         source.refresh(completion: completion)
+        source.retryImmediately()
     }
 
     func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -151,6 +151,10 @@ public class PocketSource: Source {
         space.refresh(object, mergeChanges: mergeChanges)
     }
 
+    public func retryImmediately() {
+        retrySignal.send()
+    }
+
     private func observeNetworkStatus() {
         networkMonitor.start(queue: .main)
         networkMonitor.updateHandler = { [weak self] path in

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -26,6 +26,8 @@ public protocol Source {
 
     func refresh(maxItems: Int, completion: (() -> ())?)
 
+    func retryImmediately() 
+
     func favorite(item: SavedItem)
 
     func unfavorite(item: SavedItem)

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -265,4 +265,14 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         wait(for: [snapshotExpectation], timeout: 1)
     }
+
+    func test_refresh_callsRetryImmediatelyOnSource() {
+        source.stubRefresh { _, _ in }
+        source.stubRetryImmediately { }
+
+        let viewModel = subject()
+        viewModel.refresh()
+
+        XCTAssertNotNil(source.retryImmediatelyCall(at:0))
+    }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -669,7 +669,7 @@ extension MockSource {
 
 // MARK: - Fetch details
 extension MockSource {
-    static let fetchDetails = "makeArchiveService"
+    static let fetchDetails = "fetchDetails"
     typealias FetchDetailsImpl = (SavedItem) async throws -> Void
 
     struct FetchDetailsCall {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -700,6 +700,7 @@ extension MockSource {
     }
 }
 
+// MARK: - Save URL
 extension MockSource {
     private static let saveURL = "saveURL"
     typealias SaveURLImpl = (URL) -> Void
@@ -731,5 +732,36 @@ extension MockSource {
         ]
 
         impl(url)
+    }
+}
+
+// MARK: - Retry Immediately
+extension MockSource {
+    static let retryImmediately = "retryImmediately"
+    typealias RetryImmediatelyImpl = () -> Void
+
+    struct RetryImmediatelyCall { }
+
+    func stubRetryImmediately(impl: @escaping RetryImmediatelyImpl) {
+        implementations[Self.retryImmediately] = impl
+    }
+
+    func retryImmediately() {
+        guard let impl = implementations[Self.retryImmediately] as? RetryImmediatelyImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.retryImmediately] = (calls[Self.retryImmediately] ?? []) + [RetryImmediatelyCall()]
+        print("Calling impl: \(Date().timeIntervalSince1970)")
+        return impl()
+    }
+
+    func retryImmediatelyCall(at index: Int) -> RetryImmediatelyCall? {
+        guard let calls = calls[Self.retryImmediately],
+              calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? RetryImmediatelyCall
     }
 }


### PR DESCRIPTION
## Summary
Sometimes network operations fail due to lack of connectivity or server errors. When this happens, those operations go into a "paused" state until they receive a signal to try again. That signal is sent at various times in the app lifecycle.

We consider the user-initiated "Pull to refresh" to be a strong signal that the network connection is probably available, so we initiate any retries immediately upon that interaction.

## References 
https://getpocket.atlassian.net/browse/IN-685

## Implementation Details
* `PocketSource` gains new method `retryImmediately`
* `SavedItemsListViewModel` calls this method when user initiates pull-to-refresh

## Test Steps
1. Use [network link conditioner][0] to cause network traffic to fail 100% of the time
2. Favorite an item
3. Configure network link conditioner to have a solid connection
4. On a second device, not that the item from step 2 is not favorited
5. Pull-to-refresh
6. Note that the item from steps 2 and 4 is now favorited on the second device

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

[0]: https://nshipster.com/network-link-conditioner/