### PR TITLE
Only support landscape in the reader on iPhone

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -37,6 +37,7 @@ class CompactHomeCoordinator: NSObject {
 
         super.init()
 
+        navigationController.delegate = self
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.barTintColor = UIColor(.ui.white1)
         navigationController.navigationBar.tintColor = UIColor(.ui.grey1)
@@ -254,6 +255,17 @@ class CompactHomeCoordinator: NSObject {
 }
 
 extension CompactHomeCoordinator: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        // By default, when pushing the reader, switching to landscape, and popping,
+        // the list will remain in landscape despite only supporting portrait.
+        // We have to programatically force the device orientation back to portrait,
+        // if the view controller we want to show _only_ supports portrait
+        // (e.g when popping from the reader).
+        if viewController.supportedInterfaceOrientations == .portrait, UIDevice.current.orientation.isLandscape {
+            UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: "orientation")
+        }
+    }
+
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if viewController === homeViewController {
             slateDetailSubscriptions = []
@@ -265,6 +277,11 @@ extension CompactHomeCoordinator: UINavigationControllerDelegate {
             model.clearRecommendationToReport()
             model.tappedSeeAll?.clearSelectedItem()
         }
+    }
+
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        guard navigationController.traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return navigationController.visibleViewController?.supportedInterfaceOrientations ?? .portrait
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -142,6 +142,11 @@ class HomeViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
 }
 
 extension HomeViewController {

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -88,6 +88,11 @@ class SlateDetailViewController: UIViewController {
         fatalError("init(coder:) is not implemented")
     }
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -110,6 +110,11 @@ extension CompactMainCoordinator: UITabBarControllerDelegate {
 
         model.selectedSection = MainViewModel.AppSection.allCases[index]
     }
+
+    func tabBarControllerSupportedInterfaceOrientations(_ tabBarController: UITabBarController) -> UIInterfaceOrientationMask {
+        guard tabBarController.traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return tabBarController.selectedViewController?.supportedInterfaceOrientations ?? .portrait
+    }
 }
 
 extension CompactMainCoordinator: CompactHomeCoordinatorDelegate {

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -315,6 +315,11 @@ extension RegularMainCoordinator: UISplitViewControllerDelegate {
             model.isCollapsed = true
         }
     }
+
+    func splitViewControllerSupportedInterfaceOrientations(_ splitViewController: UISplitViewController) -> UIInterfaceOrientationMask {
+        guard splitViewController.traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return splitViewController.viewController(for: .compact)?.supportedInterfaceOrientations ?? .portrait
+    }
 }
 
 // MARK: - SFSafariViewControllerDelegate

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -187,6 +187,20 @@ extension CompactMyListContainerCoordinator: UINavigationControllerDelegate {
         }
 
         model.clearSelectedItem()
+
+        // By default, when pushing the reader, switching to landscape, and popping,
+        // the list will remain in landscape despite only supporting portrait.
+        // We have to programatically force the device orientation back to portrait,
+        // if the view controller we want to show _only_ supports portrait
+        // (e.g when popping from the reader).
+        if viewController.supportedInterfaceOrientations == .portrait, UIDevice.current.orientation.isLandscape {
+            UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: "orientation")
+        }
+    }
+
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        guard navigationController.traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return navigationController.visibleViewController?.supportedInterfaceOrientations ?? .portrait
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListContainerViewController.swift
@@ -47,6 +47,11 @@ class MyListContainerViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError()
     }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
     
     private func resetTitleView() {
         let selections = viewControllers.map { vc in

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewController.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewController.swift
@@ -62,6 +62,11 @@ class AccountViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
 }
 
 extension AccountViewController: UICollectionViewDelegate {

--- a/PocketKit/Sources/PocketKit/Settings/CompactAccountCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Settings/CompactAccountCoordinator.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 
-class CompactAccountCoordinator {
+class CompactAccountCoordinator: NSObject {
     var viewController: UIViewController {
         navigationController
     }
@@ -16,8 +16,18 @@ class CompactAccountCoordinator {
         accountViewController = AccountViewController(model: model)
         navigationController = UINavigationController(rootViewController: accountViewController)
 
+        super.init()
+
+        navigationController.delegate = self
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.barTintColor = UIColor(.ui.white1)
         navigationController.navigationBar.tintColor = UIColor(.ui.grey1)
+    }
+}
+
+extension CompactAccountCoordinator: UINavigationControllerDelegate {
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        guard navigationController.traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return navigationController.visibleViewController?.supportedInterfaceOrientations ?? .portrait
     }
 }


### PR DESCRIPTION
## Summary

Disable iPhone support for landscape rotation in all views except the reader.

## References 

IN-701

## Implementation Details

`UINavigationController`, `UITabBarController`, and `UISplitViewController` each have delegate methods for returning their supported interface orientation(s). Since we're doing this on a per-viewcontroller basis (since Reader is separate), we have to return the value for the currently-displayed view controller. For `UINavigationController`, this is `visibleViewController`. For `UITabBarController`, this is `selectedViewController`. For `UISplitViewController`, on iPhone we defer to the compact view controller's supported interface orientations (i.e the tab bar controller when logged in). Each `UIViewController` then overrides `supportedInterfaceOrientations`.

The one extra "goofy" case is when popping from the reader - if the user rotates to landscape in the reader, then pops back to "My List", the app remains in landscape. I was unable to find any combination of `supportedInterfaceOrientations` and `shouldAutorotate` that would cause this to work correctly. In the end, the decision was made to use the `setValue(_:forKey)` API to programmatically set the orientation back to portrait when required.

## Test Steps

### On iPhone

#### Home
- [x] Given I am logged out, when I rotate to landscape, the app should remain in portrait.
- [x] Given I am logged in and viewing Home, when I rotate to landscape, the app should remain in portrait.
- [x] Given I am logged in and viewing the reader (from Home), when I rotate to landscape, the app should rotate.
- [x] Given I am logged in and viewing the reader (from Home) in landscape, when I go back to "Home", the app should be in portrait.
- [x] Given I am logged in and viewing a Home topic, when I rotate to landscape, the app should remain in portrait.
- [x] Given I am logged in and viewing the reader (from a Home topic), when I rotate to landscape, the app should rotate.
- [x] Given I am logged in and viewing the reader (from a Home topic) in landscape, when I go back to the Home topic, the app should be in portrait.

#### My List
- [x] Given I am logged in and viewing My List, when I rotate to landscape, the app should remain in portrait.
- [x] Given I am logged in and viewing the reader from My List, when I rotate to landscape, the app should rotate.
- [x] Given I am logged in and viewing the reader in landscape, when I go back to "My List", the app should be in portrait.

#### Account
- [x] Given I am logged in and viewing Account, when I rotate to landscape, the app should remain in portrait.

### On iPad
- [x] Regression test ensuring the app can rotate to all orientations in all views.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
