### PR TITLE
IN-672: Add Loading State to Home / Slate Detail View

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -109,10 +109,7 @@ class HomeViewModel {
         self.tracker = tracker
 
         self.snapshot = {
-            var snapshot = Snapshot()
-            snapshot.appendSections([.loading])
-            snapshot.appendItems([.loading], toSection: .loading)
-            return snapshot
+            return Self.loadingSnapshot()
         }()
 
         NotificationCenter.default.publisher(
@@ -129,7 +126,9 @@ class HomeViewModel {
 
     func fetch() {
         do {
-            snapshot = try rebuildSnapshot()
+            let snapshot = try rebuildSnapshot()
+            guard snapshot.numberOfSections != 0 else { return }
+            self.snapshot = snapshot
         } catch {
             print(error)
         }
@@ -335,6 +334,16 @@ extension HomeViewModel {
         case .loading, .slateCarousel:
             return nil
         }
+    }
+}
+
+// MARK: - Loading Section
+extension HomeViewModel {
+    static func loadingSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.loading])
+        snapshot.appendItems([.loading], toSection: .loading)
+        return snapshot
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -49,7 +49,9 @@ class SlateDetailViewModel {
     }
 
     func fetch() {
-        snapshot = buildSnapshot()
+        let snapshot = buildSnapshot()
+        guard snapshot.numberOfItems != 0 else { return }
+        self.snapshot = snapshot
     }
 
     func refresh(_ completion: @escaping () -> Void) {

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -50,18 +50,18 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 1)
     }
 
-    func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsEmptySnapshot() {
+    func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsLoadingSnapshot() {
         let viewModel = subject()
 
-        let receivedEmptySnapshot = expectation(description: "receivedEmptySnapshot")
-        viewModel.$snapshot.dropFirst().first().sink { snapshot in
-            defer { receivedEmptySnapshot.fulfill() }
-            XCTAssertEqual(snapshot.sectionIdentifiers, [])
+        let receivedLoadingSnapshot = expectation(description: "receivedLoadingSnapshot")
+        viewModel.$snapshot.sink { snapshot in
+            defer { receivedLoadingSnapshot.fulfill() }
+            XCTAssertEqual(snapshot.sectionIdentifiers, [.loading])
         }.store(in: &subscriptions)
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 1)
+        wait(for: [receivedLoadingSnapshot], timeout: 1)
     }
 
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsAvailable_sendsSnapshotWithSlates() throws {

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -51,6 +51,25 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [fetchExpectation], timeout: 1)
         XCTAssertEqual(source.fetchSlateCall(at: 0)?.identifier, "abcde")
     }
+    
+    
+    func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsLoadingSnapshot() throws {
+        let slate: Slate = try space.createSlate(
+            remoteID: "slate-1",
+            recommendations: []
+        )
+        let viewModel = subject(slate: slate)
+    
+        let receivedLoadingSnapshot = expectation(description: "receivedLoadingSnapshot")
+        viewModel.$snapshot.sink { snapshot in
+            defer { receivedLoadingSnapshot.fulfill() }
+            XCTAssertEqual(snapshot.sectionIdentifiers, [.loading])
+        }.store(in: &subscriptions)
+
+        viewModel.fetch()
+
+        wait(for: [receivedLoadingSnapshot], timeout: 1)
+    }
 
     func test_fetch_sendsSnapshotWithItemForEachRecommendation() throws {
         let recommendations: [Recommendation] = [


### PR DESCRIPTION
## Summary
Add Loading Spinner to Home + Slate Detail

## References 
IN-672, IN-692

## Implementation Details
Check if the snapshot has any sections, if not, then show loading state via `loadingSnapshot`

## Test Steps
- [x] Given I have opened the Pocket app,
when I view the Home tab and data has not yet been loaded,
then I should see a spinner in the middle of the screen.

- [x] Given I viewed the Home tab,
when data has been loaded,
then the spinner should disappear and the Home content should be visible.

- [x] Given I have opened the Pocket app,
when I view the Home tab and tap on a slate topic and data has not yet been loaded,
then I should see a spinner in the middle of the screen.

- [x] Given I viewed the Home tab and viewing a slate topic,
when data has been loaded,
then the spinner should disappear and the Home content should be visible.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPhone 12 mini - 2022-08-10 at 15 01 04](https://user-images.githubusercontent.com/6743397/183995879-8a1163cd-23e9-476b-9a83-0bdb243fc6ea.png)

