### PR TITLE
IN-232: Add Tags Screen - User Can Select From Existing Tags

### DIFF
--- a/PocketKit/Sources/PocketKit/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/PocketKit/Tags/AddTagsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import Textile
 
+
 struct AddTagsView: View {
     enum Constants {
         static let tagsHorizontalSpacing: CGFloat = 6
@@ -17,25 +18,15 @@ struct AddTagsView: View {
     @Environment(\.dismiss)
     private var dismiss
     
-    @Namespace var animation
-    
     var body: some View {
         GeometryReader { geometry in
             NavigationView {
-                VStack(alignment: .leading, spacing: 0) {
-                    Divider()
-                    VStack(spacing: 6) {
-                        ForEach(getRows(screenWidth: geometry.size.width), id: \.self) { rows in
-                            HStack(spacing: Constants.tagsHorizontalSpacing) {
-                                ForEach(rows, id: \.self) { row in
-                                    RowView(tag: row)
-                                }
-                            }
-                        }
-                    }.padding()
-                    Divider()
+                VStack {
+                    InputTagsView(viewModel: viewModel, geometry: geometry)
+                    OtherTagsView(viewModel: viewModel)
                     Spacer()
                     TextField(viewModel.placeholderText, text: $newTag)
+                        .limitText($newTag, to: 25)
                         .textFieldStyle(.roundedBorder)
                         .padding(10)
                         .onSubmit {
@@ -63,52 +54,126 @@ struct AddTagsView: View {
         }.accessibilityIdentifier("add-tags")
     }
     
-    func RowView(tag: String) -> some View {
-        Text(tag)
-            .style(.tag)
-            .padding(Constants.tagPadding)
-            .background(Rectangle().fill(Color(.ui.grey6)))
-            .cornerRadius(4)
-            .lineLimit(1)
-            .onTapGesture {
-                viewModel.removeTag(with: tag)
-            }
-            .accessibilityIdentifier("tag")
-            .matchedGeometryEffect(id: tag, in: animation)
-    }
-    
-    func getRows(screenWidth: CGFloat) -> [[String]] {
-        var rows: [[String]] = []
-        var currentRow: [String] = []
+    struct InputTagsView: View {
+        @ObservedObject
+        var viewModel: AddTagsViewModel
         
-        var totalWidth: CGFloat = 0
-        let safeWidth: CGFloat = screenWidth
-        let padding: CGFloat = Constants.tagPadding * 2 + Constants.tagsHorizontalSpacing * 2
-    
-        viewModel.tags.forEach { tag in
-            let attributes = Style.tag.textAttributes
-            let tagWidth: CGFloat = tag.size(withAttributes: attributes).width + padding
-
-            totalWidth += tagWidth
+        @Namespace
+        var animation
+        
+        let geometry: GeometryProxy
+        
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(getRows(screenWidth: geometry.size.width), id: \.self) { rows in
+                        HStack(spacing: Constants.tagsHorizontalSpacing) {
+                            ForEach(rows, id: \.self) { row in
+                                RowView(tag: row)
+                            }
+                        }
+                    }
+                }.padding()
+                Divider()
+                    .frame(height: 10)
+                    .overlay(Color(.ui.grey7))
+            }
+        }
+        
+        func RowView(tag: String) -> some View {
+            Text(tag)
+                .style(.tag)
+                .padding(Constants.tagPadding)
+                .background(Rectangle().fill(Color(.ui.grey6)))
+                .cornerRadius(4)
+                .lineLimit(1)
+                .onTapGesture {
+                    viewModel.removeTag(with: tag)
+                }
+                .accessibilityIdentifier("tag")
+                .matchedGeometryEffect(id: tag, in: animation)
+        }
+        
+        func getRows(screenWidth: CGFloat) -> [[String]] {
+            var rows: [[String]] = []
+            var currentRow: [String] = []
             
-            if totalWidth > safeWidth {
-                totalWidth = (!currentRow.isEmpty || rows.isEmpty ? tagWidth : 0)
+            var totalWidth: CGFloat = 0
+            let safeWidth: CGFloat = screenWidth
+            let padding: CGFloat = Constants.tagPadding * 2 + Constants.tagsHorizontalSpacing * 2
+        
+            viewModel.tags.forEach { tag in
+                let attributes = Style.tag.textAttributes
+                let tagWidth: CGFloat = tag.size(withAttributes: attributes).width + padding
+
+                totalWidth += tagWidth
+                
+                if totalWidth > safeWidth {
+                    totalWidth = (!currentRow.isEmpty || rows.isEmpty ? tagWidth : 0)
+                    rows.append(currentRow)
+                    currentRow.removeAll()
+                    currentRow.append(tag)
+                } else {
+                    currentRow.append(tag)
+                }
+            }
+        
+            if !currentRow.isEmpty {
                 rows.append(currentRow)
                 currentRow.removeAll()
-                currentRow.append(tag)
+            }
+            return rows
+        }
+    }
+    
+    struct OtherTagsView: View {
+        @ObservedObject
+        var viewModel: AddTagsViewModel
+        
+        var body: some View {
+            if let otherTags = viewModel.allOtherTags(), !otherTags.isEmpty {
+                List {
+                    Section(header: Text("All Tags").style(.sectionHeader)) {
+                        ForEach(otherTags, id: \.self) { tag in
+                            HStack {
+                                Text(tag).style(.tag)
+                                Spacer()
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                _ = viewModel.addTag(with: tag)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .accessibilityIdentifier("all-tags")
             } else {
-                currentRow.append(tag)
+                // TODO: Empty State View
+                VStack(alignment: .center, spacing: 20) {
+                    Spacer()
+                    Text(viewModel.emptyStateText)
+                        .style(.emptyStateText)
+                        .padding()
+                    Spacer()
+                }
             }
         }
-    
-        if !currentRow.isEmpty {
-            rows.append(currentRow)
-            currentRow.removeAll()
-        }
-        return rows
     }
 }
 
 private extension Style {
-    static let tag: Self = .header.sansSerif.h8.with(color: .ui.grey3)
+    static let emptyStateText: Self = .header.sansSerif.p2.with { $0.with(alignment: .center).with(lineSpacing: 6) }
+    static let sectionHeader: Self = .header.sansSerif.h8.with(color: .ui.grey4)
+    static let tag: Self = .header.sansSerif.h8.with(color: .ui.grey4)
+}
+
+
+extension View {
+    func limitText(_ text: Binding<String>, to characterLimit: Int) -> some View {
+        self.onChange(of: text.wrappedValue) { _ in
+            text.wrappedValue = String(text.wrappedValue.prefix(characterLimit))
+        }
+    }
 }

--- a/PocketKit/Sources/PocketKit/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/AddTagsViewModel.swift
@@ -22,6 +22,10 @@ class AddTagsViewModel: ObservableObject {
         "Enter tag name..."
     }
     
+    var emptyStateText: String {
+        "Organize your items with Tags.\n To create a tag, enter one below."
+    }
+    
     func addTag(with tag: String) -> Bool {
         let tagName = validateInput(tag)
         guard !tagName.isEmpty,
@@ -35,6 +39,11 @@ class AddTagsViewModel: ObservableObject {
     func addTags() {
         source.addTags(item: item, tags: tags)
         saveAction()
+    }
+    
+    func allOtherTags() -> [String]? {
+        let fetchedTags = source.retrieveTags(excluding: tags)
+        return fetchedTags?.compactMap { $0.name }
     }
     
     func removeTag(with tag: String) {

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -11708,6 +11708,3163 @@ public final class ReplaceSavedItemTagsMutation: GraphQLMutation {
   }
 }
 
+public final class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
+  /// The raw GraphQL definition of this operation.
+  public let operationDefinition: String =
+    """
+    mutation UpdateSavedItemRemoveTags($savedItemId: ID!) {
+      updateSavedItemRemoveTags(savedItemId: $savedItemId) {
+        __typename
+        ...SavedItemParts
+      }
+    }
+    """
+
+  public let operationName: String = "UpdateSavedItemRemoveTags"
+
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + ItemParts.fragmentDefinition)
+    document.append("\n" + MarticleTextParts.fragmentDefinition)
+    document.append("\n" + ImageParts.fragmentDefinition)
+    document.append("\n" + MarticleDividerParts.fragmentDefinition)
+    document.append("\n" + MarticleTableParts.fragmentDefinition)
+    document.append("\n" + MarticleHeadingParts.fragmentDefinition)
+    document.append("\n" + MarticleCodeBlockParts.fragmentDefinition)
+    document.append("\n" + VideoParts.fragmentDefinition)
+    document.append("\n" + MarticleBulletedListParts.fragmentDefinition)
+    document.append("\n" + MarticleNumberedListParts.fragmentDefinition)
+    document.append("\n" + MarticleBlockquoteParts.fragmentDefinition)
+    document.append("\n" + DomainMetadataParts.fragmentDefinition)
+    document.append("\n" + PendingItemParts.fragmentDefinition)
+    return document
+  }
+
+  public var savedItemId: GraphQLID
+
+  public init(savedItemId: GraphQLID) {
+    self.savedItemId = savedItemId
+  }
+
+  public var variables: GraphQLMap? {
+    return ["savedItemId": savedItemId]
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Mutation"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("updateSavedItemRemoveTags", arguments: ["savedItemId": GraphQLVariable("savedItemId")], type: .nonNull(.object(UpdateSavedItemRemoveTag.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(updateSavedItemRemoveTags: UpdateSavedItemRemoveTag) {
+      self.init(unsafeResultMap: ["__typename": "Mutation", "updateSavedItemRemoveTags": updateSavedItemRemoveTags.resultMap])
+    }
+
+    /// Removes all Tag associations from a SavedItem. Returns the
+    /// SavedItem that had its Tag associations cleared.
+    /// Note that if this operation results in a Tag having no associations
+    /// to a SavedItem, the Tag object will be deleted.
+    public var updateSavedItemRemoveTags: UpdateSavedItemRemoveTag {
+      get {
+        return UpdateSavedItemRemoveTag(unsafeResultMap: resultMap["updateSavedItemRemoveTags"]! as! ResultMap)
+      }
+      set {
+        resultMap.updateValue(newValue.resultMap, forKey: "updateSavedItemRemoveTags")
+      }
+    }
+
+    public struct UpdateSavedItemRemoveTag: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["SavedItem"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("url", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", alias: "remoteID", type: .nonNull(.scalar(GraphQLID.self))),
+          GraphQLField("isArchived", type: .nonNull(.scalar(Bool.self))),
+          GraphQLField("isFavorite", type: .nonNull(.scalar(Bool.self))),
+          GraphQLField("_deletedAt", type: .scalar(Int.self)),
+          GraphQLField("_createdAt", type: .nonNull(.scalar(Int.self))),
+          GraphQLField("archivedAt", type: .scalar(Int.self)),
+          GraphQLField("tags", type: .list(.nonNull(.object(Tag.selections)))),
+          GraphQLField("item", type: .nonNull(.object(Item.selections))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(url: String, remoteId: GraphQLID, isArchived: Bool, isFavorite: Bool, _deletedAt: Int? = nil, _createdAt: Int, archivedAt: Int? = nil, tags: [Tag]? = nil, item: Item) {
+        self.init(unsafeResultMap: ["__typename": "SavedItem", "url": url, "remoteID": remoteId, "isArchived": isArchived, "isFavorite": isFavorite, "_deletedAt": _deletedAt, "_createdAt": _createdAt, "archivedAt": archivedAt, "tags": tags.flatMap { (value: [Tag]) -> [ResultMap] in value.map { (value: Tag) -> ResultMap in value.resultMap } }, "item": item.resultMap])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// The url the user saved to their list
+      public var url: String {
+        get {
+          return resultMap["url"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "url")
+        }
+      }
+
+      /// Surrogate primary key. This is usually generated by clients, but will be generated by the server if not passed through creation
+      public var remoteId: GraphQLID {
+        get {
+          return resultMap["remoteID"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "remoteID")
+        }
+      }
+
+      /// Helper property to indicate if the SavedItem is archived
+      public var isArchived: Bool {
+        get {
+          return resultMap["isArchived"]! as! Bool
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "isArchived")
+        }
+      }
+
+      /// Helper property to indicate if the SavedItem is favorited
+      public var isFavorite: Bool {
+        get {
+          return resultMap["isFavorite"]! as! Bool
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "isFavorite")
+        }
+      }
+
+      /// Unix timestamp of when the entity was deleted, 30 days after this date this entity will be HARD deleted from the database and no longer exist
+      public var _deletedAt: Int? {
+        get {
+          return resultMap["_deletedAt"] as? Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "_deletedAt")
+        }
+      }
+
+      /// Unix timestamp of when the entity was created
+      public var _createdAt: Int {
+        get {
+          return resultMap["_createdAt"]! as! Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "_createdAt")
+        }
+      }
+
+      /// Timestamp that the SavedItem became archied, null if not archived
+      public var archivedAt: Int? {
+        get {
+          return resultMap["archivedAt"] as? Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "archivedAt")
+        }
+      }
+
+      /// The Tags associated with this SavedItem
+      public var tags: [Tag]? {
+        get {
+          return (resultMap["tags"] as? [ResultMap]).flatMap { (value: [ResultMap]) -> [Tag] in value.map { (value: ResultMap) -> Tag in Tag(unsafeResultMap: value) } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [Tag]) -> [ResultMap] in value.map { (value: Tag) -> ResultMap in value.resultMap } }, forKey: "tags")
+        }
+      }
+
+      /// Link to the underlying Pocket Item for the URL
+      public var item: Item {
+        get {
+          return Item(unsafeResultMap: resultMap["item"]! as! ResultMap)
+        }
+        set {
+          resultMap.updateValue(newValue.resultMap, forKey: "item")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var savedItemParts: SavedItemParts {
+          get {
+            return SavedItemParts(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+      }
+
+      public struct Tag: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Tag"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(name: String) {
+          self.init(unsafeResultMap: ["__typename": "Tag", "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The actual tag string the user created for their list
+        public var name: String {
+          get {
+            return resultMap["name"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+
+      public struct Item: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["PendingItem", "Item"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLTypeCase(
+              variants: ["Item": AsItem.selections, "PendingItem": AsPendingItem.selections],
+              default: [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              ]
+            )
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public static func makeItem(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [AsItem.Author?]? = nil, marticle: [AsItem.Marticle]? = nil, excerpt: String? = nil, domainMetadata: AsItem.DomainMetadatum? = nil, images: [AsItem.Image?]? = nil) -> Item {
+          return Item(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [AsItem.Author?]) -> [ResultMap?] in value.map { (value: AsItem.Author?) -> ResultMap? in value.flatMap { (value: AsItem.Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [AsItem.Marticle]) -> [ResultMap] in value.map { (value: AsItem.Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: AsItem.DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [AsItem.Image?]) -> [ResultMap?] in value.map { (value: AsItem.Image?) -> ResultMap? in value.flatMap { (value: AsItem.Image) -> ResultMap in value.resultMap } } }])
+        }
+
+        public static func makePendingItem(url: String, status: PendingItemStatus? = nil) -> Item {
+          return Item(unsafeResultMap: ["__typename": "PendingItem", "url": url, "status": status])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var itemParts: ItemParts? {
+            get {
+              if !ItemParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+              return ItemParts(unsafeResultMap: resultMap)
+            }
+            set {
+              guard let newValue = newValue else { return }
+              resultMap += newValue.resultMap
+            }
+          }
+
+          public var pendingItemParts: PendingItemParts? {
+            get {
+              if !PendingItemParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+              return PendingItemParts(unsafeResultMap: resultMap)
+            }
+            set {
+              guard let newValue = newValue else { return }
+              resultMap += newValue.resultMap
+            }
+          }
+        }
+
+        public var asItem: AsItem? {
+          get {
+            if !AsItem.possibleTypes.contains(__typename) { return nil }
+            return AsItem(unsafeResultMap: resultMap)
+          }
+          set {
+            guard let newValue = newValue else { return }
+            resultMap = newValue.resultMap
+          }
+        }
+
+        public struct AsItem: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["Item"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("itemId", alias: "remoteID", type: .nonNull(.scalar(String.self))),
+              GraphQLField("givenUrl", type: .nonNull(.scalar(String.self))),
+              GraphQLField("resolvedUrl", type: .scalar(String.self)),
+              GraphQLField("title", type: .scalar(String.self)),
+              GraphQLField("language", type: .scalar(String.self)),
+              GraphQLField("topImageUrl", type: .scalar(String.self)),
+              GraphQLField("timeToRead", type: .scalar(Int.self)),
+              GraphQLField("domain", type: .scalar(String.self)),
+              GraphQLField("datePublished", type: .scalar(String.self)),
+              GraphQLField("isArticle", type: .scalar(Bool.self)),
+              GraphQLField("hasImage", type: .scalar(Imageness.self)),
+              GraphQLField("hasVideo", type: .scalar(Videoness.self)),
+              GraphQLField("authors", type: .list(.object(Author.selections))),
+              GraphQLField("marticle", type: .list(.nonNull(.object(Marticle.selections)))),
+              GraphQLField("excerpt", type: .scalar(String.self)),
+              GraphQLField("domainMetadata", type: .object(DomainMetadatum.selections)),
+              GraphQLField("images", type: .list(.object(Image.selections))),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(remoteId: String, givenUrl: String, resolvedUrl: String? = nil, title: String? = nil, language: String? = nil, topImageUrl: String? = nil, timeToRead: Int? = nil, domain: String? = nil, datePublished: String? = nil, isArticle: Bool? = nil, hasImage: Imageness? = nil, hasVideo: Videoness? = nil, authors: [Author?]? = nil, marticle: [Marticle]? = nil, excerpt: String? = nil, domainMetadata: DomainMetadatum? = nil, images: [Image?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Item", "remoteID": remoteId, "givenUrl": givenUrl, "resolvedUrl": resolvedUrl, "title": title, "language": language, "topImageUrl": topImageUrl, "timeToRead": timeToRead, "domain": domain, "datePublished": datePublished, "isArticle": isArticle, "hasImage": hasImage, "hasVideo": hasVideo, "authors": authors.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, "marticle": marticle.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, "excerpt": excerpt, "domainMetadata": domainMetadata.flatMap { (value: DomainMetadatum) -> ResultMap in value.resultMap }, "images": images.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// The Item entity is owned by the Parser service.
+          /// We only extend it in this service to make this service's schema valid.
+          /// The key for this entity is the 'itemId'
+          public var remoteId: String {
+            get {
+              return resultMap["remoteID"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "remoteID")
+            }
+          }
+
+          /// key field to identify the Item entity in the Parser service
+          public var givenUrl: String {
+            get {
+              return resultMap["givenUrl"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "givenUrl")
+            }
+          }
+
+          /// If the givenUrl redirects (once or many times), this is the final url. Otherwise, same as givenUrl
+          public var resolvedUrl: String? {
+            get {
+              return resultMap["resolvedUrl"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "resolvedUrl")
+            }
+          }
+
+          /// The title as determined by the parser.
+          public var title: String? {
+            get {
+              return resultMap["title"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "title")
+            }
+          }
+
+          /// The detected language of the article
+          public var language: String? {
+            get {
+              return resultMap["language"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "language")
+            }
+          }
+
+          /// The page's / publisher's preferred thumbnail image
+          @available(*, deprecated, message: "use the topImage object")
+          public var topImageUrl: String? {
+            get {
+              return resultMap["topImageUrl"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "topImageUrl")
+            }
+          }
+
+          /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
+          public var timeToRead: Int? {
+            get {
+              return resultMap["timeToRead"] as? Int
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "timeToRead")
+            }
+          }
+
+          /// The domain, such as 'getpocket.com' of the {.resolved_url}
+          public var domain: String? {
+            get {
+              return resultMap["domain"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "domain")
+            }
+          }
+
+          /// The date the article was published
+          public var datePublished: String? {
+            get {
+              return resultMap["datePublished"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "datePublished")
+            }
+          }
+
+          /// true if the item is an article
+          public var isArticle: Bool? {
+            get {
+              return resultMap["isArticle"] as? Bool
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "isArticle")
+            }
+          }
+
+          /// 0=no images, 1=contains images, 2=is an image
+          public var hasImage: Imageness? {
+            get {
+              return resultMap["hasImage"] as? Imageness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasImage")
+            }
+          }
+
+          /// 0=no videos, 1=contains video, 2=is a video
+          public var hasVideo: Videoness? {
+            get {
+              return resultMap["hasVideo"] as? Videoness
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasVideo")
+            }
+          }
+
+          /// List of Authors involved with this article
+          public var authors: [Author?]? {
+            get {
+              return (resultMap["authors"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Author?] in value.map { (value: ResultMap?) -> Author? in value.flatMap { (value: ResultMap) -> Author in Author(unsafeResultMap: value) } } }
+            }
+            set {
+              resultMap.updateValue(newValue.flatMap { (value: [Author?]) -> [ResultMap?] in value.map { (value: Author?) -> ResultMap? in value.flatMap { (value: Author) -> ResultMap in value.resultMap } } }, forKey: "authors")
+            }
+          }
+
+          /// The Marticle format of the article, used by clients for native article view.
+          public var marticle: [Marticle]? {
+            get {
+              return (resultMap["marticle"] as? [ResultMap]).flatMap { (value: [ResultMap]) -> [Marticle] in value.map { (value: ResultMap) -> Marticle in Marticle(unsafeResultMap: value) } }
+            }
+            set {
+              resultMap.updateValue(newValue.flatMap { (value: [Marticle]) -> [ResultMap] in value.map { (value: Marticle) -> ResultMap in value.resultMap } }, forKey: "marticle")
+            }
+          }
+
+          /// A snippet of text from the article
+          public var excerpt: String? {
+            get {
+              return resultMap["excerpt"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "excerpt")
+            }
+          }
+
+          /// Additional information about the item domain, when present, use this for displaying the domain name
+          public var domainMetadata: DomainMetadatum? {
+            get {
+              return (resultMap["domainMetadata"] as? ResultMap).flatMap { DomainMetadatum(unsafeResultMap: $0) }
+            }
+            set {
+              resultMap.updateValue(newValue?.resultMap, forKey: "domainMetadata")
+            }
+          }
+
+          /// Array of images within an article
+          public var images: [Image?]? {
+            get {
+              return (resultMap["images"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Image?] in value.map { (value: ResultMap?) -> Image? in value.flatMap { (value: ResultMap) -> Image in Image(unsafeResultMap: value) } } }
+            }
+            set {
+              resultMap.updateValue(newValue.flatMap { (value: [Image?]) -> [ResultMap?] in value.map { (value: Image?) -> ResultMap? in value.flatMap { (value: Image) -> ResultMap in value.resultMap } } }, forKey: "images")
+            }
+          }
+
+          public var fragments: Fragments {
+            get {
+              return Fragments(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+
+          public struct Fragments {
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var itemParts: ItemParts {
+              get {
+                return ItemParts(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public var pendingItemParts: PendingItemParts? {
+              get {
+                if !PendingItemParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                return PendingItemParts(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap += newValue.resultMap
+              }
+            }
+          }
+
+          public struct Author: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Author"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                GraphQLField("name", type: .scalar(String.self)),
+                GraphQLField("url", type: .scalar(String.self)),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(id: GraphQLID, name: String? = nil, url: String? = nil) {
+              self.init(unsafeResultMap: ["__typename": "Author", "id": id, "name": name, "url": url])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// Unique id for that Author
+            public var id: GraphQLID {
+              get {
+                return resultMap["id"]! as! GraphQLID
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "id")
+              }
+            }
+
+            /// Display name
+            public var name: String? {
+              get {
+                return resultMap["name"] as? String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "name")
+              }
+            }
+
+            /// A url to that Author's site
+            public var url: String? {
+              get {
+                return resultMap["url"] as? String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "url")
+              }
+            }
+          }
+
+          public struct Marticle: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["MarticleText", "Image", "MarticleDivider", "MarticleTable", "MarticleHeading", "MarticleCodeBlock", "Video", "MarticleBulletedList", "MarticleNumberedList", "MarticleBlockquote", "UnMarseable"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLTypeCase(
+                  variants: ["MarticleText": AsMarticleText.selections, "Image": AsImage.selections, "MarticleDivider": AsMarticleDivider.selections, "MarticleTable": AsMarticleTable.selections, "MarticleHeading": AsMarticleHeading.selections, "MarticleCodeBlock": AsMarticleCodeBlock.selections, "Video": AsVideo.selections, "MarticleBulletedList": AsMarticleBulletedList.selections, "MarticleNumberedList": AsMarticleNumberedList.selections, "MarticleBlockquote": AsMarticleBlockquote.selections],
+                  default: [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  ]
+                )
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public static func makeUnMarseable() -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "UnMarseable"])
+            }
+
+            public static func makeMarticleText(content: String) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleText", "content": content])
+            }
+
+            public static func makeImage(caption: String? = nil, credit: String? = nil, imageId: Int, src: String, height: Int? = nil, width: Int? = nil) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "Image", "caption": caption, "credit": credit, "imageID": imageId, "src": src, "height": height, "width": width])
+            }
+
+            public static func makeMarticleDivider(content: String) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleDivider", "content": content])
+            }
+
+            public static func makeMarticleTable(html: String) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleTable", "html": html])
+            }
+
+            public static func makeMarticleHeading(content: String, level: Int) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleHeading", "content": content, "level": level])
+            }
+
+            public static func makeMarticleCodeBlock(text: String, language: Int? = nil) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleCodeBlock", "text": text, "language": language])
+            }
+
+            public static func makeVideo(height: Int? = nil, src: String, type: VideoType, vid: String? = nil, videoId: Int, width: Int? = nil, length: Int? = nil) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "Video", "height": height, "src": src, "type": type, "vid": vid, "videoID": videoId, "width": width, "length": length])
+            }
+
+            public static func makeMarticleBulletedList(rows: [AsMarticleBulletedList.Row]) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleBulletedList", "rows": rows.map { (value: AsMarticleBulletedList.Row) -> ResultMap in value.resultMap }])
+            }
+
+            public static func makeMarticleNumberedList(rows: [AsMarticleNumberedList.Row]) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleNumberedList", "rows": rows.map { (value: AsMarticleNumberedList.Row) -> ResultMap in value.resultMap }])
+            }
+
+            public static func makeMarticleBlockquote(content: String) -> Marticle {
+              return Marticle(unsafeResultMap: ["__typename": "MarticleBlockquote", "content": content])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var marticleTextParts: MarticleTextParts? {
+                get {
+                  if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleTextParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var imageParts: ImageParts? {
+                get {
+                  if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return ImageParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleDividerParts: MarticleDividerParts? {
+                get {
+                  if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleDividerParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleTableParts: MarticleTableParts? {
+                get {
+                  if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleTableParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleHeadingParts: MarticleHeadingParts? {
+                get {
+                  if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleHeadingParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                get {
+                  if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var videoParts: VideoParts? {
+                get {
+                  if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return VideoParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleBulletedListParts: MarticleBulletedListParts? {
+                get {
+                  if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleNumberedListParts: MarticleNumberedListParts? {
+                get {
+                  if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                get {
+                  if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                  return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  guard let newValue = newValue else { return }
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+
+            public var asMarticleText: AsMarticleText? {
+              get {
+                if !AsMarticleText.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleText(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleText: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleText"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(content: String) {
+                self.init(unsafeResultMap: ["__typename": "MarticleText", "content": content])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Markdown text content. Typically, a paragraph.
+              public var content: String {
+                get {
+                  return resultMap["content"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "content")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts {
+                  get {
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asImage: AsImage? {
+              get {
+                if !AsImage.possibleTypes.contains(__typename) { return nil }
+                return AsImage(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsImage: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["Image"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("caption", type: .scalar(String.self)),
+                  GraphQLField("credit", type: .scalar(String.self)),
+                  GraphQLField("imageId", alias: "imageID", type: .nonNull(.scalar(Int.self))),
+                  GraphQLField("src", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("height", type: .scalar(Int.self)),
+                  GraphQLField("width", type: .scalar(Int.self)),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(caption: String? = nil, credit: String? = nil, imageId: Int, src: String, height: Int? = nil, width: Int? = nil) {
+                self.init(unsafeResultMap: ["__typename": "Image", "caption": caption, "credit": credit, "imageID": imageId, "src": src, "height": height, "width": width])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// A caption or description of the image
+              public var caption: String? {
+                get {
+                  return resultMap["caption"] as? String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "caption")
+                }
+              }
+
+              /// A credit for the image, typically who the image belongs to / created by
+              public var credit: String? {
+                get {
+                  return resultMap["credit"] as? String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "credit")
+                }
+              }
+
+              /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              public var imageId: Int {
+                get {
+                  return resultMap["imageID"]! as! Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "imageID")
+                }
+              }
+
+              /// Absolute url to the image
+              @available(*, deprecated, message: "use url property moving forward")
+              public var src: String {
+                get {
+                  return resultMap["src"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "src")
+                }
+              }
+
+              /// The determined height of the image at the url
+              public var height: Int? {
+                get {
+                  return resultMap["height"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "height")
+                }
+              }
+
+              /// The determined width of the image at the url
+              public var width: Int? {
+                get {
+                  return resultMap["width"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "width")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts {
+                  get {
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asMarticleDivider: AsMarticleDivider? {
+              get {
+                if !AsMarticleDivider.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleDivider(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleDivider: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleDivider"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(content: String) {
+                self.init(unsafeResultMap: ["__typename": "MarticleDivider", "content": content])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Always '---'; provided for convenience if building a markdown string
+              public var content: String {
+                get {
+                  return resultMap["content"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "content")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts {
+                  get {
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asMarticleTable: AsMarticleTable? {
+              get {
+                if !AsMarticleTable.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleTable(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleTable: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleTable"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("html", type: .nonNull(.scalar(String.self))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(html: String) {
+                self.init(unsafeResultMap: ["__typename": "MarticleTable", "html": html])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Raw HTML representation of the table.
+              public var html: String {
+                get {
+                  return resultMap["html"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "html")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts {
+                  get {
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asMarticleHeading: AsMarticleHeading? {
+              get {
+                if !AsMarticleHeading.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleHeading(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleHeading: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleHeading"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("level", type: .nonNull(.scalar(Int.self))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(content: String, level: Int) {
+                self.init(unsafeResultMap: ["__typename": "MarticleHeading", "content": content, "level": level])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Heading text, in markdown.
+              public var content: String {
+                get {
+                  return resultMap["content"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "content")
+                }
+              }
+
+              /// Heading level. Restricted to values 1-6.
+              public var level: Int {
+                get {
+                  return resultMap["level"]! as! Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "level")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts {
+                  get {
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asMarticleCodeBlock: AsMarticleCodeBlock? {
+              get {
+                if !AsMarticleCodeBlock.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleCodeBlock(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleCodeBlock: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleCodeBlock"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("text", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("language", type: .scalar(Int.self)),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(text: String, language: Int? = nil) {
+                self.init(unsafeResultMap: ["__typename": "MarticleCodeBlock", "text": text, "language": language])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Content of a pre tag
+              public var text: String {
+                get {
+                  return resultMap["text"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "text")
+                }
+              }
+
+              /// Assuming the codeblock was a programming language, this field is used to identify it.
+              public var language: Int? {
+                get {
+                  return resultMap["language"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "language")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts {
+                  get {
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asVideo: AsVideo? {
+              get {
+                if !AsVideo.possibleTypes.contains(__typename) { return nil }
+                return AsVideo(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsVideo: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["Video"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("height", type: .scalar(Int.self)),
+                  GraphQLField("src", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("type", type: .nonNull(.scalar(VideoType.self))),
+                  GraphQLField("vid", type: .scalar(String.self)),
+                  GraphQLField("videoId", alias: "videoID", type: .nonNull(.scalar(Int.self))),
+                  GraphQLField("width", type: .scalar(Int.self)),
+                  GraphQLField("length", type: .scalar(Int.self)),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(height: Int? = nil, src: String, type: VideoType, vid: String? = nil, videoId: Int, width: Int? = nil, length: Int? = nil) {
+                self.init(unsafeResultMap: ["__typename": "Video", "height": height, "src": src, "type": type, "vid": vid, "videoID": videoId, "width": width, "length": length])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// If known, the height of the video in px
+              public var height: Int? {
+                get {
+                  return resultMap["height"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "height")
+                }
+              }
+
+              /// Absolute url to the video
+              public var src: String {
+                get {
+                  return resultMap["src"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "src")
+                }
+              }
+
+              /// The type of video
+              public var type: VideoType {
+                get {
+                  return resultMap["type"]! as! VideoType
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "type")
+                }
+              }
+
+              /// The video's id within the service defined by type
+              public var vid: String? {
+                get {
+                  return resultMap["vid"] as? String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "vid")
+                }
+              }
+
+              /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              public var videoId: Int {
+                get {
+                  return resultMap["videoID"]! as! Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "videoID")
+                }
+              }
+
+              /// If known, the width of the video in px
+              public var width: Int? {
+                get {
+                  return resultMap["width"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "width")
+                }
+              }
+
+              /// If known, the length of the video in seconds
+              public var length: Int? {
+                get {
+                  return resultMap["length"] as? Int
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "length")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts {
+                  get {
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+
+            public var asMarticleBulletedList: AsMarticleBulletedList? {
+              get {
+                if !AsMarticleBulletedList.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleBulletedList(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleBulletedList: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleBulletedList"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("rows", type: .nonNull(.list(.nonNull(.object(Row.selections))))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(rows: [Row]) {
+                self.init(unsafeResultMap: ["__typename": "MarticleBulletedList", "rows": rows.map { (value: Row) -> ResultMap in value.resultMap }])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              public var rows: [Row] {
+                get {
+                  return (resultMap["rows"] as! [ResultMap]).map { (value: ResultMap) -> Row in Row(unsafeResultMap: value) }
+                }
+                set {
+                  resultMap.updateValue(newValue.map { (value: Row) -> ResultMap in value.resultMap }, forKey: "rows")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts {
+                  get {
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+
+              public struct Row: GraphQLSelectionSet {
+                public static let possibleTypes: [String] = ["BulletedListElement"]
+
+                public static var selections: [GraphQLSelection] {
+                  return [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("level", type: .nonNull(.scalar(Int.self))),
+                  ]
+                }
+
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public init(content: String, level: Int) {
+                  self.init(unsafeResultMap: ["__typename": "BulletedListElement", "content": content, "level": level])
+                }
+
+                public var __typename: String {
+                  get {
+                    return resultMap["__typename"]! as! String
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "__typename")
+                  }
+                }
+
+                /// Row in a list.
+                public var content: String {
+                  get {
+                    return resultMap["content"]! as! String
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "content")
+                  }
+                }
+
+                /// Zero-indexed level, for handling nested lists.
+                public var level: Int {
+                  get {
+                    return resultMap["level"]! as! Int
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "level")
+                  }
+                }
+              }
+            }
+
+            public var asMarticleNumberedList: AsMarticleNumberedList? {
+              get {
+                if !AsMarticleNumberedList.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleNumberedList(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleNumberedList: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleNumberedList"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("rows", type: .nonNull(.list(.nonNull(.object(Row.selections))))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(rows: [Row]) {
+                self.init(unsafeResultMap: ["__typename": "MarticleNumberedList", "rows": rows.map { (value: Row) -> ResultMap in value.resultMap }])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              public var rows: [Row] {
+                get {
+                  return (resultMap["rows"] as! [ResultMap]).map { (value: ResultMap) -> Row in Row(unsafeResultMap: value) }
+                }
+                set {
+                  resultMap.updateValue(newValue.map { (value: Row) -> ResultMap in value.resultMap }, forKey: "rows")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts {
+                  get {
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts? {
+                  get {
+                    if !MarticleBlockquoteParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+
+              public struct Row: GraphQLSelectionSet {
+                public static let possibleTypes: [String] = ["NumberedListElement"]
+
+                public static var selections: [GraphQLSelection] {
+                  return [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("level", type: .nonNull(.scalar(Int.self))),
+                    GraphQLField("index", type: .nonNull(.scalar(Int.self))),
+                  ]
+                }
+
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public init(content: String, level: Int, index: Int) {
+                  self.init(unsafeResultMap: ["__typename": "NumberedListElement", "content": content, "level": level, "index": index])
+                }
+
+                public var __typename: String {
+                  get {
+                    return resultMap["__typename"]! as! String
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "__typename")
+                  }
+                }
+
+                /// Row in a list
+                public var content: String {
+                  get {
+                    return resultMap["content"]! as! String
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "content")
+                  }
+                }
+
+                /// Zero-indexed level, for handling nexted lists.
+                public var level: Int {
+                  get {
+                    return resultMap["level"]! as! Int
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "level")
+                  }
+                }
+
+                /// Numeric index. If a nested item, the index is zero-indexed from the first child.
+                public var index: Int {
+                  get {
+                    return resultMap["index"]! as! Int
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "index")
+                  }
+                }
+              }
+            }
+
+            public var asMarticleBlockquote: AsMarticleBlockquote? {
+              get {
+                if !AsMarticleBlockquote.possibleTypes.contains(__typename) { return nil }
+                return AsMarticleBlockquote(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap = newValue.resultMap
+              }
+            }
+
+            public struct AsMarticleBlockquote: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["MarticleBlockquote"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("content", type: .nonNull(.scalar(String.self))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(content: String) {
+                self.init(unsafeResultMap: ["__typename": "MarticleBlockquote", "content": content])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// Markdown text content.
+              public var content: String {
+                get {
+                  return resultMap["content"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "content")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var marticleTextParts: MarticleTextParts? {
+                  get {
+                    if !MarticleTextParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTextParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var imageParts: ImageParts? {
+                  get {
+                    if !ImageParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return ImageParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleDividerParts: MarticleDividerParts? {
+                  get {
+                    if !MarticleDividerParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleDividerParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleTableParts: MarticleTableParts? {
+                  get {
+                    if !MarticleTableParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleTableParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleHeadingParts: MarticleHeadingParts? {
+                  get {
+                    if !MarticleHeadingParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleHeadingParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleCodeBlockParts: MarticleCodeBlockParts? {
+                  get {
+                    if !MarticleCodeBlockParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleCodeBlockParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var videoParts: VideoParts? {
+                  get {
+                    if !VideoParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return VideoParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBulletedListParts: MarticleBulletedListParts? {
+                  get {
+                    if !MarticleBulletedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleBulletedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleNumberedListParts: MarticleNumberedListParts? {
+                  get {
+                    if !MarticleNumberedListParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                    return MarticleNumberedListParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    guard let newValue = newValue else { return }
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public var marticleBlockquoteParts: MarticleBlockquoteParts {
+                  get {
+                    return MarticleBlockquoteParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+              }
+            }
+          }
+
+          public struct DomainMetadatum: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["DomainMetadata"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .scalar(String.self)),
+                GraphQLField("logo", type: .scalar(String.self)),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(name: String? = nil, logo: String? = nil) {
+              self.init(unsafeResultMap: ["__typename": "DomainMetadata", "name": name, "logo": logo])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// The name of the domain (e.g., The New York Times)
+            public var name: String? {
+              get {
+                return resultMap["name"] as? String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "name")
+              }
+            }
+
+            /// Url for the logo image
+            public var logo: String? {
+              get {
+                return resultMap["logo"] as? String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "logo")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var domainMetadataParts: DomainMetadataParts {
+                get {
+                  return DomainMetadataParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+          }
+
+          public struct Image: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Image"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("height", type: .scalar(Int.self)),
+                GraphQLField("width", type: .scalar(Int.self)),
+                GraphQLField("src", type: .nonNull(.scalar(String.self))),
+                GraphQLField("imageId", type: .nonNull(.scalar(Int.self))),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(height: Int? = nil, width: Int? = nil, src: String, imageId: Int) {
+              self.init(unsafeResultMap: ["__typename": "Image", "height": height, "width": width, "src": src, "imageId": imageId])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// The determined height of the image at the url
+            public var height: Int? {
+              get {
+                return resultMap["height"] as? Int
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "height")
+              }
+            }
+
+            /// The determined width of the image at the url
+            public var width: Int? {
+              get {
+                return resultMap["width"] as? Int
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "width")
+              }
+            }
+
+            /// Absolute url to the image
+            @available(*, deprecated, message: "use url property moving forward")
+            public var src: String {
+              get {
+                return resultMap["src"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "src")
+              }
+            }
+
+            /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+            public var imageId: Int {
+              get {
+                return resultMap["imageId"]! as! Int
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "imageId")
+              }
+            }
+          }
+        }
+
+        public var asPendingItem: AsPendingItem? {
+          get {
+            if !AsPendingItem.possibleTypes.contains(__typename) { return nil }
+            return AsPendingItem(unsafeResultMap: resultMap)
+          }
+          set {
+            guard let newValue = newValue else { return }
+            resultMap = newValue.resultMap
+          }
+        }
+
+        public struct AsPendingItem: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["PendingItem"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("url", type: .nonNull(.scalar(String.self))),
+              GraphQLField("status", type: .scalar(PendingItemStatus.self)),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(url: String, status: PendingItemStatus? = nil) {
+            self.init(unsafeResultMap: ["__typename": "PendingItem", "url": url, "status": status])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// URL of the item that the user gave for the SavedItem
+          /// that is pending processing by parser
+          public var url: String {
+            get {
+              return resultMap["url"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "url")
+            }
+          }
+
+          public var status: PendingItemStatus? {
+            get {
+              return resultMap["status"] as? PendingItemStatus
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "status")
+            }
+          }
+
+          public var fragments: Fragments {
+            get {
+              return Fragments(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+
+          public struct Fragments {
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var itemParts: ItemParts? {
+              get {
+                if !ItemParts.possibleTypes.contains(resultMap["__typename"]! as! String) { return nil }
+                return ItemParts(unsafeResultMap: resultMap)
+              }
+              set {
+                guard let newValue = newValue else { return }
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public var pendingItemParts: PendingItemParts {
+              get {
+                return PendingItemParts(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 public final class GetSlateLineupQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
   public let operationDefinition: String =

--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -95,14 +95,14 @@ class FetchList: SyncOperation {
         guard let edges = result.data?.userByToken?.savedItems?.edges else {
             return
         }
-
+        // TODO: Add deleteOrphanTags here instead of update and refactor below to be in space (IN-788)
         for edge in edges {
             guard let edge = edge, let node = edge.node else {
                 return
             }
 
             let item = try space.fetchOrCreateSavedItem(byRemoteID: node.remoteId)
-            item.update(from: edge)
+            item.update(from: edge, with: space)
 
             if item.deletedAt != nil {
                 space.delete(item)

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -60,7 +60,7 @@ class SaveItemOperation: SyncOperation {
             return
         }
 
-        savedItem.update(from: remote)
+        savedItem.update(from: remote, with: space)
 
         do {
             try space.save()

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -20,6 +20,12 @@ protocol SyncOperationFactory {
         events: SyncEvents,
         mutation: Mutation
     ) -> SyncOperation
+    
+    func savedItemMutationOperation(
+        apollo: ApolloClientProtocol,
+        events: SyncEvents,
+        mutation: AnyMutation
+    ) -> SyncOperation
 
     func saveItemOperation(
         managedItemID: NSManagedObjectID,
@@ -55,6 +61,14 @@ class OperationFactory: SyncOperationFactory {
         apollo: ApolloClientProtocol,
         events: SyncEvents,
         mutation: Mutation
+    ) -> SyncOperation {
+        SavedItemMutationOperation(apollo: apollo, events: events, mutation: mutation)
+    }
+    
+    func savedItemMutationOperation(
+        apollo: ApolloClientProtocol,
+        events: SyncEvents,
+        mutation: AnyMutation
     ) -> SyncOperation {
         SavedItemMutationOperation(apollo: apollo, events: events, mutation: mutation)
     }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -78,7 +78,7 @@
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES" codeGenerationType="class">
         <attribute name="name" optional="YES" attributeType="String"/>
-        <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
+        <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
     </entity>
     <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -142,7 +142,7 @@ class SaveOperation: AsyncOperation {
             return
         }
 
-        savedItem.update(from: savedItemParts)
+        savedItem.update(from: savedItemParts, with: space)
         let notification: SavedItemUpdatedNotification = space.new()
         notification.savedItem = savedItem
         try? space.save()

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -316,18 +316,10 @@ extension PocketSource {
         try? space.deleteOrphanTags()
         try? space.save()
         
-        let mutation: AnyMutation
-
-        if tags.isEmpty {
-            mutation = AnyMutation(UpdateSavedItemRemoveTagsMutation(savedItemId: remoteID))
-        } else {
-            mutation = AnyMutation(ReplaceSavedItemTagsMutation(input: [SavedItemTagsInput(savedItemId: remoteID, tags: tags)]))
-        }
-        
         let operation = operations.savedItemMutationOperation(
             apollo: apollo,
             events: _events,
-            mutation: mutation
+            mutation: getMutation(for: tags, and: remoteID)
         )
 
         enqueue(operation: operation, task: .addTags(remoteID: remoteID, tags: tags))
@@ -352,6 +344,16 @@ extension PocketSource {
             savedItem.update(from: remoteSavedItem.fragments.savedItemParts, with: space)
             try space.save()
         }
+    }
+    
+    private func getMutation(for tags: [String], and remoteID: String) -> AnyMutation {
+        let mutation: AnyMutation
+        if tags.isEmpty {
+            mutation = AnyMutation(UpdateSavedItemRemoveTagsMutation(savedItemId: remoteID))
+        } else {
+            mutation = AnyMutation(ReplaceSavedItemTagsMutation(input: [SavedItemTagsInput(savedItemId: remoteID, tags: tags)]))
+        }
+        return mutation
     }
 }
 
@@ -475,16 +477,10 @@ extension PocketSource {
                 )
                 enqueue(operation: operation, persistentTask: persistentTask)
             case .addTags(let remoteID, let tags):
-                let mutation: AnyMutation
-                if tags.isEmpty {
-                    mutation = AnyMutation(UpdateSavedItemRemoveTagsMutation(savedItemId: remoteID))
-                } else {
-                    mutation = AnyMutation(ReplaceSavedItemTagsMutation(input: [SavedItemTagsInput(savedItemId: remoteID, tags: tags)]))
-                }
                 let operation = operations.savedItemMutationOperation(
                     apollo: apollo,
                     events: _events,
-                    mutation: mutation
+                    mutation: getMutation(for: tags, and: remoteID)
                 )
                 enqueue(operation: operation, persistentTask: persistentTask)
             }

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -116,9 +116,21 @@ public enum Requests {
     }
     
     public static func fetchTag(byName name: String) -> NSFetchRequest<Tag> {
-        let request = self.fetchTags()
+        let request = fetchTags()
         request.predicate = NSPredicate(format: "name = %@", name)
         request.fetchLimit = 1
+        return request
+    }
+
+    public static func fetchTagsWithNoSavedItems() -> NSFetchRequest<Tag> {
+        let request = fetchTags()
+        request.predicate = NSPredicate(format: "savedItems.@count = 0")
+        return request
+    }
+    
+    public static func fetchTags(excluding tags: [String]) -> NSFetchRequest<Tag> {
+        let request = fetchTags()
+        request.predicate = NSPredicate(format: "NOT (self.name IN %@)", tags)
         return request
     }
 

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -41,6 +41,8 @@ public protocol Source {
     func unarchive(item: SavedItem)
     
     func addTags(item: SavedItem, tags: [String])
+    
+    func retrieveTags(excluding: [String]) -> [Tag]?
 
     func fetchSlateLineup(_ identifier: String) async throws
 

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -110,6 +110,29 @@ public class Space {
     func fetchItem(byRemoteID id: String) throws -> Item? {
         return try fetch(Requests.fetchItem(byRemoteID: id)).first
     }
+    
+    func fetchTags() throws -> [Tag] {
+        return try fetch(Requests.fetchTags())
+    }
+    
+    func fetchOrCreateTag(byName name: String) -> Tag {
+        let fetchRequest = Requests.fetchTag(byName: name)
+        fetchRequest.fetchLimit = 1
+        let fetchedTag = (try? fetch(fetchRequest).first) ?? Tag(context: context)
+        guard fetchedTag.name == nil else { return fetchedTag }
+        fetchedTag.name = name
+        return fetchedTag
+    }
+    
+    func retrieveTags(excluding tags: [String]) throws -> [Tag] {
+        return try fetch(Requests.fetchTags(excluding: tags))
+    }
+    
+    func deleteOrphanTags() throws {
+        let deleteRequest = Requests.fetchTagsWithNoSavedItems()
+        let tags = try context.fetch(deleteRequest)
+        delete(tags)
+    }
 
     func fetchOrCreateItem(byRemoteID id: String) throws -> Item {
         return try fetchItem(byRemoteID: id) ?? new()
@@ -121,15 +144,6 @@ public class Space {
 
     func fetch<T>(_ request: NSFetchRequest<T>) throws -> [T] {
         try context.fetch(request)
-    }
-    
-    func fetchOrCreateTag(byName name: String) -> Tag {
-        let fetchRequest = Requests.fetchTag(byName: name)
-        fetchRequest.fetchLimit = 1
-        let fetchedTag = (try? context.fetch(fetchRequest).first) ?? Tag(context: context)
-        guard fetchedTag.name == nil else { return fetchedTag }
-        fetchedTag.name = name
-        return fetchedTag
     }
 
     func new<T: NSManagedObject>() -> T {

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -133,6 +133,12 @@ mutation ReplaceSavedItemTags($input: [SavedItemTagsInput!]!) {
     }
 }
 
+mutation UpdateSavedItemRemoveTags($savedItemId: ID!) {
+    updateSavedItemRemoveTags(savedItemId: $savedItemId) {
+        ...SavedItemParts
+    }
+}
+
 query GetSlateLineup($lineupID: String!, $maxRecommendations: Int!) {
   getSlateLineup(slateLineupId: $lineupID, recommendationCount: $maxRecommendations) {
     id

--- a/PocketKit/Tests/PocketKitTests/AddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AddTagsViewModelTests.swift
@@ -69,6 +69,33 @@ class AddTagsViewModelTests: XCTestCase {
         XCTAssertNotNil(source.addTagsToSavedItemCall(at: 0))
     }
     
+    func test_allOtherTags_retrievesValidTagNames() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let expectRetrieveTagsCall = expectation(description: "expect source.retrieveTags(excluding:)")
+        
+        source.stubRetrieveTags { [weak self] _ in
+            guard let self = self else { return nil }
+            defer { expectRetrieveTagsCall.fulfill() }
+            let tag2: Tag = self.space.new()
+            let tag3: Tag = self.space.new()
+            tag2.name = "tag 2"
+            tag3.name = "tag 3"
+            return [tag2, tag3]
+        }
+        
+        let viewModel = subject(item: item) { }
+        
+        guard let tags = viewModel.allOtherTags() else {
+            XCTFail("tags should not be nil")
+            return
+        }
+
+        XCTAssertEqual(tags, ["tag 2", "tag 3"])
+        
+        wait(for: [expectRetrieveTagsCall], timeout: 1)
+        XCTAssertNotNil(source.retrieveTagsCall(at: 0))
+    }
+    
     func test_removeTag_withValidName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1", "tag 2", "tag 3"])
         let viewModel = subject(item: item) { }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -264,6 +264,40 @@ extension MockSource {
     }
 }
 
+// MARK: - Retrieve Tags
+extension MockSource {
+    static let retrieveTags = "retrieveTags"
+    typealias RetrieveTagsImpl = ([String]) -> [Tag]?
+    struct RetrieveTagsImplCall {
+        let tags: [String]
+    }
+
+    func stubRetrieveTags(impl: @escaping RetrieveTagsImpl) {
+        implementations[Self.retrieveTags] = impl
+    }
+
+    func retrieveTags(excluding tags: [String]) -> [Tag]? {
+        guard let impl = implementations[Self.retrieveTags] as? RetrieveTagsImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.retrieveTags] = (calls[Self.retrieveTags] ?? []) + [
+            RetrieveTagsImplCall(tags: tags)
+        ]
+
+        return impl(tags)
+    }
+
+    func retrieveTagsCall(at index: Int) -> RetrieveTagsImplCall? {
+        guard let calls = calls[Self.retrieveTags],
+              calls.count > index else {
+                  return nil
+              }
+
+        return calls[index] as? RetrieveTagsImplCall
+    }
+}
+
 // MARK: - Favorite an item
 extension MockSource {
     static let favoriteSavedItem = "favoriteSavedItem"

--- a/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
@@ -28,7 +28,7 @@ class ItemMutationOperationTests: XCTestCase {
         mutation: Mutation,
         apollo: ApolloClientProtocol? = nil,
         events: SyncEvents? = nil
-    ) -> SavedItemMutationOperation<Mutation> {
+    ) -> SavedItemMutationOperation {
         SavedItemMutationOperation(
             apollo: apollo ?? self.apollo,
             events: events ?? self.events,

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -151,10 +151,10 @@ class PocketSourceTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
     
-    func test_addTagsToSavedItem_executesAddTagsMutation() throws {
+    func test_addTagsToSavedItem_executesReplaceSavedItemTagsMutation() throws {
         let item = try space.createSavedItem(tags: ["tag 1"])
         let expectationToRunOperation = expectation(description: "Run operation")
-        operations.stubItemMutationOperation { (_, _ , _: ReplaceSavedItemTagsMutation) in
+        operations.stubItemAnyMutationOperation { (_, _ , _) in
             TestSyncOperation {
                 expectationToRunOperation.fulfill()
             }
@@ -162,11 +162,38 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.addTags(item: item, tags: ["tag 2", "tag 3"])
-        XCTAssertEqual(item.tags?.count, 3)
-        XCTAssertEqual((item.tags?[0] as? Tag)?.name, "tag 1")
-        XCTAssertEqual((item.tags?[1] as? Tag)?.name, "tag 2")
-        XCTAssertEqual((item.tags?[2] as? Tag)?.name, "tag 3")
+        XCTAssertEqual(item.tags?.count, 2)
+        XCTAssertEqual((item.tags?[0] as? Tag)?.name, "tag 2")
+        XCTAssertEqual((item.tags?[1] as? Tag)?.name, "tag 3")
         waitForExpectations(timeout: 1)
+    }
+    
+    func test_addTagsToSavedItem_withNoTags_executesUpdateSavedItemRemoveTagsMutation() throws {
+        let item = try space.createSavedItem(tags: ["tag 1", "tag 2"])
+        let expectationToRunOperation = expectation(description: "Run operation")
+        operations.stubItemAnyMutationOperation { (_, _ , _) in
+            TestSyncOperation {
+                expectationToRunOperation.fulfill()
+            }
+        }
+
+        let source = subject()
+        source.addTags(item: item, tags: [])
+        XCTAssertEqual(item.tags?.count, 0)
+        waitForExpectations(timeout: 1)
+    }
+    
+    func test_retrieveTags_excludesTagsAlreadySelected() throws {
+        let tag1: Tag = space.new()
+        let tag2: Tag = space.new()
+        let tag3: Tag = space.new()
+        tag1.name = "tag 1"
+        tag2.name = "tag 2"
+        tag3.name = "tag 3"
+        let source = subject()
+        let tags = source.retrieveTags(excluding: [tag1.name ?? "", tag2.name ?? ""])
+        XCTAssertEqual(tags?.count, 1)
+        XCTAssertEqual(tags?[0].name, "tag 3")
     }
 
     func test_delete_removesItemFromLocalStorage_andExecutesDeleteMutation() throws {

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -20,12 +20,17 @@ class SpaceTests: XCTestCase {
     
     func testDeletingOrphanTags() throws {
         let space = subject()
-        let _: Tag = space.new()
-        let _: Tag = space.new()
+        _ = space.buildSavedItem(tags: ["tag 1"])
+        let tag2: Tag = space.new()
+        let tag3: Tag = space.new()
+        tag2.name = "tag 2"
+        tag3.name = "tag 3"
+    
+        try XCTAssertEqual(Set(space.fetchTags().compactMap { $0.name }), ["tag 1", "tag 2", "tag 3"])
         
         try space.deleteOrphanTags()
         
-        try XCTAssertEqual(space.fetchTags(), [])
+        try XCTAssertEqual(space.fetchTags().compactMap { $0.name }, ["tag 1"])
     }
     
     func testFetchTags() throws {

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import Sync
+import CoreData
+
+class SpaceTests: XCTestCase {
+    var context: NSManagedObjectContext!
+    
+    override func setUp() {
+        context = PersistentContainer.testContainer.viewContext
+    }
+    
+    override func tearDownWithError() throws {
+        try Space.testSpace().clear()
+    }
+    
+    func subject(context: NSManagedObjectContext? = nil) -> Space {
+        Space(context: context ?? self.context)
+    }
+    
+    func testDeletingOrphanTags() throws {
+        let space = subject()
+        let _: Tag = space.new()
+        let _: Tag = space.new()
+        
+        try space.deleteOrphanTags()
+        
+        try XCTAssertEqual(space.fetchTags(), [])
+    }
+    
+    func testFetchTags() throws {
+        let space = subject()
+        let _: Tag = space.new()
+        let _: Tag = space.new()
+        
+        let tags = try space.fetchTags()
+        XCTAssertEqual(tags.count, 2)
+    }
+    
+    func testFetchOrCreateTags() throws {
+        let space = subject()
+        let tag1: Tag = space.new()
+        tag1.name = "tag 1"
+        
+        let fetchedTag1 = space.fetchOrCreateTag(byName: "tag 1")
+        let fetchedTag2 = space.fetchOrCreateTag(byName: "tag 2")
+        
+        XCTAssertEqual(fetchedTag1.name, "tag 1")
+        XCTAssertEqual(fetchedTag2.name, "tag 2")
+        try XCTAssertEqual(space.fetchTags().count, 2)
+    }
+    
+    func testRetrieveTagsExcludingCertainTags() throws {
+        let space = subject()
+        let tag1: Tag = space.new()
+        let tag2: Tag = space.new()
+        let tag3: Tag = space.new()
+        tag1.name = "tag 1"
+        tag2.name = "tag 2"
+        tag3.name = "tag 3"
+
+        let tags = try space.retrieveTags(excluding: ["tag 1"])
+        
+        XCTAssertEqual(tags.count, 2)
+        XCTAssertTrue(tags.contains(tag2))
+        XCTAssertTrue(tags.contains(tag3))
+    }
+}

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -101,6 +101,33 @@ extension MockOperationFactory {
     }
 }
 
+// MARK: - itemAnyMutationOperation (without generics)
+extension MockOperationFactory {
+    typealias ItemAnyMutationOperationImpl = (
+        ApolloClientProtocol,
+        SyncEvents,
+        AnyMutation
+    ) -> SyncOperation
+
+    func stubItemAnyMutationOperation(
+        impl: @escaping ItemAnyMutationOperationImpl
+    ) {
+        implementations["itemAnyMutationOperation"] = impl
+    }
+
+    func savedItemMutationOperation(
+        apollo: ApolloClientProtocol,
+        events: SyncEvents,
+        mutation: AnyMutation
+    ) -> SyncOperation {
+        guard let impl = implementations["itemAnyMutationOperation"] as? ItemAnyMutationOperationImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        return impl(apollo, events, mutation)
+    }
+}
+
 // MARK: - saveItemOperation
 extension MockOperationFactory {
     typealias SaveItemOperationImpl = (NSManagedObjectID, URL, SyncEvents, ApolloClientProtocol, Space) -> SyncOperation

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -52,6 +52,7 @@ class AddTagsItemTests: XCTestCase {
 
         app.addTagsButton.wait().tap()
         let addTagsView = app.addTagsView.wait()
+        addTagsView.wait()
         addTagsView.newTagTextField.tap()
         addTagsView.newTagTextField.typeText("Tag 1")
         XCUIApplication().keyboards.buttons["return"].tap()
@@ -68,7 +69,10 @@ class AddTagsItemTests: XCTestCase {
         app.addTagsButton.wait().tap()
         app.addTagsView.wait()
         
-        addTagsView.tag(matching: "tag 1").wait()
+        addTagsView.tag(matching: "tag 1").wait().tap()
+        
+        addTagsView.allTagsRow(matching: "tag 1").wait().tap()
+        waitForDisappearance(of: addTagsView.allTagsRow(matching: "tag 1"))
     }
     
     func test_addTagsToItemFromArchive_showsAddTagsView() {
@@ -85,6 +89,7 @@ class AddTagsItemTests: XCTestCase {
 
         app.addTagsButton.wait().tap()
         app.addTagsView.wait()
+        app.addTagsView.allTagsView.wait()
     }
     
     func test_addTagsToSavedItemFromReader_showsAddTagsView() {
@@ -104,26 +109,6 @@ class AddTagsItemTests: XCTestCase {
 
         app.addTagsButton.wait().tap()
         app.addTagsView.wait()
-    }
-    
-    func test_deleteTagsForItem_removesTags() {
-        app.tabBar.myListButton.wait().tap()
-
-        let itemCell = app.myListView.itemView(matching: "Item 1")
-        itemCell.itemActionButton.wait().tap()
-
-        app.addTagsButton.wait().tap()
-        let addTagsView = app.addTagsView.wait()
-        addTagsView.newTagTextField.tap()
-        addTagsView.newTagTextField.typeText("Tag 1")
-        XCUIApplication().keyboards.buttons["return"].tap()
-        
-        addTagsView.newTagTextField.tap()
-        addTagsView.newTagTextField.typeText("Tag 2")
-        XCUIApplication().keyboards.buttons["return"].tap()
-        
-        addTagsView.tag(matching: "tag 1").wait().tap()
-                
-        waitForDisappearance(of: addTagsView.tag(matching: "tag 1"))
+        app.addTagsView.allTagsView.wait()
     }
 }

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -23,7 +23,12 @@
                             "archivedAt": null,
                             "isArchived": false,
                             "isFavorite": false,
-                            "tags": [],
+                            "tags": [
+                                {
+                                    "__typename": "Tag",
+                                    "name": "tag 0"
+                                }
+                            ],
                             "item": {
                                 "__typename": "Item",
                                 "remoteID": "item-1",

--- a/Tests iOS/Support/Elements/AddTagsViewElement.swift
+++ b/Tests iOS/Support/Elements/AddTagsViewElement.swift
@@ -18,6 +18,14 @@ struct AddTagsViewElement: PocketUIElement {
     var newTagTextField: XCUIElement {
         element.textFields["enter-tag-name"]
     }
+    
+    var allTagsView: XCUIElement {
+        element.tables["all-tags"]
+    }
+    
+    func allTagsRow(matching string: String) -> XCUIElement {
+        return allTagsView.staticTexts[string].self
+    }
        
     func tag(matching string: String) -> XCUIElement {
         return element.staticTexts[string].self


### PR DESCRIPTION
## Summary
Add Tags Screen: user can select from list of existing tags

## References 
IN-232

## Implementation Details
* Added new section in SwiftUIView called `OtherTagsView` which shows list of tags not included in the input list. 
* Added new requests methods `fetchTagsWithNoSavedItems` and `fetchTags(excluding tags: [String])` to figure out which tags to delete and which tags to show in other tags view respectively. 
* For adding tags, we had to include 2 GraphQL mutations `UpdateSavedItemRemoveTagsMutation` and `ReplaceSavedItemTagsMutation` (see ticket for slack link with context). To allow the operation to take in both mutations in a clean way, we created AnyMutation as there was a generic constraint using GraphQLMutation.

## Test Steps
- [ ] Given a user is on the Add Tags screen, 
and the user views the all tags section, 
then the user should be able to see existing tags (unless included in the text field).

- [ ] Given a user is on the Add Tags screen, 
and the user taps on one of the existing tags, 
then the user should see it appear in the text field.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
https://user-images.githubusercontent.com/6743397/187229041-a0638b44-e0eb-4f62-9298-818d4e35645b.mp4
