### PR TITLE
Hide chevron in "My List" button

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -62,15 +62,15 @@ class HomeViewControllerSectionProvider {
         )
         group.interItemSpacing = .fixed(16)
 
-        let sectionHeaderViewModel = SectionHeaderView.Model(name: "Recent Saves", buttonTitle: "My List")
+        let sectionHeaderViewModel = viewModel.sectionHeaderViewModel(for: .recentSaves)
         let width = env.container.effectiveContentSize.width
         let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
                 heightDimension: .absolute(
-                    sectionHeaderViewModel.height(
+                    sectionHeaderViewModel?.height(
                         width: width - Constants.sideMargin * 2
-                    )
+                    ) ?? 1
                 )
             ),
             elementKind: SectionHeaderView.kind,

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -350,7 +350,11 @@ extension HomeViewModel {
     func sectionHeaderViewModel(for section: Section) -> SectionHeaderView.Model? {
         switch section {
         case .recentSaves:
-            return .init(name: "Recent Saves", buttonTitle: "My List") { [weak self] in
+            return .init(
+                name: "Recent Saves",
+                buttonTitle: "My List",
+                buttonImage: nil
+            ) { [weak self] in
                 self?.tappedSeeAll = .myList
             }
         case .slateHero(let objectID):
@@ -358,7 +362,11 @@ extension HomeViewModel {
                 return nil
             }
 
-            return .init(name: slate.name ?? "", buttonTitle: "See All") { [weak self] in
+            return .init(
+                name: slate.name ?? "",
+                buttonTitle: "See All",
+                buttonImage: UIImage(asset: .chevronRight)
+            ) { [weak self] in
                 self?.select(slate: slate)
             }
         case .loading, .slateCarousel, .offline:

--- a/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
@@ -15,11 +15,8 @@ class SectionHeaderView: UICollectionReusableView {
         return label
     }()
 
-    private let myListButton: UIButton = {
+    private let seeAllButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.image = UIImage(asset: .chevronRight)
-            .resized(to: buttonImageSize)
-            .withTintColor(UIColor(.ui.lapis1), renderingMode: .alwaysOriginal)
 
         configuration.imagePadding = 10
         configuration.imagePlacement = .trailing
@@ -44,12 +41,12 @@ class SectionHeaderView: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         headerStack.addArrangedSubview(headerLabel)
-        headerStack.addArrangedSubview(myListButton)
+        headerStack.addArrangedSubview(seeAllButton)
 
         addSubview(headerStack)
 
         headerStack.translatesAutoresizingMaskIntoConstraints = false
-        myListButton.translatesAutoresizingMaskIntoConstraints = false
+        seeAllButton.translatesAutoresizingMaskIntoConstraints = false
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
@@ -69,6 +66,7 @@ extension SectionHeaderView {
     struct Model {
         let name: String
         let buttonTitle: String
+        let buttonImage: UIImage?
         var buttonAction: (() -> Void)?
 
         var attributedHeaderText: NSAttributedString {
@@ -83,20 +81,22 @@ extension SectionHeaderView {
 
     func configure(model: Model) {
         headerLabel.attributedText = model.attributedHeaderText
-        updateButtonConfiguration(with: model.buttonTitle, and: model.buttonAction)
-    }
 
-    private func updateButtonConfiguration(with text: String?, and action: (() -> Void)?) {
-        guard let text = text, let action = action else { return }
+        var config = seeAllButton.configuration
+        config?.attributedTitle = AttributedString(
+            model.buttonTitle,
+            attributes: Style.buttonText.attributes
+        )
+        config?.image = model.buttonImage?
+            .resized(to: Self.buttonImageSize)
+            .withTintColor(UIColor(.ui.lapis1), renderingMode: .alwaysOriginal)
+        seeAllButton.configuration = config
 
-        myListButton.configurationUpdateHandler = { button in
-            var config = button.configuration
-            config?.attributedTitle = AttributedString(text, attributes: Style.buttonText.attributes)
-            button.configuration = config
+        let buttonAction = UIAction(title: "", identifier: .seeAllPrimary) { _ in
+            model.buttonAction?()
         }
-        let buttonAction = UIAction(title: "", identifier: .seeAllPrimary) { _ in action() }
-        myListButton.addAction(buttonAction, for: .primaryActionTriggered)
-        myListButton.isHidden = false
+        seeAllButton.addAction(buttonAction, for: .primaryActionTriggered)
+        seeAllButton.isHidden = false
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -73,4 +73,20 @@ class MainViewModel: ObservableObject {
         home.clearPresentedWebReaderURL()
         myList.clearPresentedWebReaderURL()
     }
+
+    func navigationSidebarCellViewModel(for appSection: AppSection) -> NavigationSidebarCellViewModel {
+        let isSelected: Bool = {
+            switch (selectedSection, appSection) {
+            case (.home, .home), (.myList, .myList), (.account, .account):
+                return true
+            default:
+                return false
+            }
+        }()
+
+        return NavigationSidebarCellViewModel(
+            section: appSection,
+            isSelected: isSelected
+        )
+    }
 }

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -20,6 +20,7 @@ class RegularMainCoordinator: NSObject {
     }
 
     private let splitController: UISplitViewController
+    private let sidebarViewController: NavigationSidebarViewController
     private let navigationSidebar: UINavigationController
 
     private let myList: RegularMyListCoordinator
@@ -43,9 +44,10 @@ class RegularMainCoordinator: NSObject {
         self.model = model
 
         splitController = UISplitViewController(style: .doubleColumn)
-        splitController.displayModeButtonVisibility = .always
+        splitController.displayModeButtonVisibility = .automatic
 
-        navigationSidebar = UINavigationController(rootViewController: NavigationSidebarViewController(model: model))
+        sidebarViewController = NavigationSidebarViewController(model: model)
+        navigationSidebar = UINavigationController(rootViewController: sidebarViewController)
 
         myList = RegularMyListCoordinator(model: model.myList)
         home = RegularHomeCoordinator(model: model.home, tracker: tracker)
@@ -111,11 +113,14 @@ class RegularMainCoordinator: NSObject {
             if subsection == .myList {
                 model.myList.selection = .myList
             }
-            navigationSidebar.pushViewController(myList.viewController, animated: true)
+
+            navigationSidebar.setViewControllers([sidebarViewController, myList.viewController], animated: true)
+            splitController.show(.primary)
         case .home:
             splitController.setViewController(home.viewController, for: .secondary)
         case .account:
-            navigationSidebar.pushViewController(account, animated: true)
+            navigationSidebar.setViewControllers([sidebarViewController, account], animated: true)
+            splitController.show(.primary)
         }
 
         splitController.show(.supplementary)

--- a/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarCell.swift
+++ b/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarCell.swift
@@ -13,23 +13,29 @@ class NavigationSidebarCell: UICollectionViewCell {
         return label
     }()
 
+    private let selectedView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(.ui.teal6)
+        return view
+    }()
+
     private var subscriptions: [AnyCancellable] = []
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        selectedBackgroundView = UIView()
-        selectedBackgroundView?.backgroundColor = UIColor(.ui.teal6)
-        selectedBackgroundView?.publisher(for: \.bounds).sink { [weak self] value in
-            self?.selectedBackgroundView?.layer.cornerRadius = value.height / 2
+        selectedView.publisher(for: \.bounds).sink { [weak self] value in
+            self?.selectedView.layer.cornerRadius = value.height / 2
         }.store(in: &subscriptions)
 
         // Build View Hierarchy
+        contentView.addSubview(selectedView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(iconImageView)
 
         // Apply Layout
         iconImageView.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        selectedView.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
         NSLayoutConstraint.activate([
@@ -42,6 +48,11 @@ class NavigationSidebarCell: UICollectionViewCell {
             titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             titleLabel.topAnchor.constraint(equalTo: iconImageView.topAnchor),
             titleLabel.bottomAnchor.constraint(equalTo: iconImageView.bottomAnchor),
+
+            selectedView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            selectedView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            selectedView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            selectedView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
         ])
     }
 
@@ -55,5 +66,6 @@ extension NavigationSidebarCell {
         titleLabel.attributedText = model.attributedTitle
         iconImageView.tintColor = model.iconImageTintColor
         iconImageView.image = model.iconImage
+        selectedView.isHidden = !model.isSelected
     }
 }

--- a/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarCellViewModel.swift
@@ -3,7 +3,7 @@ import Textile
 
 struct NavigationSidebarCellViewModel {
     private let section: MainViewModel.AppSection
-    private let isSelected: Bool
+    let isSelected: Bool
 
     init(section: MainViewModel.AppSection, isSelected: Bool) {
         self.section = section

--- a/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarViewController.swift
+++ b/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarViewController.swift
@@ -104,8 +104,7 @@ class NavigationSidebarViewController: UIViewController {
         model.$selectedSection
             .receive(on: DispatchQueue.main)
             .sink { [weak self] appSection in
-                let indexPath = self?.dataSource.indexPath(for: appSection)
-                self?.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .top)
+                self?.select(appSection)
             }
             .store(in: &subscriptions)
     }
@@ -119,12 +118,12 @@ class NavigationSidebarViewController: UIViewController {
     }
 
     private func configure(_ cell: NavigationSidebarCell, appSection: MainViewModel.AppSection) {
-        let cellModel = NavigationSidebarCellViewModel(
-            section: appSection,
-            isSelected: appSection == model.selectedSection
-        )
-
+        let cellModel = model.navigationSidebarCellViewModel(for: appSection)
         cell.configure(model: cellModel)
+    }
+
+    private func select(_ appSection: MainViewModel.AppSection) {
+        collectionView.reloadData()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -138,11 +137,6 @@ class NavigationSidebarViewController: UIViewController {
 
 extension NavigationSidebarViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let previousSection = model.selectedSection
         model.selectedSection = MainViewModel.AppSection.allCases[indexPath.item]
-
-        var snapshot = dataSource.snapshot()
-        snapshot.reloadItems([previousSection, model.selectedSection])
-        dataSource.apply(snapshot)
     }
 }


### PR DESCRIPTION
## Summary
Hide the chevron for "My List" button by giving the corresponding view model a `buttonImage` property that can be passed in.

Also:
- A fix for when an edge case where the sidebar is already showing Settings or My List, but the user taps the "My List" button on Home. To handle this case, we explicitly set the navigation stack to what it should be (as opposed to simply pushing the next view controller).
- Better handling for selection status in the sidebar. We reload each cell whenever the selected section changes so that the correct cell is highlighted.

## References 
https://getpocket.atlassian.net/browse/IN-760