### PR TITLE
[IN-668] Braze SDK Integration

### DIFF
--- a/Config/secrets.xcconfig.example
+++ b/Config/secrets.xcconfig.example
@@ -1,3 +1,5 @@
 POCKET_API_CONSUMER_KEY=test-consumer-key
 #Note: you need the $() in the url because of how xcconfig expands urls.
 SENTRY_DSN=https:/$()/somesentry@testurl.sentry.io/123456
+BRAZE_API_KEY=123123123123-zcsd-132123-csd
+BRAZE_API_ENDPOINT=someendpoint

--- a/Info.plist
+++ b/Info.plist
@@ -6,6 +6,10 @@
 	<array>
 		<string>com.mozilla.pocket.next.refresh</string>
 	</array>
+	<key>BrazeAPIEndpoint</key>
+	<string>$(BRAZE_API_ENDPOINT)</string>
+	<key>BrazeAPIKey</key>
+	<string>$(BRAZE_API_KEY)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -76,6 +80,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/Pocket (iOS).entitlements
+++ b/Pocket (iOS).entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.ideashower.ReadItLaterProAlphaNeue</string>

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -44,6 +44,14 @@
 		16EE3F5026CEC80900249AF4 /* PullToRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */; };
 		16FCADBF26CB04AC00906C03 /* ArchiveAnItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */; };
 		3E8283A428B65ECF00C1DC4A /* SortMenuElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8283A328B65ECF00C1DC4A /* SortMenuElement.swift */; };
+		650FECCE28BA85F300A3CB0C /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650FECCD28BA85F300A3CB0C /* NotificationService.swift */; };
+		650FECD228BA85F300A3CB0C /* PushNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65734C2628BA89B900730661 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = 65734C2528BA89B900730661 /* BrazeNotificationService */; };
+		65EC272728BA8AD50075E1DF /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65EC272628BA8AD50075E1DF /* UserNotifications.framework */; };
+		65EC272928BA8AD50075E1DF /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */; };
+		65EC272C28BA8AD50075E1DF /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC272B28BA8AD50075E1DF /* NotificationViewController.swift */; };
+		65EC273328BA8AD50075E1DF /* PushNotificationStoryExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65EC273928BA8B120075E1DF /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = 65EC273828BA8B120075E1DF /* BrazePushStory */; };
 		8A289CD62899BD820030E5E0 /* BannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A289CD52899BD820030E5E0 /* BannerViewTests.swift */; };
 		8A3E3DBC2864DB0500483564 /* EmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */; };
 		8A3EAA5128AACC9500392057 /* AddTagsItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EAA5028AACC9500392057 /* AddTagsItemTests.swift */; };
@@ -77,6 +85,20 @@
 			remoteGlobalIDString = F204A75F27E22EC50010E155;
 			remoteInfo = SaveToPocket;
 		};
+		650FECD028BA85F300A3CB0C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 166A81A42637406B0015AA1D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 650FECCA28BA85F300A3CB0C;
+			remoteInfo = PushNotificationServiceExtension;
+		};
+		65EC273128BA8AD50075E1DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 166A81A42637406B0015AA1D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65EC272428BA8AD50075E1DF;
+			remoteInfo = PushNotificationStoryExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -87,6 +109,8 @@
 			dstSubfolderSpec = 13;
 			files = (
 				166DF27427E9160A00C03BF4 /* SaveToPocket.appex in Embed App Extensions */,
+				65EC273328BA8AD50075E1DF /* PushNotificationStoryExtension.appex in Embed App Extensions */,
+				650FECD228BA85F300A3CB0C /* PushNotificationServiceExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -145,8 +169,16 @@
 		16E4B16E27A3212900E01746 /* Response+factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Response+factories.swift"; sourceTree = "<group>"; };
 		16EE3F4F26CEC80900249AF4 /* PullToRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshTests.swift; sourceTree = "<group>"; };
 		16FCADBE26CB04AC00906C03 /* ArchiveAnItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAnItemTests.swift; sourceTree = "<group>"; };
+		650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PushNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		650FECCD28BA85F300A3CB0C /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		650FECCF28BA85F300A3CB0C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		655C274E28B67ED20040AEAB /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3E8283A328B65ECF00C1DC4A /* SortMenuElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortMenuElement.swift; sourceTree = "<group>"; };
+		65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PushNotificationStoryExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		65EC272628BA8AD50075E1DF /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
+		65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
+		65EC272B28BA8AD50075E1DF /* NotificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
+		65EC273028BA8AD50075E1DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A289CD52899BD820030E5E0 /* BannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewTests.swift; sourceTree = "<group>"; };
 		8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateTests.swift; sourceTree = "<group>"; };
 		8A3EAA5028AACC9500392057 /* AddTagsItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsItemTests.swift; sourceTree = "<group>"; };
@@ -181,6 +213,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				167F8084264B011600D8F507 /* Sails in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		650FECC828BA85F300A3CB0C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65734C2628BA89B900730661 /* BrazeNotificationService in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65EC272228BA8AD50075E1DF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65EC272928BA8AD50075E1DF /* UserNotificationsUI.framework in Frameworks */,
+				65EC273928BA8B120075E1DF /* BrazePushStory in Frameworks */,
+				65EC272728BA8AD50075E1DF /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -219,6 +269,8 @@
 				16973354263CBB290003DE2A /* Config */,
 				166A81C32637406C0015AA1D /* Tests iOS */,
 				F204A76127E22EC50010E155 /* SaveToPocket */,
+				650FECCC28BA85F300A3CB0C /* PushNotificationServiceExtension */,
+				65EC272A28BA8AD50075E1DF /* PushNotificationStoryExtension */,
 				F220F2B8264DC2750064D272 /* Frameworks */,
 				166A81B12637406C0015AA1D /* Products */,
 			);
@@ -230,6 +282,8 @@
 				166A81B02637406C0015AA1D /* Pocket.app */,
 				166A81C02637406C0015AA1D /* Tests iOS.xctest */,
 				F204A76027E22EC50010E155 /* SaveToPocket.appex */,
+				650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */,
+				65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -308,6 +362,24 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
+		650FECCC28BA85F300A3CB0C /* PushNotificationServiceExtension */ = {
+			isa = PBXGroup;
+			children = (
+				650FECCD28BA85F300A3CB0C /* NotificationService.swift */,
+				650FECCF28BA85F300A3CB0C /* Info.plist */,
+			);
+			path = PushNotificationServiceExtension;
+			sourceTree = "<group>";
+		};
+		65EC272A28BA8AD50075E1DF /* PushNotificationStoryExtension */ = {
+			isa = PBXGroup;
+			children = (
+				65EC272B28BA8AD50075E1DF /* NotificationViewController.swift */,
+				65EC273028BA8AD50075E1DF /* Info.plist */,
+			);
+			path = PushNotificationStoryExtension;
+			sourceTree = "<group>";
+		};
 		F204A76127E22EC50010E155 /* SaveToPocket */ = {
 			isa = PBXGroup;
 			children = (
@@ -322,6 +394,8 @@
 			isa = PBXGroup;
 			children = (
 				F227F0C3265E96290031F985 /* CoreText.framework */,
+				65EC272628BA8AD50075E1DF /* UserNotifications.framework */,
+				65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -344,6 +418,8 @@
 			);
 			dependencies = (
 				166DF27627E9160A00C03BF4 /* PBXTargetDependency */,
+				650FECD128BA85F300A3CB0C /* PBXTargetDependency */,
+				65EC273228BA8AD50075E1DF /* PBXTargetDependency */,
 			);
 			name = "Pocket (iOS)";
 			packageProductDependencies = (
@@ -374,6 +450,46 @@
 			productReference = 166A81C02637406C0015AA1D /* Tests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		650FECCA28BA85F300A3CB0C /* PushNotificationServiceExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 650FECD328BA85F300A3CB0C /* Build configuration list for PBXNativeTarget "PushNotificationServiceExtension" */;
+			buildPhases = (
+				650FECC728BA85F300A3CB0C /* Sources */,
+				650FECC828BA85F300A3CB0C /* Frameworks */,
+				650FECC928BA85F300A3CB0C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PushNotificationServiceExtension;
+			packageProductDependencies = (
+				65734C2528BA89B900730661 /* BrazeNotificationService */,
+			);
+			productName = PushNotificationServiceExtension;
+			productReference = 650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		65EC272428BA8AD50075E1DF /* PushNotificationStoryExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65EC273428BA8AD50075E1DF /* Build configuration list for PBXNativeTarget "PushNotificationStoryExtension" */;
+			buildPhases = (
+				65EC272128BA8AD50075E1DF /* Sources */,
+				65EC272228BA8AD50075E1DF /* Frameworks */,
+				65EC272328BA8AD50075E1DF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PushNotificationStoryExtension;
+			packageProductDependencies = (
+				65EC273828BA8B120075E1DF /* BrazePushStory */,
+			);
+			productName = PushNotificationStoryExtension;
+			productReference = 65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		F204A75F27E22EC50010E155 /* SaveToPocket */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F204A76E27E22EC50010E155 /* Build configuration list for PBXNativeTarget "SaveToPocket" */;
@@ -400,7 +516,7 @@
 		166A81A42637406B0015AA1D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1330;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					166A81AF2637406C0015AA1D = {
@@ -410,6 +526,12 @@
 					166A81BF2637406C0015AA1D = {
 						CreatedOnToolsVersion = 12.5;
 						TestTargetID = 166A81AF2637406C0015AA1D;
+					};
+					650FECCA28BA85F300A3CB0C = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+					65EC272428BA8AD50075E1DF = {
+						CreatedOnToolsVersion = 13.4.1;
 					};
 					F204A75F27E22EC50010E155 = {
 						CreatedOnToolsVersion = 13.3;
@@ -428,6 +550,7 @@
 			mainGroup = 166A81A32637406B0015AA1D;
 			packageReferences = (
 				167F8082264B011600D8F507 /* XCRemoteSwiftPackageReference "Sails" */,
+				65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
 			);
 			productRefGroup = 166A81B12637406C0015AA1D /* Products */;
 			projectDirPath = "";
@@ -436,6 +559,8 @@
 				166A81AF2637406C0015AA1D /* Pocket (iOS) */,
 				166A81BF2637406C0015AA1D /* Tests iOS */,
 				F204A75F27E22EC50010E155 /* SaveToPocket */,
+				650FECCA28BA85F300A3CB0C /* PushNotificationServiceExtension */,
+				65EC272428BA8AD50075E1DF /* PushNotificationStoryExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -454,6 +579,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				166BACF62656E34B00E401F0 /* Fixtures in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		650FECC928BA85F300A3CB0C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65EC272328BA8AD50075E1DF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -549,6 +688,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		650FECC728BA85F300A3CB0C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				650FECCE28BA85F300A3CB0C /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65EC272128BA8AD50075E1DF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65EC272C28BA8AD50075E1DF /* NotificationViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F204A75C27E22EC50010E155 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -569,6 +724,16 @@
 			isa = PBXTargetDependency;
 			target = F204A75F27E22EC50010E155 /* SaveToPocket */;
 			targetProxy = 166DF27527E9160A00C03BF4 /* PBXContainerItemProxy */;
+		};
+		650FECD128BA85F300A3CB0C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 650FECCA28BA85F300A3CB0C /* PushNotificationServiceExtension */;
+			targetProxy = 650FECD028BA85F300A3CB0C /* PBXContainerItemProxy */;
+		};
+		65EC273228BA8AD50075E1DF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65EC272428BA8AD50075E1DF /* PushNotificationStoryExtension */;
+			targetProxy = 65EC273128BA8AD50075E1DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -938,6 +1103,188 @@
 			};
 			name = Debug_Test;
 		};
+		650FECD428BA85F300A3CB0C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationServiceExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationServiceExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Service Development";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		650FECD528BA85F300A3CB0C /* Debug_Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationServiceExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationServiceExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Service Development";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Test;
+		};
+		650FECD628BA85F300A3CB0C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Read It Later, Inc (EX3VH4YFCH)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationServiceExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationServiceExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Service App Store Distribution";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		65EC273528BA8AD50075E1DF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationStoryExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationStoryExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationStoryExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story Development";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		65EC273628BA8AD50075E1DF /* Debug_Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationStoryExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationStoryExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationStoryExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story App Store Distribution";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Test;
+		};
+		65EC273728BA8AD50075E1DF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "Apple Distribution: Read It Later, Inc (EX3VH4YFCH)";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationStoryExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationStoryExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationStoryExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story App Store Distribution";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		F204A76C27E22EC50010E155 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1035,6 +1382,26 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		650FECD328BA85F300A3CB0C /* Build configuration list for PBXNativeTarget "PushNotificationServiceExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				650FECD428BA85F300A3CB0C /* Debug */,
+				650FECD528BA85F300A3CB0C /* Debug_Test */,
+				650FECD628BA85F300A3CB0C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65EC273428BA8AD50075E1DF /* Build configuration list for PBXNativeTarget "PushNotificationStoryExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65EC273528BA8AD50075E1DF /* Debug */,
+				65EC273628BA8AD50075E1DF /* Debug_Test */,
+				65EC273728BA8AD50075E1DF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F204A76E27E22EC50010E155 /* Build configuration list for PBXNativeTarget "SaveToPocket" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1056,6 +1423,14 @@
 				kind = branch;
 			};
 		};
+		65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 5.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1067,6 +1442,16 @@
 		16BA7D6526851579009A17C1 /* PocketKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PocketKit;
+		};
+		65734C2528BA89B900730661 /* BrazeNotificationService */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazeNotificationService;
+		};
+		65EC273828BA8B120075E1DF /* BrazePushStory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazePushStory;
 		};
 		F2687E7227E28F0F00E43F09 /* SaveToPocketKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,12 +11,12 @@
         }
       },
       {
-        "package": "async-http-client",
-        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "package": "braze-swift-sdk",
+        "repositoryURL": "https://github.com/braze-inc/braze-swift-sdk",
         "state": {
           "branch": null,
-          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
-          "version": "1.9.0"
+          "revision": "baf59bc6c1c06d3f909a40991c5ac59a6fc7c8cd",
+          "version": "5.3.0"
         }
       },
       {
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/jacobsimeon/Sails.git",
         "state": {
           "branch": "master",
-          "revision": "88e6c7a31b5f1c0efa9f167589d15531b7de00eb",
+          "revision": "730166aa43b900e71a128e74910b1d9a431b24cf",
           "version": null
         }
       },
@@ -101,12 +101,12 @@
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
         }
       },
       {
@@ -114,44 +114,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
-          "version": "2.39.0"
+          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
+          "version": "2.41.1"
         }
       },
       {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "package": "SwiftyBeaver",
+        "repositoryURL": "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
-          "version": "1.20.1"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
-          "version": "2.18.0"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-          "version": "1.11.4"
+          "revision": "12b5acf96d98f91d50de447369bd18df74600f1a",
+          "version": "1.9.6"
         }
       },
       {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -23,12 +23,22 @@ let package = Package(
         .package(name: "SnowplowTracker", url: "https://github.com/snowplow/snowplow-objc-tracker", .upToNextMinor(from: "2.2.0")),
         .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", from: "3.2.1"),
         .package(name: "Down", url: "https://github.com/johnxnguyen/Down", .upToNextMinor(from: "0.11.0")),
-        .package(name: "YouTubePlayerKit", url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", .upToNextMinor(from: "1.1.5"))
+        .package(name: "YouTubePlayerKit", url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", .upToNextMinor(from: "1.1.5")),
+        .package(name: "BrazeKit", url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMinor(from: "5.3.0"))
     ],
     targets: [
         .target(
             name: "PocketKit",
-            dependencies: ["Sync", "Textile", "Analytics", "Lottie", "YouTubePlayerKit", "SharedPocketKit"],
+            dependencies: [
+                "Sync",
+                "Textile",
+                "Analytics",
+                "Lottie",
+                "YouTubePlayerKit",
+                "SharedPocketKit",
+                "BrazeKit",
+                .product(name: "BrazeUI", package: "BrazeKit")
+            ],
             resources: [.copy("Assets")]
         ),
         .testTarget(

--- a/PocketKit/Sources/PocketKit/Keys.swift
+++ b/PocketKit/Sources/PocketKit/Keys.swift
@@ -9,6 +9,8 @@ struct Keys {
 
     let pocketApiConsumerKey: String
     let sentryDSN: String
+    let brazeAPIEndpoint: String
+    let brazeAPIKey: String
 
     private init() {
         guard let info = Bundle.main.infoDictionary else {
@@ -22,8 +24,19 @@ struct Keys {
         guard let sentryDSN = info["SentryDSN"] as? String else {
             fatalError("Unable to extract SentryDSN from main bundle")
         }
+        
+        guard let brazeAPIEndpoint = info["BrazeAPIEndpoint"] as? String else {
+            fatalError("Unable to extract BrazeAPIEndpoint from main bundle")
+        }
+        
+        guard let brazeAPIKey = info["BrazeAPIKey"] as? String else {
+            fatalError("Unable to extract BrazeAPIKey from main bundle")
+        }
+
 
         self.pocketApiConsumerKey = pocketApiConsumerKey
         self.sentryDSN = sentryDSN
+        self.brazeAPIEndpoint = brazeAPIEndpoint
+        self.brazeAPIKey = brazeAPIKey
     }
 }

--- a/PocketKit/Sources/PocketKit/Keys.swift
+++ b/PocketKit/Sources/PocketKit/Keys.swift
@@ -24,15 +24,14 @@ struct Keys {
         guard let sentryDSN = info["SentryDSN"] as? String else {
             fatalError("Unable to extract SentryDSN from main bundle")
         }
-        
+
         guard let brazeAPIEndpoint = info["BrazeAPIEndpoint"] as? String else {
             fatalError("Unable to extract BrazeAPIEndpoint from main bundle")
         }
-        
+
         guard let brazeAPIKey = info["BrazeAPIKey"] as? String else {
             fatalError("Unable to extract BrazeAPIKey from main bundle")
         }
-
 
         self.pocketApiConsumerKey = pocketApiConsumerKey
         self.sentryDSN = sentryDSN

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate+PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate+PocketNotificationService.swift
@@ -1,0 +1,40 @@
+import Foundation
+import UIKit
+import Sync
+
+/**
+ Extend the App Delegate so that we can add in the notification methods
+ */
+extension PocketAppDelegate {
+    
+    /**
+     Called when Apple assigns us a Push notification token.
+     */
+    public func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        notificationService.register(deviceToken: deviceToken)
+    }
+    
+    /**
+     Called when Apple gives us a notication in the background.
+     */
+    public func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        notificationService.handleBackgroundNotifcation(didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
+    }
+    
+    /**
+     Called when push notifications fail to register with Apple
+     */
+    public func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error) {
+            print("Error registering for push notifications")
+            Crashlogger.capture(error: error)
+        }
+}

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate+PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate+PocketNotificationService.swift
@@ -6,7 +6,7 @@ import Sync
  Extend the App Delegate so that we can add in the notification methods
  */
 extension PocketAppDelegate {
-    
+
     /**
      Called when Apple assigns us a Push notification token.
      */
@@ -16,18 +16,18 @@ extension PocketAppDelegate {
     ) {
         notificationService.register(deviceToken: deviceToken)
     }
-    
+
     /**
      Called when Apple gives us a notication in the background.
      */
     public func application(
         _ application: UIApplication,
-        didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
         notificationService.handleBackgroundNotifcation(didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
     }
-    
+
     /**
      Called when push notifications fail to register with Apple
      */

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -79,7 +79,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         source.restore()
         Textiles.initialize()
         refreshCoordinator.initialize()
-        
+
         application.registerForRemoteNotifications()
 
         return true

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -15,6 +15,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     private let firstLaunchDefaults: UserDefaults
     private let refreshCoordinator: RefreshCoordinator
     private let appSession: AppSession
+    internal let notificationService: PocketNotificationService
 
     convenience override init() {
         self.init(services: Services.shared)
@@ -26,6 +27,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.firstLaunchDefaults = services.firstLaunchDefaults
         self.refreshCoordinator = services.refreshCoordinator
         self.appSession = services.appSession
+        self.notificationService = services.notificationService
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -77,6 +79,8 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         source.restore()
         Textiles.initialize()
         refreshCoordinator.initialize()
+        
+        application.registerForRemoteNotifications()
 
         return true
     }

--- a/PocketKit/Sources/PocketKit/PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/PocketNotificationService.swift
@@ -9,55 +9,54 @@ import UIKit
 import UserNotifications
 
 class PocketNotificationService: NSObject {
-    
+
     /**
      The Braze service object
      */
     private let braze: Braze
-    
+
     /**
      Instance of our API client for pulling in data when we recieve pushes.
      */
     private let source: Source
-    
+
     /**
      Instance of the Pocket Analytics tracker
      */
     private let tracker: Tracker
-    
+
     /**
      Instance of the Pocket Session manager for us to subscribe to
      */
     private let sessionManager: AppSession
-    
+
     /**
      App wide subscriptions that we listen to.
      */
     private var subscriptions: Set<AnyCancellable> = []
-    
-    
+
     init(source: Source, tracker: Tracker, sessionManager: AppSession) {
         self.source = source
         self.tracker = tracker
         self.sessionManager = sessionManager
-        
+
         // Init Braze with our information.
         var configuration = Braze.Configuration(
             apiKey: Keys.shared.brazeAPIKey,
             endpoint: Keys.shared.brazeAPIEndpoint
         )
-        
+
         // Enable logging of general SDK information (e.g. user changes, etc.)
         configuration.logger.level = .info
         configuration.push.appGroup = "group.com.ideashower.ReadItLaterProAlp"
         braze = Braze(configuration: configuration)
         super.init()
-        
+
         // Set up the in app message ui
         let inAppMessageUI = BrazeInAppMessageUI()
         inAppMessageUI.delegate = self
         braze.inAppMessagePresenter = inAppMessageUI
-        
+
         sessionManager.$currentSession.receive(on: DispatchQueue.main).sink { [weak self] session in
             guard let session = session else { return }
 
@@ -65,8 +64,7 @@ class PocketNotificationService: NSObject {
             // https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/analytics/setting_user_ids/#assigning-a-user-id
             self?.braze.changeUser(userId: session.userIdentifier)
         }.store(in: &subscriptions)
-        
-        
+
         let center = UNUserNotificationCenter.current()
         // In the future we can setup other types of categories
         // https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#summary-arguments
@@ -80,23 +78,23 @@ class PocketNotificationService: NSObject {
             print("Notification authorization, granted: \(granted), error: \(String(describing: error))")
         }
     }
-    
+
     /**
      Proxy function to braze to register a device token
      */
     public func register(deviceToken: Data) {
-        //TODO: Also register the token with the Pocket Instant Sync endpoint
+        // TODO: Also register the token with the Pocket Instant Sync endpoint
         braze.notifications.register(deviceToken: deviceToken)
     }
-    
+
     /**
      Proxy function to braze to handle background notifications
      */
     public func handleBackgroundNotifcation(
-        didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
-        
+
         // Forward background notification to Braze.
         if braze.notifications.handleBackgroundNotification(
             userInfo: userInfo,
@@ -105,17 +103,16 @@ class PocketNotificationService: NSObject {
             // Braze handled the notification, nothing more to do.
             return
         }
-        
-        
+
         // Braze did not handle this remote background notification.
         // We can handle the notification yourself here.
-        //TODO: Handle the V3 Instant sync push notification.
-        
+        // TODO: Handle the V3 Instant sync push notification.
+
         // Manually call the completion handler to let the system know
         // that the background notification is processed.
         completionHandler(.noData)
     }
-    
+
     /**
      Proxy function to Braze to handle user facing notifications
      */
@@ -124,15 +121,15 @@ class PocketNotificationService: NSObject {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        let _ = braze.notifications.handleUserNotification(response: response, withCompletionHandler: completionHandler)
+        _ = braze.notifications.handleUserNotification(response: response, withCompletionHandler: completionHandler)
     }
 }
 
 /**
  Extend the Notification service to support User Notifications
  */
-extension PocketNotificationService : UNUserNotificationCenterDelegate {
-    
+extension PocketNotificationService: UNUserNotificationCenterDelegate {
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
@@ -140,8 +137,7 @@ extension PocketNotificationService : UNUserNotificationCenterDelegate {
     ) {
         didRecieveUserNotifcation(center, didReceive: response, withCompletionHandler: completionHandler)
     }
-    
-    
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -154,16 +150,15 @@ extension PocketNotificationService : UNUserNotificationCenterDelegate {
 /**
  Extend the Notification service to support Braze InApp Message UI
  */
-extension PocketNotificationService : BrazeInAppMessageUIDelegate {
-    
+extension PocketNotificationService: BrazeInAppMessageUIDelegate {
+
     func inAppMessage(
         _ ui: BrazeInAppMessageUI,
         prepareWith context: inout BrazeInAppMessageUI.PresentationContext
     ) {
         // Customize the in-app message presentation here using the context
     }
-    
-    
+
     func inAppMessage(
         _ ui: BrazeInAppMessageUI,
         didPresent message: Braze.InAppMessage,

--- a/PocketKit/Sources/PocketKit/PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/PocketNotificationService.swift
@@ -1,0 +1,174 @@
+import Foundation
+import BrazeKit
+import BrazeUI
+import Sync
+import Analytics
+import SharedPocketKit
+import Combine
+import UIKit
+import UserNotifications
+
+class PocketNotificationService: NSObject {
+    
+    /**
+     The Braze service object
+     */
+    private let braze: Braze
+    
+    /**
+     Instance of our API client for pulling in data when we recieve pushes.
+     */
+    private let source: Source
+    
+    /**
+     Instance of the Pocket Analytics tracker
+     */
+    private let tracker: Tracker
+    
+    /**
+     Instance of the Pocket Session manager for us to subscribe to
+     */
+    private let sessionManager: AppSession
+    
+    /**
+     App wide subscriptions that we listen to.
+     */
+    private var subscriptions: Set<AnyCancellable> = []
+    
+    
+    init(source: Source, tracker: Tracker, sessionManager: AppSession) {
+        self.source = source
+        self.tracker = tracker
+        self.sessionManager = sessionManager
+        
+        // Init Braze with our information.
+        var configuration = Braze.Configuration(
+            apiKey: Keys.shared.brazeAPIKey,
+            endpoint: Keys.shared.brazeAPIEndpoint
+        )
+        
+        // Enable logging of general SDK information (e.g. user changes, etc.)
+        configuration.logger.level = .info
+        configuration.push.appGroup = "group.com.ideashower.ReadItLaterProAlp"
+        braze = Braze(configuration: configuration)
+        super.init()
+        
+        // Set up the in app message ui
+        let inAppMessageUI = BrazeInAppMessageUI()
+        inAppMessageUI.delegate = self
+        braze.inAppMessagePresenter = inAppMessageUI
+        
+        sessionManager.$currentSession.receive(on: DispatchQueue.main).sink { [weak self] session in
+            guard let session = session else { return }
+
+            // Braze SDK docs say this needs to be called from the main thread.
+            // https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/analytics/setting_user_ids/#assigning-a-user-id
+            self?.braze.changeUser(userId: session.userIdentifier)
+        }.store(in: &subscriptions)
+        
+        
+        let center = UNUserNotificationCenter.current()
+        // In the future we can setup other types of categories
+        // https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#summary-arguments
+        center.setNotificationCategories(Braze.Notifications.categories)
+        center.delegate = self
+        // We also ask for provisional authotization which is in iOS 12 and above and allows us to use push notifications that only post to the notification center
+        // https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#provisional-push
+        // Developer Note: Since we are registering provisional push, the user will never see the pop up to allow push notifications.
+        // This can make it challenging to test push notification registration flows because you will not see push registration appear, so you may want to remove this during active development.
+        center.requestAuthorization(options: [.badge, .sound, .alert, .provisional]) { granted, error in
+            print("Notification authorization, granted: \(granted), error: \(String(describing: error))")
+        }
+    }
+    
+    /**
+     Proxy function to braze to register a device token
+     */
+    public func register(deviceToken: Data) {
+        //TODO: Also register the token with the Pocket Instant Sync endpoint
+        braze.notifications.register(deviceToken: deviceToken)
+    }
+    
+    /**
+     Proxy function to braze to handle background notifications
+     */
+    public func handleBackgroundNotifcation(
+        didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        
+        // Forward background notification to Braze.
+        if braze.notifications.handleBackgroundNotification(
+            userInfo: userInfo,
+            fetchCompletionHandler: completionHandler
+        ) {
+            // Braze handled the notification, nothing more to do.
+            return
+        }
+        
+        
+        // Braze did not handle this remote background notification.
+        // We can handle the notification yourself here.
+        //TODO: Handle the V3 Instant sync push notification.
+        
+        // Manually call the completion handler to let the system know
+        // that the background notification is processed.
+        completionHandler(.noData)
+    }
+    
+    /**
+     Proxy function to Braze to handle user facing notifications
+     */
+    public func didRecieveUserNotifcation(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let _ = braze.notifications.handleUserNotification(response: response, withCompletionHandler: completionHandler)
+    }
+}
+
+/**
+ Extend the Notification service to support User Notifications
+ */
+extension PocketNotificationService : UNUserNotificationCenterDelegate {
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        didRecieveUserNotifcation(center, didReceive: response, withCompletionHandler: completionHandler)
+    }
+    
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.list, .banner])
+    }
+}
+
+/**
+ Extend the Notification service to support Braze InApp Message UI
+ */
+extension PocketNotificationService : BrazeInAppMessageUIDelegate {
+    
+    func inAppMessage(
+        _ ui: BrazeInAppMessageUI,
+        prepareWith context: inout BrazeInAppMessageUI.PresentationContext
+    ) {
+        // Customize the in-app message presentation here using the context
+    }
+    
+    
+    func inAppMessage(
+        _ ui: BrazeInAppMessageUI,
+        didPresent message: Braze.InAppMessage,
+        view: InAppMessageView
+    ) {
+        // Executed when `message` is presented to the user
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -23,6 +23,8 @@ struct Services {
     let refreshCoordinator: RefreshCoordinator
     let authClient: AuthorizationClient
     let imageManager: ImageManager
+    let notificationService: PocketNotificationService
+    
     private let persistentContainer: PersistentContainer
 
     private init() {
@@ -64,6 +66,12 @@ struct Services {
             source: source
         )
         imageManager.start()
+        
+        notificationService = PocketNotificationService(
+            source: source,
+            tracker: tracker,
+            sessionManager: appSession
+        )
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -24,7 +24,7 @@ struct Services {
     let authClient: AuthorizationClient
     let imageManager: ImageManager
     let notificationService: PocketNotificationService
-    
+
     private let persistentContainer: PersistentContainer
 
     private init() {
@@ -66,7 +66,7 @@ struct Services {
             source: source
         )
         imageManager.start()
-        
+
         notificationService = PocketNotificationService(
             source: source,
             tracker: tracker,

--- a/PushNotificationServiceExtension/Info.plist
+++ b/PushNotificationServiceExtension/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/PushNotificationServiceExtension/NotificationService.swift
+++ b/PushNotificationServiceExtension/NotificationService.swift
@@ -4,5 +4,4 @@
 
 import BrazeNotificationService
 
-
 class NotificationService: BrazeNotificationService.NotificationService {}

--- a/PushNotificationServiceExtension/NotificationService.swift
+++ b/PushNotificationServiceExtension/NotificationService.swift
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BrazeNotificationService
+
+
+class NotificationService: BrazeNotificationService.NotificationService {}

--- a/PushNotificationStoryExtension/Info.plist
+++ b/PushNotificationStoryExtension/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Braze</key>
+	<dict>
+		<key>AppGroup</key>
+		<string>group.com.ideashower.ReadItLaterProAlp</string>
+	</dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>UNNotificationExtensionCategory</key>
+			<string>ab_cat_push_story_v2</string>
+			<key>UNNotificationExtensionDefaultContentHidden</key>
+			<true/>
+			<key>UNNotificationExtensionInitialContentSizeRatio</key>
+			<real>0.59999999999999998</real>
+			<key>UNNotificationExtensionUserInteractionEnabled</key>
+			<true/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.content-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/PushNotificationStoryExtension/NotificationViewController.swift
+++ b/PushNotificationStoryExtension/NotificationViewController.swift
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BrazePushStory
+
+
+class NotificationViewController: BrazePushStory.NotificationViewController {}

--- a/PushNotificationStoryExtension/NotificationViewController.swift
+++ b/PushNotificationStoryExtension/NotificationViewController.swift
@@ -4,5 +4,4 @@
 
 import BrazePushStory
 
-
 class NotificationViewController: BrazePushStory.NotificationViewController {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -95,9 +95,11 @@ workflows:
 
   qa-build:
     steps:
-      - brew-install@0:
+      - file-downloader@1:
           inputs:
-            - packages: swiftlint
+            - source: '$BITRISEIO_SECRETS_DEVELOPMENT_XCCONFIG_URL'
+            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+          title: Install development secrets.xcconfig
       - xcode-archive@4:
           inputs:
             - xcconfig_content: |-


### PR DESCRIPTION
## Summary
* Allow us to use Braze for push notifications and in app messages

## References 
* https://getpocket.atlassian.net/browse/IN-668

## Implementation Details
* Push notifications are registered for a user [provisionally](https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#provisional-push) as soon as the application is launched (not after they login), this will cause a user to not see a modal for push and allow us to push notifications to the notification center quietly. Braze recommends this, because it allows us to start sending push notifications and give a user a taste of what they can get if they explicitly opt in.
   * An update to the Braze SDK in September will allow us to use in-app messages to also convince a user to give Pocket explicit push action after they perform a high-value action. This is called [push primers](https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#provisional-push)
* There are no tests because this integration fully uses Apple app delegates and a third-party SDK. I am open to ideas on how to provide test coverage here.
* Deep links while available for Braze, are not setup in this PR and will be a future follow up as we figure out what deep links iOS Next will support and those necessary views are built.

Note: That all the keys used will need to change when we move the Pocket app to the production identifier.

## Test Steps

Note if using a Debug (QA) build you need to use the Development Braze Account because that targets the development Apple Push Notification Service (APNS)


### Provisional Push (Notification Center Quiet Pushes)

> iOS 12+ provides the ability to [deliver push notifications](https://www.braze.com/docs/user_guide/message_building_by_channel/push/ios/notification_options/#provisional-push) to a user's notification center and allow them to opt-out of push notifications or explicitly opt in.

As a user that doesn't explicitly opt-in to push notifications
  I can see push notifications delivered quietly to my notification center.

Have the app backgrounded after launching it once after a fresh install, then send a test push notification in Braze. If you look at your notification center you should see the push notification was delivered quietly there.

### Regular Push Notification - Open Web View
Using the Braze account, send a push test notification that links to a web page in the app and contains an image, title, and excerpt.

As a user that explicitly opts-in to push notifications
  I can see push notifications delivered to my lock screen

* Observe that you can see:
    * An Image
    * A title
    * A excerpt
* If you tap the message it should open in the Pocket App within a modal web view

### In App Message

Note: In-App messages uses push notifications during testing. You must explicitly opt-in to push notifications to test In App messages.

As a user that opens Pocket
  I can see various In App prompts when sent from Braze.



## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
- [x] Added needed secrets to Bitrise


## Screenshots
<img src="https://user-images.githubusercontent.com/1010384/187581134-1ecb8b0a-f4f8-44fa-a1e9-3b9984a3a97c.PNG" width="200">

<img src="https://user-images.githubusercontent.com/1010384/187581140-06a24681-13ea-4baa-ba11-3a2edf4a6165.PNG" width="200">

<img src="https://user-images.githubusercontent.com/1010384/187581144-e038554e-08b9-4b29-83a4-8aaa1d9f658a.PNG" width="200">

<img src="https://user-images.githubusercontent.com/1010384/187581150-026c2fdf-b427-4183-aac0-b55def1b6b45.PNG" width="200">

<img src="https://user-images.githubusercontent.com/1010384/187581152-82768fa2-70c7-430c-bf99-d297436d540e.PNG" width="200">

<img src="https://user-images.githubusercontent.com/1010384/187581156-d11e590d-8b6d-478e-b234-dc7754a90da5.PNG" width="200">


