### PR TITLE
Use correct consumer key on iPad

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -68,6 +68,8 @@
 	<string>$(POCKET_API_BASE_URL)</string>
 	<key>PocketAPIConsumerKey</key>
 	<string>$(POCKET_API_CONSUMER_KEY)</string>
+	<key>PocketAPIConsumerKeyPad</key>
+	<string>$(POCKET_API_CONSUMER_KEY_PAD)</string>
 	<key>PocketPremiumAnnual</key>
 	<string>$(POCKET_PREMIUM_ANNUAL)</string>
 	<key>PocketPremiumMonthly</key>

--- a/PocketKit/Sources/PocketKit/Keys.swift
+++ b/PocketKit/Sources/PocketKit/Keys.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Foundation
+import UIKit
 
 struct Keys {
     static let shared = Keys()
@@ -24,6 +24,10 @@ struct Keys {
 
         guard let pocketApiConsumerKey = info["PocketAPIConsumerKey"] as? String else {
             fatalError("Unable to extract PocketApiConsumerKey from main bundle")
+        }
+
+        guard let pocketApiConsumerKeyPad = info["PocketAPIConsumerKeyPad"] as? String else {
+            fatalError("Unable to extract PocketApiConsumerKeyPad from main bundle")
         }
 
         guard let sentryDSN = info["SentryDSN"] as? String else {
@@ -58,7 +62,7 @@ struct Keys {
             fatalError("Unable to extract adjustEventToken from main bundle")
         }
 
-        self.pocketApiConsumerKey = pocketApiConsumerKey
+        self.pocketApiConsumerKey = UIDevice.current.userInterfaceIdiom == .pad ? pocketApiConsumerKeyPad : pocketApiConsumerKey
         self.sentryDSN = sentryDSN
         self.brazeAPIEndpoint = brazeAPIEndpoint
         self.brazeAPIKey = brazeAPIKey

--- a/PocketKit/Sources/SaveToPocketKit/Keys.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Keys.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Foundation
+import UIKit
 
 struct Keys {
     static let shared = Keys()
@@ -20,6 +20,10 @@ struct Keys {
             fatalError("Unable to extract PocketApiConsumerKey from main bundle")
         }
 
+        guard let pocketApiConsumerKeyPad = info["PocketAPIConsumerKeyPad"] as? String else {
+            fatalError("Unable to extract PocketApiConsumerKeyPad from main bundle")
+        }
+
         guard let sentryDSN = info["SentryDSN"] as? String else {
             fatalError("Unable to extract SentryDSN from main bundle")
         }
@@ -28,7 +32,7 @@ struct Keys {
             fatalError("Unable to extract GroupId from main bundle")
         }
 
-        self.pocketApiConsumerKey = pocketApiConsumerKey
+        self.pocketApiConsumerKey = UIDevice.current.userInterfaceIdiom == .pad ? pocketApiConsumerKeyPad : pocketApiConsumerKey
         self.sentryDSN = sentryDSN
         self.groupdId = groupID
     }

--- a/SaveToPocket/Info.plist
+++ b/SaveToPocket/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(POCKET_API_BASE_URL)</string>
 	<key>PocketAPIConsumerKey</key>
 	<string>$(POCKET_API_CONSUMER_KEY)</string>
+	<key>PocketAPIConsumerKeyPad</key>
+	<string>$(POCKET_API_CONSUMER_KEY_PAD)</string>
 	<key>SentryDSN</key>
 	<string>$(SENTRY_DSN)</string>
 </dict>


### PR DESCRIPTION
## Summary

Use the "legacy" consumer key for "pad" idioms. This should *_not_* be merged until all the appropriate bitrise config files have been updated as well.

## References 

- IN-872

## Implementation Details

- [ ] Add new row to `Info.plist` for both `PocketKit` and `SaveToPocketKit`
- [ ] Update `Keys.swift` in both `PocketKit` and `SaveToPocketKit` to obtain _both_ consumer keys, and set the appropriate key based on the device's user interface idiom.

Note: the key contains the word "pad" vs "iPad" because the idiom is "pad", and I wanted the two to match.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
