### PR TITLE
IN-700: Home Design Polish

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
 		8A3E3DBC2864DB0500483564 /* EmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */; };
 		8A4ECEF9287775F90007DB67 /* SectionHeaderElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4ECEF8287775F90007DB67 /* SectionHeaderElement.swift */; };
+		8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
 		F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */; };
 		F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */; };
@@ -142,6 +143,7 @@
 		16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAnItemTests.swift; sourceTree = "<group>"; };
 		8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateTests.swift; sourceTree = "<group>"; };
 		8A4ECEF8287775F90007DB67 /* SectionHeaderElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderElement.swift; sourceTree = "<group>"; };
+		8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesCellElement.swift; sourceTree = "<group>"; };
 		F204A76027E22EC50010E155 /* SaveToPocket.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaveToPocket.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 				16A6808026EBC78800A64545 /* HomeViewElement.swift */,
 				1648D5A627024C6400F67C4B /* SlateDetailElement.swift */,
 				16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */,
+				8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */,
 				8A4ECEF8287775F90007DB67 /* SectionHeaderElement.swift */,
 				F2843C1F2714D97000E03ED5 /* ReportViewElement.swift */,
 				1613B2B2275571940014F301 /* AccountViewElement.swift */,
@@ -468,6 +471,7 @@
 				166BAD0C2656E76B00E401F0 /* MyListElement.swift in Sources */,
 				F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */,
 				166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */,
+				8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */,
 				164FB66E278F7ECC002959D6 /* MyListFiltersTests.swift in Sources */,
 				F2843C1E2714D18200E03ED5 /* ReportARecommendationTests.swift in Sources */,
 				1605237E27A4627F00E09FD2 /* XCTestCase+extensions.swift in Sources */,

--- a/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
@@ -1,0 +1,221 @@
+import UIKit
+import Kingfisher
+import Textile
+
+protocol HomeCarouselItemCellModel {
+    var thumbnailURL: URL? { get }
+    var saveButtonMode: RecommendationSaveButton.Mode? { get }
+    var favoriteAction: ItemAction? { get }
+    var overflowActions: [ItemAction]? { get }
+    var saveAction: ItemAction? { get }
+    var attributedTitle: NSAttributedString { get }
+    var attributedDomain: NSAttributedString { get }
+    var attributedTimeToRead: NSAttributedString { get }
+}
+
+class HomeCarouselItemCell: UICollectionViewCell {
+    enum Constants {
+        static let cornerRadius: CGFloat = 16
+        static let maxTitleLines = 3
+        static let maxDetailLines = 2
+        static let actionButtonImageSize = CGSize(width: 20, height: 20)
+        static let layoutMargins = UIEdgeInsets(top: Margins.normal.rawValue, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
+    }
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = Constants.maxTitleLines
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        return label
+    }()
+
+    private let domainLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = Constants.maxDetailLines
+        return label
+    }()
+    
+    private let timeToReadLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = Constants.maxDetailLines
+        return label
+    }()
+
+    private let thumbnailView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.layer.cornerRadius = Constants.cornerRadius
+        imageView.layer.masksToBounds = true
+        imageView.backgroundColor = UIColor(.ui.grey6)
+        imageView.contentMode = .center
+        return imageView
+    }()
+
+    private let favoriteButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.contentInsets = .zero
+
+        let button = UIButton(configuration: config, primaryAction: nil)
+        button.accessibilityIdentifier = "favorite"
+        return button
+    }()
+    
+    let saveButton: RecommendationSaveButton = {
+        let button = RecommendationSaveButton()
+        button.accessibilityIdentifier = "save-button"
+        return button
+    }()
+
+    private let overflowButton: UIButton = {
+        let button = RecommendationOverflowButton()
+        button.accessibilityIdentifier = "overflow-button"
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }()
+
+    private let mainContentView = UIView()
+    
+    private let mainContentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.alignment = .top
+        stack.distribution = .equalSpacing
+        stack.spacing = 20
+        stack.axis = .horizontal
+        return stack
+    }()
+
+    private let bottomStack: UIStackView = {
+        let stack = UIStackView()
+        stack.distribution = .equalSpacing
+        stack.axis = .horizontal
+        return stack
+    }()
+    
+    private let subtitleStack: UIStackView = {
+        let stack = UIStackView()
+        stack.distribution = .fillProportionally
+        stack.axis = .vertical
+        stack.spacing = 4
+        return stack
+    }()
+    
+    private let buttonStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 0
+        return stack
+    }()
+
+    private var thumbnailWidthConstraint: NSLayoutConstraint!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        accessibilityIdentifier = "home-carousel-item"
+        
+        contentView.addSubview(mainContentStack)
+        contentView.addSubview(bottomStack)
+        contentView.layoutMargins = Constants.layoutMargins
+
+        mainContentStack.translatesAutoresizingMaskIntoConstraints = false
+        thumbnailView.translatesAutoresizingMaskIntoConstraints = false
+        bottomStack.translatesAutoresizingMaskIntoConstraints = false
+
+        thumbnailWidthConstraint = thumbnailView.widthAnchor.constraint(
+            equalToConstant: StyleConstants.thumbnailSize.width
+        ).with(priority: .required)
+
+        contentView.layoutMargins = Constants.layoutMargins
+        NSLayoutConstraint.activate([
+            mainContentStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            mainContentStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            mainContentStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+
+            thumbnailView.heightAnchor.constraint(equalToConstant: StyleConstants.thumbnailSize.height).with(priority: .required),
+            thumbnailWidthConstraint!,
+
+            bottomStack.leadingAnchor.constraint(equalTo: mainContentStack.leadingAnchor),
+            bottomStack.trailingAnchor.constraint(equalTo: mainContentStack.trailingAnchor),
+            bottomStack.bottomAnchor.constraint(equalTo:  contentView.layoutMarginsGuide.bottomAnchor).with(priority: .required),
+        ])
+        
+        [UIView(), domainLabel, timeToReadLabel, UIView()].forEach(subtitleStack.addArrangedSubview)
+        [favoriteButton, saveButton, overflowButton].forEach(buttonStack.addArrangedSubview)
+        [titleLabel, thumbnailView].forEach(mainContentStack.addArrangedSubview)
+        [subtitleStack, UIView(), buttonStack].forEach(bottomStack.addArrangedSubview)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension HomeCarouselItemCell {
+    func configure(model: HomeCarouselItemCellModel) {
+        titleLabel.attributedText = model.attributedTitle
+        domainLabel.attributedText = model.attributedDomain
+        timeToReadLabel.attributedText = model.attributedTimeToRead
+        
+        if model.attributedTimeToRead.string == "" {
+            timeToReadLabel.isHidden = true
+        } else {
+            timeToReadLabel.isHidden = false
+        }
+        
+        favoriteButton.accessibilityLabel = model.favoriteAction?.title
+        favoriteButton.accessibilityIdentifier = model.favoriteAction?.accessibilityIdentifier
+        favoriteButton.configuration?.image = model.favoriteAction?.image?.resized(to: Constants.actionButtonImageSize)
+
+        if let favoriteAction = UIAction(model.favoriteAction) {
+            favoriteButton.addAction(favoriteAction, for: .primaryActionTriggered)
+        }
+        
+        if let mode = model.saveButtonMode {
+            saveButton.isHidden = false
+            saveButton.mode = mode
+        } else {
+            saveButton.isHidden = true
+        }
+        
+        if let saveAction = UIAction(model.saveAction) {
+            saveButton.addAction(saveAction, for: .primaryActionTriggered)
+        }
+        
+        let menuActions = model.overflowActions?.compactMap(UIAction.init) ?? []
+        overflowButton.menu = UIMenu(children: menuActions)
+
+        thumbnailView.image = nil
+        guard let thumbnailURL = model.thumbnailURL else {
+            thumbnailWidthConstraint.constant = 0
+            return
+        }
+
+        thumbnailWidthConstraint.constant = StyleConstants.thumbnailSize.width
+        thumbnailView.kf.setImage(
+            with: thumbnailURL,
+            options: [
+                .scaleFactor(UIScreen.main.scale),
+                .processor(
+                    ResizingImageProcessor(
+                        referenceSize: StyleConstants.thumbnailSize,
+                        mode: .aspectFit
+                    ).append(
+                        another: CroppingImageProcessor(
+                            size: StyleConstants.thumbnailSize
+                        )
+                    )
+                )
+            ]
+        )
+    }
+    
+    override func layoutSubviews() {
+        contentView.layer.masksToBounds = false
+        layer.cornerRadius = Constants.cornerRadius
+        contentView.layer.cornerRadius = Constants.cornerRadius
+        contentView.layer.shadowColor = UIColor(.ui.border).cgColor
+        contentView.layer.shadowOffset = .zero
+        contentView.layer.shadowOpacity = 1.0
+        contentView.layer.shadowRadius = 6
+        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.layer.bounds, cornerRadius: contentView.layer.cornerRadius).cgPath
+        contentView.layer.backgroundColor = UIColor(.ui.white1).cgColor
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -1,8 +1,19 @@
 import UIKit
 import Sync
+import CoreData
 
 
 class HomeViewControllerSectionProvider {
+    
+    struct Constants {
+        static let margin: CGFloat = Margins.thin.rawValue
+        static let sideMargin: CGFloat = Margins.normal.rawValue
+        static let carouselHeight: CGFloat = 146
+        static let heroHeight: CGFloat = 370
+        static let spacing: CGFloat = 16
+        static let sectionSpacing: CGFloat = 64
+    }
+    
     func loadingSection() -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(
@@ -18,194 +29,89 @@ class HomeViewControllerSectionProvider {
             ),
             subitems: [item]
         )
-
+        
         return NSCollectionLayoutSection(group: group)
     }
-    
-    func recentSavesSection(width: CGFloat) -> NSCollectionLayoutSection {
-        let groupHeight: CGFloat = 152
-        let margin: CGFloat = 8
 
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+    func recentSavesSection(in viewModel: HomeViewModel, width: CGFloat) -> NSCollectionLayoutSection? {
+        let numberOfRecentSavesItems = viewModel.numberOfRecentSavesItem()
+        guard numberOfRecentSavesItems > 0 else { return nil }
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: margin, bottom: 0, trailing: margin)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.80), heightDimension: .absolute(groupHeight))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: margin, leading: margin, bottom: margin, trailing: margin)
-        section.orthogonalScrollingBehavior = .continuous
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfRecentSavesItems)), heightDimension: .absolute(Constants.carouselHeight))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: numberOfRecentSavesItems)
+        group.interItemSpacing = .fixed(16)
         
         let sectionHeaderViewModel: SectionHeaderView.Model = .init(name: "Recent Saves", buttonTitle: "My List")
         let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1.0),
-                    heightDimension: .absolute(sectionHeaderViewModel.height(width: width))
-                ),
-                elementKind: SectionHeaderView.kind,
-                alignment: .top
-            )
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(sectionHeaderViewModel.height(width: width - Constants.sideMargin*2))
+            ),
+            elementKind: SectionHeaderView.kind,
+            alignment: .top
+        )
         
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
         section.boundarySupplementaryItems = [headerItem]
-        return section
-    }
-
-    func section(for slate: Slate?, in viewModel: HomeViewModel, width: CGFloat) -> NSCollectionLayoutSection? {
-        let dividerHeight: CGFloat = 17
-        let margin: CGFloat = 8
-        let spacing: CGFloat = margin * 2
-
-        let recommendations: [Recommendation] = slate?.recommendations?.compactMap { $0 as? Recommendation } ?? []
-
-        guard let slate = slate, !recommendations.isEmpty else {
-            return nil
-        }
-
-        guard let hero = viewModel.viewModel(for: recommendations[0].objectID) else {
-            return nil
-        }
-
-        let heroHeight = RecommendationCell.fullHeight(viewModel: hero, availableWidth: width - spacing)
-        let heroItem = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(heroHeight)
-            )
-        )
-
-        let heroGroup = NSCollectionLayoutGroup.vertical(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(heroHeight + dividerHeight)
-            ),
-            subitems: [heroItem]
-        )
-
-        heroGroup.supplementaryItems = [
-            NSCollectionLayoutSupplementaryItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(dividerHeight)
-                ),
-                elementKind: "divider",
-                containerAnchor: NSCollectionLayoutAnchor(edges: .bottom)
-            )
-        ]
-
-        let twoUp = twoUpGroup(slate: slate, viewModel: viewModel, width: width, spacing: spacing, dividerHeight: dividerHeight)
-
-        let topLevelGroup = NSCollectionLayoutGroup.vertical(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(heroHeight + dividerHeight + (twoUp.height + dividerHeight) * 2)
-            ),
-            subitems: [heroGroup, twoUp.group]
-        )
-
-        let section = NSCollectionLayoutSection(group: topLevelGroup)
-        let sectionHeaderViewModel: SectionHeaderView.Model = .init(name: slate.name ?? "", buttonTitle: "See All")
-        section.boundarySupplementaryItems = [
-            NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1.0),
-                    heightDimension: .absolute(sectionHeaderViewModel.height(width: width))
-                ),
-                elementKind: SectionHeaderView.kind,
-                alignment: .top
-            )
-        ]
-
         section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: margin,
-            bottom: 0,
-            trailing: margin
+            top: Constants.margin,
+            leading: Constants.sideMargin,
+            bottom: Constants.sectionSpacing,
+            trailing: Constants.sideMargin
         )
-
         return section
     }
-}
-
-extension HomeViewControllerSectionProvider {
-    private func twoUpGroup(
-        slate: Slate,
-        viewModel: HomeViewModel,
-        width: CGFloat,
-        spacing: CGFloat,
-        dividerHeight: CGFloat
-    ) -> (group: NSCollectionLayoutGroup, height: CGFloat) {
-        let recommendations: [Recommendation] = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
-
-        guard recommendations.count > 1 else {
-            return (
-                group: NSCollectionLayoutGroup.vertical(
-                    layoutSize: NSCollectionLayoutSize(
-                        widthDimension: .absolute(1),
-                        heightDimension: .absolute(1)
-                    ),
-                    subitems: []
-                ),
-                height: 0
-            )
-        }
-
-        let endIndex = recommendations.index(
-            1,
-            offsetBy: 3,
-            limitedBy: recommendations.endIndex - 1
-        ) ?? recommendations.endIndex - 1
-        let recommendationsToShow = recommendations[1...endIndex]
-
-        let miniCardHeight = recommendationsToShow.map { recommendation -> CGFloat in
-            guard let viewModel = viewModel.viewModel(for: recommendation.objectID) else {
-                return 0
-            }
-
-            return RecommendationCell.miniHeight(
-                viewModel: viewModel,
-                availableWidth: width - spacing
-            )
-        }.max() ?? 0
-
-        let twoUpInner = NSCollectionLayoutGroup.horizontal(
+    
+    func heroSection(for slateID: NSManagedObjectID, in viewModel: HomeViewModel, width: CGFloat) -> NSCollectionLayoutSection? {
+        let heroItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1))
+        let heroItem = NSCollectionLayoutItem(layoutSize: heroItemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(Constants.heroHeight))
+        let heroGroup = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [heroItem])
+        
+        let title = viewModel.slate(with: slateID)?.name ?? ""
+        let sectionHeaderViewModel: SectionHeaderView.Model = .init(name: title, buttonTitle: "See All")
+        let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1),
-                heightDimension: .absolute(miniCardHeight)
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(sectionHeaderViewModel.height(width: width - Constants.sideMargin*2))
             ),
-            subitem: NSCollectionLayoutItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(0.5),
-                    heightDimension: .absolute(miniCardHeight)
-                )
-            ),
-            count: 2
+            elementKind: SectionHeaderView.kind,
+            alignment: .top
         )
-
-        twoUpInner.supplementaryItems = [
-            NSCollectionLayoutSupplementaryItem(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(dividerHeight)
-                ),
-                elementKind: "twoup-divider",
-                containerAnchor: NSCollectionLayoutAnchor(edges: .bottom),
-                itemAnchor: NSCollectionLayoutAnchor(edges: .bottom)
-            )
-        ]
-
-        let numberOfRows = Int((Float(recommendationsToShow.count) / 2).rounded(.up))
-        return (
-            group: NSCollectionLayoutGroup.vertical(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute((miniCardHeight + dividerHeight) * 2)
-                ),
-                subitem: twoUpInner,
-                count: numberOfRows
-            ),
-            height: miniCardHeight
+        
+        let section = NSCollectionLayoutSection(group: heroGroup)
+        section.boundarySupplementaryItems = [headerItem]
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: Constants.margin,
+            leading: Constants.sideMargin,
+            bottom: Constants.margin,
+            trailing: Constants.sideMargin
         )
+        return section
     }
+    
+    func carouselSection(for slateID: NSManagedObjectID, in viewModel: HomeViewModel, width: CGFloat) -> NSCollectionLayoutSection? {
+        let numberOfCarouselItems = viewModel.numberOfCarouselItemsForSlate(with: slateID)
+        guard numberOfCarouselItems > 0 else { return nil }
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfCarouselItems)), heightDimension: .absolute(Constants.carouselHeight))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: numberOfCarouselItems)
+        group.interItemSpacing = .fixed(16)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: Constants.margin,
+            leading: Constants.sideMargin,
+            bottom: Constants.sectionSpacing,
+            trailing: Constants.sideMargin
+        )
+        return section
+    }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -8,7 +8,9 @@ import CoreData
 class HomeRecommendationCellViewModel: NSObject {
     let updated: PassthroughSubject<Void, Never> = .init()
     let recommendation: Recommendation
-
+    var overflowActions: [ItemAction]? = nil
+    var saveAction: ItemAction? = nil
+    
     var isSaved: Bool {
         resultsController?.fetchedObjects?.first != nil
     }
@@ -43,12 +45,16 @@ extension HomeRecommendationCellViewModel: RecommendationCellViewModel {
         NSAttributedString(string: recommendation.item?.title ?? "", style: .title)
     }
 
-    var attributedDetail: NSAttributedString {
-        NSAttributedString(string: detail, style: .subtitle)
+    var attributedDomain: NSAttributedString {
+        NSAttributedString(string: domain ?? "", style: .domain)
     }
-
-    var attributedExcerpt: NSAttributedString {
-        NSAttributedString(string: recommendation.item?.excerpt ?? "", style: .excerpt)
+    
+    var attributedTimeToRead: NSAttributedString {
+        NSAttributedString(string: timeToRead ?? "", style: .timeToRead)
+    }
+    
+    var title: String? {
+        recommendation.item?.title
     }
 
     var imageURL: URL? {
@@ -60,38 +66,30 @@ extension HomeRecommendationCellViewModel: RecommendationCellViewModel {
         isSaved ? .saved : .save
     }
 
-    private var detail: String {
-        [domain, timeToRead].compactMap { $0 }.joined(separator: " • ")
-    }
-
-    private var domain: String? {
+    var domain: String? {
         recommendation.item?.domainMetadata?.name ?? recommendation.item?.domain ?? recommendation.item?.bestURL?.host
     }
 
-    private var timeToRead: String? {
+    var timeToRead: String? {
         guard let timeToRead = recommendation.item?.timeToRead,
               timeToRead > 0 else {
             return nil
         }
 
-        return "\(timeToRead) min"
+        return "\(timeToRead) min read"
     }
 }
 
 private extension Style {
     static let title: Style = .header.sansSerif.h6.with { paragraph in
-        paragraph.with(lineBreakMode: .byTruncatingTail)
+        paragraph.with(lineBreakMode: .byTruncatingTail).with(lineSpacing: 4)
     }
 
-    static let miniTitle: Style = .header.sansSerif.h7.with { paragraph in
+    static let domain: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium).with { paragraph in
         paragraph.with(lineBreakMode: .byTruncatingTail)
     }
-
-    static let subtitle: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
-        paragraph.with(lineBreakMode: .byTruncatingTail)
-    }
-
-    static let excerpt: Style = .header.sansSerif.p4.with(color: .ui.grey4).with { paragraph in
+    
+    static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
         paragraph.with(lineBreakMode: .byTruncatingTail)
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -11,9 +11,6 @@ import Lottie
 
 
 class HomeViewController: UIViewController {
-    static let dividerElementKind: String = "divider"
-    static let twoUpDividerElementKind: String = "twoup-divider"
-
     private let source: Sync.Source
     private let tracker: Tracker
     private let model: HomeViewModel
@@ -30,18 +27,19 @@ class HomeViewController: UIViewController {
         case .loading:
             return self.sectionProvider.loadingSection()
         case .recentSaves:
-            return self.sectionProvider.recentSavesSection(width: env.container.effectiveContentSize.width)
-        case .slate(let slate):
-            return self.sectionProvider.section(for: slate, in: self.model, width: env.container.effectiveContentSize.width)
+            return self.sectionProvider.recentSavesSection(in: self.model, width: env.container.effectiveContentSize.width)
+        case .slateHero(let slateID):
+            return self.sectionProvider.heroSection(for: slateID, in: self.model, width: env.container.effectiveContentSize.width)
+        case .slateCarousel(let slateID):
+            return self.sectionProvider.carouselSection(for: slateID, in: self.model, width: env.container.effectiveContentSize.width)
         }
     }
 
     private var dataSource: UICollectionViewDiffableDataSource<HomeViewModel.Section, HomeViewModel.Cell>!
 
-    private lazy var collectionView: UICollectionView = UICollectionView(
-        frame: .zero,
-        collectionViewLayout: layout
-    )
+    private lazy var collectionView: UICollectionView = {
+        return UICollectionView(frame: .zero, collectionViewLayout: layout)
+    }()
     
     private lazy var overscrollView: EndOfFeedAnimationView = {
         let view = EndOfFeedAnimationView(frame: .zero)
@@ -77,10 +75,9 @@ class HomeViewController: UIViewController {
         collectionView.backgroundColor = UIColor(.ui.white1)
         collectionView.register(cellClass: LoadingCell.self)
         collectionView.register(cellClass: RecommendationCell.self)
-        collectionView.register(cellClass: ItemsListItemCell.self)
+        collectionView.register(cellClass: RecentSavesItemCell.self)
+        collectionView.register(cellClass: RecommendationCarouselCell.self)
         collectionView.register(viewClass: SectionHeaderView.self, forSupplementaryViewOfKind: SectionHeaderView.kind)
-        collectionView.register(viewClass: DividerView.self, forSupplementaryViewOfKind: Self.dividerElementKind)
-        collectionView.register(viewClass: DividerView.self, forSupplementaryViewOfKind: Self.twoUpDividerElementKind)
         collectionView.delegate = self
 
         let action = UIAction { [weak self] _ in
@@ -90,7 +87,6 @@ class HomeViewController: UIViewController {
         collectionView.refreshControl = UIRefreshControl(frame: .zero, primaryAction: action)
 
         navigationItem.title = "Home"
-        
         collectionView.publisher(for: \.contentSize, options: [.new]).sink { [weak self] contentSize in
             self?.setupOverflowView(contentSize: contentSize)
         }.store(in: &subscriptions)
@@ -159,41 +155,31 @@ extension HomeViewController {
             let cell: LoadingCell = collectionView.dequeueCell(for: indexPath)
             return cell
         case .recentSaves(let objectID):
-            let cell: ItemsListItemCell = collectionView.dequeueCell(for: indexPath)
-            
-            guard let presenter = model.presenter(for: objectID) else {
+            let cell: RecentSavesItemCell = collectionView.dequeueCell(for: indexPath)
+
+            guard let viewModel = model.recentSavesViewModel(for: objectID, and: item, at: indexPath) else {
                 return cell
             }
-
-            cell.model = .init(
-                attributedTitle: presenter.attributedTitle,
-                attributedDetail: presenter.attributedDetail,
-                thumbnailURL: presenter.thumbnailURL,
-                shareAction: nil,
-                favoriteAction: model.favoriteAction(for: item),
-                overflowActions: model.overflowActions(for: item),
-                style: .bordered
-            )
-
+            
+            cell.configure(model: viewModel)
             return cell
-        case .recommendation(let objectID):
+        case .recommendationHero(let objectID):
             let cell: RecommendationCell = collectionView.dequeueCell(for: indexPath)
-            cell.mode = indexPath.item == 0 ? .hero : .mini
-
-            guard let viewModel = model.viewModel(for: objectID) else {
+ 
+            guard let viewModel = model.recommendationHeroViewModel(for: objectID, and: item, at: indexPath) else {
                 return cell
             }
 
             cell.configure(model: viewModel)
-
-            if let action = model.saveAction(for: item, at: indexPath), let uiAction = UIAction(action) {
-                cell.saveButton.addAction(uiAction, for: .primaryActionTriggered)
+            return cell
+        case .recommendationCarousel(let objectID):
+            let cell: RecommendationCarouselCell = collectionView.dequeueCell(for: indexPath)
+            
+            guard let viewModel = model.recommendationCarouselViewModel(for: objectID, and: item, at: indexPath) else {
+                return cell
             }
-
-            if let action = model.reportAction(for: item, at: indexPath), let uiAction = UIAction(action) {
-                cell.overflowButton.addAction(uiAction, for: .primaryActionTriggered)
-            }
-
+            
+            cell.configure(model: viewModel)
             return cell
         }
     }
@@ -208,18 +194,15 @@ extension HomeViewController {
                 header.configure(model: .init(name: "Recent Saves", buttonTitle: "My List") { [weak self] in
                     self?.model.tappedSeeAll = .recentSaves
                 })
-            case .slate(let slate):
-                header.configure(model: .init(name: slate.name ?? "", buttonTitle: "See All") { [weak self] in
-                    self?.model.tappedSeeAll = .slate(slate)
+            case .slateHero(let objectID):
+                header.configure(model: .init(name: model.slate(with: objectID)?.name ?? "", buttonTitle: "See All") { [weak self] in
+                    self?.model.tappedSeeAll = .slateHero(objectID)
                 })
             default:
                 break
             }
 
             return header
-        case Self.dividerElementKind, Self.twoUpDividerElementKind:
-            let divider: DividerView = collectionView.dequeueReusableView(forSupplementaryViewOfKind: kind, for: indexPath)
-            return divider
         default:
             fatalError("Unknown supplementary view kind: \(kind)")
         }

--- a/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
@@ -1,0 +1,60 @@
+import Foundation
+import UIKit
+import Textile
+
+class RecentSavesItemCell: HomeCarouselItemCell {
+    struct Model: HomeCarouselItemCellModel {
+        let item: ItemsListItem
+        let thumbnailURL: URL?
+        let saveButtonMode: RecommendationSaveButton.Mode?
+        
+        init(item: ItemsListItem) {
+            self.item = item
+            self.thumbnailURL = imageCacheURL(for: item.topImageURL)
+            self.saveButtonMode = nil
+        }
+        
+        var favoriteAction: ItemAction? = nil
+        var saveAction: ItemAction? = nil
+        var overflowActions: [ItemAction]? = nil
+        
+        var attributedTitle: NSAttributedString {
+            NSAttributedString(string: item.title ?? "", style: .title)
+        }
+        
+        var attributedDomain: NSAttributedString {
+            return NSAttributedString(string: domain ?? "", style: .domain)
+        }
+        
+        var attributedTimeToRead: NSAttributedString {
+            return NSAttributedString(string: timeToRead ?? "", style: .timeToRead)
+        }
+        
+        private var domain: String? {
+            item.domainMetadata?.name ?? item.domain ?? item.bestURL?.host
+        }
+        
+        private var timeToRead: String? {
+            guard let timeToRead = item.timeToRead,
+                  timeToRead > 0 else {
+                return nil
+            }
+
+            return "\(timeToRead) min read"
+        }
+    }
+}
+
+private extension Style {
+    static let title: Style = .header.sansSerif.h8.with { paragraph in
+        paragraph.with(lineSpacing: 4).with(lineBreakMode: .byTruncatingTail)
+    }
+
+    static let domain: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium).with { paragraph in
+        paragraph.with(lineBreakMode: .byTruncatingTail)
+    }
+    
+    static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
+        paragraph.with(lineBreakMode: .byTruncatingTail)
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -1,0 +1,48 @@
+import Foundation
+import UIKit
+import Textile
+
+
+class RecommendationCarouselCell: HomeCarouselItemCell {
+    struct Model: HomeCarouselItemCellModel {
+        let viewModel: HomeRecommendationCellViewModel
+        let thumbnailURL: URL?
+        let saveButtonMode: RecommendationSaveButton.Mode?
+        
+        init(viewModel: HomeRecommendationCellViewModel) {
+            self.viewModel = viewModel
+            self.thumbnailURL = viewModel.imageURL
+            self.saveButtonMode = viewModel.saveButtonMode
+        }
+
+        var favoriteAction: ItemAction? = nil
+        var saveAction: ItemAction? = nil
+        var overflowActions: [ItemAction]? = nil
+        
+        var attributedTitle: NSAttributedString {
+            return NSAttributedString(string: viewModel.title ?? "", style: .title)
+        }
+        
+        var attributedDomain: NSAttributedString {
+            return NSAttributedString(string: viewModel.domain ?? "", style: .domain)
+        }
+        
+        var attributedTimeToRead: NSAttributedString {
+            return NSAttributedString(string: viewModel.timeToRead ?? "", style: .timeToRead)
+        }
+    }
+}
+
+private extension Style {
+    static let title: Style = .header.sansSerif.h8.with { paragraph in
+        paragraph.with(lineSpacing: 4).with(lineBreakMode: .byTruncatingTail)
+    }
+
+    static let domain: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium).with { paragraph in
+        paragraph.with(lineBreakMode: .byTruncatingTail)
+    }
+    
+    static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
+        paragraph.with(lineBreakMode: .byTruncatingTail)
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -5,28 +5,20 @@ import Textile
 
 protocol RecommendationCellViewModel {
     var attributedTitle: NSAttributedString { get }
-    var attributedDetail: NSAttributedString { get }
-    var attributedExcerpt: NSAttributedString { get }
+    var attributedDomain: NSAttributedString { get }
+    var attributedTimeToRead: NSAttributedString { get }
     var imageURL: URL? { get }
     var saveButtonMode: RecommendationSaveButton.Mode { get }
+    var overflowActions: [ItemAction]? { get }
+    var saveAction: ItemAction? { get }
 }
 
 class RecommendationCell: UICollectionViewCell {
-    enum Mode {
-        case hero
-        case mini
-    }
-
-    var mode: Mode = .hero {
-        didSet {
-            adjustLayoutForMode()
-        }
-    }
-
     private let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.layer.cornerRadius = 4
+        imageView.layer.cornerRadius = 16
         imageView.clipsToBounds = true
+        imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         imageView.backgroundColor = UIColor(.ui.grey6)
         return imageView
     }()
@@ -34,96 +26,87 @@ class RecommendationCell: UICollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = RecommendationCell.numberOfTitleLines
-        label.setContentHuggingPriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
 
-    private let subtitleLabel: UILabel = {
+    private let domainLabel: UILabel = {
         let label = UILabel()
-        label.setContentHuggingPriority(.required, for: .vertical)
+        label.numberOfLines = RecommendationCell.numberOfSubtitleLines
         return label
     }()
-
-    private let excerptLabel: UILabel = {
+    
+    private let timeToReadLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = RecommendationCell.numberOfExcerptLines
-        label.setContentHuggingPriority(.required, for: .vertical)
+        label.numberOfLines = RecommendationCell.numberOfSubtitleLines
         return label
     }()
 
     let saveButton: RecommendationSaveButton = {
         let button = RecommendationSaveButton()
         button.accessibilityIdentifier = "save-button"
-
         return button
     }()
 
     let overflowButton: RecommendationOverflowButton = {
         let button = RecommendationOverflowButton()
-        button.accessibilityIdentifier = "report-button"
+        button.accessibilityIdentifier = "overflow-button"
+        button.showsMenuAsPrimaryAction = true
         return button
     }()
 
-    private let textStack: UIStackView = {
+    private let subtitleStack: UIStackView = {
         let stack = UIStackView()
+        stack.distribution = .fillProportionally
         stack.axis = .vertical
-        stack.distribution = .fill
-        stack.setContentHuggingPriority(.required, for: .vertical)
+        stack.spacing = 4
         return stack
     }()
 
     private let buttonStack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
+        stack.spacing = 0
+        return stack
+    }()
+    
+    private let bottomStack: UIStackView = {
+        let stack = UIStackView()
+        stack.distribution = .equalSpacing
+        stack.axis = .horizontal
         return stack
     }()
 
-    private var textStackTopConstraint: NSLayoutConstraint
-    private var buttonStackTopConstraintHero: NSLayoutConstraint
-    private var buttonStackTopConstraintMini: NSLayoutConstraint
-
     override init(frame: CGRect) {
-        textStackTopConstraint = textStack.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 0)
-
-        buttonStackTopConstraintHero = buttonStack.topAnchor.constraint(
-            equalTo: textStack.bottomAnchor,
-            constant: Hero.buttonStackTopMargin
-        )
-
-        buttonStackTopConstraintMini = buttonStack.topAnchor.constraint(
-            greaterThanOrEqualTo: textStack.bottomAnchor,
-            constant: Mini.buttonStackTopMargin
-        )
-
         super.init(frame: frame)
-
+        
         contentView.addSubview(thumbnailImageView)
-        contentView.addSubview(textStack)
-        contentView.addSubview(buttonStack)
-
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(bottomStack)
         contentView.layoutMargins = Self.layoutMargins
 
         thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
-        textStack.translatesAutoresizingMaskIntoConstraints = false
-        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        bottomStack.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
             thumbnailImageView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             thumbnailImageView.heightAnchor.constraint(equalTo: thumbnailImageView.widthAnchor, multiplier: Self.imageAspectRatio),
 
-            textStackTopConstraint,
-            textStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            textStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-
-            buttonStackTopConstraintHero,
-            buttonStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            titleLabel.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: RecommendationCell.textStackTopMargin),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            
+            bottomStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            bottomStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            bottomStack.bottomAnchor.constraint(equalTo:  contentView.layoutMarginsGuide.bottomAnchor).with(priority: .required),
         ])
 
-        [titleLabel, subtitleLabel, excerptLabel].forEach(textStack.addArrangedSubview)
-        [saveButton, UIView(), overflowButton].forEach(buttonStack.addArrangedSubview)
+        [UIView(), domainLabel, timeToReadLabel, UIView()].forEach(subtitleStack.addArrangedSubview)
+        [saveButton, overflowButton].forEach(buttonStack.addArrangedSubview)
+        [subtitleStack, UIView(), buttonStack].forEach(bottomStack.addArrangedSubview)
     }
 
     required init?(coder: NSCoder) {
@@ -132,111 +115,73 @@ class RecommendationCell: UICollectionViewCell {
 
     func configure(model: RecommendationCellViewModel) {
         titleLabel.attributedText = model.attributedTitle
-        subtitleLabel.attributedText = model.attributedDetail
-        excerptLabel.attributedText = model.attributedExcerpt
+        domainLabel.attributedText = model.attributedDomain
+        timeToReadLabel.attributedText = model.attributedTimeToRead
 
         saveButton.mode = model.saveButtonMode
-
+        
+        if model.attributedTimeToRead.string == "" {
+            timeToReadLabel.isHidden = true
+        } else {
+            timeToReadLabel.isHidden = false
+        }
+        
+        if let saveAction = UIAction(model.saveAction) {
+            saveButton.addAction(saveAction, for: .primaryActionTriggered)
+        }
+        
+        let menuActions = model.overflowActions?.compactMap(UIAction.init) ?? []
+        overflowButton.menu = UIMenu(children: menuActions)
+        
         let imageWidth = bounds.width
-        - RecommendationCell.layoutMargins.left
-        - RecommendationCell.layoutMargins.right
+                - RecommendationCell.layoutMargins.left
+                - RecommendationCell.layoutMargins.right
 
         let imageSize = CGSize(
             width: imageWidth,
-            height: imageWidth * RecommendationCell.imageAspectRatio
+            height: (imageWidth * RecommendationCell.imageAspectRatio).rounded(.down)
         )
-
         thumbnailImageView.kf.indicatorType = .activity
         thumbnailImageView.kf.setImage(
             with: model.imageURL,
             options: [
                 .scaleFactor(UIScreen.main.scale),
-                .processor(ResizingImageProcessor(
-                    referenceSize: imageSize,
-                    mode: .aspectFill
-                ).append(
-                    another: CroppingImageProcessor(size: imageSize)
-                )),
+                .processor(
+                    ResizingImageProcessor(
+                        referenceSize: imageSize,
+                        mode: .aspectFill
+                    ).append(
+                        another: CroppingImageProcessor(
+                            size: imageSize
+                        )
+                    )
+                )
             ]
         )
     }
-}
-
-extension RecommendationCell {
-    private func adjustLayoutForMode() {
-        switch mode {
-        case .hero:
-            textStackTopConstraint.constant = Hero.textStackTopMargin
-            textStack.spacing = Hero.textStackSpacing
-            excerptLabel.isHidden = false
-            saveButton.isTitleHidden = false
-            subtitleLabel.numberOfLines = Hero.numberOfSubtitleLines
-
-            buttonStackTopConstraintHero.isActive = true
-            buttonStackTopConstraintMini.isActive = false
-        case .mini:
-            textStackTopConstraint.constant = Mini.textStackTopMargin
-            textStack.spacing = Mini.textStackSpacing
-            excerptLabel.isHidden = true
-            saveButton.isTitleHidden = true
-            subtitleLabel.numberOfLines = Mini.numberOfSubtitleLines
-
-            buttonStackTopConstraintHero.isActive = false
-            buttonStackTopConstraintMini.isActive = true
-        }
+    
+    override func layoutSubviews() {
+        contentView.layer.masksToBounds = false
+        layer.cornerRadius = 16
+        contentView.layer.cornerRadius = 16
+        contentView.layer.shadowColor = UIColor(.ui.border).cgColor
+        contentView.layer.shadowOffset = .zero
+        contentView.layer.shadowOpacity = 1.0
+        contentView.layer.shadowRadius = 6
+        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.layer.bounds, cornerRadius: contentView.layer.cornerRadius).cgPath
+        contentView.layer.backgroundColor = UIColor(.ui.white1).cgColor
     }
 }
 
 extension RecommendationCell {
-    struct Hero {
-        static let textStackTopMargin: CGFloat = 16
-        static let buttonStackTopMargin: CGFloat = 10
-        static let textStackSpacing: CGFloat = 8
-        static let numberOfSubtitleLines = 1
-    }
-
-    struct Mini {
-        static let textStackTopMargin: CGFloat = 10
-        static let buttonStackTopMargin: CGFloat = 4
-        static let textStackSpacing: CGFloat = 4
-        static let numberOfSubtitleLines = 2
-    }
-
-    static let layoutMargins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    static let textStackTopMargin: CGFloat = 16
+    static let layoutMargins = UIEdgeInsets(top: 0, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
     static let imageAspectRatio: CGFloat = 9/16
     static let numberOfTitleLines = 3
-    static let numberOfExcerptLines = 3
-    static let saveButtonHeight: CGFloat = 21
+    static let numberOfSubtitleLines = 2
 }
 
 extension RecommendationCell {
-    static func miniHeight(viewModel: RecommendationCellViewModel, availableWidth: CGFloat) -> CGFloat {
-        let adjustedWidth = (availableWidth / 2).rounded(.down) - Self.layoutMargins.left - Self.layoutMargins.right
-        let imageHeight = adjustedWidth * Self.imageAspectRatio
-
-        let titleHeight = adjustedHeight(
-            of: viewModel.attributedTitle,
-            availableWidth: adjustedWidth,
-            numberOfLines: numberOfTitleLines
-        )
-
-        let detailHeight = adjustedHeight(
-            of: viewModel.attributedDetail,
-            availableWidth: adjustedWidth,
-            numberOfLines: Hero.numberOfSubtitleLines
-        )
-
-        return Self.layoutMargins.top
-        + imageHeight
-        + Mini.textStackTopMargin
-        + titleHeight
-        + Mini.textStackSpacing
-        + detailHeight
-        + Mini.buttonStackTopMargin
-        + Self.saveButtonHeight
-        + Self.layoutMargins.bottom
-    }
-
     static func fullHeight(viewModel: RecommendationCellViewModel, availableWidth: CGFloat) -> CGFloat {
         let adjustedWidth = availableWidth - Self.layoutMargins.left - Self.layoutMargins.right
         let imageHeight = (adjustedWidth * Self.imageAspectRatio).rounded(.up)
@@ -246,27 +191,25 @@ extension RecommendationCell {
             availableWidth: adjustedWidth,
             numberOfLines: numberOfTitleLines
         )
-        let detailHeight = adjustedHeight(
-            of: viewModel.attributedDetail,
+        
+        let domainHeight = adjustedHeight(
+            of: viewModel.attributedDomain,
             availableWidth: adjustedWidth,
-            numberOfLines: Hero.numberOfSubtitleLines
+            numberOfLines: numberOfTitleLines
         )
-        let excerptHeight = adjustedHeight(
-            of: viewModel.attributedExcerpt,
+        
+        let timeToReadHeight = adjustedHeight(
+            of: viewModel.attributedTimeToRead,
             availableWidth: adjustedWidth,
-            numberOfLines: numberOfExcerptLines
+            numberOfLines: numberOfTitleLines
         )
 
         return Self.layoutMargins.top
         + imageHeight
-        + Hero.textStackTopMargin
+        + textStackTopMargin
         + titleHeight
-        + Hero.textStackSpacing
-        + detailHeight
-        + Hero.textStackSpacing
-        + excerptHeight
-        + Hero.buttonStackTopMargin
-        + Self.saveButtonHeight
+        + domainHeight
+        + timeToReadHeight
         + Self.layoutMargins.bottom
     }
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationOverflowButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationOverflowButton.swift
@@ -9,16 +9,18 @@ class RecommendationOverflowButton: UIButton {
         configuration = .plain()
         configuration?.contentInsets = NSDirectionalEdgeInsets(
             top: 16,
-            leading: 16,
+            leading: 8,
             bottom: 16,
             trailing: 8
         )
-        configuration?.image = UIImage(asset: .alert)
-            .withRenderingMode(.alwaysTemplate)
-
+        configuration?.image = UIImage(asset: .overflow)
+            .resized(to: CGSize(width: 20, height: 20))
+            .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
+        
         configuration?.imageColorTransformer = UIConfigurationColorTransformer { [weak self] _ in
-            self?.imageColor() ?? UIColor(.ui.grey4)
+            self?.imageColor() ?? UIColor(.ui.grey5)
         }
+        
     }
 
     required init?(coder: NSCoder) {
@@ -30,7 +32,7 @@ class RecommendationOverflowButton: UIButton {
         case .selected, .highlighted:
             return UIColor(.ui.grey1)
         default:
-            return UIColor(.ui.grey4)
+            return UIColor(.ui.grey5)
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
@@ -3,8 +3,8 @@ import Textile
 
 
 private extension Style {
-    static let saveTitle: Style = .header.sansSerif.p3.with(color: .ui.grey4).with(weight: .medium)
-    static let saveTitleHighlighted: Style = .header.sansSerif.p3.with(color: .ui.grey1).with(weight: .medium)
+    static let saveTitle: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium)
+    static let saveTitleHighlighted: Style = .header.sansSerif.p4.with(color: .ui.grey1).with(weight: .medium)
 }
 
 class RecommendationSaveButton: UIButton {
@@ -51,13 +51,13 @@ class RecommendationSaveButton: UIButton {
             top: 16,
             leading: 8,
             bottom: 16,
-            trailing: 16
+            trailing: 8
         )
 
-        configuration?.imagePadding = 4
+        configuration?.imagePadding = 6
 
         configuration?.imageColorTransformer = UIConfigurationColorTransformer { [weak self] _ in
-            return self?.imageColor() ?? UIColor(.ui.grey1)
+            return self?.imageColor() ?? UIColor(.ui.coral2)
         }
 
         configuration?.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { [weak self] _ in
@@ -84,14 +84,14 @@ class RecommendationSaveButton: UIButton {
             case .highlighted, .selected:
                 switch mode {
                 case .save:
-                    return .ui.grey1
+                    return .ui.coral1
                 case .saved:
                     return .ui.coral1
                 }
             default:
                 switch mode {
                 case .save:
-                    return .ui.grey4
+                    return .ui.coral2
                 case .saved:
                     return .ui.coral2
                 }
@@ -102,10 +102,6 @@ class RecommendationSaveButton: UIButton {
     }
 
     private func updateTitle() {
-        if isTitleHidden {
-            configuration?.title = ""
-        } else {
-            configuration?.title = mode.title
-        }
+        configuration?.title = mode.title
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
@@ -5,34 +5,40 @@ import Textile
 class SectionHeaderView: UICollectionReusableView {
     static let kind = "SectionHeader"
     static let buttonImageSize = CGSize(width: 6.75, height: 12)
+    static let stackSpacing: CGFloat = 10
     
     private let headerLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         label.textColor = UIColor(.ui.lapis1)
-        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
     private let myListButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(asset: .chevronRight)
-            .withTintColor(UIColor(.ui.lapis1), renderingMode: .alwaysTemplate)
             .resized(to: buttonImageSize)
+            .withTintColor(UIColor(.ui.lapis1), renderingMode: .alwaysOriginal)
+
         configuration.imagePadding = 10
         configuration.imagePlacement = .trailing
+        configuration.contentInsets.leading = 0
+        configuration.contentInsets.trailing = 0
         
         let button = UIButton(configuration: configuration, primaryAction: nil)
         button.accessibilityIdentifier = "see-all-button"
         button.isHidden = true
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        
         return button
     }()
     
     private let headerStack: UIStackView = {
         let stack = UIStackView()
-        stack.distribution = .equalCentering
+        stack.distribution = .fill
         stack.axis = .horizontal
-
+        stack.spacing = stackSpacing
         return stack
     }()
 
@@ -48,10 +54,10 @@ class SectionHeaderView: UICollectionReusableView {
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            headerStack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
-            headerStack.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
-            headerStack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            headerStack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            headerStack.topAnchor.constraint(equalTo: topAnchor),
+            headerStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            headerStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            headerStack.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
     }
 
@@ -69,9 +75,10 @@ extension SectionHeaderView {
         var attributedHeaderText: NSAttributedString {
             NSAttributedString(string: name, style: .sectionHeader)
         }
-        
+
         func height(width: CGFloat) -> CGFloat {
-            attributedHeaderText.sizeFitting(availableWidth: width).height + 16
+            let buttonWidth = NSAttributedString(string: buttonTitle, style: .buttonText).sizeFitting().width + buttonImageSize.width
+            return attributedHeaderText.sizeFitting(availableWidth: width - stackSpacing - buttonWidth).height + 16
         }
     }
     

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -50,9 +50,12 @@ class SlateDetailViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         view.accessibilityIdentifier = "slate-detail"
-
-        title = nil
-        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.title = model.slateName
+        
+        let largeTitleTwoLineMode = "_largeTitleTwoLineMode"
+        if class_getProperty(UINavigationItem.self, largeTitleTwoLineMode) != nil {
+            navigationItem.setValue(true, forKey: largeTitleTwoLineMode)
+        }
 
         dataSource.supplementaryViewProvider = { [unowned self] _, kind, indexPath in
             let divider: DividerView = collectionView.dequeueReusableView(forSupplementaryViewOfKind: kind, for: indexPath)
@@ -108,6 +111,7 @@ class SlateDetailViewController: UIViewController {
 
         model.fetch()
         model.refresh { }
+    
     }
 }
 
@@ -168,50 +172,22 @@ private extension SlateDetailViewController {
 
             return NSCollectionLayoutSection(group: group)
         case .slate(let slate):
-            let width = environment.container.effectiveContentSize.width
-            let dividerHeight: CGFloat = 17
-            let margin: CGFloat = 8
-            let spacing: CGFloat = margin * 2
-
+            let margin: CGFloat = Margins.normal.rawValue
             let recommendations = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
-            let components = recommendations.reduce((CGFloat(0), [NSCollectionLayoutItem]())) { result, recommendation in
-                guard let viewModel = self.model.viewModel(for: recommendation.objectID) else {
-                    return result
-                }
-
-                let currentHeight = result.0
-                let height = RecommendationCell.fullHeight(viewModel: viewModel, availableWidth: width - spacing) + dividerHeight
-                var items = result.1
-                items.append(
-                    NSCollectionLayoutItem(
-                        layoutSize: NSCollectionLayoutSize(
-                            widthDimension: .fractionalWidth(1),
-                            heightDimension: .absolute(height)
-                        )
-                    )
-                )
-
-                return (currentHeight + height, items)
-            }
-
+            let count = recommendations.count
+            let height: CGFloat = 370
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(height))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
             let heroGroup = NSCollectionLayoutGroup.vertical(
                 layoutSize: NSCollectionLayoutSize(
                     widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(components.0 + dividerHeight)
+                    heightDimension: .absolute(height*Double(count))
                 ),
-                subitems: components.1
+                subitem: item,
+                count: count
             )
-
-            heroGroup.supplementaryItems = [
-                NSCollectionLayoutSupplementaryItem(
-                    layoutSize: NSCollectionLayoutSize(
-                        widthDimension: .fractionalWidth(1),
-                        heightDimension: .absolute(dividerHeight)
-                    ),
-                    elementKind: "divider",
-                    containerAnchor: NSCollectionLayoutAnchor(edges: .bottom)
-                )
-            ]
+            heroGroup.interItemSpacing = .fixed(16)
 
             let section = NSCollectionLayoutSection(group: heroGroup)
 
@@ -238,24 +214,12 @@ private extension SlateDetailViewController {
             return cell
         case .recommendation(let objectID):
             let cell: RecommendationCell = collectionView.dequeueCell(for: indexPath)
-            cell.mode = .hero
 
-            guard let viewModel = self.model.viewModel(for: objectID) else {
+            guard let viewModel = self.model.recommendationViewModel(for: objectID, and: viewModelCell, at: indexPath) else {
                 return cell
             }
 
             cell.configure(model: viewModel)
-
-            if let action = self.model.saveAction(for: viewModelCell, at: indexPath),
-               let uiAction = UIAction(action) {
-                cell.saveButton.addAction(uiAction, for: .primaryActionTriggered)
-            }
-
-            if let action = self.model.reportAction(for: viewModelCell, at: indexPath),
-               let uiAction = UIAction(action) {
-                cell.overflowButton.addAction(uiAction, for: .primaryActionTriggered)
-            }
-
             return cell
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -9,6 +9,7 @@ import Analytics
 class SlateDetailViewModel {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
 
+    let slateName: String?
     private let slateID: String
     private let source: Source
     private let tracker: Tracker
@@ -29,8 +30,9 @@ class SlateDetailViewModel {
     @Published
     var selectedRecommendationToReport: Recommendation? = nil
 
-    init(slateID: String, source: Source, tracker: Tracker) {
+    init(slateID: String, slateName: String?, source: Source, tracker: Tracker) {
         self.slateID = slateID
+        self.slateName = slateName
         self.source = source
         self.tracker = tracker
         self.slateController = source.makeSlateController(byID: slateID)
@@ -104,6 +106,15 @@ class SlateDetailViewModel {
 
     func viewModel(for objectID: NSManagedObjectID) -> HomeRecommendationCellViewModel? {
         return viewModels[objectID]
+    }
+    
+    func recommendationViewModel(for objectID: NSManagedObjectID, and item: SlateDetailViewModel.Cell, at indexPath: IndexPath) -> HomeRecommendationCellViewModel? {
+        guard let viewModel = viewModels[objectID] else { return nil }
+        if let action = reportAction(for: item, at: indexPath) {
+            viewModel.overflowActions = [action]
+        }
+        viewModel.saveAction = saveAction(for: item, at: indexPath)
+        return viewModel
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -73,7 +73,8 @@ class CompactMainCoordinator: NSObject {
                 switch section {
                 case .recentSaves:
                     self?.model.selectedSection = .myList(.myList)
-                case .slate(let slate):
+                case .slateHero(let slateID):
+                    guard let slate = self?.model.home.slate(with: slateID) else { return }
                     self?.model.home.select(slate: slate)
                 default:
                     return

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -185,7 +185,8 @@ class RegularMainCoordinator: NSObject {
             switch section {
             case .recentSaves:
                 self?.model.selectedSection = .myList(.myList)
-            case .slate(let slate):
+            case .slateHero(let slateID):
+                guard let slate = self?.model.home.slate(with: slateID) else { return }
                 self?.model.home.select(slate: slate)
             default:
                 return

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -33,7 +33,7 @@ class ItemsListItemCell: UICollectionViewListCell {
         static let actionButtonHeight: CGFloat = 28
         static let actionButtonImageSize = CGSize(width: 20, height: 20)
         static let mainStackSpacing: CGFloat = 8
-        static let margins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let margins = UIEdgeInsets(top: Margins.normal.rawValue, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
     }
 
     private let titleLabel: UILabel = {
@@ -72,9 +72,9 @@ class ItemsListItemCell: UICollectionViewListCell {
         var config = UIButton.Configuration.plain()
         config.contentInsets = .zero
         config.image = UIImage(asset: .share)
-            .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
             .resized(to: Constants.actionButtonImageSize)
-
+            .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
+           
         let button = UIButton(configuration: config, primaryAction: nil)
         button.accessibilityIdentifier = "share"
         return button
@@ -84,8 +84,8 @@ class ItemsListItemCell: UICollectionViewListCell {
         var config = UIButton.Configuration.plain()
         config.contentInsets = .zero
         config.image = UIImage(asset: .overflow)
-            .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
             .resized(to: Constants.actionButtonImageSize)
+            .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
         
         let button = UIButton(configuration: config, primaryAction: nil)
         button.accessibilityIdentifier = "item-actions"
@@ -197,7 +197,6 @@ extension ItemsListItemCell {
         let shareAction: ItemAction?
         let favoriteAction: ItemAction?
         let overflowActions: [ItemAction]
-        var style: CellStyle = .plain
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -209,10 +208,6 @@ extension ItemsListItemCell {
             state.isSelected ? UIColor(.ui.grey6) : UIColor(.ui.white1)
         }
         backgroundConfiguration = bgConfig
-        
-        if state.model?.style == .bordered {
-            styleBorder()
-        }
         
         titleLabel.attributedText = state.model?.attributedTitle
         detailLabel.attributedText = state.model?.attributedDetail
@@ -233,7 +228,6 @@ extension ItemsListItemCell {
 
         let menuActions = state.model?.overflowActions.compactMap(UIAction.init) ?? []
         menuButton.menu = UIMenu(children: menuActions)
-
 
         thumbnailView.image = nil
         guard let thumbnailURL = state.model?.thumbnailURL else {
@@ -258,12 +252,6 @@ extension ItemsListItemCell {
                 )
             ]
         )
-    }
-    
-    private func styleBorder() {
-        layer.borderWidth = 0.5
-        layer.borderColor = UIColor(.ui.grey6).cgColor
-        layer.cornerRadius = 16
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
+++ b/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
@@ -1,0 +1,13 @@
+import Foundation
+import UIKit
+
+
+enum Margins: CGFloat {
+  case thin = 8
+  case normal = 16
+  case wide = 32
+}
+
+enum StyleConstants {
+    static let thumbnailSize = CGSize(width: 90, height: 60)
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/border.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/border.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -33,7 +33,7 @@ public struct UIPalette {
     public let white1 = ColorAsset.ui("white1")
 
     public let black = ColorAsset.ui("black")
-
+    public let border = ColorAsset.ui("border")
     public let skeletonCellImageBackground = ColorAsset.ui("skeletonCellImageBackground")
 }
 

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -115,14 +115,14 @@ class HomeViewModelTests: XCTestCase {
 
         let snapshotExpectation = expectation(description: "expected snapshot to update")
         viewModel.$snapshot.sink { snapshot in
-            XCTAssertEqual(snapshot.sectionIdentifiers, [.slate(slates[0]), .slate(slates[1]), .slate(slates[2])])
+            XCTAssertEqual(snapshot.sectionIdentifiers, [.slateHero(slates[0].objectID), .slateCarousel(slates[0].objectID), .slateHero(slates[1].objectID), .slateHero(slates[2].objectID)])
 
-            let firstSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[0])
+            let firstSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[0]) + snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[1])
             let firstSlateRecommendations = firstSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
                 case .loading, .recentSaves:
                     return nil
-                case .recommendation(let objectID):
+                case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
                     return objectID
                 }
             }
@@ -131,12 +131,12 @@ class HomeViewModelTests: XCTestCase {
                 [recommendations[0].objectID, recommendations[1].objectID]
             )
 
-            let secondSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[1])
+            let secondSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[2])
             let secondSlateRecommendations = secondSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
                 case .loading, .recentSaves:
                     return nil
-                case .recommendation(let objectID):
+                case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
                     return objectID
                 }
             }
@@ -145,12 +145,12 @@ class HomeViewModelTests: XCTestCase {
                 [recommendations[2].objectID]
             )
 
-            let thirdSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[2])
+            let thirdSlate = snapshot.itemIdentifiers(inSection: snapshot.sectionIdentifiers[3])
             let thirdSlateRecommendations = thirdSlate.compactMap { cell -> NSManagedObjectID? in
                 switch cell {
                 case .loading, .recentSaves:
                     return nil
-                case .recommendation(let objectID):
+                case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
                     return objectID
                 }
             }
@@ -185,7 +185,7 @@ class HomeViewModelTests: XCTestCase {
                 switch cell {
                 case .loading, .recentSaves:
                     return nil
-                case .recommendation(let objectID):
+                case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
                     return objectID
                 }
             }
@@ -199,13 +199,17 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 1)
     }
 
-    func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() {
+    func test_selectCell_whenSelectingHeroRecommendation_recommendationIsReadable_updatesSelectedReadable() {
         let viewModel = subject()
 
         let recommendation = Recommendation.build()
+        let slate: Slate = .build(recommendations: [recommendation])
         slateLineupController.slateLineup = .build(
-            slates: [.build(recommendations: [recommendation])]
+            slates: [slate]
         )
+        source.stubObject { _ in
+            slate
+        }
         viewModel.controllerDidChangeContent(slateLineupController)
 
         let readableExpectation = expectation(description: "expected to update selected readable")
@@ -218,13 +222,79 @@ class HomeViewModelTests: XCTestCase {
             }
         }.store(in: &subscriptions)
 
-        let cell = HomeViewModel.Cell.recommendation(recommendation.objectID)
+        let cell = HomeViewModel.Cell.recommendationHero(recommendation.objectID)
         viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
 
         wait(for: [readableExpectation], timeout: 1)
     }
 
-    func test_selectCell_whenSelectingRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() {
+    func test_selectCell_whenSelectingCarouselRecommendation_recommendationIsReadable_updatesSelectedReadable() {
+        let viewModel = subject()
+
+        let recommendation = Recommendation.build()
+        slateLineupController.slateLineup = .build(
+            slates: [.build(recommendations: [recommendation])]
+        )
+        viewModel.controllerDidChangeContent(slateLineupController)
+
+        let readableExpectation = expectation(description: "expected to update selected readable")
+        viewModel.$selectedReadableType.dropFirst().sink { readable in
+            readableExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        let cell = HomeViewModel.Cell.recommendationCarousel(recommendation.objectID)
+        viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
+
+        wait(for: [readableExpectation], timeout: 1)
+    }
+    
+    func test_selectCell_whenSelectingHeroRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() {
+        let viewModel = subject()
+        let item = Item.build()
+        let recommendation = Recommendation.build(item: item)
+        let slate: Slate = .build(recommendations: [recommendation])
+        slateLineupController.slateLineup = .build(
+            slates: [slate]
+        )
+        source.stubObject { _ in
+            slate
+        }
+        viewModel.controllerDidChangeContent(slateLineupController)
+
+        let urlExpectation = expectation(description: "expected to update presented URL")
+        urlExpectation.expectedFulfillmentCount = 3
+        viewModel.$presentedWebReaderURL.filter { $0 != nil }.sink { readable in
+            urlExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        do {
+            item.isArticle = false
+
+            let cell = HomeViewModel.Cell.recommendationHero(recommendation.objectID)
+            viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
+        }
+
+        do {
+            item.isArticle = true
+            item.imageness = Imageness.isImage.rawValue
+
+            let cell = HomeViewModel.Cell.recommendationHero(recommendation.objectID)
+            viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
+        }
+
+        do {
+            item.isArticle = true
+            item.imageness = nil
+            item.videoness = Videoness.isVideo.rawValue
+
+            let cell = HomeViewModel.Cell.recommendationHero(recommendation.objectID)
+            viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
+        }
+
+        wait(for: [urlExpectation], timeout: 1)
+    }
+    
+    func test_selectCell_whenSelectingCarouselRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() {
         let viewModel = subject()
         let item = Item.build()
         let recommendation = Recommendation.build(item: item)
@@ -242,7 +312,7 @@ class HomeViewModelTests: XCTestCase {
         do {
             item.isArticle = false
 
-            let cell = HomeViewModel.Cell.recommendation(recommendation.objectID)
+            let cell = HomeViewModel.Cell.recommendationCarousel(recommendation.objectID)
             viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
         }
 
@@ -250,7 +320,7 @@ class HomeViewModelTests: XCTestCase {
             item.isArticle = true
             item.imageness = Imageness.isImage.rawValue
 
-            let cell = HomeViewModel.Cell.recommendation(recommendation.objectID)
+            let cell = HomeViewModel.Cell.recommendationCarousel(recommendation.objectID)
             viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
         }
 
@@ -259,7 +329,7 @@ class HomeViewModelTests: XCTestCase {
             item.imageness = nil
             item.videoness = Videoness.isVideo.rawValue
 
-            let cell = HomeViewModel.Cell.recommendation(recommendation.objectID)
+            let cell = HomeViewModel.Cell.recommendationCarousel(recommendation.objectID)
             viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
         }
 
@@ -360,7 +430,35 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [detailExpectation], timeout: 1)
     }
 
-    func test_reportAction_forRecommendation_updatesSelectedRecommendationToReport() {
+    func test_reportAction_forHeroRecommendation_updatesSelectedRecommendationToReport() {
+        
+        let viewModel = subject()
+        let recommendation = Recommendation.build()
+        let slate: Slate = .build(recommendations: [recommendation])
+        slateLineupController.slateLineup = .build(
+            slates: [slate]
+        )
+        source.stubObject { _ in
+            slate
+        }
+        
+        viewModel.controllerDidChangeContent(slateLineupController)
+
+        let cell = HomeViewModel.Cell.recommendationHero(recommendation.objectID)
+        let action = viewModel.reportAction(for: cell, at: IndexPath(item: 0, section: 0))
+        XCTAssertNotNil(action)
+
+        let reportExpectation = expectation(description: "expected to update selected recommendation to report")
+        viewModel.$selectedRecommendationToReport.dropFirst().sink { recommendation in
+            XCTAssertNotNil(recommendation)
+            reportExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        action?.handler?(nil)
+        wait(for: [reportExpectation], timeout: 1)
+    }
+    
+    func test_reportAction_forCarouselRecommendation_updatesSelectedRecommendationToReport() {
         let viewModel = subject()
         let recommendation = Recommendation.build()
         slateLineupController.slateLineup = .build(
@@ -368,7 +466,7 @@ class HomeViewModelTests: XCTestCase {
         )
         viewModel.controllerDidChangeContent(slateLineupController)
 
-        let cell = HomeViewModel.Cell.recommendation(recommendation.objectID)
+        let cell = HomeViewModel.Cell.recommendationCarousel(recommendation.objectID)
         let action = viewModel.reportAction(for: cell, at: IndexPath(item: 0, section: 0))
         XCTAssertNotNil(action)
 
@@ -382,7 +480,31 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 1)
     }
 
-    func test_saveAction_whenRecommendationIsNotSaved_savesWithSource() {
+    func test_saveAction_whenHeroRecommendationIsNotSaved_savesWithSource() {
+        source.stubSaveRecommendation { _ in }
+
+        let viewModel = subject()
+        let recommendation = Recommendation.build()
+        let slate: Slate = .build(recommendations: [recommendation])
+        slateLineupController.slateLineup = .build(
+            slates: [slate]
+        )
+        source.stubObject { _ in
+            slate
+        }
+        viewModel.controllerDidChangeContent(slateLineupController)
+
+        let action = viewModel.saveAction(
+            for: .recommendationHero(recommendation.objectID),
+            at: IndexPath(item: 0, section: 0)
+        )
+        XCTAssertNotNil(action)
+
+        action?.handler?(nil)
+        XCTAssertEqual(source.saveRecommendationCall(at: 0)?.recommendation, recommendation)
+    }
+    
+    func test_saveAction_whenCarouselRecommendationIsNotSaved_savesWithSource() {
         source.stubSaveRecommendation { _ in }
 
         let viewModel = subject()
@@ -393,7 +515,7 @@ class HomeViewModelTests: XCTestCase {
         viewModel.controllerDidChangeContent(slateLineupController)
 
         let action = viewModel.saveAction(
-            for: .recommendation(recommendation.objectID),
+            for: .recommendationCarousel(recommendation.objectID),
             at: IndexPath(item: 0, section: 0)
         )
         XCTAssertNotNil(action)
@@ -402,7 +524,34 @@ class HomeViewModelTests: XCTestCase {
         XCTAssertEqual(source.saveRecommendationCall(at: 0)?.recommendation, recommendation)
     }
 
-    func test_saveAction_whenRecommendationIsSaved_archivesWithSource() {
+    func test_saveAction_whenHeroRecommendationIsSaved_archivesWithSource() {
+        source.stubArchiveRecommendation { _ in }
+
+        let item = Item.build()
+        item.savedItem = .build()
+        let recommendation = Recommendation.build(item: item)
+
+        let viewModel = subject()
+        let slate: Slate = .build(recommendations: [recommendation])
+        slateLineupController.slateLineup = .build(
+            slates: [slate]
+        )
+        source.stubObject { _ in
+            slate
+        }
+        viewModel.controllerDidChangeContent(slateLineupController)
+
+        let action = viewModel.saveAction(
+            for: .recommendationHero(recommendation.objectID),
+            at: IndexPath(item: 0, section: 0)
+        )
+        XCTAssertNotNil(action)
+
+        action?.handler?(nil)
+        XCTAssertEqual(source.archiveRecommendationCall(at: 0)?.recommendation, recommendation)
+    }
+    
+    func test_saveAction_whenCarouselRecommendationIsSaved_archivesWithSource() {
         source.stubArchiveRecommendation { _ in }
 
         let item = Item.build()
@@ -416,7 +565,7 @@ class HomeViewModelTests: XCTestCase {
         viewModel.controllerDidChangeContent(slateLineupController)
 
         let action = viewModel.saveAction(
-            for: .recommendation(recommendation.objectID),
+            for: .recommendationCarousel(recommendation.objectID),
             at: IndexPath(item: 0, section: 0)
         )
         XCTAssertNotNil(action)
@@ -458,4 +607,60 @@ class HomeViewModelTests: XCTestCase {
         viewModel.fetch()
         wait(for: [expectSnapshot], timeout: 1)
     }
+    
+    func test_numberOfCarouselItemsForSlate_returnsAccurateCount() {
+        let recommendations: [Recommendation] = [
+            .build(remoteID: "slate-1-recommendation-1"),
+            .build(remoteID: "slate-1-recommendation-2"),
+            .build(remoteID: "slate-1-recommendation-3"),
+            .build(remoteID: "slate-2-recommendation-1"),
+            .build(remoteID: "slate-2-recommendation-2"),
+            .build(remoteID: "slate-3-recommendation-1"),
+        ]
+        let slates: [Slate] = [
+            .build(
+                remoteID: "slate-1",
+                recommendations: [recommendations[0], recommendations[1], recommendations[2]]
+            ),
+            .build(
+                remoteID: "slate-2",
+                recommendations: [recommendations[3], recommendations[4]]
+            ),
+            .build(
+                remoteID: "slate-3",
+                recommendations: [recommendations[5]]
+            ),
+        ]
+
+        let slateLineupController = MockSlateLineupController()
+        slateLineupController.slateLineup = SlateLineup.build(slates: slates)
+        source.stubMakeSlateLineupController {
+            slateLineupController
+        }
+
+        source.stubObject { objectID in
+            slates.first { slate in
+                slate.objectID == objectID
+            }
+        }
+
+        let viewModel = subject()
+
+        let count1 = viewModel.numberOfCarouselItemsForSlate(with: slates[0].objectID)
+        let count2 = viewModel.numberOfCarouselItemsForSlate(with: slates[1].objectID)
+        let count3 = viewModel.numberOfCarouselItemsForSlate(with: slates[2].objectID)
+
+        XCTAssertEqual(count1, 2)
+        XCTAssertEqual(count2, 1)
+        XCTAssertEqual(count3, 0)
+    }
+    
+//    func test_numberOfRecentSavesItem_returnsAccurateCount() throws {
+//        let items: [SavedItem] = [.build(), .build(), .build()]
+//        try space.save()
+//        let viewModel = subject()
+//        let count = viewModel.numberOfRecentSavesItem()
+//
+//        XCTAssertEqual(count, items.count)
+//    }
 }

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -29,11 +29,13 @@ class SlateDetailViewModelTests: XCTestCase {
 
     func subject(
         slateID: String? = nil,
+        slateName: String? = nil,
         source: Source? = nil,
         tracker: Tracker? = nil
     ) -> SlateDetailViewModel {
         SlateDetailViewModel(
             slateID: slateID ?? "abcde",
+            slateName: slateName ?? "",
             source: source ?? self.source,
             tracker: tracker ?? self.tracker
         )

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -30,13 +30,15 @@ class MockSource: Source {
 
 extension MockSource {
     private static let object = "object"
-    typealias ObjectImpl<T> = (NSManagedObjectID) -> T
+    typealias ObjectImpl<T> = (NSManagedObjectID) -> T?
 
     func stubObject<T: NSManagedObject>(_ impl: @escaping ObjectImpl<T>) {
         implementations[Self.object] = impl
     }
 
     func object<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
+        print(T.self)        
+        
         guard let impl = implementations[Self.object] as? ObjectImpl<T> else {
             fatalError("\(Self.self)#\(#function) is not implemented")
         }

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -66,6 +66,8 @@ class HomeTests: XCTestCase {
         let home = app.launch().homeView
 
         home.sectionHeader("Slate 1").wait()
+        home.element.swipeUp()
+        
         home.recommendationCell("Slate 1, Recommendation 1").verify()
         home.recommendationCell("Slate 1, Recommendation 2").verify()
 
@@ -81,8 +83,8 @@ class HomeTests: XCTestCase {
         home.savedItemCell("Item 1").wait()
         home.savedItemCell("Item 2").wait()
         
-        home.savedItemCell("Item 2").swipeLeft(velocity: .fast)
-        home.savedItemCell("Item 4").swipeLeft(velocity: .fast)
+        home.savedItemCell("Item 1").swipeLeft(velocity: .fast)
+        home.savedItemCell("Item 3").swipeLeft(velocity: .fast)
         waitForDisappearance(of: home.savedItemCell("Item 6"))
     }
 
@@ -131,7 +133,7 @@ class HomeTests: XCTestCase {
     func test_archivingRecentSavesItem_removesItemFromRecentSaves() {
         let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
-        home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
+        home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.archiveButton.wait().tap()
 
         waitForDisappearance(of: home.savedItemCell("Item 1"))
@@ -140,7 +142,7 @@ class HomeTests: XCTestCase {
     func test_deletingRecentSavesItem_removesItemFromRecentSaves() {
         let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
-        home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
+        home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.deleteButton.wait().tap()
         app.alert.yes.wait().tap()
         waitForDisappearance(of: home.savedItemCell("Item 1"))
@@ -152,7 +154,7 @@ class HomeTests: XCTestCase {
     func test_sharingRecentSavesItem_removesItemFromRecentSaves() {
         let home = app.launch().homeView.wait()
         home.savedItemCell("Item 1").wait()
-        home.recentSavesView(matching: "Item 1").itemActionButton.wait().tap()
+        home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.shareButton.wait().tap()
         app.shareSheet.wait()
     }
@@ -178,6 +180,7 @@ class HomeTests: XCTestCase {
         home.sectionHeader("Slate 1").seeAllButton.wait().tap()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 1").wait()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 2").verify()
+        app.slateDetailView.element.swipeUp()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 3").verify()
 
         app.tabBar.homeButton.wait().tap()
@@ -191,7 +194,7 @@ class HomeTests: XCTestCase {
         app.launch().homeView.recommendationCell("Slate 1, Recommendation 1").wait().tap()
         app.readerView.cell(containing: "Jacob and David").wait()
     }
-
+    
     func test_tappingSaveButtonInRecommendationCell_savesItemToList() {
         let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")
         let saveButton = cell.saveButton.wait()

--- a/Tests iOS/HomeWebViewTests.swift
+++ b/Tests iOS/HomeWebViewTests.swift
@@ -61,13 +61,15 @@ class HomeWebViewTests: XCTestCase {
     }
 
     func test_home_showsWebViewWhenItemIsVideo() {
+        app.homeView.element.swipeUp()
         test_home_showsWebView(from: "Slate 1, Recommendation 2")
     }
 
     func test_home_showsWebViewWhenItemIsNotAnArticle() {
+        app.homeView.element.swipeUp()
         test_home_showsWebView(from: "Slate 1, Recommendation 3")
     }
-
+    
     func test_home_showsWebView(from name: String) {
         app.homeView.sectionHeader("Slate 1").wait()
         app.homeView.recommendationCell(name).wait().tap()

--- a/Tests iOS/Support/Elements/HomeViewElement.swift
+++ b/Tests iOS/Support/Elements/HomeViewElement.swift
@@ -25,11 +25,11 @@ struct HomeViewElement: PocketUIElement {
     }
     
     var savedItemCells: XCUIElementQuery {
-        return element.cells.matching(identifier: "my-list-item")
+        return element.cells.matching(identifier: "home-carousel-item")
     }
     
-    func recentSavesView(matching string: String) -> ItemRowElement {
-        return ItemRowElement(savedItemCell(string))
+    func recentSavesView(matching string: String) -> RecentSavesCellElement {
+        return RecentSavesCellElement(savedItemCell(string))
     }
     
     func sectionHeader(_ title: String) -> SectionHeaderElement {

--- a/Tests iOS/Support/Elements/RecentSavesCellElement.swift
+++ b/Tests iOS/Support/Elements/RecentSavesCellElement.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+
+struct RecentSavesCellElement: PocketUIElement {
+    let element: XCUIElement
+
+    init(_ element: XCUIElement) {
+        self.element = element
+    }
+
+    var favoriteButton: FavoriteButton {
+        FavoriteButton(element.buttons["item-action-favorite"])
+    }
+    
+    var overflowButton: XCUIElement {
+        element.buttons["overflow-button"]
+    }
+}
+
+extension RecentSavesCellElement {
+    struct FavoriteButton: PocketUIElement {
+        let element: XCUIElement
+
+        init(_ element: XCUIElement) {
+            self.element = element
+        }
+
+        var isFilled: Bool {
+            element.label == "Unfavorite"
+        }
+    }
+}

--- a/Tests iOS/Support/Elements/RecommendationCellElement.swift
+++ b/Tests iOS/Support/Elements/RecommendationCellElement.swift
@@ -16,7 +16,7 @@ struct RecommendationCellElement: PocketUIElement {
         element.buttons["save-button"]
     }
     
-    var reportButton: XCUIElement {
-        element.buttons["report-button"]
+    var overflowButton: XCUIElement {
+        element.buttons["overflow-button"]
     }
 }


### PR DESCRIPTION
## Summary
Polishes the Home Design to better match the Figma File and added horizontal carousel for the recommendation cells.

## References 
IN-700, IN-707

## Implementation Details
Separated the Slate section to use two types of section `.slateHero` and `.slateCarousel`. Also, separated the slate cells from `.recommendation` to using `.recommendationHero` and `.recommendationCarousel`. Modified the `RecommendationCell` which is used for the hero card and added a new cell called `HomeCarouselItemCell` that is used for both recent saves and the horizontal recommendation cells. Made a couple of design tweaks such as adding section titles to the See All views, changing report button flow and made sure design worked for both dark / light mode. 

## Test Steps
- [ ] Given I am on the home tab, when I navigate between the slates and recent saves, the cells should behave as previously but with the new design
- [ ] Given I am on the home tab, When I swipe from right to left on the cells below the hero cell, Then the cells should scroll and reveal more recommendation cells
- [ ] Given I am on the home tab, when I tap on the see All button for the slate headers, then I should be able to see the slate section title in the next view
- [ ] Given I am on the home tab, when I tap on overflow button for the recommendation cells, then I should be able to see a menu option that shows report

Note: This work does not take care of dynamic fonts. That work will be addressed in a new ticket: https://getpocket.atlassian.net/browse/IN-723

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://user-images.githubusercontent.com/6743397/180838659-fe2ec5ff-08b0-4b7e-871b-9a8980b5b447.mp4