### PR TITLE
fix(testflight): wait for build to process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :ios do
 
     #upload to testflight for our internal apps store connect nightly builds.
     upload_to_testflight(
-      skip_waiting_for_build_processing: true,
+      skip_waiting_for_build_processing: false,
       groups: ['Nightly Internal Builds'],
       submit_beta_review: false,
       ipa: BITRISE_IPA_PATH


### PR DESCRIPTION
## Summary
* After digging through fastlane code, we still need to wait for the build to process.

However we will need to wait till https://github.com/fastlane/fastlane/pull/20644 is merged or another answer is provided

