### PR TITLE
Home: open item when tapping on recent save

### DIFF
--- a/PocketKit/Sources/Analytics/Context/UIContext.swift
+++ b/PocketKit/Sources/Analytics/Context/UIContext.swift
@@ -104,7 +104,23 @@ extension UIContext {
         public let screen = UIContext(type: .screen, identifier: .home)
         
         public func item(index: UIIndex) -> UIContext {
-            UIContext(type: .card, hierarchy: 0, identifier: .item, componentDetail: .homeCard, index: index)
+            UIContext(
+                type: .card,
+                hierarchy: 0,
+                identifier: .item,
+                componentDetail: .homeCard,
+                index: index
+            )
+        }
+
+        public func recentSave(index: UIIndex) -> UIContext {
+            UIContext(
+                type: .card,
+                hierarchy: 0,
+                identifier: .item,
+                componentDetail: .itemRow,
+                index: index
+            )
         }
     }
     

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -52,7 +52,6 @@ class CompactHomeCoordinator: NSObject {
             case .none:
                 self?.readerSubscriptions = []
             }
-            return
         }.store(in: &subscriptions)
 
         model.$selectedSlateDetailViewModel.receive(on: DispatchQueue.main).sink { [weak self] viewModel in
@@ -198,7 +197,6 @@ class CompactHomeCoordinator: NSObject {
         activityVC.popoverPresentationController?.sourceView = navigationController.splitViewController?.view
 
         activityVC.completionWithItemsHandler = { [weak self] _, _, _, _ in
-//            self?.model.selectedReadableViewModel?.sharedActivity = nil
             self?.model.selectedSlateDetailViewModel?.selectedReadableViewModel?.sharedActivity = nil
         }
 
@@ -245,7 +243,6 @@ extension CompactHomeCoordinator: UINavigationControllerDelegate {
         if viewController === homeViewController {
             model.selectedSlateDetailViewModel?.resetSlate(keeping: 5)
 
-//            model.selectedReadableViewModel = nil
             model.selectedRecommendationToReport = nil
             model.selectedSlateDetailViewModel = nil
         }
@@ -259,7 +256,6 @@ extension CompactHomeCoordinator: UINavigationControllerDelegate {
 
 extension CompactHomeCoordinator: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-//        model.selectedReadableViewModel?.presentedWebReaderURL = nil
         model.selectedSlateDetailViewModel?.selectedReadableViewModel?.presentedWebReaderURL = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -358,11 +358,8 @@ extension HomeViewModel {
             contexts(for: cell, at: indexPath)
         )
 
-        let item = savedItem.item
-        if let isArticle = item?.isArticle, isArticle == false
-            || item?.hasImage == .isImage
-            || item?.hasVideo == .isVideo {
-            presentedWebReaderURL = item?.bestURL
+        if let item = savedItem.item, item.shouldOpenInWebView {
+            presentedWebReaderURL = item.bestURL
 
             tracker.track(
                 event: ContentOpenEvent(destination: .external, trigger: .click),

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -161,11 +161,8 @@ private extension SlateDetailViewModel {
             contexts(for: cell, at: indexPath)
         )
 
-        let item = viewModel.recommendation.item
-        if let isArticle = item?.isArticle, isArticle == false
-            || item?.hasImage == .isImage
-            || item?.hasVideo == .isVideo {
-            presentedWebReaderURL = item?.bestURL
+        if let item = viewModel.recommendation.item, item.shouldOpenInWebView {
+            presentedWebReaderURL = item.bestURL
 
             tracker.track(
                 event: ContentOpenEvent(destination: .external, trigger: .click),

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -19,3 +19,11 @@ public extension SavedItem {
         item == nil
     }
 }
+
+public extension Item {
+    var shouldOpenInWebView: Bool {
+        return isArticle == false
+        || hasImage == .isImage
+        || hasVideo == .isVideo
+    }
+}

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -155,9 +155,8 @@ class RegularMainCoordinator: NSObject {
             case .savedItem(let viewModel):
                 self?.show(viewModel)
             case .none:
-                return
+                self?.readerSubscriptions = []
             }
-            return
         }.store(in: &subscriptions)
 
         model.home.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
@@ -236,6 +235,7 @@ class RegularMainCoordinator: NSObject {
             return
         }
 
+        readerSubscriptions = []
         readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
@@ -304,7 +304,6 @@ class RegularMainCoordinator: NSObject {
 
         slate.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             if readable != nil {
-//                self?.model.home.selectedReadableViewModel = nil
                 self?.model.myList.savedItemsList.selectedItem = nil
                 self?.model.myList.archivedItemsList.selectedItem = nil
             }
@@ -412,7 +411,6 @@ extension RegularMainCoordinator: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         model.myList.savedItemsList.selectedItem?.clearPresentedWebReaderURL()
         model.myList.archivedItemsList.selectedItem?.clearPresentedWebReaderURL()
-//        model.home.selectedReadableViewModel?.presentedWebReaderURL = nil
         model.home.selectedSlateDetailViewModel?.selectedReadableViewModel?.presentedWebReaderURL = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -148,14 +148,16 @@ class RegularMainCoordinator: NSObject {
         }.store(in: &subscriptions)
 
         // HOME
-        model.home.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
-            if readable != nil {
-                self?.model.home.selectedSlateDetailViewModel?.selectedReadableViewModel = nil
-                self?.model.myList.savedItemsList.selectedItem = nil
-                self?.model.myList.archivedItemsList.selectedItem = nil
+        model.home.$selectedReadableType.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+            switch readableType {
+            case .recommendation(let viewModel):
+                self?.show(viewModel)
+            case .savedItem(let viewModel):
+                self?.show(viewModel)
+            case .none:
+                return
             }
-
-            self?.show(readable)
+            return
         }.store(in: &subscriptions)
 
         model.home.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
@@ -197,6 +199,10 @@ class RegularMainCoordinator: NSObject {
     private func navigate(selectedItem: SelectedItem) {
         switch selectedItem {
         case .readable(let readable):
+            readerSubscriptions = []
+            model.home.selectedReadableType = nil
+            model.home.selectedSlateDetailViewModel?.selectedReadableViewModel = nil
+
             self.show(readable)
         case .webView(let url):
             self.present(url)
@@ -229,10 +235,6 @@ class RegularMainCoordinator: NSObject {
         guard let readable = readable else {
             return
         }
-
-        readerSubscriptions = []
-        model.home.selectedReadableViewModel = nil
-        model.home.selectedSlateDetailViewModel?.selectedReadableViewModel = nil
 
         readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
             self?.present(url)
@@ -302,7 +304,7 @@ class RegularMainCoordinator: NSObject {
 
         slate.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
             if readable != nil {
-                self?.model.home.selectedReadableViewModel = nil
+//                self?.model.home.selectedReadableViewModel = nil
                 self?.model.myList.savedItemsList.selectedItem = nil
                 self?.model.myList.archivedItemsList.selectedItem = nil
             }
@@ -410,7 +412,7 @@ extension RegularMainCoordinator: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         model.myList.savedItemsList.selectedItem?.clearPresentedWebReaderURL()
         model.myList.archivedItemsList.selectedItem?.clearPresentedWebReaderURL()
-        model.home.selectedReadableViewModel?.presentedWebReaderURL = nil
+//        model.home.selectedReadableViewModel?.presentedWebReaderURL = nil
         model.home.selectedSlateDetailViewModel?.selectedReadableViewModel?.presentedWebReaderURL = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -275,9 +275,7 @@ extension ArchivedItemsListViewModel {
             return
         }
 
-        if let isArticle = item.item?.isArticle, isArticle == false
-            || item.item?.hasImage == .isImage
-            || item.item?.hasVideo == .isVideo {
+        if let item = item.item, item.shouldOpenInWebView {
             selectedItem = .webView(item.bestURL)
         } else {
             selectedItem = .readable(

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -329,9 +329,7 @@ extension SavedItemsListViewModel {
             return
         }
 
-        if let isArticle = item.item?.isArticle, isArticle == false
-            || item.item?.hasImage == .isImage
-            || item.item?.hasVideo == .isVideo {
+        if let item = item.item, item.shouldOpenInWebView {
             selectedItem = .webView(item.bestURL)
         } else {
             let selectedReadable = bareItem(with: itemID).flatMap {

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -55,8 +55,6 @@ class HomeTests: XCTestCase {
         }
 
         try server.start()
-
-        app.launch()
     }
 
     override func tearDownWithError() throws {
@@ -65,7 +63,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_navigatingToHomeTab_showsASectionForEachSlate() {
-        let home = app.homeView
+        let home = app.launch().homeView
 
         home.sectionHeader("Slate 1").wait()
         home.recommendationCell("Slate 1, Recommendation 1").verify()
@@ -78,7 +76,7 @@ class HomeTests: XCTestCase {
     }
     
     func test_navigatingToHomeTab_showsRecentlySavedItems() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         
         home.savedItemCell("Item 1").wait()
         home.savedItemCell("Item 2").wait()
@@ -87,9 +85,28 @@ class HomeTests: XCTestCase {
         home.savedItemCell("Item 4").swipeLeft(velocity: .fast)
         waitForDisappearance(of: home.savedItemCell("Item 6"))
     }
+
+    func test_tappingRecentSavesItem_showsReader() {
+        let home = app.launch().homeView.wait()
+        home.savedItemCell("Item 1").wait().tap()
+        app.readerView.wait()
+        app.readerView.cell(containing: "Commodo Consectetur Dapibus").wait()
+    }
+
+    func test_tappingRecentSavesItem_showsWebViewWhenItemIsImage() {
+        test_tappingRecentSavesItem_showsWebView("Item 1")
+    }
+
+    func test_tappingRecentSavesItem_showsWebViewWhenItemIsVideo() {
+        test_tappingRecentSavesItem_showsWebView("Item 2")
+    }
+
+    func test_tappingRecentSavesItem_showsWebViewWhenItemIsNotAnArticle() {
+        test_tappingRecentSavesItem_showsWebView("Item 3")
+    }
     
     func test_favoritingRecentSavesItem_shouldShowFavoriteInMyList() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").favoriteButton.tap()
         XCTAssertTrue(home.recentSavesView(matching: "Item 1").favoriteButton.isFilled)
@@ -100,7 +117,7 @@ class HomeTests: XCTestCase {
     }
     
     func test_unfavoritingRecentSavesItem_shouldNotAppearForFavoriteInMyList() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         home.savedItemCell("Item 2").wait()
         XCTAssertTrue(home.recentSavesView(matching: "Item 2").favoriteButton.isFilled)
         home.recentSavesView(matching: "Item 2").favoriteButton.tap()
@@ -112,7 +129,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_archivingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
         app.archiveButton.wait().tap()
@@ -121,7 +138,7 @@ class HomeTests: XCTestCase {
     }
     
     func test_deletingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
         app.deleteButton.wait().tap()
@@ -133,7 +150,7 @@ class HomeTests: XCTestCase {
     }
     
     func test_sharingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.homeView.wait()
+        let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
         app.shareButton.wait().tap()
@@ -141,13 +158,13 @@ class HomeTests: XCTestCase {
     }
 
     func test_tappingRecentSavesMyListButton_opensMyListView() {
-        app.homeView.sectionHeader("Recent Saves").seeAllButton.wait().tap()
+        app.launch().homeView.sectionHeader("Recent Saves").seeAllButton.wait().tap()
         app.myListView.itemView(matching: "Item 1").wait()
         XCTAssertTrue(app.myListView.selectionSwitcher.myListButton.isSelected)
     }
     
     func test_tappingRecentSavesMyListButton_whenPreviouslyArchiveView_opensMyListView() {
-        app.tabBar.myListButton.wait().tap()
+        app.launch().tabBar.myListButton.wait().tap()
         app.myListView.selectionSwitcher.archiveButton.wait().tap()
         app.tabBar.homeButton.wait().tap()
         app.homeView.sectionHeader("Recent Saves").seeAllButton.wait().tap()
@@ -156,7 +173,7 @@ class HomeTests: XCTestCase {
     }
     
     func test_tappingSlatesSeeAllButton_showsSlateDetailView() {
-        let home = app.homeView
+        let home = app.launch().homeView
         
         home.sectionHeader("Slate 1").seeAllButton.wait().tap()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 1").wait()
@@ -171,12 +188,12 @@ class HomeTests: XCTestCase {
     }
     
     func test_tappingRecommendationCell_opensItemInReader() {
-        app.homeView.recommendationCell("Slate 1, Recommendation 1").wait().tap()
+        app.launch().homeView.recommendationCell("Slate 1, Recommendation 1").wait().tap()
         app.readerView.cell(containing: "Jacob and David").wait()
     }
 
     func test_tappingSaveButtonInRecommendationCell_savesItemToList() {
-        let cell = app.homeView.recommendationCell("Slate 1, Recommendation 1")
+        let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")
         let saveButton = cell.saveButton.wait()
 
         let saveRequestExpectation = expectation(description: "A save mutation request")
@@ -228,7 +245,7 @@ class HomeTests: XCTestCase {
 
 extension HomeTests {
     func test_pullToRefresh_fetchesUpdatedContent() {
-        let home = app.homeView
+        let home = app.launch().homeView
         home.recommendationCell("Slate 1, Recommendation 1").wait()
         
         server.routes.post("/graphql") { request, _ in
@@ -257,5 +274,41 @@ extension HomeTests {
         let isHittable = NSPredicate(format: "isHittable == 1")
         let hittable = expectation(for: isHittable, evaluatedWith: overscrollView)
         wait(for: [doesExist, hittable], timeout: 20)
+    }
+}
+
+extension HomeTests {
+    private func test_tappingRecentSavesItem_showsWebView(_ item: String) {
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+
+            if apiRequest.isForSlateLineup {
+                return Response.slateLineup()
+            } else if apiRequest.isForMyListContent {
+                return Response.myList("list-for-web-view")
+            } else if apiRequest.isForArchivedContent {
+                return Response.archivedContent()
+            } else {
+                fatalError("Unexpected request")
+            }
+        }
+
+        app.launch().homeView.wait()
+
+        // If an item isn't initially visible (e.g "Item 3"),
+        // take the first cell and swipe left so that it becomes visible.
+        // This works because the fixture for "My List" contains 3 items.
+        // The first two tests for "Item 1" and "Item 2" work because
+        // they are on-screen, but we have to scroll for "Item 3".
+        if !app.homeView.savedItemCell(item).exists {
+            app.homeView.savedItemCell(at: 0).swipeLeft()
+        }
+
+        app.homeView.savedItemCell(item).wait().tap()
+
+        app
+            .webReaderView
+            .staticText(matching: "Hello, world")
+            .wait()
     }
 }

--- a/Tests iOS/Support/Elements/HomeViewElement.swift
+++ b/Tests iOS/Support/Elements/HomeViewElement.swift
@@ -19,6 +19,10 @@ struct HomeViewElement: PocketUIElement {
         let predicate = NSPredicate(format: "label = %@", title)
         return savedItemCells.containing(predicate).element(boundBy: 0)
     }
+
+    func savedItemCell(at index: Int) -> XCUIElement {
+        return savedItemCells.element(boundBy: index)
+    }
     
     var savedItemCells: XCUIElementQuery {
         return element.cells.matching(identifier: "my-list-item")


### PR DESCRIPTION
## Summary

Add support for opening a recent save (either in Safari or in the reader) on tap.

## References 

IN-690

## Implementation Details

The biggest change here is moving from the `selectedReadableViewModel` to a more generic `selectedReadableType` enum, which supports two cases: recent save, and recommendation. I was hoping that we could just repurpose `ReadableViewModel` and publish a property of this type so that we could subscribe to all published properties in one spot, but there is one difference that prevented me from doing so: the fact that a `RecommendationViewModel` has to support reporting a recommendation, which I did not want to just add to the `ReadableViewModel` protocol since it is not shared with a `SavedItemViewModel`. Otherwise, everything is handled the same - tapping an item (recent save or recommendation) updates `selectedReadableType` as the corresponding case with the appropriate view model. For either case, the coordinators are subscribed to this new property, and then subscribe to the correct published properties of the new value's associated type (i.e view model), also presenting the correct view as necessary.

## Test Steps

- [x] Given I have a recent save and it has been parsed for offline viewing, when I tap on the item, then it should open in the reader view.
- [x] Given I have a recent save and it cannot be parsed for offline viewing (e.g Pocket collection), when I tap on the item, then it should open in a Safari view.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
