### PR TITLE
Transition provisioning profiles and app groups to RIL

### DIFF
--- a/Pocket (iOS).entitlements
+++ b/Pocket (iOS).entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.mozilla.pocket</string>
+		<string>group.com.ideashower.ReadItLaterProAlphaNeue</string>
 	</array>
 </dict>
 </plist>

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -589,7 +589,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 8.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -646,7 +646,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				POCKET_API_BASE_URL = "https://getpocket.com/graphql";
@@ -663,9 +663,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Pocket (iOS).entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development: Jacob Morris (W6NRVULLCG)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -673,9 +673,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue;
 				PRODUCT_NAME = Pocket;
-				PROVISIONING_PROFILE_SPECIFIER = "Pocket Next Development";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Development";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -691,9 +691,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Pocket (iOS).entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Mozilla Corporation (43AQ936H96)";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Read It Later, Inc (EX3VH4YFCH)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -701,9 +701,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue;
 				PRODUCT_NAME = Pocket;
-				PROVISIONING_PROFILE_SPECIFIER = "bitrise com.mozilla.pocket.next";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next App Store Distribution";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -807,7 +807,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 8.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -825,9 +825,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Pocket (iOS).entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development: Jacob Morris (W6NRVULLCG)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -835,9 +835,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue;
 				PRODUCT_NAME = Pocket;
-				PROVISIONING_PROFILE_SPECIFIER = "Pocket Next Development";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Development";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -872,9 +872,9 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development: Jacob Morris (W6NRVULLCG)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Save to Pocket";
@@ -885,9 +885,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next.SaveToPocket;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.SaveTo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Save to Pocket Development";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next SaveTo Development";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -903,9 +903,9 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development: Jacob Morris (W6NRVULLCG)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Save to Pocket";
@@ -916,9 +916,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next.SaveToPocket;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.SaveTo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Save to Pocket Development";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next SaveTo Development";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -934,9 +934,9 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Mozilla Corporation (43AQ936H96)";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Read It Later, Inc (EX3VH4YFCH)";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Save to Pocket";
@@ -947,9 +947,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.pocket.next.SaveToPocket;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.SaveTo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "bitrise com.mozilla.pocket.next.SaveToPocket";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next SaveTo App Store Distribution";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
+++ b/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
@@ -37,7 +37,7 @@ public class KeychainStorage<T: Codable & Equatable> {
         keychain: Keychain = SecItemKeychain(),
         service: String = "pocket",
         account: String,
-        accessGroup: String = "group.com.mozilla.pocket"
+        accessGroup: String = "group.com.ideashower.ReadItLaterProAlphaNeue"
     ) {
         self.keychain = keychain
         self.service = service

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -28,7 +28,7 @@ public class PersistentContainer: NSPersistentContainer {
             ]
         case .shared:
             let sharedContainerURL = FileManager.default
-                .containerURL(forSecurityApplicationGroupIdentifier: "group.com.mozilla.pocket")!
+                .containerURL(forSecurityApplicationGroupIdentifier: "group.com.ideashower.ReadItLaterProAlphaNeue")!
                 .appendingPathComponent("PocketModel.sqlite")
 
             persistentStoreDescriptions = [

--- a/PocketKit/Tests/SharedPocketKitTests/KeychainStorageTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/KeychainStorageTests.swift
@@ -23,7 +23,7 @@ class KeychainStorageTests: XCTestCase {
         XCTAssertEqual(query[kSecAttrService as String] as? String, service)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, account)
         XCTAssertEqual(query[kSecReturnData as String] as? Bool, true)
-        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.mozilla.pocket")
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.ideashower.ReadItLaterProAlphaNeue")
     }
 
     func test_set_whenInitialValue_callsAdd_withCorrectQuery() {
@@ -40,7 +40,7 @@ class KeychainStorageTests: XCTestCase {
         XCTAssertEqual(query[kSecAttrService as String] as? String, service)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, account)
         XCTAssertEqual(query[kSecAttrAccessible as String] as? String, kSecAttrAccessibleAfterFirstUnlock as String)
-        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.mozilla.pocket")
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.ideashower.ReadItLaterProAlphaNeue")
     }
 
     func test_set_whenValueExists_callsUpdate_withCorrectQuery() {
@@ -62,7 +62,7 @@ class KeychainStorageTests: XCTestCase {
         XCTAssertEqual(query[kSecClass as String] as? String, kSecClassGenericPassword as String)
         XCTAssertEqual(query[kSecAttrService as String] as? String, service)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, account)
-        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.mozilla.pocket")
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.ideashower.ReadItLaterProAlphaNeue")
     }
 
     func test_set_whenNil_callsDelete_withCorrectQuery() {
@@ -80,7 +80,7 @@ class KeychainStorageTests: XCTestCase {
         XCTAssertEqual(query[kSecClass as String] as? String, kSecClassGenericPassword as String)
         XCTAssertEqual(query[kSecAttrService as String] as? String, service)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, account)
-        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.mozilla.pocket")
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, "group.com.ideashower.ReadItLaterProAlphaNeue")
     }
 
     func test_read_usesCachedValue() {

--- a/SaveToPocket/SaveToPocket.entitlements
+++ b/SaveToPocket/SaveToPocket.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.mozilla.pocket</string>
+		<string>group.com.ideashower.ReadItLaterProAlphaNeue</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Update the project to use provisioning profiles and certificates for development from the RIL team. This does not yet contain changes for release (i.e Bitrise).

## References 
IN-729

## Implementation Details
- [x] Update the bundle identifier(s) to `com.ideashower.ReadItLaterProAlphaNeue(.SaveTo)`
- [x] Update the app group to `group.com.ideashower.ReadItLaterProAlphaNeue`
- [x] Add new devices
- [x] Generate new provisioning profiles for app and save extension
