### PR TITLE
feat(coverage): adding code coverage reports

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "DangerSwiftCoverage",
+        "repositoryURL": "https://github.com/f-meloni/danger-swift-coverage",
+        "state": {
+          "branch": null,
+          "revision": "6a21a6e595e2b13443428942ce128b3ba6b827ee",
+          "version": "1.2.1"
+        }
+      },
+      {
         "package": "Down",
         "repositoryURL": "https://github.com/johnxnguyen/Down",
         "state": {
@@ -47,12 +56,39 @@
         }
       },
       {
+        "package": "Logger",
+        "repositoryURL": "https://github.com/shibapm/Logger",
+        "state": {
+          "branch": null,
+          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
+          "version": "0.2.3"
+        }
+      },
+      {
         "package": "Lottie",
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
           "revision": "314537ec697719fa33a9d48210f4d06a463286d3",
           "version": "3.4.3"
+        }
+      },
+      {
+        "package": "OctoKit",
+        "repositoryURL": "https://github.com/nerdishbynature/octokit.swift",
+        "state": {
+          "branch": null,
+          "revision": "9521cdff919053868ab13cd08a228f7bc1bde2a9",
+          "version": "0.11.0"
+        }
+      },
+      {
+        "package": "RequestKit",
+        "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
+        "state": {
+          "branch": null,
+          "revision": "fd5e9e99aada7432170366c9e95967011ce13bad",
+          "version": "2.4.0"
         }
       },
       {
@@ -92,6 +128,15 @@
         }
       },
       {
+        "package": "danger-swift",
+        "repositoryURL": "https://github.com/danger/swift.git",
+        "state": {
+          "branch": null,
+          "revision": "0d62144a8bdfdb087c476ac3e88e96491c158a7b",
+          "version": "3.14.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
@@ -125,6 +170,15 @@
           "branch": null,
           "revision": "12b5acf96d98f91d50de447369bd18df74600f1a",
           "version": "1.9.6"
+        }
+      },
+      {
+        "package": "Version",
+        "repositoryURL": "https://github.com/mxcl/Version",
+        "state": {
+          "branch": null,
+          "revision": "1fe824b80d89201652e7eca7c9252269a1d85e25",
+          "version": "2.0.1"
         }
       },
       {

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug_Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/PocketKit/Dangerfile.swift
+++ b/PocketKit/Dangerfile.swift
@@ -1,0 +1,26 @@
+import Danger
+import DangerSwiftCoverage
+import Foundation
+
+let danger = Danger()
+let editedFiles = danger.git.modifiedFiles + danger.git.createdFiles
+
+// Instead of making a markdown table in the main message
+// sprinkle those comments inline, this can be a bit noisy
+// but it definitely feels magical.
+SwiftLint.lint(.modifiedAndCreatedFiles(directory: "../"), inline: false, configFile: "../.swiftlint.yml")
+
+let xcresult = ProcessInfo.processInfo.environment["BITRISE_XCRESULT_PATH"]!.escapeString()
+
+Coverage.xcodeBuildCoverage(.xcresultBundle(xcresult), 
+                            minimumCoverage: 50)
+
+extension String {
+    // Helper function to escape (iOS) in our file name for xcov.
+    func escapeString() -> String {
+        var newString = self.replacingOccurrences(of: "(", with: "\\(")
+        newString = newString.replacingOccurrences(of: ")", with: "\\)")
+        newString = newString.replacingOccurrences(of: " ", with: "\\ ")
+        return newString
+    }
+}

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -6,8 +6,26 @@
         "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
         "state": {
           "branch": null,
-          "revision": "6aea4edfc40e8a81beae182656c83ac99584af9f",
-          "version": "0.48.0"
+          "revision": "42646f765d22dac0f22bfff48590102195c76da4",
+          "version": "0.53.0"
+        }
+      },
+      {
+        "package": "braze-swift-sdk",
+        "repositoryURL": "https://github.com/braze-inc/braze-swift-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "bf3c855aa4780b7d2b0157b8a15d78c6a91bd07a",
+          "version": "5.3.2"
+        }
+      },
+      {
+        "package": "DangerSwiftCoverage",
+        "repositoryURL": "https://github.com/f-meloni/danger-swift-coverage",
+        "state": {
+          "branch": null,
+          "revision": "6a21a6e595e2b13443428942ce128b3ba6b827ee",
+          "version": "1.2.1"
         }
       },
       {
@@ -32,9 +50,18 @@
         "package": "Kingfisher",
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
-          "branch": "fix/xcode-13",
-          "revision": "f012224344f09421588a28e9f6259968e3574f8b",
-          "version": null
+          "branch": null,
+          "revision": "be1a1acb283a702b99b630f586877ba02234b4cb",
+          "version": "7.3.2"
+        }
+      },
+      {
+        "package": "Logger",
+        "repositoryURL": "https://github.com/shibapm/Logger",
+        "state": {
+          "branch": null,
+          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
+          "version": "0.2.3"
         }
       },
       {
@@ -42,8 +69,26 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "79a0b70547f7c40ea54c67487f935fa2f2eaaadc",
-          "version": "3.2.3"
+          "revision": "314537ec697719fa33a9d48210f4d06a463286d3",
+          "version": "3.4.3"
+        }
+      },
+      {
+        "package": "OctoKit",
+        "repositoryURL": "https://github.com/nerdishbynature/octokit.swift",
+        "state": {
+          "branch": null,
+          "revision": "9521cdff919053868ab13cd08a228f7bc1bde2a9",
+          "version": "0.11.0"
+        }
+      },
+      {
+        "package": "RequestKit",
+        "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
+        "state": {
+          "branch": null,
+          "revision": "fd5e9e99aada7432170366c9e95967011ce13bad",
+          "version": "2.4.0"
         }
       },
       {
@@ -51,8 +96,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "f7c3de2d9fc09d7a61f7259521d97091fb2f8bda",
-          "version": "7.1.3"
+          "revision": "199000acd6a0a3f9c8e0bff03ef233f930993c71",
+          "version": "7.25.1"
         }
       },
       {
@@ -60,8 +105,8 @@
         "repositoryURL": "https://github.com/snowplow/snowplow-objc-tracker",
         "state": {
           "branch": null,
-          "revision": "2cf806e834a75ce801c46f0182f23b481655762b",
-          "version": "2.2.1"
+          "revision": "dc5ecb6ad2921a50f629ef600cc1ee700e608f66",
+          "version": "3.2.0"
         }
       },
       {
@@ -69,8 +114,17 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
-          "version": "0.12.2"
+          "revision": "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
+          "version": "0.13.3"
+        }
+      },
+      {
+        "package": "danger-swift",
+        "repositoryURL": "https://github.com/danger/swift.git",
+        "state": {
+          "branch": null,
+          "revision": "0d62144a8bdfdb087c476ac3e88e96491c158a7b",
+          "version": "3.14.0"
         }
       },
       {
@@ -80,6 +134,24 @@
           "branch": null,
           "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
           "version": "0.3.2"
+        }
+      },
+      {
+        "package": "Version",
+        "repositoryURL": "https://github.com/mxcl/Version",
+        "state": {
+          "branch": null,
+          "revision": "1fe824b80d89201652e7eca7c9252269a1d85e25",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "package": "YouTubePlayerKit",
+        "repositoryURL": "https://github.com/SvenTiigi/YouTubePlayerKit.git",
+        "state": {
+          "branch": null,
+          "revision": "fa70945f48780b2f78102c5905b6a65b2531b618",
+          "version": "1.1.12"
         }
       }
     ]

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .library(name: "Textile", targets: ["Textile"]),
         .library(name: "Sync", targets: ["Sync"]),
         .library(name: "Analytics", targets: ["Analytics"]),
+        .library(name: "DangerDeps", type: .dynamic, targets: ["DangerDependencies"]), // dev
         .executable(name: "ApolloCodegen", targets: ["ApolloCodegen"]),
     ],
     dependencies: [
@@ -24,7 +25,9 @@ let package = Package(
         .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", from: "3.4.3"),
         .package(name: "Down", url: "https://github.com/johnxnguyen/Down", .upToNextMinor(from: "0.11.0")),
         .package(name: "YouTubePlayerKit", url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", .upToNextMinor(from: "1.1.5")),
-        .package(name: "BrazeKit", url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMinor(from: "5.3.0"))
+        .package(name: "BrazeKit", url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMinor(from: "5.3.0")),
+        .package(name: "Danger", url: "https://github.com/danger/swift.git", from: "3.12.3"), // dev
+        .package(name: "DangerSwiftCoverage", url: "https://github.com/f-meloni/danger-swift-coverage", .upToNextMinor(from: "1.2.1")) // dev
     ],
     targets: [
         .target(
@@ -108,6 +111,7 @@ let package = Package(
                 .product(name: "ApolloCodegenLib", package: "Apollo"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]
-        )
+        ),
+        .target(name: "DangerDependencies", dependencies: ["Danger", "DangerSwiftCoverage"]), // dev
     ]
 )

--- a/PocketKit/Sources/DangerDependencies/Fake.swift
+++ b/PocketKit/Sources/DangerDependencies/Fake.swift
@@ -1,0 +1,1 @@
+// An empty file to allow the DangerDependencies target to build via SPM

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -90,6 +90,23 @@ workflows:
                 sentry-cli --log-level=debug --auth-token $SENTRY_AUTH_TOKEN  upload-dif -o pocket -p ios-next $BITRISE_DSYM_PATH
                 #TODO: In the future we can add Sentry releases here.
 
+  _danger:
+    steps:
+      - cache-pull@2: {}
+      - script@1:
+          inputs:
+            - content: |
+                #!/usr/bin/env bash
+
+                # fail if any commands fails
+                set -e
+
+                cd PocketKit/
+
+                echo "Run danger"
+                swift run danger-swift ci
+      - cache-push@2: {}
+
   #Builds a release build that could be uploaded to App Store Connect
   release-build:
     steps:
@@ -184,9 +201,10 @@ workflows:
           inputs:
             - destination: platform=iOS Simulator,name=iPhone 13,OS=latest
       - deploy-to-bitrise-io@2: {}
-      - xcode-result-bundle-to-checks@1: {}
     before_run:
       - _setup
+    after_run:
+      - _danger
 
 app:
   envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -183,6 +183,8 @@ workflows:
       - xcode-test@4:
           inputs:
             - destination: platform=iOS Simulator,name=iPhone 13,OS=latest
+      - deploy-to-bitrise-io@2: {}
+      - xcode-result-bundle-to-checks@1: {}
     before_run:
       - _setup
 


### PR DESCRIPTION
## Summary
* Turns on xcode coverage
* Adds in Danger.systems to post code coverage of changed files to the pr comments
    *  Note: we can build more on danger later if we want.

## References 
* https://pocket.slack.com/archives/C01UH57EJKD/p1663186743065739

## Implementation Details
* This implements danger with swift which adds some dependencies.
* Note that code coverage is on for all targets, this is because for some reason Xcode won't generate code coverage  unless it we tell it all.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
