### PR TITLE
Refactor coordinators and properly unwind navigational view model properties

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -32,6 +32,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     func showWebReader()
     func fetchDetailsIfNeeded()
     func externalActions(for url: URL) -> [ItemAction]
+    func clearPresentedWebReaderURL()
 }
 
 // MARK: - ReadableViewControllerDelegate

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -120,14 +120,6 @@ class RecommendationViewModel: ReadableViewModel {
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
     }
-
-    func clearPresentedWebReaderURL() {
-        presentedWebReaderURL = nil
-    }
-
-    func clearIsPresentingReaderSettings() {
-        isPresentingReaderSettings = false
-    }
 }
 
 extension RecommendationViewModel {
@@ -236,5 +228,23 @@ extension RecommendationViewModel {
 
     private func openExternalURL(_ url: URL) {
         presentedWebReaderURL = url
+    }
+}
+
+extension RecommendationViewModel {
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+    }
+
+    func clearIsPresentingReaderSettings() {
+        isPresentingReaderSettings = false
+    }
+
+    func clearSharedActivity() {
+        sharedActivity = nil
+    }
+
+    func clearSelectedRecommendationToReport() {
+        selectedRecommendationToReport = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -120,6 +120,14 @@ class RecommendationViewModel: ReadableViewModel {
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
     }
+
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+    }
+
+    func clearIsPresentingReaderSettings() {
+        isPresentingReaderSettings = false
+    }
 }
 
 extension RecommendationViewModel {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -116,6 +116,18 @@ class SavedItemViewModel: ReadableViewModel {
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
     }
+
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+    }
+
+    func clearIsPresentingReaderSettings() {
+        isPresentingReaderSettings = false
+    }
+
+    func clearSharedActivity() {
+        sharedActivity = nil
+    }
 }
 
 extension SavedItemViewModel {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -116,18 +116,6 @@ class SavedItemViewModel: ReadableViewModel {
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
     }
-
-    func clearPresentedWebReaderURL() {
-        presentedWebReaderURL = nil
-    }
-
-    func clearIsPresentingReaderSettings() {
-        isPresentingReaderSettings = false
-    }
-
-    func clearSharedActivity() {
-        sharedActivity = nil
-    }
 }
 
 extension SavedItemViewModel {
@@ -185,5 +173,19 @@ extension SavedItemViewModel {
 
     private func openExternalURL(_ url: URL) {
         presentedWebReaderURL = url
+    }
+}
+
+extension SavedItemViewModel {
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+    }
+
+    func clearIsPresentingReaderSettings() {
+        isPresentingReaderSettings = false
+    }
+
+    func clearSharedActivity() {
+        sharedActivity = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -48,7 +48,7 @@ class CompactHomeCoordinator: NSObject {
         navigationController.popToRootViewController(animated: false)
         isResetting = true
 
-        model.$selectedReadableType.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+        model.$selectedReadableType.sink { [weak self] readableType in
             switch readableType {
             case .savedItem(let viewModel):
                 self?.show(viewModel)
@@ -59,29 +59,29 @@ class CompactHomeCoordinator: NSObject {
             }
         }.store(in: &subscriptions)
 
-        model.$selectedSlateDetailViewModel.receive(on: DispatchQueue.main).sink { [weak self] viewModel in
+        model.$selectedSlateDetailViewModel.sink { [weak self] viewModel in
             self?.show(viewModel)
         }.store(in: &subscriptions)
 
-        model.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
+        model.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation) {
                 self?.model.selectedRecommendationToReport = nil
             }
         }.store(in: &subscriptions)
 
-        model.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        model.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &subscriptions)
         
-        model.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
         
-        model.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.$tappedSeeAll.dropFirst().receive(on: DispatchQueue.main).sink { [weak self] seeAll in
+        model.$tappedSeeAll.dropFirst().sink { [weak self] seeAll in
             self?.show(seeAll)
         }.store(in: &subscriptions)
 
@@ -110,17 +110,17 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
-        viewModel.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
+        viewModel.$selectedReadableViewModel.sink { [weak self] readable in
             self?.show(readable)
         }.store(in: &slateDetailSubscriptions)
 
-        viewModel.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
+        viewModel.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation) {
                 viewModel.selectedRecommendationToReport = nil
             }
         }.store(in: &slateDetailSubscriptions)
 
-        viewModel.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        viewModel.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &subscriptions)
     }
@@ -136,23 +136,23 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
-        recommendation.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        recommendation.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        recommendation.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        recommendation.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
+        recommendation.$isPresentingReaderSettings.sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: recommendation)
         }.store(in: &readerSubscriptions)
 
-        recommendation.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] selected in
+        recommendation.$selectedRecommendationToReport.sink { [weak self] selected in
             self?.report(selected) {
                 recommendation.selectedRecommendationToReport = nil
             }
@@ -165,19 +165,19 @@ class CompactHomeCoordinator: NSObject {
             animated: !isResetting
         )
 
-        savedItem.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        savedItem.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readerSubscriptions)
 
-        savedItem.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        savedItem.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readerSubscriptions)
 
-        savedItem.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        savedItem.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readerSubscriptions)
 
-        savedItem.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
+        savedItem.$isPresentingReaderSettings.sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: savedItem)
         }.store(in: &readerSubscriptions)
     }

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -26,11 +26,9 @@ class CompactHomeCoordinator: NSObject {
 
     // only necessary for creating nested view controller
     // should use a factory instead
-    private let source: Source
     private let tracker: Tracker
 
-    init(source: Source, tracker: Tracker, model: HomeViewModel) {
-        self.source = source
+    init(tracker: Tracker, model: HomeViewModel) {
         self.tracker = tracker
         self.model = model
 

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -34,7 +34,7 @@ class CompactHomeCoordinator: NSObject {
         self.tracker = tracker
         self.model = model
 
-        homeViewController = HomeViewController(source: source, tracker: tracker, model: model)
+        homeViewController = HomeViewController(model: model)
         navigationController = UINavigationController(rootViewController: homeViewController)
 
         super.init()

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -257,7 +257,7 @@ extension CompactHomeCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if viewController === homeViewController {
             slateDetailSubscriptions = []
-            model.tappedSeeAll = nil
+            model.clearTappedSeeAll()
             model.clearSelectedItem()
         }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -11,8 +11,6 @@ import Lottie
 
 
 class HomeViewController: UIViewController {
-    private let source: Sync.Source
-    private let tracker: Tracker
     private let model: HomeViewModel
     private let sectionProvider: HomeViewControllerSectionProvider
     private var subscriptions: [AnyCancellable] = []
@@ -55,9 +53,7 @@ class HomeViewController: UIViewController {
     private var overscrollTopConstraint: NSLayoutConstraint? = nil
     private var overscrollOffset = 0
 
-    init(source: Sync.Source, tracker: Tracker, model: HomeViewModel) {
-        self.source = source
-        self.tracker = tracker
+    init(model: HomeViewModel) {
         self.model = model
 
         self.sectionProvider = HomeViewControllerSectionProvider()

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -8,11 +8,65 @@ import Analytics
 enum ReadableType {
     case recommendation(RecommendationViewModel)
     case savedItem(SavedItemViewModel)
+
+    func clearIsPresentingReaderSettings() {
+        switch self {
+        case .recommendation(let recommendationViewModel):
+            recommendationViewModel.clearIsPresentingReaderSettings()
+        case .savedItem(let savedItemViewModel):
+            savedItemViewModel.clearIsPresentingReaderSettings()
+        }
+    }
 }
 
 enum SeeAll {
     case myList
     case slate(SlateDetailViewModel)
+
+    func clearRecommendationToReport() {
+        switch self {
+        case .myList:
+            break
+        case .slate(let viewModel):
+            viewModel.selectedRecommendationToReport = nil
+        }
+    }
+
+    func clearPresentedWebReaderURL() {
+        switch self {
+        case .myList:
+            break
+        case .slate(let viewModel):
+            viewModel.presentedWebReaderURL = nil
+        }
+    }
+
+    func clearSharedActivity() {
+        switch self {
+        case .myList:
+            break
+        case .slate(let viewModel):
+            viewModel.selectedReadableViewModel?.sharedActivity = nil
+        }
+    }
+
+    func clearIsPresentingReaderSettings() {
+        switch self {
+        case .myList:
+            break
+        case .slate(let viewModel):
+            viewModel.clearIsPresentingReaderSettings()
+        }
+    }
+
+    func clearSelectedItem() {
+        switch self {
+        case .myList:
+            break
+        case .slate(let viewModel):
+            viewModel.clearSelectedItem()
+        }
+    }
 }
 
 class HomeViewModel {
@@ -35,9 +89,6 @@ class HomeViewModel {
 
     @Published
     var selectedRecommendationToReport: Recommendation? = nil
-
-    @Published
-    var selectedSlateDetailViewModel: SlateDetailViewModel? = nil
 
     @Published
     var presentedWebReaderURL: URL? = nil
@@ -89,6 +140,31 @@ class HomeViewModel {
             try await source.fetchSlateLineup(Self.lineupIdentifier)
             completion()
         }
+    }
+
+    func clearRecommendationToReport() {
+        selectedRecommendationToReport = nil
+        tappedSeeAll?.clearRecommendationToReport()
+    }
+
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+        tappedSeeAll?.clearPresentedWebReaderURL()
+    }
+
+    func clearSharedActivity() {
+        sharedActivity = nil
+        tappedSeeAll?.clearSharedActivity()
+    }
+
+    func clearIsPresentingReaderSettings() {
+        selectedReadableType?.clearIsPresentingReaderSettings()
+        tappedSeeAll?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        selectedReadableType = nil
+        tappedSeeAll?.clearSelectedItem()
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -28,7 +28,7 @@ enum SeeAll {
         case .myList:
             break
         case .slate(let viewModel):
-            viewModel.selectedRecommendationToReport = nil
+            viewModel.clearRecommendationToReport()
         }
     }
 
@@ -37,7 +37,7 @@ enum SeeAll {
         case .myList:
             break
         case .slate(let viewModel):
-            viewModel.presentedWebReaderURL = nil
+            viewModel.clearPresentedWebReaderURL()
         }
     }
 
@@ -46,7 +46,7 @@ enum SeeAll {
         case .myList:
             break
         case .slate(let viewModel):
-            viewModel.selectedReadableViewModel?.sharedActivity = nil
+            viewModel.clearSharedActivity()
         }
     }
 
@@ -140,31 +140,6 @@ class HomeViewModel {
             try await source.fetchSlateLineup(Self.lineupIdentifier)
             completion()
         }
-    }
-
-    func clearRecommendationToReport() {
-        selectedRecommendationToReport = nil
-        tappedSeeAll?.clearRecommendationToReport()
-    }
-
-    func clearPresentedWebReaderURL() {
-        presentedWebReaderURL = nil
-        tappedSeeAll?.clearPresentedWebReaderURL()
-    }
-
-    func clearSharedActivity() {
-        sharedActivity = nil
-        tappedSeeAll?.clearSharedActivity()
-    }
-
-    func clearIsPresentingReaderSettings() {
-        selectedReadableType?.clearIsPresentingReaderSettings()
-        tappedSeeAll?.clearIsPresentingReaderSettings()
-    }
-
-    func clearSelectedItem() {
-        selectedReadableType = nil
-        tappedSeeAll?.clearSelectedItem()
     }
 }
 
@@ -612,5 +587,36 @@ extension HomeViewModel {
         case recentSaves(NSManagedObjectID)
         case recommendationHero(NSManagedObjectID)
         case recommendationCarousel(NSManagedObjectID)
+    }
+}
+
+extension HomeViewModel {
+    func clearRecommendationToReport() {
+        tappedSeeAll?.clearRecommendationToReport()
+        selectedRecommendationToReport = nil
+    }
+
+    func clearPresentedWebReaderURL() {
+        tappedSeeAll?.clearPresentedWebReaderURL()
+        presentedWebReaderURL = nil
+    }
+
+    func clearSharedActivity() {
+        tappedSeeAll?.clearSharedActivity()
+        sharedActivity = nil
+    }
+
+    func clearIsPresentingReaderSettings() {
+        selectedReadableType?.clearIsPresentingReaderSettings()
+        tappedSeeAll?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        tappedSeeAll?.clearSelectedItem()
+        selectedReadableType = nil
+    }
+
+    func clearTappedSeeAll() {
+        tappedSeeAll = nil
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -51,6 +51,7 @@ class SlateDetailViewController: UIViewController {
 
         view.accessibilityIdentifier = "slate-detail"
         navigationItem.title = model.slateName
+        hidesBottomBarWhenPushed = true
         
         let largeTitleTwoLineMode = "_largeTitleTwoLineMode"
         if class_getProperty(UINavigationItem.self, largeTitleTwoLineMode) != nil {

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -78,6 +78,14 @@ class SlateDetailViewModel {
             )
         }
     }
+
+    func clearIsPresentingReaderSettings() {
+        selectedReadableViewModel?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        selectedReadableViewModel = nil
+    }
 }
 
 // MARK: - Cell Selection

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -78,14 +78,6 @@ class SlateDetailViewModel {
             )
         }
     }
-
-    func clearIsPresentingReaderSettings() {
-        selectedReadableViewModel?.clearIsPresentingReaderSettings()
-    }
-
-    func clearSelectedItem() {
-        selectedReadableViewModel = nil
-    }
 }
 
 // MARK: - Cell Selection
@@ -292,5 +284,29 @@ extension SlateDetailViewModel {
     enum Cell: Hashable {
         case loading
         case recommendation(NSManagedObjectID)
+    }
+}
+
+extension SlateDetailViewModel {
+    func clearIsPresentingReaderSettings() {
+        selectedReadableViewModel?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        selectedReadableViewModel = nil
+    }
+
+    func clearSharedActivity() {
+        selectedReadableViewModel?.clearSharedActivity()
+    }
+
+    func clearPresentedWebReaderURL() {
+        presentedWebReaderURL = nil
+        selectedReadableViewModel?.clearPresentedWebReaderURL()
+    }
+
+    func clearRecommendationToReport() {
+        selectedRecommendationToReport = nil
+        selectedReadableViewModel?.clearSelectedRecommendationToReport()
     }
 }

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutCoordinator.swift
@@ -17,7 +17,7 @@ class LoggedOutCoordinator: NSObject {
         super.init()
 
         self.viewModel.contextProvider = self
-        self.viewModel.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        self.viewModel.$presentedAlert.sink { [weak self] alert in
             guard let alert = alert else {
                 return
             }

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -34,7 +34,7 @@ class CompactMainCoordinator: NSObject {
         myList.viewController.tabBarItem.image = UIImage(asset: .tabMyListDeselected)
         myList.viewController.tabBarItem.selectedImage = UIImage(asset: .tabMyListSelected)
 
-        home = CompactHomeCoordinator(source: source, tracker: tracker, model: model.home)
+        home = CompactHomeCoordinator(tracker: tracker, model: model.home)
         home.viewController.tabBarItem.accessibilityIdentifier = "home-tab-bar-button"
         home.viewController.tabBarItem.title = "Home"
         home.viewController.tabBarItem.image = UIImage(asset: .tabHomeDeselected)

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -61,7 +61,7 @@ class CompactMainCoordinator: NSObject {
         tabBarController.delegate = self
         home.delegate = self
 
-        collapsedSubscription = model.$isCollapsed.receive(on: DispatchQueue.main).sink { [weak self] isCollapsed in
+        collapsedSubscription = model.$isCollapsed.sink { [weak self] isCollapsed in
             if isCollapsed {
                 self?.observeModelChanges()
             } else {

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -21,11 +21,7 @@ class CompactMainCoordinator: NSObject {
     private var subscriptions: [AnyCancellable] = []
     private var collapsedSubscription: AnyCancellable?
 
-    init(
-        source: Source,
-        tracker: Tracker,
-        model: MainViewModel
-    ) {
+    init(tracker: Tracker, model: MainViewModel) {
         self.model = model
 
         myList = CompactMyListContainerCoordinator(model: model.myList)

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -27,7 +27,6 @@ class MainCoordinator {
         )
 
         regular = RegularMainCoordinator(
-            source: source,
             tracker: tracker,
             model: model
         )

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -20,16 +20,8 @@ class MainCoordinator {
         source: Source,
         tracker: Tracker
     ) {
-        compact = CompactMainCoordinator(
-            source: source,
-            tracker: tracker,
-            model: model
-        )
-
-        regular = RegularMainCoordinator(
-            tracker: tracker,
-            model: model
-        )
+        compact = CompactMainCoordinator(tracker: tracker, model: model)
+        regular = RegularMainCoordinator(tracker: tracker, model: model)
 
         regular.setCompactViewController(compact.viewController)
         

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -55,4 +55,23 @@ class MainViewModel: ObservableObject {
             return self
         }
     }
+
+    func clearRecommendationToReport() {
+        home.clearRecommendationToReport()
+    }
+
+    func clearSharedActivity() {
+        home.clearSharedActivity()
+        myList.clearSharedActivity()
+    }
+
+    func clearIsPresentingReaderSettings() {
+        home.clearIsPresentingReaderSettings()
+        myList.clearIsPresentingReaderSettings()
+    }
+
+    func clearPresentedWebReaderURL() {
+        home.clearPresentedWebReaderURL()
+        myList.clearPresentedWebReaderURL()
+    }
 }

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -146,7 +146,7 @@ extension RegularHomeCoordinator: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if viewController === homeViewController {
             slateDetailSubscriptions = []
-            model.tappedSeeAll = nil
+            model.clearTappedSeeAll()
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -1,0 +1,152 @@
+import UIKit
+import Combine
+import SafariServices
+import Analytics
+import Sync
+
+
+protocol RegularHomeCoordinatorDelegate: ModalContentPresenting {
+    func homeCoordinatorDidSelectMyList(_ coordinator: RegularHomeCoordinator)
+    func homeCoordinator(_ coordinator: RegularHomeCoordinator, didSelectReadableType readableType: ReadableType?)
+    func homeCoordinator(_ coordinator: RegularHomeCoordinator, didSelectRecommendation recommendation: RecommendationViewModel?)
+}
+
+
+class RegularHomeCoordinator: NSObject {
+    weak var delegate: RegularHomeCoordinatorDelegate?
+
+    var viewController: UIViewController {
+        navigationController
+    }
+
+    private let model: HomeViewModel
+    private let tracker: Tracker
+    private let navigationController: UINavigationController
+    private let homeViewController: HomeViewController
+    private var subscriptions: [AnyCancellable] = []
+    private var slateDetailSubscriptions: [AnyCancellable] = []
+    private var isResetting: Bool = false
+
+    init(model: HomeViewModel, tracker: Tracker) {
+        self.model = model
+        self.tracker = tracker
+
+        homeViewController = HomeViewController(model: model)
+        navigationController = UINavigationController(rootViewController: homeViewController)
+
+        super.init()
+
+        navigationController.navigationBar.prefersLargeTitles = true
+        navigationController.navigationBar.barTintColor = UIColor(.ui.white1)
+        navigationController.navigationBar.tintColor = UIColor(.ui.grey1)
+        navigationController.delegate = self
+    }
+
+    func stopObservingModelChanges() {
+        subscriptions = []
+        slateDetailSubscriptions = []
+    }
+
+    func observeModelChanges() {
+        isResetting = true
+
+        navigationController.popToRootViewController(animated: !isResetting)
+
+        model.$selectedReadableType.sink { [weak self] readableType in
+            self?.show(readableType)
+        }.store(in: &subscriptions)
+
+        model.$selectedRecommendationToReport.sink { [weak self] recommendation in
+            self?.report(recommendation)
+        }.store(in: &subscriptions)
+
+        model.$presentedWebReaderURL.sink { [weak self] url in
+            self?.present(url)
+        }.store(in: &subscriptions)
+
+        model.$presentedAlert.sink { [weak self] alert in
+            self?.present(alert)
+        }.store(in: &subscriptions)
+
+        model.$sharedActivity.sink { [weak self] activity in
+            self?.share(activity)
+        }.store(in: &subscriptions)
+
+        model.$tappedSeeAll.sink { [weak self] seeAll in
+            self?.show(seeAll)
+        }.store(in: &subscriptions)
+
+        isResetting = false
+    }
+}
+
+// MARK: - Showing slate detail
+extension RegularHomeCoordinator {
+    private func show(_ seeAll: SeeAll?) {
+        switch seeAll {
+        case .slate(let slateDetail):
+            show(slateDetail)
+        case .myList:
+            delegate?.homeCoordinatorDidSelectMyList(self)
+        case .none:
+            break
+        }
+    }
+
+    private func show(_ slate: SlateDetailViewModel) {
+        slate.$selectedReadableViewModel.sink { [weak self] readable in
+            self?.show(readable)
+        }.store(in: &slateDetailSubscriptions)
+
+        slate.$presentedWebReaderURL.sink { [weak self] url in
+            self?.present(url)
+        }.store(in: &slateDetailSubscriptions)
+
+        slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
+            self?.report(recommendation)
+        }.store(in: &slateDetailSubscriptions)
+
+        let slateDetailVC = SlateDetailViewController(model: slate)
+        navigationController.pushViewController(slateDetailVC, animated: !isResetting)
+    }
+}
+
+// MARK: - Showing reader content
+extension RegularHomeCoordinator {
+    private func show(_ readable: ReadableType?) {
+        delegate?.homeCoordinator(self, didSelectReadableType: readable)
+    }
+
+    private func show(_ readable: RecommendationViewModel?) {
+        delegate?.homeCoordinator(self, didSelectRecommendation: readable)
+    }
+}
+
+// MARK: - Presenting modals
+extension RegularHomeCoordinator {
+    private func report(_ recommendation: Recommendation?) {
+        delegate?.report(recommendation)
+    }
+
+    private func present(_ url: URL?) {
+        delegate?.present(url)
+    }
+
+    private func present(_ alert: PocketAlert?) {
+        delegate?.present(alert)
+    }
+
+    private func share(_ activity: PocketActivity?) {
+        delegate?.share(activity)
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+extension RegularHomeCoordinator: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        if viewController === homeViewController {
+            slateDetailSubscriptions = []
+            model.tappedSeeAll = nil
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -88,7 +88,7 @@ class RegularMainCoordinator: NSObject {
     }
 
     func showInitialView() {
-        model.$isCollapsed.receive(on: DispatchQueue.main).sink { [weak self] isCollapsed in
+        model.$isCollapsed.sink { [weak self] isCollapsed in
             if !isCollapsed {
                 self?.observeModelChanges()
             } else {
@@ -104,20 +104,20 @@ class RegularMainCoordinator: NSObject {
         myList.navigationController?.popToRootViewController(animated: false)
         readerRoot.viewControllers = []
 
-        model.$selectedSection.receive(on: DispatchQueue.main).sink { [weak self] section in
+        model.$selectedSection.sink { [weak self] section in
             self?.show(section)
         }.store(in: &subscriptions)
 
         // My List - Saved Items
-        model.myList.savedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.myList.savedItemsList.$presentedAlert.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
-        model.myList.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.myList.savedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
         
-        model.myList.$selection.receive(on: DispatchQueue.main).sink { [weak self] selection in
+        model.myList.$selection.sink { [weak self] selection in
             switch selection {
             case .myList:
                 self?.myList.selectedIndex = 0
@@ -126,29 +126,29 @@ class RegularMainCoordinator: NSObject {
             }
         }.store(in: &subscriptions)
 
-        model.myList.savedItemsList.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] selectedSavedItem in
+        model.myList.savedItemsList.$selectedItem.sink { [weak self] selectedSavedItem in
             guard let selectedSavedItem = selectedSavedItem else { return }
             self?.model.myList.archivedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedSavedItem)
         }.store(in: &subscriptions)
 
         // My List - Archived Items
-        model.myList.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.myList.archivedItemsList.$presentedAlert.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
-        model.myList.archivedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.myList.archivedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
 
-        model.myList.archivedItemsList.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] selectedArchivedItem in
+        model.myList.archivedItemsList.$selectedItem.sink { [weak self] selectedArchivedItem in
             guard let selectedArchivedItem = selectedArchivedItem else { return }
             self?.model.myList.savedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedArchivedItem)
         }.store(in: &subscriptions)
 
         // HOME
-        model.home.$selectedReadableType.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+        model.home.$selectedReadableType.sink { [weak self] readableType in
             switch readableType {
             case .recommendation(let viewModel):
                 self?.show(viewModel)
@@ -159,25 +159,25 @@ class RegularMainCoordinator: NSObject {
             }
         }.store(in: &subscriptions)
 
-        model.home.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
+        model.home.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation) {
                 self?.model.home.selectedRecommendationToReport = nil
             }
         }.store(in: &subscriptions)
 
-        model.home.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        model.home.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url)
         }.store(in: &subscriptions)
         
-        model.home.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.home.$presentedAlert.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 
-        model.home.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.home.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)
 
-        model.home.$tappedSeeAll.dropFirst().receive(on: DispatchQueue.main).sink { [weak self] section in
+        model.home.$tappedSeeAll.dropFirst().sink { [weak self] section in
             switch section {
             case .myList:
                 self?.model.selectedSection = .myList(.myList)
@@ -232,19 +232,19 @@ class RegularMainCoordinator: NSObject {
         }
 
         readerSubscriptions = []
-        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        readable.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
 
-        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
-        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        readable.$presentedAlert.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &readerSubscriptions)
 
-        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        readable.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
@@ -259,23 +259,23 @@ class RegularMainCoordinator: NSObject {
         }
 
         readerSubscriptions = []
-        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        readable.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url)
         }.store(in: &readerSubscriptions)
 
-        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readerSubscriptions)
 
-        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        readable.$presentedAlert.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &readerSubscriptions)
 
-        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        readable.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
-        readable.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
+        readable.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation) {
                 readable.selectedRecommendationToReport = nil
             }
@@ -292,13 +292,13 @@ class RegularMainCoordinator: NSObject {
             return
         }
 
-        slate.$selectedRecommendationToReport.receive(on: DispatchQueue.main).sink { [weak self] recommendation in
+        slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation) {
                 slate.selectedRecommendationToReport = nil
             }
         }.store(in: &slateDetailSubscriptions)
 
-        slate.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readable in
+        slate.$selectedReadableViewModel.sink { [weak self] readable in
             if readable != nil {
                 self?.model.myList.savedItemsList.selectedItem = nil
                 self?.model.myList.archivedItemsList.selectedItem = nil
@@ -307,7 +307,7 @@ class RegularMainCoordinator: NSObject {
             self?.show(readable)
         }.store(in: &slateDetailSubscriptions)
 
-        slate.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        slate.$presentedWebReaderURL.sink { [weak self] alert in
             self?.present(alert)
         }.store(in: &subscriptions)
 

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -20,7 +20,6 @@ class RegularMainCoordinator: NSObject {
     private let readerRoot: UINavigationController
 
     private let tracker: Tracker
-    private let source: Source
 
     private let model: MainViewModel
 
@@ -31,11 +30,9 @@ class RegularMainCoordinator: NSObject {
     private var isResetting: Bool = false
 
     init(
-        source: Source,
         tracker: Tracker,
         model: MainViewModel
     ) {
-        self.source = source
         self.tracker = tracker
         self.model = model
 

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -51,11 +51,7 @@ class RegularMainCoordinator: NSObject {
             ]
         )
         
-        home = HomeViewController(
-            source: source,
-            tracker: tracker.childTracker(hosting: UIContext.home.screen),
-            model: model.home
-        )
+        home = HomeViewController(model: model.home)
 
         account = AccountViewController(model: model.account)
         readerRoot = UINavigationController(rootViewController: UIViewController())

--- a/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
@@ -102,7 +102,7 @@ extension RegularMyListCoordinator {
             return
         }
 
-        model.archivedItemsList.selectedItem = nil
+        model.archivedItemsList.clearSelectedItem()
         show(selectedSavedItem)
     }
 
@@ -111,7 +111,7 @@ extension RegularMyListCoordinator {
             return
         }
 
-        model.savedItemsList.selectedItem = nil
+        model.savedItemsList.clearSelectedItem()
         show(selectedArchivedItem)
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -432,3 +432,30 @@ extension ArchivedItemsListViewModel {
         return snapshot
     }
 }
+
+// MARK: - Clearing presented content
+extension ArchivedItemsListViewModel {
+    func clearSharedActivity() {
+        sharedActivity = nil
+        selectedItem?.clearSharedActivity()
+    }
+
+    func clearPresentedWebReaderURL() {
+        switch selectedItem {
+        case .readable(let readable):
+            readable?.clearPresentedWebReaderURL()
+        case .webView:
+            selectedItem = nil
+        case .none:
+            break
+        }
+    }
+
+    func clearIsPresentingReaderSettings() {
+        selectedItem?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        selectedItem = nil
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -146,10 +146,7 @@ class CompactMyListContainerCoordinator: NSObject {
         activityVC.popoverPresentationController?.sourceView = navigationController.splitViewController?.view
 
         activityVC.completionWithItemsHandler = { [weak self] _, _, _, _ in
-            self?.model.archivedItemsList.sharedActivity = nil
-            self?.model.archivedItemsList.selectedItem?.clearSharedActivity()
-            self?.model.savedItemsList.sharedActivity = nil
-            self?.model.savedItemsList.selectedItem?.clearSharedActivity()
+            self?.model.clearSharedActivity()
         }
 
         viewController.present(activityVC, animated: !isResetting)
@@ -168,8 +165,8 @@ class CompactMyListContainerCoordinator: NSObject {
             return
         }
 
-        let readerSettingsVC = ReaderSettingsViewController(settings: readable.readerSettings) {
-            readable.isPresentingReaderSettings = false
+        let readerSettingsVC = ReaderSettingsViewController(settings: readable.readerSettings) { [weak self] in
+            self?.model.clearIsPresentingReaderSettings()
         }
 
         // iPhone (Portrait): defaults to .medium(); iPhone (Landscape): defaults to .large()
@@ -186,27 +183,17 @@ class CompactMyListContainerCoordinator: NSObject {
 }
 
 extension CompactMyListContainerCoordinator: UINavigationControllerDelegate {
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        guard viewController == containerViewController else {
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        guard viewController === containerViewController else {
             return
         }
 
-        model.archivedItemsList.selectedItem = nil
-        model.savedItemsList.selectedItem = nil
+        model.clearSelectedItem()
     }
 }
 
 extension CompactMyListContainerCoordinator: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        model.archivedItemsList.selectedItem?.clearPresentedWebReaderURL()
-        model.savedItemsList.selectedItem?.clearPresentedWebReaderURL()
-        
-        if case .webView = model.archivedItemsList.selectedItem {
-            model.archivedItemsList.selectedItem = nil
-        }
-        
-        if case .webView = model.savedItemsList.selectedItem {
-            model.savedItemsList.selectedItem = nil
-        }
+        model.clearPresentedWebReaderURL()
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -64,14 +64,12 @@ class CompactMyListContainerCoordinator: NSObject {
 
         model.savedItemsList.$selectedItem.sink { [weak self] selectedSavedItem in
             guard let selectedSavedItem = selectedSavedItem else { return }
-            self?.model.archivedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedSavedItem)
         }.store(in: &subscriptions)
 
         // Archive navigation
         model.archivedItemsList.$selectedItem.sink { [weak self] selectedArchivedItem in
             guard let selectedArchivedItem = selectedArchivedItem else { return }
-            self?.model.savedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedArchivedItem)
         }.store(in: &subscriptions)
 

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -44,7 +44,7 @@ class CompactMyListContainerCoordinator: NSObject {
 
         navigationController.popToRootViewController(animated: false)
         
-        model.$selection.receive(on: DispatchQueue.main).sink { [weak self] selection in
+        model.$selection.sink { [weak self] selection in
             switch selection {
             case .myList:
                 self?.containerViewController.selectedIndex = 0
@@ -54,32 +54,32 @@ class CompactMyListContainerCoordinator: NSObject {
         }.store(in: &subscriptions)
 
         // My List navigation
-        model.savedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.savedItemsList.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
-        model.savedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.savedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.savedItemsList.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] selectedSavedItem in
+        model.savedItemsList.$selectedItem.sink { [weak self] selectedSavedItem in
             guard let selectedSavedItem = selectedSavedItem else { return }
             self?.model.archivedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedSavedItem)
         }.store(in: &subscriptions)
 
         // Archive navigation
-        model.archivedItemsList.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] selectedArchivedItem in
+        model.archivedItemsList.$selectedItem.sink { [weak self] selectedArchivedItem in
             guard let selectedArchivedItem = selectedArchivedItem else { return }
             self?.model.savedItemsList.selectedItem = nil
             self?.navigate(selectedItem: selectedArchivedItem)
         }.store(in: &subscriptions)
 
-        model.archivedItemsList.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        model.archivedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.archivedItemsList.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        model.archivedItemsList.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
@@ -102,23 +102,23 @@ class CompactMyListContainerCoordinator: NSObject {
             return
         }
 
-        readable.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
+        readable.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
 
-        readable.$presentedWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+        readable.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &readableSubscriptions)
 
-        readable.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+        readable.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readableSubscriptions)
 
-        readable.$isPresentingReaderSettings.receive(on: DispatchQueue.main).sink { [weak self] isPresenting in
+        readable.$isPresentingReaderSettings.sink { [weak self] isPresenting in
             self?.presentReaderSettings(isPresenting, on: readable)
         }.store(in: &readableSubscriptions)
 
-        readable.events.receive(on: DispatchQueue.main).sink { [weak self] event in
+        readable.events.sink { [weak self] event in
             switch event {
             case .contentUpdated:
                 break

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -8,7 +8,7 @@ enum SelectedItem {
     func clearPresentedWebReaderURL() {
         switch self {
         case .readable(let viewModel):
-            viewModel?.presentedWebReaderURL = nil
+            viewModel?.clearPresentedWebReaderURL()
         default:
             break
         }
@@ -17,8 +17,17 @@ enum SelectedItem {
     func clearSharedActivity() {
         switch self {
         case .readable(let viewModel):
-            viewModel?.sharedActivity = nil
+            viewModel?.clearSharedActivity()
         default:
+            break
+        }
+    }
+
+    func clearIsPresentingReaderSettings() {
+        switch self {
+        case .readable(let readable):
+            readable?.clearIsPresentingReaderSettings()
+        case .webView:
             break
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/MyListContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/MyListContainerViewModel.swift
@@ -17,4 +17,24 @@ class MyListContainerViewModel {
         self.savedItemsList = savedItemsList
         self.archivedItemsList = archivedItemsList
     }
+
+    func clearSharedActivity() {
+        savedItemsList.clearSharedActivity()
+        archivedItemsList.clearSharedActivity()
+    }
+
+    func clearPresentedWebReaderURL() {
+        savedItemsList.clearPresentedWebReaderURL()
+        archivedItemsList.clearPresentedWebReaderURL()
+    }
+
+    func clearIsPresentingReaderSettings() {
+        savedItemsList.clearIsPresentingReaderSettings()
+        archivedItemsList.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        savedItemsList.clearSelectedItem()
+        archivedItemsList.clearSelectedItem()
+    }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -423,3 +423,23 @@ extension SavedItemsListViewModel {
         // no op, prefetching is only needed in archive
     }
 }
+
+// MARK: - Clearing presented content
+extension SavedItemsListViewModel {
+    func clearSharedActivity() {
+        sharedActivity = nil
+        selectedItem?.clearSharedActivity()
+    }
+
+    func clearPresentedWebReaderURL() {
+        selectedItem?.clearPresentedWebReaderURL()
+    }
+
+    func clearIsPresentingReaderSettings() {
+        selectedItem?.clearIsPresentingReaderSettings()
+    }
+
+    func clearSelectedItem() {
+        selectedItem = nil
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -432,7 +432,14 @@ extension SavedItemsListViewModel {
     }
 
     func clearPresentedWebReaderURL() {
-        selectedItem?.clearPresentedWebReaderURL()
+        switch selectedItem {
+        case .readable(let readable):
+            readable?.clearPresentedWebReaderURL()
+        case .webView:
+            selectedItem = nil
+        case .none:
+            break
+        }
     }
 
     func clearIsPresentingReaderSettings() {

--- a/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
@@ -36,7 +36,7 @@ class RootCoordinator {
 
         window = UIWindow(windowScene: windowScene)
 
-        rootViewModel.$isLoggedIn.receive(on: DispatchQueue.main).sink { isLoggedIn in
+        rootViewModel.$isLoggedIn.sink { isLoggedIn in
             self.updateState(isLoggedIn)
         }.store(in: &subscriptions)
 

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -185,7 +185,7 @@ class HomeTests: XCTestCase {
         app.slateDetailView.element.swipeUp()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 3").wait()
 
-        app.tabBar.homeButton.wait().tap()
+        app.navigationBar.buttons["Home"].wait().tap()
         home.element.swipeUp()
 
         home.sectionHeader("Slate 2").seeAllButton.wait().tap()


### PR DESCRIPTION
## Summary
* Refactor coordinators and properly unwind navigational view model properties

## Implementation Details
The goal of our coordinators is twofold:

1. We want to be able to encapsulate all business logic within our
   view models, and simply observe their state to know when to present
   modal views or push views onto a navigation controller.
2. When users transition from compact to regular size classes (or vice
   versa), we can keep our compact view hiearchy in sync with the split
   view's hiearchy.

The theoretical concept is mostly good —containing state within view
models that are shared between both the regular and compact coordinators
allows us to easily reconstruct the view hiearchy when the user
transitions size classes.

However, the practical reality is...less good. One of the complications
with this approach is that we need to clean up after ourselves when
users dismiss modals or pop the navigation stack. For example, when the
share sheet is dismissed, we need to clear the `sharedActivity` property
of the view model that presented it.

To make this "unwinding" easier to keep track of, a set of methods to
clear certain properties have been added to objects throughout the view
model tree. This means the coordinators can call a single method on
their top level view model to "clearPresentedSharedActivity" and the
message will delegate down the tree to ensure that the correct property
is cleared, regardless of what level the shared activity was shared
from.

In addition to this change (and to make it somewhat easier to reason through), `RegularHomeCoordinator` and `RegularMyListCoordinator` have been extracted from `RegularMainCoordinator`. These sub-coordinators are focused on single parts of the app and delegate to higher level coordinator(s) when necessary to present modal content.

https://getpocket.atlassian.net/browse/IN-701