### PR TITLE
Home crasher

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -99,7 +99,7 @@ class HomeViewController: UIViewController {
             self?.updateOverflowView(contentOffset: contentOffset)
         }.store(in: &subscriptions)
 
-        model.$snapshot.receive(on: DispatchQueue.main).sink { [weak self] snapshot in
+        model.$snapshot.sink { [weak self] snapshot in
             self?.dataSource.apply(snapshot)
         }.store(in: &subscriptions)
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -62,9 +62,10 @@ class HomeViewModel {
         }.store(in: &subscriptions)
         
         recentSavesController.itemChanged.receive(on: DispatchQueue.main).sink { [weak self] savedItem in
-            guard var snapshot = self?.buildSnapshot() else { return }
-            snapshot.reloadItems([.recentSaves(savedItem.objectID)])
-            self?.snapshot = snapshot
+            let item = Cell.recentSaves(savedItem.objectID)
+            if self?.snapshot.indexOfItem(item) != nil {
+                self?.snapshot.reloadItems([item])
+            }
         }.store(in: &subscriptions)
     }
 
@@ -285,9 +286,11 @@ extension HomeViewModel {
                 let viewModel = HomeRecommendationCellViewModel(recommendation: rec)
                 viewModels[rec.objectID] = viewModel
 
-                viewModel.$isSaved.dropFirst().sink { [weak self] isSaved in
-                    snapshot.reloadItems([.recommendation(rec.objectID)])
-                    self?.snapshot = snapshot
+                viewModel.updated.sink { [weak self] isSaved in
+                    let item = Cell.recommendation(rec.objectID)
+                    if self?.snapshot.indexOfItem(item) != nil {
+                        self?.snapshot.reloadItems([item])
+                    }
                 }.store(in: &viewModelSubscriptions)
             }
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -139,9 +139,11 @@ private extension SlateDetailViewModel {
                 toSection: section
             )
 
-            viewModel.$isSaved.dropFirst().sink { [weak self] isSaved in
-                snapshot.reloadItems([.recommendation(recommendation.objectID)])
-                self?.snapshot = snapshot
+            viewModel.updated.sink { [weak self] in
+                let item: SlateDetailViewModel.Cell = .recommendation(recommendation.objectID)
+                if self?.snapshot.indexOfItem(item) != nil {
+                    self?.snapshot.reloadItems([item])
+                }
             }.store(in: &viewModelSubscriptions)
         }
 

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -115,7 +115,9 @@ extension ArchivedItemsListViewModel {
     }
 
     func handleUpdatedItem(_ updatedItem: SavedItem) {
-        _snapshot.reloadItems([.item(updatedItem.objectID)])
+        if _snapshot.indexOfItem(.item(updatedItem.objectID)) != nil {
+            _snapshot.reloadItems([.item(updatedItem.objectID)])
+        }
     }
 }
 

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -122,6 +122,13 @@ public enum Requests {
         request.predicate = NSPredicate(format: "isDownloaded = NO")
         return request
     }
+
+    public static func fetchSavedItem(for item: Item) -> NSFetchRequest<SavedItem> {
+        let request = fetchAllSavedItems()
+        request.predicate = Predicates.savedItems(filters: [NSPredicate(format: "item = %@", item)])
+
+        return request
+    }
 }
 
 public enum Predicates {


### PR DESCRIPTION
## Summary
Immediately processing changes to the `isSaved` property of a recommendation cell's view model can be problematic due to the possibility that other significant changes are being made to the underlying recommendation in core data (i.e. it's being deleted).

Instead, we observe changes made at the CoreData level so that we don't send collection view snapshots too often.

## References 
https://getpocket.atlassian.net/browse/IN-711

## Implementation Details
Instead of using Key-value observation to respond to changes to a recommendation, we use an NSFetchedResultsController. This means we get notified of changes when the context is saved, as opposed to immediately when the property changes.

## Test Steps
- Launch the app
- Make sure it doesn't crash ;)

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA