### PR TITLE
fix(fastfile): removing wait step

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :ios do
 
     #upload to testflight for our internal apps store connect nightly builds.
     upload_to_testflight(
-      skip_waiting_for_build_processing: false, #wait for build to process in app store connect
+      skip_waiting_for_build_processing: true, #dont wait for build to process in app store connect
       skip_submission: true, # Don't submit the build
       distribute_external: false, # Don't distrubte the build externally
       notify_external_testers: false, # Don't notify externally


### PR DESCRIPTION
## Summary
* Quick fix for uploading to internal teams. We don't need to wait for processing.