### PR TITLE
fix(query): updating list query name to be representiative

### DIFF
--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -1729,11 +1729,11 @@ public final class SavedItemSummariesQuery: GraphQLQuery {
   }
 }
 
-public final class UserByTokenQuery: GraphQLQuery {
+public final class FetchSavesQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
   public let operationDefinition: String =
     """
-    query UserByToken($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
+    query FetchSaves($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
       userByToken(token: $token) {
         __typename
         savedItems(pagination: $pagination, filter: $savedItemsFilter) {
@@ -1757,7 +1757,7 @@ public final class UserByTokenQuery: GraphQLQuery {
     }
     """
 
-  public let operationName: String = "UserByToken"
+  public let operationName: String = "FetchSaves"
 
   public var queryDocument: String {
     var document: String = operationDefinition
@@ -1797,7 +1797,7 @@ public final class UserByTokenQuery: GraphQLQuery {
 
     public static var selections: [GraphQLSelection] {
       return [
-        GraphQLField("userByToken", arguments: ["token": GraphQLVariable("token")], type: .object(UserByToken.selections)),
+        GraphQLField("userByToken", arguments: ["token": GraphQLVariable("token")], type: .object(FetchSaves.selections)),
       ]
     }
 
@@ -1807,21 +1807,21 @@ public final class UserByTokenQuery: GraphQLQuery {
       self.resultMap = unsafeResultMap
     }
 
-    public init(userByToken: UserByToken? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Query", "userByToken": userByToken.flatMap { (value: UserByToken) -> ResultMap in value.resultMap }])
+    public init(userByToken: FetchSaves? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Query", "userByToken": userByToken.flatMap { (value: FetchSaves) -> ResultMap in value.resultMap }])
     }
 
     /// Gets a user entity for a given access token
-    public var userByToken: UserByToken? {
+    public var userByToken: FetchSaves? {
       get {
-        return (resultMap["userByToken"] as? ResultMap).flatMap { UserByToken(unsafeResultMap: $0) }
+        return (resultMap["userByToken"] as? ResultMap).flatMap { FetchSaves(unsafeResultMap: $0) }
       }
       set {
         resultMap.updateValue(newValue?.resultMap, forKey: "userByToken")
       }
     }
 
-    public struct UserByToken: GraphQLSelectionSet {
+    public struct FetchSaves: GraphQLSelectionSet {
       public static let possibleTypes: [String] = ["User"]
 
       public static var selections: [GraphQLSelection] {

--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -73,8 +73,8 @@ class FetchList: SyncOperation {
         initialDownloadState.send(.completed)
     }
 
-    private func fetchPage(_ pagination: PaginationSpec) async throws -> GraphQLResult<UserByTokenQuery.Data> {
-        let query = UserByTokenQuery(token: token)
+    private func fetchPage(_ pagination: PaginationSpec) async throws -> GraphQLResult<FetchSavesQuery.Data> {
+        let query = FetchSavesQuery(token: token)
         query.pagination = PaginationInput(
             after: pagination.cursor,
             first: pagination.maxItems
@@ -90,7 +90,7 @@ class FetchList: SyncOperation {
     }
 
     @MainActor
-    private func updateLocalStorage(result: GraphQLResult<UserByTokenQuery.Data>) throws {
+    private func updateLocalStorage(result: GraphQLResult<FetchSavesQuery.Data>) throws {
         guard let edges = result.data?.userByToken?.savedItems?.edges else {
             return
         }
@@ -126,7 +126,7 @@ class FetchList: SyncOperation {
             self.maxItems = maxItems
         }
 
-        func nextPage(result: GraphQLResult<UserByTokenQuery.Data>) -> PaginationSpec {
+        func nextPage(result: GraphQLResult<FetchSavesQuery.Data>) -> PaginationSpec {
             guard let savedItems = result.data?.userByToken?.savedItems,
                   let itemCount = savedItems.edges?.count,
                   let endCursor = savedItems.pageInfo.endCursor else {

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -6,7 +6,7 @@ import Foundation
 import CoreData
 
 extension SavedItem {
-    typealias SavedItemEdge = UserByTokenQuery.Data.UserByToken.SavedItem.Edge
+    typealias SavedItemEdge = FetchSavesQuery.Data.FetchSaves.SavedItem.Edge
     public typealias RemoteSavedItem = SavedItemParts
     typealias RemoteItem = ItemParts
 

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -81,7 +81,7 @@ fragment SlateParts on Slate {
   }
 }
 
-query UserByToken($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
+query FetchSaves($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
   userByToken(token: $token) {
     savedItems(pagination: $pagination, filter: $savedItemsFilter) {
       totalCount

--- a/PocketKit/Tests/SyncTests/Operations/FetchListTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/FetchListTests.swift
@@ -48,16 +48,16 @@ class FetchListTests: XCTestCase {
         )
     }
 
-    func test_refresh_fetchesUserByTokenQueryWithGivenToken() async {
+    func test_refresh_fetchesFetchSavesQueryWithGivenToken() async {
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let service = subject()
         _ = await service.execute()
 
         XCTAssertFalse(apollo.fetchCalls.isEmpty)
-        let call: MockApolloClient.FetchCall<UserByTokenQuery>? = apollo.fetchCall(at: 0)
+        let call: MockApolloClient.FetchCall<FetchSavesQuery>? = apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.token, "test-token")
 
         XCTAssertEqual(lastRefresh.refreshedCallCount, 1)
@@ -66,7 +66,7 @@ class FetchListTests: XCTestCase {
     func test_refresh_whenFetchSucceeds_andResultContainsNewItems_createsNewItems() async throws {
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let service = subject()
         _ = await service.execute()
@@ -116,7 +116,7 @@ class FetchListTests: XCTestCase {
     }
 
     func test_refresh_whenFetchSucceeds_andResultContainsDuplicateItems_createsSingleItem() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "duplicate-list", asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "duplicate-list", asResultType: FetchSavesQuery.self)
 
         let service = subject()
         _ = await service.execute()
@@ -126,7 +126,7 @@ class FetchListTests: XCTestCase {
     }
 
     func test_refresh_whenFetchSucceeds_andResultContainsUpdatedItems_updatesExistingItems() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "updated-item", asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "updated-item", asResultType: FetchSavesQuery.self)
         try space.createSavedItem(
             remoteID: "saved-item-1",
             item: space.buildItem(title: "Item 1")
@@ -140,7 +140,7 @@ class FetchListTests: XCTestCase {
     }
 
     func test_refresh_whenFetchFails_sendsErrorOverGivenSubject() async throws {
-        apollo.stubFetch(ofQueryType: UserByTokenQuery.self, toReturnError: TestError.anError)
+        apollo.stubFetch(ofQueryType: FetchSavesQuery.self, toReturnError: TestError.anError)
 
         var error: Error?
         events.sink { event in
@@ -160,7 +160,7 @@ class FetchListTests: XCTestCase {
 
     func test_refresh_whenResponseIncludesMultiplePages_fetchesNextPage() async throws {
         var fetches = 0
-        apollo.stubFetch { (query: UserByTokenQuery, _, _, queue, completion) -> Apollo.Cancellable in
+        apollo.stubFetch { (query: FetchSavesQuery, _, _, queue, completion) -> Apollo.Cancellable in
             defer { fetches += 1 }
 
             let result: Fixture
@@ -190,7 +190,7 @@ class FetchListTests: XCTestCase {
 
     func test_refresh_whenItemCountExceedsMax_fetchesMaxNumberOfItems() async throws {
         var fetches = 0
-        apollo.stubFetch { (query: UserByTokenQuery, _, _, queue, completion) -> Apollo.Cancellable in
+        apollo.stubFetch { (query: FetchSavesQuery, _, _, queue, completion) -> Apollo.Cancellable in
             defer { fetches += 1 }
 
             let result: Fixture
@@ -233,12 +233,12 @@ class FetchListTests: XCTestCase {
 
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let service = subject()
         _ = await service.execute()
 
-        let call: MockApolloClient.FetchCall<UserByTokenQuery>? = apollo.fetchCall(at: 0)
+        let call: MockApolloClient.FetchCall<FetchSavesQuery>? = apollo.fetchCall(at: 0)
         XCTAssertNotNil(call?.query.savedItemsFilter)
         XCTAssertEqual(call?.query.savedItemsFilter?.updatedSince, 123456789)
     }
@@ -248,7 +248,7 @@ class FetchListTests: XCTestCase {
 
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let receivedEvent = expectation(description: "receivedEvent")
         receivedEvent.isInverted = true
@@ -271,12 +271,12 @@ class FetchListTests: XCTestCase {
     func test_refresh_whenUpdatedSinceIsNotPresent_onlyFetchesUnreadItems() async {
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let service = subject()
         _ = await service.execute()
 
-        let call: MockApolloClient.FetchCall<UserByTokenQuery>? = apollo.fetchCall(at: 0)
+        let call: MockApolloClient.FetchCall<FetchSavesQuery>? = apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.savedItemsFilter?.status, .unread)
     }
 
@@ -285,7 +285,7 @@ class FetchListTests: XCTestCase {
 
         let fixture = Fixture.load(name: "list")
             .replacing("MARTICLE", withFixtureNamed: "marticle")
-        apollo.stubFetch(toReturnFixture: fixture, asResultType: UserByTokenQuery.self)
+        apollo.stubFetch(toReturnFixture: fixture, asResultType: FetchSavesQuery.self)
 
         let receivedFirstPageEvent = expectation(description: "receivedFirstPageEvent")
         let receivedCompletedEvent = expectation(description: "receivedCompletedEvent")
@@ -310,7 +310,7 @@ class FetchListTests: XCTestCase {
     func test_refresh_whenResultsAreEmpty_finishesOperationSuccessfully() async {
         apollo.stubFetch(
             toReturnFixtureNamed: "empty-list",
-            asResultType: UserByTokenQuery.self
+            asResultType: FetchSavesQuery.self
         )
 
         let service = subject()
@@ -326,7 +326,7 @@ class FetchListTests: XCTestCase {
             underlying: TestError.anError
         )
 
-        apollo.stubFetch(ofQueryType: UserByTokenQuery.self, toReturnError: initialError)
+        apollo.stubFetch(ofQueryType: FetchSavesQuery.self, toReturnError: initialError)
 
         let service = subject()
         let result = await service.execute()
@@ -339,7 +339,7 @@ class FetchListTests: XCTestCase {
 
     func test_execute_whenResponseIs5XX_retries() async {
         let initialError = ResponseCodeInterceptor.ResponseCodeError.withStatusCode(500)
-        apollo.stubFetch(ofQueryType: UserByTokenQuery.self, toReturnError: initialError)
+        apollo.stubFetch(ofQueryType: FetchSavesQuery.self, toReturnError: initialError)
 
         let service = subject()
         let result = await service.execute()


### PR DESCRIPTION
## Summary
* In apollo studio unless you drill down it was hard to realize that UserByToken was for fetching a user's saves. This renames it so it is clear to others.


## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
