### PR TITLE
Home: show offline view when there is no network connection

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -124,3 +124,27 @@ class HomeViewControllerSectionProvider {
         return section
     }
 }
+
+
+extension HomeViewControllerSectionProvider {
+    func offlineSection(environment: NSCollectionLayoutEnvironment, withRecentSaves: Bool) -> NSCollectionLayoutSection {
+        var config = UICollectionLayoutListConfiguration(appearance: .plain)
+        config.backgroundColor = UIColor(.ui.white1)
+        config.showsSeparators = false
+        let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
+
+        let layoutHeight = environment.container.contentSize.height
+        let availableWidth = environment.container.contentSize.width
+        - ItemsListOfflineCell.Constants.padding
+        - ItemsListOfflineCell.Constants.padding
+        let topInset: CGFloat = withRecentSaves ? 16 : (layoutHeight - ItemsListOfflineCell.height(fitting: availableWidth)) / 2 - 128
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: topInset,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
+
+        return section
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -133,17 +133,18 @@ extension HomeViewControllerSectionProvider {
         config.showsSeparators = false
         let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
 
-        let layoutHeight = environment.container.contentSize.height
         let availableWidth = environment.container.contentSize.width
         - ItemsListOfflineCell.Constants.padding
         - ItemsListOfflineCell.Constants.padding
-        let topInset: CGFloat = withRecentSaves ? 16 : (layoutHeight - ItemsListOfflineCell.height(fitting: availableWidth)) / 2 - 128
-        section.contentInsets = NSDirectionalEdgeInsets(
-            top: topInset,
-            leading: 0,
-            bottom: 0,
-            trailing: 0
-        )
+
+        if !withRecentSaves {
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top:  ItemsListOfflineCell.height(fitting: availableWidth) / 4, // Insets the top so "No Internet Connection" is centered
+                leading: 0,
+                bottom: 0,
+                trailing: 0
+            )
+        }
 
         return section
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -30,6 +30,9 @@ class HomeViewController: UIViewController {
             return self.sectionProvider.heroSection(for: slateID, in: self.model, width: env.container.effectiveContentSize.width)
         case .slateCarousel(let slateID):
             return self.sectionProvider.carouselSection(for: slateID, in: self.model, width: env.container.effectiveContentSize.width)
+        case .offline:
+            let hasRecentSaves = self.dataSource.index(for: .recentSaves) != nil
+            return self.sectionProvider.offlineSection(environment: env, withRecentSaves: hasRecentSaves)
         }
     }
 
@@ -73,6 +76,7 @@ class HomeViewController: UIViewController {
         collectionView.register(cellClass: RecommendationCell.self)
         collectionView.register(cellClass: RecentSavesItemCell.self)
         collectionView.register(cellClass: RecommendationCarouselCell.self)
+        collectionView.register(cellClass: ItemsListOfflineCell.self)
         collectionView.register(viewClass: SectionHeaderView.self, forSupplementaryViewOfKind: SectionHeaderView.kind)
         collectionView.delegate = self
 
@@ -178,6 +182,9 @@ extension HomeViewController {
             }
 
             cell.configure(model: viewModel)
+            return cell
+        case .offline:
+            let cell: ItemsListOfflineCell = collectionView.dequeueCell(for: indexPath)
             return cell
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -110,15 +110,9 @@ class HomeViewModel {
         self.source = source
         self.tracker = tracker
         self.networkPathMonitor = networkPathMonitor
+        networkPathMonitor.start(queue: .global())
 
         self.snapshot = {
-            guard networkPathMonitor.currentNetworkPath.status == .satisfied else {
-                var snapshot = Snapshot()
-                snapshot.appendSections([.offline])
-                snapshot.appendItems([.offline], toSection: .offline)
-                return snapshot
-            }
-
             return Self.loadingSnapshot()
         }()
 
@@ -133,7 +127,6 @@ class HomeViewModel {
             }
         }.store(in: &subscriptions)
 
-        networkPathMonitor.start(queue: .global())
         networkPathMonitor.updateHandler = { [weak self] path in
             if path.status == .satisfied {
                 self?.refresh { }

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -94,12 +94,12 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
 // MARK: - Fetching Items
 extension ArchivedItemsListViewModel {
     func fetch() {
-        guard isNetworkAvailable else {
+        if isNetworkAvailable {
+            refresh { }
+        } else {
             _snapshot = offlineSnapshot()
-            return
         }
 
-        refresh { }
         observeNetworkChanges()
     }
 
@@ -133,18 +133,18 @@ extension ArchivedItemsListViewModel {
 
     private func observeNetworkChanges() {
         networkMonitor.updateHandler = { [weak self] path in
-            let currentPathStatus = path.status
-
-            guard let self = self,
-                  self.lastPathStatus != path.status,
-                  currentPathStatus == .satisfied else {
-                self?.lastPathStatus = path.status
-                return
-            }
-
-            self.refresh { }
-            self.lastPathStatus = currentPathStatus
+            self?.handleNetworkChange(path)
         }
+    }
+
+    private func handleNetworkChange(_ path: NetworkPath?) {
+        let currentPathStatus = path?.status
+
+        if lastPathStatus != currentPathStatus, currentPathStatus == .satisfied {
+            refresh { }
+        }
+
+        lastPathStatus = currentPathStatus
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
@@ -14,11 +14,6 @@ class ItemsListOfflineCell: UICollectionViewCell {
         static let imageSpacing: CGFloat = 48
         static let stackSpacing: CGFloat = 16
         static let padding: CGFloat = 18
-        
-        static let buttonColor = UIColor(.ui.white1)
-        static let buttonHighlightedColor = UIColor(.ui.grey1).withAlphaComponent(0.5)
-        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
-        static let buttonTitle = NSAttributedString(string: "Try Again", style: .header.sansSerif.p2)
     }
     
     private let imageView: UIImageView = {
@@ -39,26 +34,8 @@ class ItemsListOfflineCell: UICollectionViewCell {
         return label
     }()
     
-    private var actionButton: UIButton = {
-        var config = UIButton.Configuration.borderedTinted()
-        config.attributedTitle = AttributedString(Constants.buttonTitle)
-        config.cornerStyle = .capsule
-        config.background.strokeColor = UIColor(.ui.grey5)
-        config.contentInsets = Constants.buttonContentInsets
-        
-        let button = UIButton(configuration: config)
-        button.configurationUpdateHandler = { button in
-            var config = button.configuration
-            config?.baseBackgroundColor = button.isHighlighted ? Constants.buttonHighlightedColor : Constants.buttonColor
-            button.configuration = config
-        }
-        return button
-    }()
-    
-    var buttonAction: (() -> ())? = nil
-    
     private lazy var textStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [textLabel, detailTextLabel, actionButton])
+        let stackView = UIStackView(arrangedSubviews: [textLabel, detailTextLabel])
         stackView.axis = .vertical
         stackView.spacing = Constants.stackSpacing
         stackView.alignment = .center
@@ -75,9 +52,6 @@ class ItemsListOfflineCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
-        let action = UIAction(title: "") { [weak self] _ in self?.buttonAction?() }
-        actionButton.addAction(action, for: .primaryActionTriggered)
         
         contentView.addSubview(stackView)
         
@@ -101,8 +75,5 @@ class ItemsListOfflineCell: UICollectionViewCell {
         + Constants.stackSpacing
         + Constants.detailText.sizeFitting(availableWidth: availableWidth).height
         + Constants.stackSpacing
-        + Constants.buttonContentInsets.top
-        + Constants.buttonTitle.sizeFitting(availableWidth: availableWidth).height
-        + Constants.buttonContentInsets.bottom
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
@@ -22,14 +22,14 @@ class ItemsListOfflineCell: UICollectionViewCell {
     
     private let textLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         label.attributedText = Constants.text
         return label
     }()
     
     private let detailTextLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 2
+        label.numberOfLines = 0
         label.attributedText = Constants.detailText
         return label
     }()

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -143,9 +143,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         }
         
         let offlineCellRegistration: UICollectionView.CellRegistration<ItemsListOfflineCell, String> = .init { cell, _, _ in
-            cell.buttonAction = {
-                model.fetch()
-            }
+            
         }
 
         let placeholderCellRegistration: UICollectionView.CellRegistration<ItemPlaceholderCell, Int> = .init { cell, indexPath, itemIndex in

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -27,7 +27,8 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                     ),
                     home: HomeViewModel(
                         source: Services.shared.source,
-                        tracker: Services.shared.tracker.childTracker(hosting: .home.screen)
+                        tracker: Services.shared.tracker.childTracker(hosting: .home.screen),
+                        networkPathMonitor: NWPathMonitor()
                     ),
                     account: AccountViewModel(appSession: Services.shared.appSession)
                 ),

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -459,15 +459,6 @@ class HomeViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 1)
     }
 
-     func test_snapshot_whenNetworkIsInitiallyUnvailable_hasCorrectSnapshot() {
-         networkPathMonitor.update(status: .unsatisfied)
-         source.stubFetchSlateLineup { _ in }
-
-         let viewModel = subject()
-         XCTAssertNotNil(viewModel.snapshot.indexOfSection(.offline))
-         XCTAssertEqual(viewModel.snapshot.itemIdentifiers(inSection: .offline), [.offline])
-     }
-
      func test_snapshot_whenNetworkIsInitiallyAvailable_hasCorrectSnapshot() {
          source.stubFetchSlateLineup { _ in }
 


### PR DESCRIPTION
## Summary

This pull request adds support for presenting an "offline view" when there is no network connection (e.g airplane mode). When the user regains connection, Home will automatically refresh. Additionally, this functionality is mimicked in the Archive, where upon regaining network connection, the Archive will automatically refresh as well.

## References 

IN-694
IN-727

## Test Steps

### Scenario: No recent saves, offline

Given the app has not been opened and I am in airplane mode,
when I open the app and the Home tab is visible,
then I should see an offline screen.

### Scenario: Airplane mode turned off
Given the app has been opened and I am in airplane mode with the offline screen visible,
when I turn off airplane mode,
then the loading state should appear.

### Scenario: Recent saves but offline

Given I have some recent saves
And I have airplane mode turned on
When I view the home tab and attempt to refresh,
Then I should see my recent saves
And I should see the “no internet connection” illustration

### Scenario: Archive, offline

Given I am viewing my Archived items
And I have airplane mode turned on
When I view my Archive and attempt to refresh,
Then I should see the "no internet connection" illustration, and no archived items should be visible

### Scenario: Archive, regained connection

Given I am viewing my Archived items
And I have airplane mode turned on
When I view my Archive
Then I should not see the "no internet connection" illustration, and my Archived items should appear

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

![File](https://user-images.githubusercontent.com/1158092/185224587-319d328d-314f-43ac-b9a4-86a940c61a11.png)

