### PR TITLE
IN-700: Accessibility - Dynamic Fonts

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
@@ -25,6 +25,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = Constants.maxTitleLines
+        label.adjustsFontForContentSizeCategory = true
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
@@ -32,12 +33,14 @@ class HomeCarouselItemCell: UICollectionViewCell {
     private let domainLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = Constants.maxDetailLines
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
     private let timeToReadLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = Constants.maxDetailLines
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
@@ -118,6 +121,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
         mainContentStack.translatesAutoresizingMaskIntoConstraints = false
         thumbnailView.translatesAutoresizingMaskIntoConstraints = false
         bottomStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
 
         thumbnailWidthConstraint = thumbnailView.widthAnchor.constraint(
             equalToConstant: StyleConstants.thumbnailSize.width
@@ -135,6 +139,12 @@ class HomeCarouselItemCell: UICollectionViewCell {
             bottomStack.leadingAnchor.constraint(equalTo: mainContentStack.leadingAnchor),
             bottomStack.trailingAnchor.constraint(equalTo: mainContentStack.trailingAnchor),
             bottomStack.bottomAnchor.constraint(equalTo:  contentView.layoutMarginsGuide.bottomAnchor).with(priority: .required),
+
+            contentView.topAnchor.constraint(equalTo:  topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo:  bottomAnchor),
+
         ])
         
         [UIView(), domainLabel, timeToReadLabel, UIView()].forEach(subtitleStack.addArrangedSubview)
@@ -153,7 +163,7 @@ extension HomeCarouselItemCell {
         titleLabel.attributedText = model.attributedTitle
         domainLabel.attributedText = model.attributedDomain
         timeToReadLabel.attributedText = model.attributedTimeToRead
-        
+
         if model.attributedTimeToRead.string == "" {
             timeToReadLabel.isHidden = true
         } else {
@@ -208,14 +218,13 @@ extension HomeCarouselItemCell {
     }
     
     override func layoutSubviews() {
-        contentView.layer.masksToBounds = false
+        layer.masksToBounds = false
         layer.cornerRadius = Constants.cornerRadius
-        contentView.layer.cornerRadius = Constants.cornerRadius
-        contentView.layer.shadowColor = UIColor(.ui.border).cgColor
-        contentView.layer.shadowOffset = .zero
-        contentView.layer.shadowOpacity = 1.0
-        contentView.layer.shadowRadius = 6
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.layer.bounds, cornerRadius: contentView.layer.cornerRadius).cgPath
-        contentView.layer.backgroundColor = UIColor(.ui.white1).cgColor
+        layer.shadowColor = UIColor(.ui.border).cgColor
+        layer.shadowOffset = .zero
+        layer.shadowOpacity = 1.0
+        layer.shadowRadius = 6
+        layer.shadowPath = UIBezierPath(roundedRect: layer.bounds, cornerRadius: layer.cornerRadius).cgPath
+        layer.backgroundColor = UIColor(.ui.white1).cgColor
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -4,12 +4,9 @@ import CoreData
 
 
 class HomeViewControllerSectionProvider {
-    
     struct Constants {
         static let margin: CGFloat = Margins.thin.rawValue
         static let sideMargin: CGFloat = Margins.normal.rawValue
-        static let carouselHeight: CGFloat = 146
-        static let heroHeight: CGFloat = 370
         static let spacing: CGFloat = 16
         static let sectionSpacing: CGFloat = 64
     }
@@ -38,11 +35,11 @@ class HomeViewControllerSectionProvider {
         guard numberOfRecentSavesItems > 0 else { return .empty() }
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfRecentSavesItems)), heightDimension: .absolute(Constants.carouselHeight))
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfRecentSavesItems)), heightDimension: .absolute(StyleConstants.groupHeight))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: numberOfRecentSavesItems)
         group.interItemSpacing = .fixed(16)
-        
+
         let sectionHeaderViewModel: SectionHeaderView.Model = .init(name: "Recent Saves", buttonTitle: "My List")
         let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: NSCollectionLayoutSize(
@@ -69,7 +66,16 @@ class HomeViewControllerSectionProvider {
         let heroItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1))
         let heroItem = NSCollectionLayoutItem(layoutSize: heroItemSize)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(Constants.heroHeight))
+        let slate = viewModel.slateModel(for: slateID)
+        let recommendations: [Recommendation] = slate?.recommendations?.compactMap { $0 as? Recommendation } ?? []
+        
+        guard !recommendations.isEmpty,
+              let hero = viewModel.recommendationHeroViewModel(for: recommendations[0].objectID) else {
+            return nil
+        }
+        
+        let heroHeight = RecommendationCell.fullHeight(viewModel: hero, availableWidth: width - (Constants.sideMargin * 2))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(heroHeight))
         let heroGroup = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [heroItem])
         let sectionHeaderViewModel = viewModel.sectionHeaderViewModel(for: .slateHero(slateID))
 
@@ -92,6 +98,7 @@ class HomeViewControllerSectionProvider {
         )
         return section
     }
+
     
     func carouselSection(for slateID: NSManagedObjectID, in viewModel: HomeViewModel, width: CGFloat) -> NSCollectionLayoutSection? {
         let numberOfCarouselItems = viewModel.numberOfCarouselItemsForSlate(with: slateID)
@@ -102,7 +109,7 @@ class HomeViewControllerSectionProvider {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfCarouselItems)), heightDimension: .absolute(Constants.carouselHeight))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.8*Double(numberOfCarouselItems)), heightDimension: .absolute(StyleConstants.groupHeight))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: numberOfCarouselItems)
         group.interItemSpacing = .fixed(16)
         

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -77,5 +77,5 @@ private extension Style {
     
     static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
         paragraph.with(lineBreakMode: .byTruncatingTail)
-    }
+    }.with(maxScaleSize: 22)
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -362,6 +362,13 @@ extension HomeViewModel {
     }
 }
 
+// MARK: - Slate Model
+extension HomeViewModel {
+    func slateModel(for objectID: NSManagedObjectID) -> Slate? {
+        return source.mainContext.object(with: objectID) as? Slate
+    }
+}
+
 // MARK: Recommendation View Model & Actions
 extension HomeViewModel {
     func numberOfCarouselItemsForSlate(with id: NSManagedObjectID) -> Int {
@@ -373,10 +380,14 @@ extension HomeViewModel {
 
     func recommendationHeroViewModel(
         for objectID: NSManagedObjectID,
-        at indexPath: IndexPath
+        at indexPath: IndexPath? = nil
     ) -> HomeRecommendationCellViewModel? {
         guard let recommendation = source.mainContext.object(with: objectID) as? Recommendation else {
             return nil
+        }
+        
+        guard let indexPath = indexPath else {
+            return HomeRecommendationCellViewModel(recommendation: recommendation)
         }
 
         return HomeRecommendationCellViewModel(

--- a/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
@@ -62,5 +62,5 @@ private extension Style {
     
     static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
         paragraph.with(lineBreakMode: .byTruncatingTail)
-    }
+    }.with(maxScaleSize: 22)
 }

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -57,5 +57,5 @@ private extension Style {
     
     static let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey5).with { paragraph in
         paragraph.with(lineBreakMode: .byTruncatingTail)
-    }
+    }.with(maxScaleSize: 22)
 }

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -16,7 +16,7 @@ protocol RecommendationCellViewModel {
 class RecommendationCell: UICollectionViewCell {
     private let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.layer.cornerRadius = 16
+        imageView.layer.cornerRadius = Constants.cornerRadius
         imageView.clipsToBounds = true
         imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         imageView.backgroundColor = UIColor(.ui.grey6)
@@ -25,20 +25,23 @@ class RecommendationCell: UICollectionViewCell {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = RecommendationCell.numberOfTitleLines
+        label.numberOfLines = Constants.numberOfTitleLines
         label.setContentCompressionResistancePriority(.required, for: .vertical)
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
     private let domainLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = RecommendationCell.numberOfSubtitleLines
+        label.numberOfLines = Constants.numberOfSubtitleLines
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
     private let timeToReadLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = RecommendationCell.numberOfSubtitleLines
+        label.numberOfLines = Constants.numberOfSubtitleLines
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
@@ -59,7 +62,7 @@ class RecommendationCell: UICollectionViewCell {
         let stack = UIStackView()
         stack.distribution = .fillProportionally
         stack.axis = .vertical
-        stack.spacing = 4
+        stack.spacing = Constants.stackSpacing
         return stack
     }()
 
@@ -76,32 +79,37 @@ class RecommendationCell: UICollectionViewCell {
         stack.axis = .horizontal
         return stack
     }()
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
         contentView.addSubview(thumbnailImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(bottomStack)
-        contentView.layoutMargins = Self.layoutMargins
+        contentView.layoutMargins = Constants.layoutMargins
 
         thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         bottomStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             thumbnailImageView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            thumbnailImageView.heightAnchor.constraint(equalTo: thumbnailImageView.widthAnchor, multiplier: Self.imageAspectRatio),
+            thumbnailImageView.heightAnchor.constraint(equalTo: thumbnailImageView.widthAnchor, multiplier: Constants.imageAspectRatio),
 
-            titleLabel.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: RecommendationCell.textStackTopMargin),
+            titleLabel.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: Constants.textStackTopMargin),
             titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             
             bottomStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             bottomStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             bottomStack.bottomAnchor.constraint(equalTo:  contentView.layoutMarginsGuide.bottomAnchor).with(priority: .required),
+            
+            contentView.topAnchor.constraint(equalTo:  topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo:  bottomAnchor),
         ])
 
         [UIView(), domainLabel, timeToReadLabel, UIView()].forEach(subtitleStack.addArrangedSubview)
@@ -134,12 +142,12 @@ class RecommendationCell: UICollectionViewCell {
         overflowButton.menu = UIMenu(children: menuActions)
         
         let imageWidth = bounds.width
-                - RecommendationCell.layoutMargins.left
-                - RecommendationCell.layoutMargins.right
+                - Constants.layoutMargins.left
+                - Constants.layoutMargins.right
 
         let imageSize = CGSize(
             width: imageWidth,
-            height: (imageWidth * RecommendationCell.imageAspectRatio).rounded(.down)
+            height: (imageWidth * Constants.imageAspectRatio).rounded(.down)
         )
         thumbnailImageView.kf.indicatorType = .activity
         thumbnailImageView.kf.setImage(
@@ -161,56 +169,63 @@ class RecommendationCell: UICollectionViewCell {
     }
     
     override func layoutSubviews() {
-        contentView.layer.masksToBounds = false
-        layer.cornerRadius = 16
-        contentView.layer.cornerRadius = 16
-        contentView.layer.shadowColor = UIColor(.ui.border).cgColor
-        contentView.layer.shadowOffset = .zero
-        contentView.layer.shadowOpacity = 1.0
-        contentView.layer.shadowRadius = 6
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: contentView.layer.bounds, cornerRadius: contentView.layer.cornerRadius).cgPath
-        contentView.layer.backgroundColor = UIColor(.ui.white1).cgColor
+        layer.masksToBounds = false
+        layer.cornerRadius = Constants.cornerRadius
+        layer.shadowColor = UIColor(.ui.border).cgColor
+        layer.shadowOffset = .zero
+        layer.shadowOpacity = 1.0
+        layer.shadowRadius = 6
+        layer.shadowPath = UIBezierPath(roundedRect: layer.bounds, cornerRadius: layer.cornerRadius).cgPath
+        layer.backgroundColor = UIColor(.ui.white1).cgColor
     }
 }
 
 extension RecommendationCell {
-    static let textStackTopMargin: CGFloat = 16
-    static let layoutMargins = UIEdgeInsets(top: 0, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
-    static let imageAspectRatio: CGFloat = 9/16
-    static let numberOfTitleLines = 3
-    static let numberOfSubtitleLines = 2
+    enum Constants {
+        static let cornerRadius: CGFloat = 16
+        static let textStackTopMargin: CGFloat = 16
+        static let imageAspectRatio: CGFloat = 9/16
+        static let numberOfTitleLines = 3
+        static let numberOfSubtitleLines = 2
+        static let numberOfTimeToReadLines = 1
+        static let layoutMargins = UIEdgeInsets(top: 0, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
+        static let stackSpacing: CGFloat = 4
+        static let textStackBottomMargin: CGFloat = 12
+    }
 }
 
 extension RecommendationCell {
-    static func fullHeight(viewModel: RecommendationCellViewModel, availableWidth: CGFloat) -> CGFloat {
-        let adjustedWidth = availableWidth - Self.layoutMargins.left - Self.layoutMargins.right
-        let imageHeight = (adjustedWidth * Self.imageAspectRatio).rounded(.up)
+    static func fullHeight(viewModel: HomeRecommendationCellViewModel, availableWidth: CGFloat) -> CGFloat {
+        let adjustedWidth = availableWidth - Constants.layoutMargins.left - Constants.layoutMargins.right
+        let imageHeight = (availableWidth * Constants.imageAspectRatio).rounded(.up)
 
         let titleHeight = adjustedHeight(
             of: viewModel.attributedTitle,
             availableWidth: adjustedWidth,
-            numberOfLines: numberOfTitleLines
+            numberOfLines: Constants.numberOfTitleLines
         )
         
         let domainHeight = adjustedHeight(
             of: viewModel.attributedDomain,
-            availableWidth: adjustedWidth,
-            numberOfLines: numberOfTitleLines
+            availableWidth: adjustedWidth / 2,
+            numberOfLines: Constants.numberOfSubtitleLines
         )
         
         let timeToReadHeight = adjustedHeight(
             of: viewModel.attributedTimeToRead,
-            availableWidth: adjustedWidth,
-            numberOfLines: numberOfTitleLines
+            availableWidth: adjustedWidth / 2,
+            numberOfLines: Constants.numberOfTimeToReadLines
         )
-
-        return Self.layoutMargins.top
+        
+        let stackHeight = Constants.stackSpacing + domainHeight + Constants.stackSpacing + timeToReadHeight + Constants.stackSpacing
+        
+        return Constants.layoutMargins.top
         + imageHeight
-        + textStackTopMargin
+        + Constants.textStackTopMargin
         + titleHeight
-        + domainHeight
-        + timeToReadHeight
-        + Self.layoutMargins.bottom
+        + Constants.textStackBottomMargin
+        + stackHeight
+        + Constants.layoutMargins.bottom
     }
 
     static func height(of attributedString: NSAttributedString, width: CGFloat, numberOfLines: Int) -> CGFloat {

--- a/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
@@ -3,8 +3,8 @@ import Textile
 
 
 private extension Style {
-    static let saveTitle: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium)
-    static let saveTitleHighlighted: Style = .header.sansSerif.p4.with(color: .ui.grey1).with(weight: .medium)
+    static let saveTitle: Style = .header.sansSerif.p4.with(color: .ui.grey5).with(weight: .medium).with(maxScaleSize: 17)
+    static let saveTitleHighlighted: Style = .header.sansSerif.p4.with(color: .ui.grey1).with(weight: .medium).with(maxScaleSize: 17)
 }
 
 class RecommendationSaveButton: UIButton {

--- a/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
@@ -10,8 +10,8 @@ class SectionHeaderView: UICollectionReusableView {
     private let headerLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.textColor = UIColor(.ui.lapis1)
         label.lineBreakMode = .byWordWrapping
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -30,7 +30,6 @@ class SectionHeaderView: UICollectionReusableView {
         button.accessibilityIdentifier = "see-all-button"
         button.isHidden = true
         button.setContentHuggingPriority(.required, for: .horizontal)
-        
         return button
     }()
     
@@ -103,5 +102,5 @@ extension SectionHeaderView {
 
 private extension Style {
     static let sectionHeader: Style = .header.sansSerif.h6.with(weight: .semibold)
-    static let buttonText: Style = .header.sansSerif.p4.with(color: .ui.lapis1)
+    static let buttonText: Style = .header.sansSerif.p4.with(color: .ui.lapis1).with(maxScaleSize: 22)
 }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -127,10 +127,14 @@ extension SlateDetailViewModel {
 extension SlateDetailViewModel {
     func recommendationViewModel(
         for objectID: NSManagedObjectID,
-        at indexPath: IndexPath
+        at indexPath: IndexPath? = nil
     ) -> HomeRecommendationCellViewModel? {
         guard let recommendation = source.mainContext.object(with: objectID) as? Recommendation else {
             return nil
+        }
+        
+        guard let indexPath = indexPath else {
+            return HomeRecommendationCellViewModel(recommendation: recommendation)
         }
 
         return HomeRecommendationCellViewModel(

--- a/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
@@ -18,6 +18,7 @@ class TopicChipCell: UICollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -39,14 +39,14 @@ class ItemsListItemCell: UICollectionViewListCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = Constants.maxTitleLines
-
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
     private let detailLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = Constants.maxDetailLines
-
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 

--- a/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
@@ -79,19 +79,6 @@ class MyListTitleView: UIView {
         stackView.setNeedsLayout()
         stackView.layoutIfNeeded()
     }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        buttons.forEach { button in
-            button.layer.cornerRadius = 16
-            if button.isSelected {
-                button.configuration?.background.backgroundColor = UIColor(.ui.teal6)
-            } else {
-                button.configuration?.background.backgroundColor = .clear
-            }
-        }
-    }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not implemented")
@@ -108,12 +95,15 @@ private class MyListSelectionButton: UIButton {
         accessibilityLabel = selection.title
 
         configuration = UIButton.Configuration.plain()
+        configuration?.background.cornerRadius = 16
+        configuration?.background.backgroundColorTransformer = UIConfigurationColorTransformer { [weak self] _ in
+            guard self?.isSelected ?? false else { return .clear }
+            return UIColor(.ui.teal6)
+        }
+
         configuration?.image = selection.image
         configuration?.imagePadding = 8
-        configuration?.background = .clear()
-        configuration?.background.backgroundColor = .clear
-        configuration?.background.backgroundColorTransformer = .none
-
+        
         addAction(action, for: .primaryActionTriggered)
         clipsToBounds = true
     }

--- a/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListTitleView.swift
@@ -14,14 +14,6 @@ class MyListTitleView: UIView {
         stackView.axis = .horizontal
         return stackView
     }()
-    
-    private var selection: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor(.ui.teal6)
-
-        return view
-    }()
-
     private let selections: [MyListSelection]
     private var buttons: [UIButton] = []
 
@@ -31,8 +23,6 @@ class MyListTitleView: UIView {
         super.init(frame: .zero)
 
         accessibilityIdentifier = "my-list-selection-switcher"
-
-        addSubview(selection)
         addSubview(stackView)
         
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -88,18 +78,19 @@ class MyListTitleView: UIView {
 
         stackView.setNeedsLayout()
         stackView.layoutIfNeeded()
-        selection.frame = selectedButton.frame
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-
-        if selection.frame == .zero,
-           let selectedButton = buttons.first(where: \.isSelected) {
-            selection.frame = selectedButton.frame
+        
+        buttons.forEach { button in
+            button.layer.cornerRadius = 16
+            if button.isSelected {
+                button.configuration?.background.backgroundColor = UIColor(.ui.teal6)
+            } else {
+                button.configuration?.background.backgroundColor = .clear
+            }
         }
-
-        selection.layer.cornerRadius = selection.frame.height / 2
     }
     
     required init?(coder: NSCoder) {

--- a/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
+++ b/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
@@ -8,7 +8,7 @@ enum Margins: CGFloat {
   case wide = 32
 }
 
-struct StyleConstants {
+enum StyleConstants {
     static let thumbnailSize = CGSize(width: 90, height: 60)
     static let carouselHeight: CGFloat = 146
     static var groupHeight: CGFloat {

--- a/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
+++ b/PocketKit/Sources/PocketKit/Style/StyleConstants.swift
@@ -8,6 +8,10 @@ enum Margins: CGFloat {
   case wide = 32
 }
 
-enum StyleConstants {
+struct StyleConstants {
     static let thumbnailSize = CGSize(width: 90, height: 60)
+    static let carouselHeight: CGFloat = 146
+    static var groupHeight: CGFloat {
+        return min(UIFontMetrics.default.scaledValue(for: carouselHeight), 300)
+    }
 }

--- a/PocketKit/Sources/Textile/Style/Style+UIKit.swift
+++ b/PocketKit/Sources/Textile/Style/Style+UIKit.swift
@@ -136,13 +136,17 @@ extension NSParagraphStyle {
 
 public extension Style {
     var textAttributes: [NSAttributedString.Key: Any] {
+        var font = UIFontMetrics.default.scaledFont(for: UIFont(fontDescriptor))
+        if let maxScaleSize = maxScaleSize {
+            font = UIFontMetrics.default.scaledFont(for: UIFont(fontDescriptor), maximumPointSize: maxScaleSize)
+        }
         var attributes: [NSAttributedString.Key: Any] = [
             .style: self,
-            .font: UIFontMetrics.default.scaledFont(for: UIFont(fontDescriptor)),
+            .font: font,
             .paragraphStyle: NSParagraphStyle.from(paragraph),
             .foregroundColor: UIColor(colorAsset),
         ]
-
+        
         if let underline = NSUnderlineStyle(underlineStyle) {
             attributes[.underlineStyle] = underline.rawValue
         }

--- a/PocketKit/Sources/Textile/Style/Style.swift
+++ b/PocketKit/Sources/Textile/Style/Style.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 public struct Style {
     let fontDescriptor: FontDescriptor
+    let maxScaleSize: CGFloat?
     let colorAsset: ColorAsset
     let underlineStyle: UnderlineStyle
     let strike: Strike
@@ -16,6 +17,7 @@ public struct Style {
 
     init(
         fontDescriptor: FontDescriptor,
+        maxScaleSize: CGFloat? = nil,
         color: ColorAsset = .ui.grey1,
         underlineStyle: UnderlineStyle = .none,
         strike: Strike = .none,
@@ -23,6 +25,7 @@ public struct Style {
         backgroundColor: ColorAsset? = nil
     ) {
         self.fontDescriptor = fontDescriptor
+        self.maxScaleSize = maxScaleSize
         self.colorAsset = color
         self.underlineStyle = underlineStyle
         self.strike = strike
@@ -56,6 +59,18 @@ public struct Style {
     public func with(size: FontDescriptor.Size) -> Style {
         Style(
             fontDescriptor: fontDescriptor.with(size: size),
+            color: colorAsset,
+            underlineStyle: underlineStyle,
+            strike: strike,
+            paragraph: paragraph,
+            backgroundColor: backgroundColorAsset
+        )
+    }
+    
+    public func with(maxScaleSize: CGFloat) -> Style {
+        Style(
+            fontDescriptor: fontDescriptor,
+            maxScaleSize: maxScaleSize,
             color: colorAsset,
             underlineStyle: underlineStyle,
             strike: strike,


### PR DESCRIPTION
## Summary
Allow users to be able to read and view items in their preferred font size for Home, Slate Detail, My List / Archive

## References 
IN-723

## Implementation Details
Home
* Carousel cells are using a static height of 146, which gets scaled using `UIFontMetrics.default.scaledValue`, but because of additional white space for larger fonts, we cap this value to 300
* Hero Recommendation cells are configured based on the height calculations of the margins and views within the cell
* Set border on the view itself vs. content view because the content view was not resizing properly with the height change of the cell
* Added `maxScaleSize` to our Style extension as some labels we don't want to scale larger than a certain size (i.e. time to read, see all button, save)

SlateDetail
* Uses similar height calculation for a single card recommendation as Home 
* Difference is that we need to calculate the total height based on all the items (which was implemented previously)

MyList / Archive
* Remove `selection` view and configure background color on `button` so that view adjusts itself properly when preferred font changes
* Set `label.adjustsFontForContentSizeCategory = true` as text was not updating when switching between sizes

## Test Steps
- [ ] Given that I change my font settings to use small font, when I navigate to the app, then I should be able to have a good user experience in that size.
- [ ] Given that I change my font settings to use extra large font, when I navigate to the app, then I should be able to have a good user experience in that size.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPhone 8 - 2022-08-02 at 12 22 08](https://user-images.githubusercontent.com/6743397/182424354-848ea3f4-ac07-4afc-b597-e47c1e62e41c.png)
![Simulator Screen Shot - iPhone 8 - 2022-08-02 at 12 22 28](https://user-images.githubusercontent.com/6743397/182424425-d41a3505-2e49-4092-9bcd-76bf93e548ba.png)
