### PR TITLE
fix(sentry): attaching the user id to sentry

### DIFF
--- a/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
@@ -44,6 +44,7 @@ class RootViewModel {
             APIUserContext(consumerKey: Keys.shared.pocketApiConsumerKey)
         ])
         tracker.addPersistentContext(UserContext(guid: session.guid, userID: session.userIdentifier))
+        Crashlogger.setUserID(session.userIdentifier)
         source.refresh()
     }
 


### PR DESCRIPTION
## Summary
* I noticed that we were not attaching the user identifier to Sentry when doing my weekly sentry perusal.

## References 
* https://docs.sentry.io/platforms/apple/guides/ios/

## Implementation Details
* Added a call to set the sentry user identifier

## Test Steps
* Trigger a crash
* Check sentry to ensure your hashed user id is linked in the sentry issue

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
