### PR TITLE
Use consistent action identifiers when attaching button actions

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -8,7 +8,7 @@ import CoreData
 class HomeRecommendationCellViewModel {
     let recommendation: Recommendation
     let overflowActions: [ItemAction]?
-    let saveAction: ItemAction?
+    let primaryAction: ItemAction?
     
     var isSaved: Bool {
         recommendation.item?.savedItem != nil &&
@@ -18,11 +18,11 @@ class HomeRecommendationCellViewModel {
     init(
         recommendation: Recommendation,
         overflowActions: [ItemAction]? = nil,
-        saveAction: ItemAction? = nil
+        primaryAction: ItemAction? = nil
     ) {
         self.recommendation = recommendation
         self.overflowActions = overflowActions
-        self.saveAction = saveAction
+        self.primaryAction = primaryAction
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -386,7 +386,7 @@ extension HomeViewModel {
                     self?.report(recommendation, at: indexPath)
                 }
             ],
-            saveAction: .recommendationPrimary { [weak self] _ in
+            primaryAction: .recommendationPrimary { [weak self] _ in
                 let isSaved = recommendation.item?.savedItem != nil
                 && recommendation.item?.savedItem?.isArchived == false
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -29,7 +29,7 @@ class RecommendationCarouselCell: HomeCarouselItemCell {
         }
 
         var saveAction: ItemAction? {
-            viewModel.saveAction
+            viewModel.primaryAction
         }
 
         var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -10,7 +10,7 @@ protocol RecommendationCellViewModel {
     var imageURL: URL? { get }
     var saveButtonMode: RecommendationSaveButton.Mode { get }
     var overflowActions: [ItemAction]? { get }
-    var saveAction: ItemAction? { get }
+    var primaryAction: ItemAction? { get }
 }
 
 class RecommendationCell: UICollectionViewCell {
@@ -126,7 +126,7 @@ class RecommendationCell: UICollectionViewCell {
             timeToReadLabel.isHidden = false
         }
         
-        if let saveAction = UIAction(model.saveAction) {
+        if let saveAction = UIAction(model.primaryAction) {
             saveButton.addAction(saveAction, for: .primaryActionTriggered)
         }
         

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -140,7 +140,7 @@ extension SlateDetailViewModel {
                     self?.report(recommendation, at: indexPath)
                 }
             ],
-            saveAction: .recommendationPrimary { [weak self] _ in
+            primaryAction: .recommendationPrimary { [weak self] _ in
                 let isSaved = recommendation.item?.savedItem != nil
                 && recommendation.item?.savedItem?.isArchived == false
 

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -687,7 +687,7 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 1)
     }
     
-    func test_saveAction_whenRecommendationIsNotSaved_savesWithSource() throws {
+    func test_primary_whenRecommendationIsNotSaved_savesWithSource() throws {
         source.stubSaveRecommendation { _ in }
         let item = space.buildItem(isArticle: true)
         let recommendation = space.buildRecommendation(item: item)
@@ -701,7 +701,7 @@ class HomeViewModelTests: XCTestCase {
 
         let action = viewModel.recommendationHeroViewModel(
             for: recommendation.objectID, at: [0, 0]
-        )?.saveAction
+        )?.primaryAction
         XCTAssertNotNil(action)
         action?.handler?(nil)
         XCTAssertEqual(
@@ -710,7 +710,7 @@ class HomeViewModelTests: XCTestCase {
         )
     }
 
-    func test_saveAction_whenRecommendationIsSaved_archivesWithSource() throws {
+    func test_primary_whenRecommendationIsSaved_archivesWithSource() throws {
         source.stubArchiveRecommendation { _ in }
         let item = space.buildItem(isArticle: true)
         let recommendation = space.buildRecommendation(item: item)
@@ -726,7 +726,7 @@ class HomeViewModelTests: XCTestCase {
 
         let action = viewModel.recommendationHeroViewModel(
             for: recommendation.objectID, at: [0, 0]
-        )?.saveAction
+        )?.primaryAction
         XCTAssertNotNil(action)
         action?.handler?(nil)
         XCTAssertEqual(

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -197,7 +197,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 1)
     }
 
-    func test_saveAction_whenRecommendationIsNotSaved_savesWithSource() throws {
+    func test_primaryAction_whenRecommendationIsNotSaved_savesWithSource() throws {
         source.stubSaveRecommendation { _ in }
 
         let item = space.buildItem()
@@ -207,14 +207,14 @@ class SlateDetailViewModelTests: XCTestCase {
 
         let action = viewModel
             .recommendationViewModel(for: recommendation.objectID, at: [0,0])?
-            .saveAction
+            .primaryAction
         XCTAssertNotNil(action)
         action?.handler?(nil)
 
         XCTAssertEqual(source.saveRecommendationCall(at: 0)?.recommendation, recommendation)
     }
 
-    func test_saveAction_whenRecommendationIsSaved_archivesWithSource() throws {
+    func test_primaryAction_whenRecommendationIsSaved_archivesWithSource() throws {
         source.stubArchiveRecommendation { _ in }
 
         let item = space.buildItem()
@@ -226,7 +226,7 @@ class SlateDetailViewModelTests: XCTestCase {
         let action = viewModel.recommendationViewModel(
             for: recommendation.objectID,
             at: IndexPath(item: 0, section: 0)
-        )?.saveAction
+        )?.primaryAction
         XCTAssertNotNil(action)
         action?.handler?(nil)
 

--- a/Tests iOS/Fixtures/save-recommendation-1.json
+++ b/Tests iOS/Fixtures/save-recommendation-1.json
@@ -1,0 +1,51 @@
+{
+    "data": {
+        "upsertSavedItem": {
+            "__typename": "[type-name-here]",
+            "remoteID": "slate-1-rec-1-saved-item",
+            "url": "https://example.com/item-1",
+            "_createdAt": 1,
+            "_deletedAt": null,
+            "archivedAt": null,
+            "isArchived": false,
+            "isFavorite": false,
+            "item": {
+                "__typename": "[some-type-name]",
+                "remoteID": "recommended-item-1",
+                "givenUrl": "https://example.com/item-1",
+                "resolvedUrl": "https://example.com/item-1",
+                "title": "Slate 1, Recommendation 1",
+                "language": "en",
+                "topImageUrl": "http://example.com/slate-1-rec-1/top-image.png",
+                "timeToRead": 1,
+                "marticle": [],
+                "authors": [
+                    {
+                        "__typename": "Author",
+                        "id": "author-1",
+                        "name": "Jacob",
+                        "url": "http://example.com/authors/author-1"
+                    },
+                    {
+                        "__typename": "Author",
+                        "id": "author-2",
+                        "name": "David",
+                        "url": "http://example.com/authors/author-2"
+                    }
+                ],
+                "datePublished": "2021-01-01 12:01:01",
+                "images": [],
+                "excerpt": "Cursus Aenean Elit",
+                "domain": "slate-1-rec-1.example.com",
+                "domainMetadata": {
+                    "__typename": "[some-type-name]",
+                    "name": "Lifehacker",
+                    "logo": "https://slate-1-rec-1.example.com/logo.png"
+                },
+                "isArticle": true,
+                "hasImage": "HAS_IMAGES",
+                "hasVideo": "HAS_VIDEOS",
+            }
+        }
+    }
+}

--- a/Tests iOS/Fixtures/save-recommendation-2.json
+++ b/Tests iOS/Fixtures/save-recommendation-2.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "upsertSavedItem": {
+            "__typename": "[type-name-here]",
+            "remoteID": "slate-1-rec-2-saved-item",
+            "url": "https://example.com/item-2",
+            "_createdAt": 1,
+            "_deletedAt": null,
+            "archivedAt": null,
+            "isArchived": false,
+            "isFavorite": false,
+            "item": {
+                "__typename": "[some-type-name]",
+                "remoteID": "recommended-item-2",
+                "givenUrl": "https://example.com/item-2",
+                "resolvedUrl": "https://example.com/item-2",
+                "title": "Slate 1, Recommendation 2",
+                "language": "en",
+                "topImageUrl": "http://example.com/slate-1-rec-2/top-image.png",
+                "timeToRead": 2,
+                "marticle": [],
+                "authors": [],
+                "datePublished": "2021-01-01 12:01:01",
+                "images": [],
+                "excerpt": "Cursus Aenean Elit",
+                "domain": "slate-1-rec-2.example.com",
+                "domainMetadata": {
+                    "__typename": "[some-type-name]",
+                    "name": "Lifehacker",
+                    "logo": "https://slate-1-rec-2.example.com/logo.png"
+                },
+                "isArticle": true,
+                "hasImage": "HAS_IMAGES",
+                "hasVideo": "HAS_VIDEOS",
+            }
+        }
+    }
+}

--- a/Tests iOS/Support/Elements/RecommendationCellElement.swift
+++ b/Tests iOS/Support/Elements/RecommendationCellElement.swift
@@ -13,10 +13,26 @@ struct RecommendationCellElement: PocketUIElement {
     }
 
     var saveButton: XCUIElement {
-        element.buttons["save-button"]
+        element.buttons["Save"]
+    }
+
+    var savedButton: XCUIElement {
+        element.buttons["Saved"]
     }
     
     var overflowButton: XCUIElement {
         element.buttons["overflow-button"]
+    }
+
+    struct SaveButton: PocketUIElement {
+        let element: XCUIElement
+
+        init(_ element: XCUIElement) {
+            self.element = element
+        }
+
+        var isSaved: Bool {
+            element.label == "Saved"
+        }
     }
 }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -31,8 +31,8 @@ extension Response {
         fixture(named: "slate-detail-\(number)")
     }
 
-    static func saveItem() -> Response {
-        fixture(named: "save-item")
+    static func saveItem(_ fixtureName: String = "save-item") -> Response {
+        fixture(named: fixtureName)
     }
 
     static func delete() -> Response {


### PR DESCRIPTION
When adding a button action *that should replace another button action*,
it's crucial that the two actions have the same identifier.

Per Apple's documentation:
> UIActions are uniqued based on their identifier, and subsequent
> actions with the same identifier replace previously added actions.

In the case of save/archive actions, the save action should be replaced
by the archive action, so the two need to have the same identifier.

https://getpocket.atlassian.net/browse/IN-724