### PR TITLE
fix(tests): making tests use example secrets

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -114,6 +114,11 @@ workflows:
 
   test:
     steps:
+      - file-downloader@1:
+          inputs:
+            - source: '$BITRISEIO_SECRETS_TEST_URL'
+            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+          title: Install test secrets.xcconfig
       - xcode-test@4:
           inputs:
             - destination: platform=iOS Simulator,name=iPhone 13,OS=latest


### PR DESCRIPTION
## Summary
* Noticed we should be using the example secrets for tests
