### PR TITLE
build(concurency): switch to concurrent tests and test plans [IN-902]

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
 		65EC272B28BA8AD50075E1DF /* NotificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
 		65EC273028BA8AD50075E1DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		65EDF6B22901979800D737E0 /* UITests-3.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-3.xctestplan"; sourceTree = "<group>"; };
 		8A289CD52899BD820030E5E0 /* BannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerViewTests.swift; sourceTree = "<group>"; };
 		8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateTests.swift; sourceTree = "<group>"; };
 		8A3EAA5028AACC9500392057 /* AddTagsItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsItemTests.swift; sourceTree = "<group>"; };
@@ -279,6 +280,7 @@
 				6551C9D42900B27D00247C40 /* UnitTests.xctestplan */,
 				6551C9D62900B27D00247C40 /* UITests.xctestplan */,
 				6551C9D52900B27D00247C40 /* UITests-2.xctestplan */,
+				65EDF6B22901979800D737E0 /* UITests-3.xctestplan */,
 				16D47E7F26851AB40095D5A4 /* Assets.xcassets */,
 				166A81B32637406C0015AA1D /* Info.plist */,
 				650D169B28FFA54B00EE9339 /* Dangerfile.swift */,

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -178,6 +178,10 @@
 		650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PushNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		650FECCD28BA85F300A3CB0C /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		650FECCF28BA85F300A3CB0C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6551C9D42900B27D00247C40 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		6551C9D52900B27D00247C40 /* UITests-2.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-2.xctestplan"; sourceTree = "<group>"; };
+		6551C9D62900B27D00247C40 /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		6551C9D72900B46000247C40 /* bitrise.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = bitrise.yml; sourceTree = "<group>"; };
 		655C274E28B67ED20040AEAB /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PushNotificationStoryExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EC272628BA8AD50075E1DF /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
@@ -271,6 +275,10 @@
 				166DF27827E9172800C03BF4 /* Pocket (iOS).entitlements */,
 				1624B85A268508180099B6EF /* PocketKit */,
 				16BA7D6226851513009A17C1 /* main.swift */,
+				6551C9D72900B46000247C40 /* bitrise.yml */,
+				6551C9D42900B27D00247C40 /* UnitTests.xctestplan */,
+				6551C9D62900B27D00247C40 /* UITests.xctestplan */,
+				6551C9D52900B27D00247C40 /* UITests-2.xctestplan */,
 				16D47E7F26851AB40095D5A4 /* Assets.xcassets */,
 				166A81B32637406C0015AA1D /* Info.plist */,
 				650D169B28FFA54B00EE9339 /* Dangerfile.swift */,

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1300"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -199,6 +199,18 @@
             ReferencedContainer = "container:Pocket.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests-2.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -210,6 +210,9 @@
             reference = "container:UnitTests.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests-3.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/UITests-2.xctestplan
+++ b/UITests-2.xctestplan
@@ -9,6 +9,60 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "166A81AF2637406C0015AA1D",
+          "name" : "Pocket (iOS)"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "F204A75F27E22EC50010E155",
+          "name" : "SaveToPocket"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "65EC272428BA8AD50075E1DF",
+          "name" : "PushNotificationStoryExtension"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "650FECCA28BA85F300A3CB0C",
+          "name" : "PushNotificationServiceExtension"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Analytics",
+          "name" : "Analytics"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "PocketKit",
+          "name" : "PocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "SaveToPocketKit",
+          "name" : "SaveToPocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "SharedPocketKit",
+          "name" : "SharedPocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Sync",
+          "name" : "Sync"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Textile",
+          "name" : "Textile"
+        }
+      ]
+    },
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [
@@ -22,7 +76,14 @@
         "DeleteAnItemTests",
         "EditTagsTests",
         "EmptyStateTests",
-        "FavoriteAnItemTests"
+        "FavoriteAnItemTests",
+        "MyListFiltersTests",
+        "MyListTests",
+        "PullToRefreshTests",
+        "ReportARecommendationTests",
+        "SaveToPocketTests",
+        "ShareAnItemTests",
+        "SignOutTests"
       ],
       "target" : {
         "containerPath" : "container:Pocket.xcodeproj",

--- a/UITests-2.xctestplan
+++ b/UITests-2.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "71CBD44E-2117-44AE-B032-6918B5B9C2E0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "AddTagsItemTests",
+        "ArchiveAnItemTests",
+        "ArchiveFiltersTests",
+        "ArchiveTests",
+        "BannerViewTests",
+        "DeleteAnItemTests",
+        "EditTagsTests",
+        "EmptyStateTests",
+        "FavoriteAnItemTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Pocket.xcodeproj",
+        "identifier" : "166A81BF2637406C0015AA1D",
+        "name" : "Tests iOS"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UITests-3.xctestplan
+++ b/UITests-3.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "A4EB5A67-4AB5-4BAF-934F-5BDCE7E091F6",
+      "id" : "101CDED1-1A9D-4A85-8EDB-6090311C70C0",
       "name" : "Configuration 1",
       "options" : {
 
@@ -11,11 +11,6 @@
   "defaultOptions" : {
     "codeCoverage" : {
       "targets" : [
-        {
-          "containerPath" : "container:PocketKit",
-          "identifier" : "Analytics",
-          "name" : "Analytics"
-        },
         {
           "containerPath" : "container:Pocket.xcodeproj",
           "identifier" : "166A81AF2637406C0015AA1D",
@@ -35,6 +30,11 @@
           "containerPath" : "container:Pocket.xcodeproj",
           "identifier" : "65EC272428BA8AD50075E1DF",
           "name" : "PushNotificationStoryExtension"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Analytics",
+          "name" : "Analytics"
         },
         {
           "containerPath" : "container:PocketKit",
@@ -68,15 +68,17 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "AddTagsItemTests",
+        "ArchiveAnItemTests",
+        "ArchiveFiltersTests",
+        "ArchiveTests",
+        "BannerViewTests",
+        "DeleteAnItemTests",
+        "EditTagsTests",
+        "EmptyStateTests",
+        "FavoriteAnItemTests",
         "HomeTests",
-        "HomeWebViewTests",
-        "MyListFiltersTests",
-        "MyListTests",
-        "PullToRefreshTests",
-        "ReportARecommendationTests",
-        "SaveToPocketTests",
-        "ShareAnItemTests",
-        "SignOutTests"
+        "HomeWebViewTests"
       ],
       "target" : {
         "containerPath" : "container:Pocket.xcodeproj",

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "A4EB5A67-4AB5-4BAF-934F-5BDCE7E091F6",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "HomeTests",
+        "HomeWebViewTests",
+        "MyListFiltersTests",
+        "MyListTests",
+        "PullToRefreshTests",
+        "ReportARecommendationTests",
+        "SaveToPocketTests",
+        "ShareAnItemTests",
+        "SignOutTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Pocket.xcodeproj",
+        "identifier" : "166A81BF2637406C0015AA1D",
+        "name" : "Tests iOS"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -1,0 +1,52 @@
+{
+  "configurations" : [
+    {
+      "id" : "D7A8561E-5086-4968-9C3A-9D568C5F3698",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "AnalyticsTests",
+        "name" : "AnalyticsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "PocketKitTests",
+        "name" : "PocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SaveToPocketKitTests",
+        "name" : "SaveToPocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SharedPocketKitTests",
+        "name" : "SharedPocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SyncTests",
+        "name" : "SyncTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -9,6 +9,60 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Analytics",
+          "name" : "Analytics"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "PocketKit",
+          "name" : "PocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "SaveToPocketKit",
+          "name" : "SaveToPocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "SharedPocketKit",
+          "name" : "SharedPocketKit"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Sync",
+          "name" : "Sync"
+        },
+        {
+          "containerPath" : "container:PocketKit",
+          "identifier" : "Textile",
+          "name" : "Textile"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "166A81AF2637406C0015AA1D",
+          "name" : "Pocket (iOS)"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "F204A75F27E22EC50010E155",
+          "name" : "SaveToPocket"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "650FECCA28BA85F300A3CB0C",
+          "name" : "PushNotificationServiceExtension"
+        },
+        {
+          "containerPath" : "container:Pocket.xcodeproj",
+          "identifier" : "65EC272428BA8AD50075E1DF",
+          "name" : "PushNotificationStoryExtension"
+        }
+      ]
+    },
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,8 +15,8 @@ pipelines:
       # Build a qa build, and build a test build in parallel
       - build-and-test: {}
       # Run multiple tests on simulators in parallel
-      - run_test_groups: {}
-      - deploy_test_results: {}
+      - run-test-groups: {}
+      - deploy-test-results: {}
   # Will create an app store build and upload it to itunes connect
   app-store-pipeline:
     stages:
@@ -36,18 +36,19 @@ stages:
   build-and-test:
     workflows:
       # Build a test build
-      - test_build: {}
+      - test-build: {}
       # Build a qa build
       - qa-build: {}
 
-  run_test_groups:
+  run-test-groups:
     workflows:
-      - run_tests_iphone_14: {}
-      - run_tests_iphone_13_mini: {}
+      - run-tests-unit: {}
+      - run-tests-ui-1: {}
+      - run-tests-ui-2: {}
 
-  deploy_test_results:
+  deploy-test-results:
     workflows:
-      - deploy_test_results: {}
+      - deploy-test-results: {}
 
   release-build:
     workflows:
@@ -128,7 +129,7 @@ workflows:
     steps:
       - pull-intermediate-files@1:
           inputs:
-            - artifact_sources: build-and-test.test_build
+            - artifact_sources: build-and-test.test-build
 
   #Builds a release build that could be uploaded to App Store Connect
   release-build:
@@ -217,7 +218,7 @@ workflows:
     after_run:
       - _upload_sentry
 
-  test_build:
+  test-build:
     steps:
       - file-downloader@1:
           inputs:
@@ -233,42 +234,56 @@ workflows:
     before_run:
       - _setup
 
-  run_tests_iphone_14:
+  run-tests-unit:
     before_run:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
           inputs:
-            - xctestrun: '$BITRISE_TEST_BUNDLE_PATH/$TEST_BUNDLE_NAME'
+            - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UnitTests_iphonesimulator16.0.xctestrun'
             - destination: platform=iOS Simulator,name=iPhone 14,OS=16
       - deploy-to-bitrise-io@2.1.1:
           inputs:
-            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_IPHONE_14_TEST_XCRESULT_PATH'
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UNIT_XCRESULT_PATH'
 
-  run_tests_iphone_13_mini:
+  run-tests-ui-1:
     before_run:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
           inputs:
-            - xctestrun: '$BITRISE_TEST_BUNDLE_PATH/$TEST_BUNDLE_NAME'
-            - destination: platform=iOS Simulator,name=iPhone 13 mini,OS=16
+            - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests_iphonesimulator16.0-arm64-x86_64.xctestrun'
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=16
       - deploy-to-bitrise-io@2.1.1:
           inputs:
-            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_IPHONE_13_MINI_TEST_XCRESULT_PATH'
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_1_XCRESULT_PATH'
 
-  deploy_test_results:
+  run-tests-ui-2:
+    before_run:
+      - _pull_test_bundle
+    steps:
+      - xcode-test-without-building:
+          inputs:
+            - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests-2_iphonesimulator16.0-arm64-x86_64.xctestrun'
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=16
+            - test_plan: UITests-2
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
+
+
+  deploy-test-results:
     steps:
       - pull-intermediate-files@1:
           inputs:
-            - artifact_sources: run_tests_groups\..*
+            - artifact_sources: run-test-groups\..*
       - script@1:
           inputs:
             - content: |
                 #!/usr/bin/env bash
                 set -eo pipefail
 
-                for item in "${BITRISE_IPHONE_14_TEST_XCRESULT_PATH}" "${BITRISE_IPHONE_13_MINI_TEST_XCRESULT_PATH}";
+                for item in "${BITRISE_UITESTS_1_XCRESULT_PATH}" "${BITRISE_UITESTS_2_XCRESULT_PATH}" "${BITRISE_UNIT_XCRESULT_PATH}";
                   do
                     echo "Exporting ${item}"
 
@@ -302,9 +317,7 @@ app:
     - opts:
         is_expand: false
       SKIP_APOLLO_CODEGEN: '1'
-    - opts:
-        is_expand: false
-      TEST_BUNDLE_NAME: 'Pocket (iOS)_iphonesimulator16.0-arm64-x86_64.xctestrun'
+
 meta:
   bitrise.io:
     machine_type_id: g2-m1.8core

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,19 +6,26 @@ trigger_map:
   - push_branch: main
     pipeline: app-store-pipeline
   - pull_request_target_branch: '*'
-    pipeline: build-test-pipeline
+    pipeline: qa-build-test-pipeline
 
 pipelines:
-  build-test-pipeline:
+  # Will create a QA Build and run a test across multiple simulator devices
+  qa-build-test-pipeline:
     stages:
-      # Run the buld and test stage workflows
-      - build-test: {}
+      # Build a qa build, and build a test build in parallel
+      - build-and-test: {}
+      # Run multiple tests on simulators in parallel
+      - run_test_groups: {}
+      - deploy_test_results: {}
+  # Will create an app store build and upload it to itunes connect
   app-store-pipeline:
     stages:
       # First Build the release build (app store build)
       - release-build: {}
       # Run the steps to deploy to the app store
       - deploy-app-store: {}
+  # Will create an app store capabale build, but release it to Internal Testing users in Testflight.
+  # Intended to run nightly.
   nightly-internal-pipeline:
     stages:
       # First Build the release build (app store build)
@@ -26,11 +33,22 @@ pipelines:
       # Run the steps to deploy to testflight internally
       - deploy-internal-testflight: {}
 stages:
-  build-test:
+  build-and-test:
     workflows:
-      # Run the test and qa build flow in parallel
-      - test: {}
+      # Build a test build
+      - test_build: {}
+      # Build a qa build
       - qa-build: {}
+
+  run_test_groups:
+    workflows:
+      - run_tests_iphone_14: {}
+      - run_tests_iphone_13_mini: {}
+
+  deploy_test_results:
+    workflows:
+      - deploy_test_results: {}
+
   release-build:
     workflows:
       - release-build: {}
@@ -105,6 +123,13 @@ workflows:
                 swift run danger-swift ci
       - cache-push@2: {}
 
+  # Helper step to pull the built test bundle.
+  _pull_test_bundle:
+    steps:
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: build-and-test.test_build
+
   #Builds a release build that could be uploaded to App Store Connect
   release-build:
     steps:
@@ -164,6 +189,10 @@ workflows:
             - tag: 8.0+$BITRISE_BUILD_NUMBER
             - commit: '$GIT_CLONE_COMMIT_HASH'
             - api_token: '$GITHUB_RELEASE_TOKEN'
+    before_run:
+      - _setup
+    after_run:
+      - _upload_sentry
 
   qa-build:
     steps:
@@ -188,19 +217,74 @@ workflows:
     after_run:
       - _upload_sentry
 
-  test:
+  test_build:
     steps:
       - file-downloader@1:
           inputs:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
-      - xcode-test@4:
+      - xcode-build-for-test:
           inputs:
-            - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
-      - deploy-to-bitrise-io@2: {}
+            - destination: generic/platform=iOS Simulator
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_TEST_BUNDLE_PATH:BITRISE_TEST_BUNDLE_PATH'
     before_run:
       - _setup
+
+  run_tests_iphone_14:
+    before_run:
+      - _pull_test_bundle
+    steps:
+      - xcode-test-without-building:
+          inputs:
+            - xctestrun: '$BITRISE_TEST_BUNDLE_PATH/$TEST_BUNDLE_NAME'
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=16
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_IPHONE_14_TEST_XCRESULT_PATH'
+
+  run_tests_iphone_13_mini:
+    before_run:
+      - _pull_test_bundle
+    steps:
+      - xcode-test-without-building:
+          inputs:
+            - xctestrun: '$BITRISE_TEST_BUNDLE_PATH/$TEST_BUNDLE_NAME'
+            - destination: platform=iOS Simulator,name=iPhone 13 mini,OS=16
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_IPHONE_13_MINI_TEST_XCRESULT_PATH'
+
+  deploy_test_results:
+    steps:
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: run_tests_groups\..*
+      - script@1:
+          inputs:
+            - content: |
+                #!/usr/bin/env bash
+                set -eo pipefail
+
+                for item in "${BITRISE_IPHONE_14_TEST_XCRESULT_PATH}" "${BITRISE_IPHONE_13_MINI_TEST_XCRESULT_PATH}";
+                  do
+                    echo "Exporting ${item}"
+
+                    test_name=$(basename "$item" .xcresult)
+                    echo "Test name: $test_name"
+
+                    test_dir="${BITRISE_TEST_RESULT_DIR}/${test_name}"
+                    mkdir -p "${test_dir}"
+                    echo "Moving test result to: ${test_dir}"
+                    cp -R "${item}" "${test_dir}/$(basename ${item})"
+
+                    test_info="${test_dir}/test-info.json"
+                    echo "Creating Test info at: ${test_info}"
+                    echo "{ \"test-name\": \"${test_name}\" }" > "$test_info"
+                  done
+      - deploy-to-bitrise-io@2: {}
     after_run:
       - _danger
 
@@ -218,7 +302,10 @@ app:
     - opts:
         is_expand: false
       SKIP_APOLLO_CODEGEN: '1'
+    - opts:
+        is_expand: false
+      TEST_BUNDLE_NAME: 'Pocket (iOS)_iphonesimulator16.0-arm64-x86_64.xctestrun'
 meta:
   bitrise.io:
-    machine_type_id: g2.12core
+    machine_type_id: g2-m1.8core
     stack: osx-xcode-14.0.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -45,6 +45,7 @@ stages:
       - run-tests-unit: {}
       - run-tests-ui-1: {}
       - run-tests-ui-2: {}
+      - run-tests-ui-3: {}
 
   deploy-test-results:
     workflows:
@@ -112,6 +113,8 @@ workflows:
   _danger:
     steps:
       - cache-pull@2: {}
+      - activate-ssh-key@4: {}
+      - git-clone@6: {}
       - script@1:
           inputs:
             - content: |
@@ -239,6 +242,7 @@ workflows:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
+          title: Unit Tests
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UnitTests_iphonesimulator16.0.xctestrun'
             - destination: platform=iOS Simulator,name=iPhone 14,OS=16
@@ -247,10 +251,14 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UNIT_XCRESULT_PATH'
 
   run-tests-ui-1:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1.8core
     before_run:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
+          title: UI Test Suite 1
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests_iphonesimulator16.0-arm64-x86_64.xctestrun'
             - destination: platform=iOS Simulator,name=iPhone 14,OS=16
@@ -259,18 +267,36 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_1_XCRESULT_PATH'
 
   run-tests-ui-2:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1.8core
     before_run:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
+          title: UI Test Suite 2
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests-2_iphonesimulator16.0-arm64-x86_64.xctestrun'
             - destination: platform=iOS Simulator,name=iPhone 14,OS=16
-            - test_plan: UITests-2
       - deploy-to-bitrise-io@2.1.1:
           inputs:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
 
+  run-tests-ui-3:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1.8core
+    before_run:
+      - _pull_test_bundle
+    steps:
+      - xcode-test-without-building:
+          title: UI Test Suite 3
+          inputs:
+            - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests-3_iphonesimulator16.0-arm64-x86_64.xctestrun'
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=16
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_3_XCRESULT_PATH'
 
   deploy-test-results:
     steps:
@@ -283,23 +309,17 @@ workflows:
                 #!/usr/bin/env bash
                 set -eo pipefail
 
-                for item in "${BITRISE_UITESTS_1_XCRESULT_PATH}" "${BITRISE_UITESTS_2_XCRESULT_PATH}" "${BITRISE_UNIT_XCRESULT_PATH}";
-                  do
-                    echo "Exporting ${item}"
+                xcrun xcresulttool merge "${BITRISE_UITESTS_1_XCRESULT_PATH}" "${BITRISE_UITESTS_2_XCRESULT_PATH}" "${BITRISE_UITESTS_3_XCRESULT_PATH}" "${BITRISE_UNIT_XCRESULT_PATH}"  --output-path "merged.xcresult"
 
-                    test_name=$(basename "$item" .xcresult)
-                    echo "Test name: $test_name"
-
-                    test_dir="${BITRISE_TEST_RESULT_DIR}/${test_name}"
-                    mkdir -p "${test_dir}"
-                    echo "Moving test result to: ${test_dir}"
-                    cp -R "${item}" "${test_dir}/$(basename ${item})"
-
-                    test_info="${test_dir}/test-info.json"
-                    echo "Creating Test info at: ${test_info}"
-                    echo "{ \"test-name\": \"${test_name}\" }" > "$test_info"
-                  done
-      - deploy-to-bitrise-io@2: {}
+                envman add --key BITRISE_XCRESULT_PATH --value "$(pwd)/merged.xcresult"
+      - custom-test-results-export@0:
+          inputs:
+          - search_pattern: '*'
+          - base_path: $BITRISE_XCRESULT_PATH
+          - test_name: Pocket Tests
+      - deploy-to-bitrise-io@2.1.1:
+          inputs:
+            - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_XCRESULT_PATH'
     after_run:
       - _danger
 
@@ -320,5 +340,5 @@ app:
 
 meta:
   bitrise.io:
-    machine_type_id: g2-m1.8core
+    machine_type_id: g2.4core
     stack: osx-xcode-14.0.x


### PR DESCRIPTION
## Summary

https://getpocket.atlassian.net/browse/IN-902

- [x] Setup bitrise to create 1 build used for all the tests
- [x] Re-jigger bitrise steps and workflows to support waiting for multiple tests to run
- [x] Switch to iOS Test Plans from https://github.com/Pocket/pocket-ios/pull/276


## In Future Work
- Figure out how to de-dupe build steps
- Add multiple device types

## Implementation Details
* This builds on https://github.com/Pocket/pocket-ios/pull/244
