### PR TITLE
Updates for Xcode 14

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -30,15 +30,17 @@ class RecommendationViewModel: ReadableViewModel {
 
     private let recommendation: Recommendation
     private let source: Source
+    private let pasteboard: Pasteboard
     let tracker: Tracker
 
     private var savedItemCancellable: AnyCancellable?
     private var savedItemSubscriptions: Set<AnyCancellable> = []
 
-    init(recommendation: Recommendation, source: Source, tracker: Tracker) {
+    init(recommendation: Recommendation, source: Source, tracker: Tracker, pasteboard: Pasteboard) {
         self.recommendation = recommendation
         self.source = source
         self.tracker = tracker
+        self.pasteboard = pasteboard
 
         self.savedItemCancellable = recommendation.item?.publisher(for: \.savedItem).sink { [weak self] savedItem in
             self?.update(for: savedItem)
@@ -218,7 +220,7 @@ extension RecommendationViewModel {
     }
 
     private func copyExternalURL(_ url: URL) {
-        UIPasteboard.general.url = url
+        pasteboard.url = url
     }
 
     private func shareExternalURL(_ url: URL) {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -32,16 +32,19 @@ class SavedItemViewModel: ReadableViewModel {
 
     private let item: SavedItem
     private let source: Source
+    private let pasteboard: Pasteboard
     private var subscriptions: [AnyCancellable] = []
 
     init(
         item: SavedItem,
         source: Source,
-        tracker: Tracker
+        tracker: Tracker,
+        pasteboard: Pasteboard
     ) {
         self.item = item
         self.source = source
         self.tracker = tracker
+        self.pasteboard = pasteboard
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()
@@ -177,7 +180,7 @@ extension SavedItemViewModel {
     }
 
     private func copyExternalURL(_ url: URL) {
-        UIPasteboard.general.url = url
+        pasteboard.url = url
     }
 
     private func shareExternalURL(_ url: URL) {

--- a/PocketKit/Sources/PocketKit/Banner/BannerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Banner/BannerViewModel.swift
@@ -7,11 +7,15 @@ struct BannerViewModel {
     let prompt: String
     let backgroundColor: UIColor
     let borderColor: UIColor
-    let primaryAction: ([NSItemProvider]) -> Void
+    let primaryAction: (URL?) -> Void
     let dismissAction: () -> Void
 
     var attributedText: NSAttributedString {
         return NSAttributedString(string: prompt, style: .main)
+    }
+
+    var attributedButtonText: AttributedString {
+        return AttributedString(NSAttributedString(string: "Save", style: .button))
     }
 }
 
@@ -19,4 +23,6 @@ private extension Style {
     static let main: Self = .header.sansSerif.p2.with(weight: .semibold).with { paragraph in
         paragraph.with(lineSpacing: 4)
     }
+
+    static let button: Self = .header.sansSerif.h8.with(color: .ui.white)
 }

--- a/PocketKit/Sources/PocketKit/Banner/BannerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Banner/BannerViewModel.swift
@@ -5,23 +5,13 @@ import UIKit
 
 struct BannerViewModel {
     let prompt: String
-    let clipboardURL: String?
-    var buttonText: String? = "Save"
     let backgroundColor: UIColor
     let borderColor: UIColor
-    let primaryAction: () -> Void
+    let primaryAction: ([NSItemProvider]) -> Void
     let dismissAction: () -> Void
 
     var attributedText: NSAttributedString {
         return NSAttributedString(string: prompt, style: .main)
-    }
-
-    var attributedDetailText: NSAttributedString {
-        return NSAttributedString(string: clipboardURL ?? "", style: .detail)
-    }
-
-    var attributedButtonText: NSAttributedString {
-        return NSAttributedString(string: buttonText ?? "", style: .button)
     }
 }
 
@@ -29,8 +19,4 @@ private extension Style {
     static let main: Self = .header.sansSerif.p2.with(weight: .semibold).with { paragraph in
         paragraph.with(lineSpacing: 4)
     }
-    static let detail: Self = .header.sansSerif.p4.with { paragraph in
-        paragraph.with(lineBreakMode: .byTruncatingTail)
-    }.with(maxScaleSize: 16)
-    static let button: Self = .header.sansSerif.h8.with(color: .ui.white)
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -305,7 +305,8 @@ extension HomeViewModel {
             let viewModel = RecommendationViewModel(
                 recommendation: recommendation,
                 source: source,
-                tracker: tracker.childTracker(hosting: .articleView.screen)
+                tracker: tracker.childTracker(hosting: .articleView.screen),
+                pasteboard: UIPasteboard.general
             )
             selectedReadableType = .recommendation(viewModel)
 
@@ -333,7 +334,8 @@ extension HomeViewModel {
             let viewModel = SavedItemViewModel(
                 item: savedItem,
                 source: source,
-                tracker: tracker.childTracker(hosting: .articleView.screen)
+                tracker: tracker.childTracker(hosting: .articleView.screen),
+                pasteboard: UIPasteboard.general
             )
             selectedReadableType = .savedItem(viewModel)
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -113,7 +113,8 @@ extension SlateDetailViewModel {
             selectedReadableViewModel = RecommendationViewModel(
                 recommendation: recommendation,
                 source: source,
-                tracker: tracker.childTracker(hosting: .articleView.screen)
+                tracker: tracker.childTracker(hosting: .articleView.screen),
+                pasteboard: UIPasteboard.general
             )
 
             tracker.track(

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -325,7 +325,8 @@ extension ArchivedItemsListViewModel {
                 SavedItemViewModel(
                     item: item,
                     source: source,
-                    tracker: tracker.childTracker(hosting: .articleView.screen)
+                    tracker: tracker.childTracker(hosting: .articleView.screen),
+                    pasteboard: UIPasteboard.general
                 )
             )
         }

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -358,7 +358,8 @@ extension SavedItemsListViewModel {
                 SavedItemViewModel(
                     item: $0,
                     source: source,
-                    tracker: tracker.childTracker(hosting: .articleView.screen)
+                    tracker: tracker.childTracker(hosting: .articleView.screen),
+                    pasteboard: UIPasteboard.general
                 )
             }
             selectedItem = .readable(selectedReadable)

--- a/PocketKit/Sources/PocketKit/Pasteboard.swift
+++ b/PocketKit/Sources/PocketKit/Pasteboard.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+protocol Pasteboard: AnyObject {
+    var url: URL? { get set }
+}
+
+extension UIPasteboard: Pasteboard {
+
+}

--- a/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
@@ -42,7 +42,7 @@ class RootCoordinator {
 
         window?.makeKeyAndVisible()
 
-        rootViewModel.$bannerViewModel.sink { [weak self] viewModel in
+        rootViewModel.$bannerViewModel.receive(on: DispatchQueue.main).sink { [weak self] viewModel in
             if let viewModel = viewModel {
                 self?.setupBanner(with: viewModel)
             } else {

--- a/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
@@ -57,8 +57,8 @@ class RootViewModel {
                 prompt: "Add copied URL to your Saves?",
                 backgroundColor: UIColor(.ui.teal6),
                 borderColor: UIColor(.ui.teal5),
-                primaryAction: { [weak self] itemProviders in
-                    self?.handleBannerPrimaryAction(itemProviders: itemProviders)
+                primaryAction: { [weak self] url in
+                    self?.handleBannerPrimaryAction(url: url)
                 },
                 dismissAction: { [weak self] in
                     self?.bannerViewModel = nil
@@ -67,20 +67,11 @@ class RootViewModel {
         }
     }
 
-    private func handleBannerPrimaryAction(itemProviders: [NSItemProvider]) {
+    private func handleBannerPrimaryAction(url: URL?) {
         bannerViewModel = nil
 
-        for provider in itemProviders {
-            if provider.canLoadObject(ofClass: URL.self) {
-                _ = provider.loadObject(ofClass: URL.self) { [weak self] url, error in
-                    guard let url = url else {
-                        return
-                    }
-
-                    self?.source.save(url: url)
-                }
-            }
-        }
+        guard let url = url else { return }
+        source.save(url: url)
     }
 
     private func setUpSession(_ session: SharedPocketKit.Session) {

--- a/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
@@ -51,22 +51,35 @@ class RootViewModel {
     }
 
     func showSaveFromClipboardBanner() {
-        if UIPasteboard.general.hasURLs,
-           let clipboardURL = UIPasteboard.general.url, isLoggedIn {
+        if UIPasteboard.general.hasURLs, isLoggedIn {
 
             bannerViewModel = BannerViewModel(
                 prompt: "Add copied URL to your Saves?",
-                clipboardURL: clipboardURL.absoluteString,
                 backgroundColor: UIColor(.ui.teal6),
                 borderColor: UIColor(.ui.teal5),
-                primaryAction: { [weak self] in
-                    self?.source.save(url: clipboardURL)
-                    self?.bannerViewModel = nil
+                primaryAction: { [weak self] itemProviders in
+                    self?.handleBannerPrimaryAction(itemProviders: itemProviders)
                 },
                 dismissAction: { [weak self] in
                     self?.bannerViewModel = nil
                 }
             )
+        }
+    }
+
+    private func handleBannerPrimaryAction(itemProviders: [NSItemProvider]) {
+        bannerViewModel = nil
+
+        for provider in itemProviders {
+            if provider.canLoadObject(ofClass: URL.self) {
+                _ = provider.loadObject(ofClass: URL.self) { [weak self] url, error in
+                    guard let url = url else {
+                        return
+                    }
+
+                    self?.source.save(url: url)
+                }
+            }
         }
     }
 

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -76,7 +76,8 @@ extension LoggedOutViewModelTests {
         wait(for: [startExpectation], timeout: 1)
     }
 
-    func test_logIn_onFxAError_setsPresentedAlert() async {
+    @MainActor
+    func test_logIn_onFxAError_setsPresentedAlert() {
         mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()
 
@@ -86,12 +87,13 @@ extension LoggedOutViewModelTests {
             alertExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        await viewModel.logIn()
+        viewModel.logIn()
 
         wait(for: [alertExpectation], timeout: 1)
     }
 
-    func test_logIn_onFxASuccess_updatesSession() async {
+    @MainActor
+    func test_logIn_onFxASuccess_updatesSession() {
         mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")!
         let viewModel = subject()
 
@@ -103,7 +105,7 @@ extension LoggedOutViewModelTests {
             sessionExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        await viewModel.logIn()
+        viewModel.logIn()
         wait(for: [sessionExpectation], timeout: 1)
     }
 }
@@ -129,7 +131,8 @@ extension LoggedOutViewModelTests {
         wait(for: [startExpectation], timeout: 1)
     }
 
-    func test_signUp_onFxAError_setsPresentedAlert() async {
+    @MainActor
+    func test_signUp_onFxAError_setsPresentedAlert() {
         mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         let viewModel = subject()
 
@@ -139,11 +142,12 @@ extension LoggedOutViewModelTests {
             alertExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        await viewModel.signUp()
+        viewModel.signUp()
         wait(for: [alertExpectation], timeout: 1)
     }
 
-    func test_signUp_onFxASuccess_updatesSession() async {
+    @MainActor
+    func test_signUp_onFxASuccess_updatesSession() {
         mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")!
         let viewModel = subject()
 
@@ -155,7 +159,7 @@ extension LoggedOutViewModelTests {
             sessionExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        await viewModel.signUp()
+        viewModel.signUp()
         wait(for: [sessionExpectation], timeout: 1)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -10,19 +10,20 @@ class RecommendationViewModelTests: XCTestCase {
     private var source: MockSource!
     private var space: Space!
     private var tracker: MockTracker!
+    private var pasteboard: MockPasteboard!
 
     private var subscriptions: Set<AnyCancellable> = []
 
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
+        pasteboard = MockPasteboard()
         space = .testSpace()
 
         continueAfterFailure = false
     }
 
     override func tearDownWithError() throws {
-        UIPasteboard.general.string = ""
         subscriptions = []
         try space.clear()
     }
@@ -30,12 +31,14 @@ class RecommendationViewModelTests: XCTestCase {
     func subject(
         recommendation: Recommendation,
         source: Source? = nil,
-        tracker: Tracker? = nil
+        tracker: Tracker? = nil,
+        pasteboard: Pasteboard? = nil
     ) -> RecommendationViewModel {
         RecommendationViewModel(
             recommendation: recommendation,
             source: source ?? self.source,
-            tracker: tracker ?? self.tracker
+            tracker: tracker ?? self.tracker,
+            pasteboard: pasteboard ?? self.pasteboard
         )
     }
 
@@ -303,7 +306,8 @@ class RecommendationViewModelTests: XCTestCase {
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Copy link")
-        XCTAssertEqual(UIPasteboard.general.url, url)
+
+        XCTAssertEqual(pasteboard.url, url)
     }
 
     func test_externalShare_updatesSharedActivity() throws {

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -273,7 +273,7 @@ class SavedItemViewModelTests: XCTestCase {
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Copy link")
-        XCTAssertEqual(pasteboard.general.url, url)
+        XCTAssertEqual(pasteboard.url, url)
     }
 
     func test_externalShare_updatesSharedActivity() {

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -9,26 +9,33 @@ class SavedItemViewModelTests: XCTestCase {
     private var source: MockSource!
     private var tracker: MockTracker!
     private var space: Space!
+    private var pasteboard: Pasteboard!
 
     private var subscriptions: Set<AnyCancellable> = []
 
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
+        pasteboard = MockPasteboard()
         space = .testSpace()
     }
 
     override func tearDown() async throws {
-        UIPasteboard.general.string = ""
         subscriptions = []
         try space.clear()
     }
 
-    func subject(item: SavedItem, source: Source? = nil, tracker: Tracker? = nil) -> SavedItemViewModel {
+    func subject(
+        item: SavedItem,
+        source: Source? = nil,
+        tracker: Tracker? = nil,
+        pasteboard: UIPasteboard? = nil
+    ) -> SavedItemViewModel {
         SavedItemViewModel(
             item: item,
             source: source ?? self.source,
-            tracker: tracker ?? self.tracker
+            tracker: tracker ?? self.tracker,
+            pasteboard: pasteboard ?? self.pasteboard
         )
     }
 
@@ -266,7 +273,7 @@ class SavedItemViewModelTests: XCTestCase {
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Copy link")
-        XCTAssertEqual(UIPasteboard.general.url, url)
+        XCTAssertEqual(pasteboard.general.url, url)
     }
 
     func test_externalShare_updatesSharedActivity() {

--- a/PocketKit/Tests/PocketKitTests/Support/MockPasteboard.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPasteboard.swift
@@ -1,0 +1,6 @@
+import Foundation
+@testable import PocketKit
+
+class MockPasteboard: Pasteboard {
+    var url: URL?
+}

--- a/Tests iOS/BannerViewTests.swift
+++ b/Tests iOS/BannerViewTests.swift
@@ -41,11 +41,11 @@ class BannerViewTests: XCTestCase {
         let banner = app.bannerView.wait()
 
         banner.buttons.firstMatch.tap()
-        waitForDisappearance(of: banner)
+        waitForDisappearance(of: banner, timeout: 10)
 
-        home.recentSavesView(matching: "Slate 1, Recommendation 1").wait()
+        home.recentSavesView(matching: "Slate 1, Recommendation 1").wait(timeout: 10)
         app.tabBar.myListButton.tap()
-        app.myListView.itemView(matching: "Slate 1, Recommendation 1").wait()
+        app.myListView.itemView(matching: "Slate 1, Recommendation 1").wait(timeout: 10)
     }
 
     func test_foregroundingTheApp_withURL_showsSaveFromClipboardBanner() {
@@ -83,9 +83,9 @@ class BannerViewTests: XCTestCase {
         }
 
         banner.buttons.firstMatch.tap()
-        waitForDisappearance(of: banner)
+        waitForDisappearance(of: banner, timeout: 10)
 
-        app.homeView.recentSavesView(matching: "Item 3").wait()
+        app.homeView.recentSavesView(matching: "Item 3").wait(timeout: 10)
     }
 
     func test_navigatingToHomeTab_withoutSavedURL_doesNotShowSaveFromClipboardBanner() {

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -385,6 +385,6 @@ extension HomeTests {
         app
             .webReaderView
             .staticText(matching: "Hello, world")
-            .wait()
+            .wait(timeout: 10)
     }
 }

--- a/Tests iOS/HomeWebViewTests.swift
+++ b/Tests iOS/HomeWebViewTests.swift
@@ -76,6 +76,6 @@ class HomeWebViewTests: XCTestCase {
         app
             .webReaderView
             .staticText(matching: "Hello, world")
-            .wait()
+            .wait(timeout: 10)
     }
 }

--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -168,7 +168,7 @@ extension ArchiveTests {
         app
             .webReaderView
             .staticText(matching: "Hello, world")
-            .wait()
+            .wait(timeout: 10)
     }
 }
 

--- a/Tests iOS/MyList/MyListTests.swift
+++ b/Tests iOS/MyList/MyListTests.swift
@@ -366,6 +366,6 @@ extension MyListTests {
         app
             .webReaderView
             .staticText(matching: "Hello, world")
-            .wait()
+            .wait(timeout: 10)
     }
 }

--- a/Tests iOS/Support/Elements/AddTagsViewElement.swift
+++ b/Tests iOS/Support/Elements/AddTagsViewElement.swift
@@ -20,7 +20,7 @@ struct AddTagsViewElement: PocketUIElement {
     }
 
     var allTagsView: XCUIElement {
-        element.tables["all-tags"]
+        element.collectionViews["all-tags"]
     }
 
     func allTagsRow(matching string: String) -> XCUIElement {

--- a/Tests iOS/Support/Elements/AddTagsViewElement.swift
+++ b/Tests iOS/Support/Elements/AddTagsViewElement.swift
@@ -20,14 +20,22 @@ struct AddTagsViewElement: PocketUIElement {
     }
 
     var allTagsView: XCUIElement {
-        element.collectionViews["all-tags"]
+        let query: XCUIElementQuery
+
+        if #available(iOS 16, *) {
+            query = element.collectionViews
+        } else {
+            query = element.tables
+        }
+
+        return query["all-tags"]
     }
 
     func allTagsRow(matching string: String) -> XCUIElement {
-        return allTagsView.staticTexts[string].self
+        return allTagsView.staticTexts[string]
     }
 
     func tag(matching string: String) -> XCUIElement {
-        return element.staticTexts[string].self
+        return element.staticTexts[string]
     }
 }

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -48,7 +48,7 @@ struct PocketAppElement {
     }
 
     var reportView: ReportViewElement {
-        return ReportViewElement(app.tables["report-recommendation"])
+        return ReportViewElement(app.collectionViews["report-recommendation"])
     }
 
     var sortMenu: SortMenuElement {

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -48,7 +48,14 @@ struct PocketAppElement {
     }
 
     var reportView: ReportViewElement {
-        return ReportViewElement(app.collectionViews["report-recommendation"])
+        let query: XCUIElementQuery
+        if #available(iOS 16, *) {
+            query = app.collectionViews
+        } else {
+            query = app.tables
+        }
+
+        return ReportViewElement(query["report-recommendation"])
     }
 
     var sortMenu: SortMenuElement {

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -1,10 +1,10 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForDisappearance(of element: XCUIElement) {
+    func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval = 3) {
         let doesNotExist = NSPredicate(format: "exists == 0")
         let elementToNotExist = expectation(for: doesNotExist, evaluatedWith: element)
-        wait(for: [elementToNotExist], timeout: 3)
+        wait(for: [elementToNotExist], timeout: timeout)
     }
 
     func waitForDisappearance(of element: PocketUIElement) {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -223,4 +223,4 @@ app:
 meta:
   bitrise.io:
     machine_type_id: g2.12core
-    stack: osx-xcode-13.4.x
+    stack: osx-xcode-14.0.x

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -199,7 +199,7 @@ workflows:
           title: Install test secrets.xcconfig
       - xcode-test@4:
           inputs:
-            - destination: platform=iOS Simulator,name=iPhone 13,OS=latest
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
       - deploy-to-bitrise-io@2: {}
     before_run:
       - _setup


### PR DESCRIPTION
## Summary
The biggest change here is the switch from using a regular `UIButton` to trigger a save action from a URL in the clipboard. It also contains a few other fixes to unit and UI tests to account for slight changes in behavior in the new version of XCTest.

## References 
* Links to docs, tickets, designs if available

## Implementation Details
- [Avoid usages of pasteboard in unit tests](https://github.com/Pocket/pocket-ios/commit/70a9be36410387784cd2930a872979a9665e3ba1)
- [Run tests via MainActor when necessary](https://github.com/Pocket/pocket-ios/commit/ef800f851517c477677bb32fa6f6505cd0c25508)
- [Avoid system alert when pasting URLs](https://github.com/Pocket/pocket-ios/commit/83e617aff092a7a49e842383f480a3d2c687c623)
- [Fix a network retry tests](https://github.com/Pocket/pocket-ios/commit/4c1cafbe1ee45b31bbf371d1f87f32a59929737f)
- [Fix UI tests for Xcode 14](https://github.com/Pocket/pocket-ios/commit/4d477d5a1d8ca04b4a80d034a1793752b43fea6c)