### PR TITLE
IN-725: Update Toggle Text for Dark Mode + Fix Image Mode for Home Cell

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
@@ -196,7 +196,7 @@ extension HomeCarouselItemCell {
                 .processor(
                     ResizingImageProcessor(
                         referenceSize: StyleConstants.thumbnailSize,
-                        mode: .aspectFit
+                        mode: .aspectFill
                     ).append(
                         another: CroppingImageProcessor(
                             size: StyleConstants.thumbnailSize

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/teal1.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/teal1.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x48",
-          "green" : "0x4D",
-          "red" : "0x00"
+          "blue" : "0xBB",
+          "green" : "0xBF",
+          "red" : "0x80"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Summary
Update Toggle Text for Dark Mode + Fix for Image Aspect Mode for Home Carousel Cell

## References 
IN-725

## Implementation Details
Added Dark Mode color for `teal1` asset. Change image mode for `HomeCarouselItemCell` from `.aspectFit` to `.aspectFill`

## Test Steps
- [x] Given that the user has their settings in dark mode, when toggling between My List + Archive, then the user should see the proper colors. 

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-07-29 at 15 06 11](https://user-images.githubusercontent.com/6743397/181827767-cc018f64-171b-45a5-a5cf-21bca7b57bc1.png)