### PR TITLE
Swiftlint: Enable multiline_arguments_brackets

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -95,6 +95,7 @@ opt_in_rules: # some rules are only opt-in
   - multiline_arguments
   - opening_brace
   - return_arrow_whitespace
+  - multiline_arguments_brackets
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build

--- a/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
@@ -4,7 +4,8 @@ import SafariServices
 import Analytics
 import Sync
 
-protocol RegularMyListCoordinatorDelegate: AnyObject, ModalContentPresenting {
+// swiftlint:disable:next class_delegate_protocol
+protocol RegularMyListCoordinatorDelegate: ModalContentPresenting {
     func myListCoordinator(_ coordinator: RegularMyListCoordinator, didSelectSavedItem savedItem: SavedItemViewModel?)
 }
 

--- a/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
@@ -99,10 +99,11 @@ class RootCoordinator {
             delay: 0,
             options: [.allowUserInteraction],
             animations: { [weak self] in
-            self?.bannerView?.transform = CGAffineTransform(translationX: 0, y: animationDistance ?? CGFloat.greatestFiniteMagnitude)
-        }, completion: { [weak self] _ in
-            self?.removeBanner()
-        })
+                self?.bannerView?.transform = CGAffineTransform(translationX: 0, y: animationDistance ?? CGFloat.greatestFiniteMagnitude)
+            }, completion: { [weak self] _ in
+                self?.removeBanner()
+            }
+        )
     }
 
     private func updateState(_ isLoggedIn: Bool) {

--- a/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
@@ -65,7 +65,8 @@ class RootViewModel {
                 },
                 dismissAction: { [weak self] in
                     self?.bannerViewModel = nil
-                })
+                }
+            )
         }
     }
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
@@ -54,7 +54,7 @@ extension PocketSourceTests {
             }
         }
 
-        let source = subject()
+        var source: PocketSource? = subject()
 
         let savedItem = try! space.createSavedItem()
         let unresolved: UnresolvedSavedItem = space.new()
@@ -66,6 +66,8 @@ extension PocketSourceTests {
         wait(for: [operationStarted], timeout: 1)
 
         try XCTAssertEqual(space.fetchUnresolvedSavedItems(), [])
+
+        source = nil
     }
 
     func test_events_whenOSNotificationCenterPostsUnresolvedItemCreatedNotification_whenSavedItemIsDuplicated_includesSavedItemOnlyOnce() throws {

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -305,10 +305,8 @@ class HomeTests: XCTestCase {
         coord
             .press(
                 forDuration: 0.1,
-                thenDragTo: coord.withOffset(.init(
-                        dx: 0,
-                        dy: -50
-                    )
+                thenDragTo: coord.withOffset(
+                    .init(dx: 0, dy: -50)
                 ),
                 withVelocity: .default,
                 thenHoldForDuration: 0.1


### PR DESCRIPTION
## Summary

A few touch ups after enabling swiftlint:

[Enable `multiline_arguments_brackets` in swiftlint](e52d3b811efec029a6abada46e3159d91aaddad0) (There were only three violations this rule 👍)
[Remove AnyObject from protocol constraints list](a736baedee6324d98f51bff11a4a7611897763db)
[Work around Swift's warning for unused constant](9daf2578e0aa52f7685642054f26096277640bbf)