### PR TITLE
Fetch all tags on initial sync

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -375,7 +375,7 @@ extension ArchivedItemsListViewModel {
                 presentedTagsFilter = TagsFilterViewModel(
                     source: source,
                     fetchedTags: { [weak self] in
-                        self?.source.fetchTags(isArchived: true)
+                        self?.source.fetchAllTags()
                     }(),
                     selectAllAction: { [weak self] in
                         self?.selectCell(with: .filterButton(.all))

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -94,7 +94,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
                 presentedTagsFilter = TagsFilterViewModel(
                     source: source,
                     fetchedTags: { [weak self] in
-                        self?.source.fetchTags(isArchived: false)
+                        self?.source.fetchAllTags()
                     }(),
                     selectAllAction: { [weak self] in
                         self?.selectCell(with: .filterButton(.all))

--- a/PocketKit/Sources/Sync/API.swift
+++ b/PocketKit/Sources/Sync/API.swift
@@ -1845,6 +1845,7 @@ public final class FetchSavesQuery: GraphQLQuery {
   public var queryDocument: String {
     var document: String = operationDefinition
     document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + TagParts.fragmentDefinition)
     document.append("\n" + ItemParts.fragmentDefinition)
     document.append("\n" + MarticleTextParts.fragmentDefinition)
     document.append("\n" + ImageParts.fragmentDefinition)
@@ -2265,6 +2266,7 @@ public final class FetchSavesQuery: GraphQLQuery {
               public static var selections: [GraphQLSelection] {
                 return [
                   GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                   GraphQLField("name", type: .nonNull(.scalar(String.self))),
                   GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
                 ]
@@ -2306,6 +2308,32 @@ public final class FetchSavesQuery: GraphQLQuery {
                 }
                 set {
                   resultMap.updateValue(newValue, forKey: "id")
+                }
+              }
+
+              public var fragments: Fragments {
+                get {
+                  return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+
+              public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var tagParts: TagParts {
+                  get {
+                    return TagParts(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
                 }
               }
             }
@@ -5269,6 +5297,7 @@ public final class SaveItemMutation: GraphQLMutation {
   public var queryDocument: String {
     var document: String = operationDefinition
     document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + TagParts.fragmentDefinition)
     document.append("\n" + ItemParts.fragmentDefinition)
     document.append("\n" + MarticleTextParts.fragmentDefinition)
     document.append("\n" + ImageParts.fragmentDefinition)
@@ -5485,6 +5514,7 @@ public final class SaveItemMutation: GraphQLMutation {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
           ]
@@ -5526,6 +5556,32 @@ public final class SaveItemMutation: GraphQLMutation {
           }
           set {
             resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var tagParts: TagParts {
+            get {
+              return TagParts(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
           }
         }
       }
@@ -8987,6 +9043,7 @@ public final class ReplaceSavedItemTagsMutation: GraphQLMutation {
   public var queryDocument: String {
     var document: String = operationDefinition
     document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + TagParts.fragmentDefinition)
     document.append("\n" + ItemParts.fragmentDefinition)
     document.append("\n" + MarticleTextParts.fragmentDefinition)
     document.append("\n" + ImageParts.fragmentDefinition)
@@ -9207,6 +9264,7 @@ public final class ReplaceSavedItemTagsMutation: GraphQLMutation {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
           ]
@@ -9248,6 +9306,32 @@ public final class ReplaceSavedItemTagsMutation: GraphQLMutation {
           }
           set {
             resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var tagParts: TagParts {
+            get {
+              return TagParts(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
           }
         }
       }
@@ -12208,6 +12292,7 @@ public final class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
   public var queryDocument: String {
     var document: String = operationDefinition
     document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + TagParts.fragmentDefinition)
     document.append("\n" + ItemParts.fragmentDefinition)
     document.append("\n" + MarticleTextParts.fragmentDefinition)
     document.append("\n" + ImageParts.fragmentDefinition)
@@ -12426,6 +12511,7 @@ public final class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
           ]
@@ -12467,6 +12553,32 @@ public final class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
           }
           set {
             resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var tagParts: TagParts {
+            get {
+              return TagParts(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
           }
         }
       }
@@ -16992,6 +17104,7 @@ public final class SavedItemByIdQuery: GraphQLQuery {
   public var queryDocument: String {
     var document: String = operationDefinition
     document.append("\n" + SavedItemParts.fragmentDefinition)
+    document.append("\n" + TagParts.fragmentDefinition)
     document.append("\n" + ItemParts.fragmentDefinition)
     document.append("\n" + MarticleTextParts.fragmentDefinition)
     document.append("\n" + ImageParts.fragmentDefinition)
@@ -17246,6 +17359,7 @@ public final class SavedItemByIdQuery: GraphQLQuery {
           public static var selections: [GraphQLSelection] {
             return [
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
               GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
             ]
@@ -17287,6 +17401,32 @@ public final class SavedItemByIdQuery: GraphQLQuery {
             }
             set {
               resultMap.updateValue(newValue, forKey: "id")
+            }
+          }
+
+          public var fragments: Fragments {
+            get {
+              return Fragments(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+
+          public struct Fragments {
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var tagParts: TagParts {
+              get {
+                return TagParts(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
             }
           }
         }
@@ -23040,6 +23180,389 @@ public final class ItemByIdQuery: GraphQLQuery {
   }
 }
 
+public final class TagsQuery: GraphQLQuery {
+  /// The raw GraphQL definition of this operation.
+  public let operationDefinition: String =
+    """
+    query Tags($pagination: PaginationInput) {
+      user {
+        __typename
+        tags(pagination: $pagination) {
+          __typename
+          edges {
+            __typename
+            node {
+              __typename
+              ...TagParts
+            }
+            cursor
+          }
+          pageInfo {
+            __typename
+            endCursor
+            hasNextPage
+            hasPreviousPage
+            startCursor
+          }
+          totalCount
+        }
+      }
+    }
+    """
+
+  public let operationName: String = "Tags"
+
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append("\n" + TagParts.fragmentDefinition)
+    return document
+  }
+
+  public var pagination: PaginationInput?
+
+  public init(pagination: PaginationInput? = nil) {
+    self.pagination = pagination
+  }
+
+  public var variables: GraphQLMap? {
+    return ["pagination": pagination]
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Query"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("user", type: .object(User.selections)),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(user: User? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Query", "user": user.flatMap { (value: User) -> ResultMap in value.resultMap }])
+    }
+
+    /// Get a user entity for an authenticated client
+    public var user: User? {
+      get {
+        return (resultMap["user"] as? ResultMap).flatMap { User(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "user")
+      }
+    }
+
+    public struct User: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["User"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("tags", arguments: ["pagination": GraphQLVariable("pagination")], type: .object(Tag.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(tags: Tag? = nil) {
+        self.init(unsafeResultMap: ["__typename": "User", "tags": tags.flatMap { (value: Tag) -> ResultMap in value.resultMap }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// Get a paginated listing of all a user's Tags
+      public var tags: Tag? {
+        get {
+          return (resultMap["tags"] as? ResultMap).flatMap { Tag(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "tags")
+        }
+      }
+
+      public struct Tag: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["TagConnection"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("edges", type: .list(.object(Edge.selections))),
+            GraphQLField("pageInfo", type: .nonNull(.object(PageInfo.selections))),
+            GraphQLField("totalCount", type: .nonNull(.scalar(Int.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(edges: [Edge?]? = nil, pageInfo: PageInfo, totalCount: Int) {
+          self.init(unsafeResultMap: ["__typename": "TagConnection", "edges": edges.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }, "pageInfo": pageInfo.resultMap, "totalCount": totalCount])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// A list of edges.
+        public var edges: [Edge?]? {
+          get {
+            return (resultMap["edges"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Edge?] in value.map { (value: ResultMap?) -> Edge? in value.flatMap { (value: ResultMap) -> Edge in Edge(unsafeResultMap: value) } } }
+          }
+          set {
+            resultMap.updateValue(newValue.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }, forKey: "edges")
+          }
+        }
+
+        /// Information to aid in pagination.
+        public var pageInfo: PageInfo {
+          get {
+            return PageInfo(unsafeResultMap: resultMap["pageInfo"]! as! ResultMap)
+          }
+          set {
+            resultMap.updateValue(newValue.resultMap, forKey: "pageInfo")
+          }
+        }
+
+        /// Identifies the total count of Tags in the connection.
+        public var totalCount: Int {
+          get {
+            return resultMap["totalCount"]! as! Int
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "totalCount")
+          }
+        }
+
+        public struct Edge: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["TagEdge"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("node", type: .object(Node.selections)),
+              GraphQLField("cursor", type: .nonNull(.scalar(String.self))),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(node: Node? = nil, cursor: String) {
+            self.init(unsafeResultMap: ["__typename": "TagEdge", "node": node.flatMap { (value: Node) -> ResultMap in value.resultMap }, "cursor": cursor])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// The Tag at the end of the edge.
+          public var node: Node? {
+            get {
+              return (resultMap["node"] as? ResultMap).flatMap { Node(unsafeResultMap: $0) }
+            }
+            set {
+              resultMap.updateValue(newValue?.resultMap, forKey: "node")
+            }
+          }
+
+          /// A cursor for use in pagination.
+          public var cursor: String {
+            get {
+              return resultMap["cursor"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "cursor")
+            }
+          }
+
+          public struct Node: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Tag"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(name: String, id: GraphQLID) {
+              self.init(unsafeResultMap: ["__typename": "Tag", "name": name, "id": id])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// The actual tag string the user created for their list
+            public var name: String {
+              get {
+                return resultMap["name"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "name")
+              }
+            }
+
+            /// Surrogate primary key. This is usually generated by clients, but will be generated by the server if not passed through creation
+            public var id: GraphQLID {
+              get {
+                return resultMap["id"]! as! GraphQLID
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "id")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var tagParts: TagParts {
+                get {
+                  return TagParts(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+          }
+        }
+
+        public struct PageInfo: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["PageInfo"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("endCursor", type: .scalar(String.self)),
+              GraphQLField("hasNextPage", type: .nonNull(.scalar(Bool.self))),
+              GraphQLField("hasPreviousPage", type: .nonNull(.scalar(Bool.self))),
+              GraphQLField("startCursor", type: .scalar(String.self)),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(endCursor: String? = nil, hasNextPage: Bool, hasPreviousPage: Bool, startCursor: String? = nil) {
+            self.init(unsafeResultMap: ["__typename": "PageInfo", "endCursor": endCursor, "hasNextPage": hasNextPage, "hasPreviousPage": hasPreviousPage, "startCursor": startCursor])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// When paginating forwards, the cursor to continue.
+          public var endCursor: String? {
+            get {
+              return resultMap["endCursor"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "endCursor")
+            }
+          }
+
+          /// When paginating forwards, are there more items?
+          public var hasNextPage: Bool {
+            get {
+              return resultMap["hasNextPage"]! as! Bool
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasNextPage")
+            }
+          }
+
+          /// When paginating backwards, are there more items?
+          public var hasPreviousPage: Bool {
+            get {
+              return resultMap["hasPreviousPage"]! as! Bool
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "hasPreviousPage")
+            }
+          }
+
+          /// When paginating backwards, the cursor to continue.
+          public var startCursor: String? {
+            get {
+              return resultMap["startCursor"] as? String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "startCursor")
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 public struct SavedItemSummary: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition: String =
@@ -24338,8 +24861,7 @@ public struct SavedItemParts: GraphQLFragment {
       archivedAt
       tags {
         __typename
-        name
-        id
+        ...TagParts
       }
       item {
         __typename
@@ -24481,6 +25003,7 @@ public struct SavedItemParts: GraphQLFragment {
     public static var selections: [GraphQLSelection] {
       return [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
         GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
       ]
@@ -24522,6 +25045,32 @@ public struct SavedItemParts: GraphQLFragment {
       }
       set {
         resultMap.updateValue(newValue, forKey: "id")
+      }
+    }
+
+    public var fragments: Fragments {
+      get {
+        return Fragments(unsafeResultMap: resultMap)
+      }
+      set {
+        resultMap += newValue.resultMap
+      }
+    }
+
+    public struct Fragments {
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public var tagParts: TagParts {
+        get {
+          return TagParts(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
       }
     }
   }
@@ -27459,6 +28008,67 @@ public struct SavedItemParts: GraphQLFragment {
           }
         }
       }
+    }
+  }
+}
+
+public struct TagParts: GraphQLFragment {
+  /// The raw GraphQL definition of this fragment.
+  public static let fragmentDefinition: String =
+    """
+    fragment TagParts on Tag {
+      __typename
+      name
+      id
+    }
+    """
+
+  public static let possibleTypes: [String] = ["Tag"]
+
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+      GraphQLField("name", type: .nonNull(.scalar(String.self))),
+      GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+    ]
+  }
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public init(name: String, id: GraphQLID) {
+    self.init(unsafeResultMap: ["__typename": "Tag", "name": name, "id": id])
+  }
+
+  public var __typename: String {
+    get {
+      return resultMap["__typename"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "__typename")
+    }
+  }
+
+  /// The actual tag string the user created for their list
+  public var name: String {
+    get {
+      return resultMap["name"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "name")
+    }
+  }
+
+  /// Surrogate primary key. This is usually generated by clients, but will be generated by the server if not passed through creation
+  public var id: GraphQLID {
+    get {
+      return resultMap["id"]! as! GraphQLID
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "id")
     }
   }
 }

--- a/PocketKit/Sources/Sync/Operations/ArchiveService.swift
+++ b/PocketKit/Sources/Sync/Operations/ArchiveService.swift
@@ -252,7 +252,6 @@ extension PocketArchiveService: FetchArchivePagesOperationDelegate {
         }
 
         isStoring = true
-        try space.deleteOrphanTags()
         try space.save()
         isStoring = false
 

--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -94,7 +94,7 @@ class FetchList: SyncOperation {
         guard let edges = result.data?.userByToken?.savedItems?.edges else {
             return
         }
-        // TODO: Add deleteOrphanTags here instead of update and refactor below to be in space (IN-788)
+
         for edge in edges {
             guard let edge = edge, let node = edge.node else {
                 return

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -358,6 +358,10 @@ extension PocketSource {
         try? space.retrieveTags(excluding: tags)
     }
 
+    public func fetchAllTags() -> [Tag]? {
+        try? space.fetchAllTags()
+    }
+
     public func fetchTags(isArchived: Bool = false) -> [Tag]? {
         try? space.fetchTags(isArchived: isArchived)
     }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -312,7 +312,6 @@ extension PocketSource {
            space.fetchOrCreateTag(byName: tag)
         }))
 
-        try? space.deleteOrphanTags()
         try? space.save()
 
         let operation = operations.savedItemMutationOperation(

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -44,8 +44,6 @@ extension SavedItem {
             return fetchedTag
         } ?? [])
 
-        try? space.deleteOrphanTags()
-
         let fetchRequest = Requests.fetchItem(byRemoteID: itemParts.remoteId)
         fetchRequest.fetchLimit = 1
         let itemToUpdate = try? context.fetch(fetchRequest).first ?? Item(context: context)

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -40,7 +40,7 @@ extension SavedItem {
 
         tags = NSOrderedSet(array: remote.tags?.compactMap { $0 }.map { remoteTag in
             let fetchedTag = space.fetchOrCreateTag(byName: remoteTag.name)
-            fetchedTag.update(remote: remoteTag)
+            fetchedTag.update(remote: remoteTag.fragments.tagParts)
             return fetchedTag
         } ?? [])
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Tag+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Tag+RemoteMapping.swift
@@ -1,7 +1,7 @@
 import CoreData
 
 extension Tag {
-    func update(remote: SavedItemParts.Tag) {
+    func update(remote: TagParts) {
         remoteID = remote.id
         name = remote.name
     }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -48,6 +48,8 @@ public protocol Source {
 
     func retrieveTags(excluding: [String]) -> [Tag]?
 
+    func fetchAllTags() -> [Tag]?
+
     func fetchTags(isArchived: Bool) -> [Tag]?
 
     func fetchSlateLineup(_ identifier: String) async throws

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -140,12 +140,6 @@ public class Space {
         return try fetch(Requests.fetchTags(excluding: tags))
     }
 
-    func deleteOrphanTags() throws {
-        let deleteRequest = Requests.fetchTagsWithNoSavedItems()
-        let tags = try context.fetch(deleteRequest)
-        delete(tags)
-    }
-
     func deleteTag(byID id: String) throws {
         let fetchRequest = Requests.fetchTag(byID: id)
         fetchRequest.fetchLimit = 1

--- a/PocketKit/Sources/Sync/list.graphql
+++ b/PocketKit/Sources/Sync/list.graphql
@@ -7,13 +7,17 @@ fragment SavedItemParts on SavedItem {
   _createdAt
   archivedAt
   tags {
-    name
-    id
+    ...TagParts
   }
   item {
     ...ItemParts
     ...PendingItemParts
   }
+}
+
+fragment TagParts on Tag {
+  name
+  id
 }
 
 fragment ItemParts on Item {
@@ -143,15 +147,15 @@ mutation TagUpdate($input: TagUpdateInput!) {
 }
 
 mutation ReplaceSavedItemTags($input: [SavedItemTagsInput!]!) {
-    replaceSavedItemTags(input: $input) {
-        ...SavedItemParts
-    }
+  replaceSavedItemTags(input: $input) {
+    ...SavedItemParts
+  }
 }
 
 mutation UpdateSavedItemRemoveTags($savedItemId: ID!) {
-    updateSavedItemRemoveTags(savedItemId: $savedItemId) {
-        ...SavedItemParts
-    }
+  updateSavedItemRemoveTags(savedItemId: $savedItemId) {
+    ...SavedItemParts
+  }
 }
 
 query GetSlateLineup($lineupID: String!, $maxRecommendations: Int!) {
@@ -182,5 +186,25 @@ query SavedItemByID($id: ID!) {
 query ItemByID($id: ID!) {
   itemByItemId(id: $id) {
     ...ItemParts
+  }
+}
+
+query Tags($pagination: PaginationInput) {
+  user {
+    tags(pagination: $pagination) {
+      edges {
+        node {
+          ...TagParts
+        }
+        cursor
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+        hasPreviousPage
+        startCursor
+      }
+      totalCount
+    }
   }
 }

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
@@ -511,7 +511,7 @@ extension ArchivedItemsListViewModelTests {
     func test_fetch_whenTaggedSelected_sendsTagsFilterViewModel() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         archiveService._results = [.loaded(item)]
-        source.stubFetchTags {
+        source.stubFetchAllTags {
             []
         }
         let viewModel = subject()

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -385,7 +385,7 @@ extension SavedItemsListViewModelTests {
         itemsController.stubPerformFetch {
             self.itemsController.fetchedObjects = []
         }
-        source.stubFetchTags {
+        source.stubFetchAllTags {
             []
         }
         let viewModel = subject()

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -297,7 +297,7 @@ extension MockSource {
     }
 }
 
-// MARK: - Fetch All Tags
+// MARK: - Fetch Tags
 extension MockSource {
     static let fetchTags = "fetchTags"
     typealias FetchTagsImpl = () -> [Tag]?
@@ -326,6 +326,38 @@ extension MockSource {
               }
 
         return calls[index] as? FetchTagsImplCall
+    }
+}
+
+// MARK: - Fetch All Tags
+extension MockSource {
+    static let fetchAllTags = "fetchAllTags"
+    typealias FetchAllTagsImpl = () -> [Tag]?
+    struct FetchAllTagsCall { }
+
+    func stubFetchAllTags(impl: @escaping FetchAllTagsImpl) {
+        implementations[Self.fetchAllTags] = impl
+    }
+
+    func fetchAllTags() -> [Tag]? {
+        guard let impl = implementations[Self.fetchAllTags] as? FetchAllTagsImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.fetchAllTags] = (calls[Self.fetchAllTags] ?? []) + [
+            FetchAllTagsCall()
+        ]
+
+        return impl()
+    }
+
+    func fetchTagsCall(at index: Int) -> FetchAllTagsCall? {
+        guard let calls = calls[Self.fetchAllTags],
+              calls.count > index else {
+                  return nil
+              }
+
+        return calls[index] as? FetchAllTagsCall
     }
 }
 

--- a/PocketKit/Tests/SyncTests/Fixtures/empty-tags.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/empty-tags.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "tags": {
+                "__typename": "[type-name-here]",
+                "edges": [],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": null,
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 0
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/Fixtures/tags-page-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/tags-page-1.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "tags": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "name": "tag-1",
+                            "id": "tag-1-id"
+                        },
+                        "cursor": "tag-1-cursor"
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "name": "tag-2",
+                            "id": "tag-2-id"
+                        },
+                        "cursor": "tag-2-cursor"
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "tag-2-cursor",
+                    "hasNextPage": true,
+                    "hasPreviousPage": false,
+                    "startCursor": "tag-1-cursor"
+                },
+                "totalCount": 4
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/Fixtures/tags-page-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/tags-page-2.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "tags": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "name": "tag-3",
+                            "id": "tag-3-id"
+                        },
+                        "cursor": "tag-3-cursor"
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "name": "tag-4",
+                            "id": "tag-4-id"
+                        },
+                        "cursor": "tag-4-cursor"
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "tag-4-cursor",
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": "tag-3-cursor"
+                },
+                "totalCount": 4
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/Operations/PocketArchiveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/PocketArchiveServiceTests.swift
@@ -324,7 +324,7 @@ class PocketArchiveServiceTests: XCTestCase {
         service.fetch()
 
         wait(for: [initialLoad, secondLoad], timeout: 1)
-        XCTAssertEqual(apollo.fetchCalls.count, 1)
+        XCTAssertEqual(apollo.fetchCalls(withQueryType: SavedItemSummariesQuery.self).count, 1)
     }
 
     func test_handlingUpdatedSavedItems_sendsEvent() throws {

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -18,19 +18,6 @@ class SpaceTests: XCTestCase {
         Space(context: context ?? self.context)
     }
 
-    func testDeletingOrphanTags() throws {
-        let space = subject()
-        let tag: Tag = space.new()
-        tag.name = "tag 0"
-        _ = createItemsWithTags(1)
-
-        try XCTAssertEqual(Set(space.fetchAllTags().compactMap { $0.name }), ["tag 0", "tag 1"])
-
-        try space.deleteOrphanTags()
-
-        try XCTAssertEqual(space.fetchAllTags().compactMap { $0.name }, ["tag 1"])
-    }
-
     func testDeleteTags() throws {
         let space = subject()
         let items = createItemsWithTags(2)

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -28,6 +28,8 @@ class AddTagsItemTests: XCTestCase {
                 return Response.archivedContent()
             } else if apiRequest.isForRecommendationDetail {
                 return Response.recommendationDetail()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/ArchiveAnItemTests.swift
+++ b/Tests iOS/ArchiveAnItemTests.swift
@@ -26,6 +26,8 @@ class ArchiveAnItemTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/BannerViewTests.swift
+++ b/Tests iOS/BannerViewTests.swift
@@ -20,6 +20,8 @@ class BannerViewTests: XCTestCase {
                 return Response.myList("initial-list-recent-saves")
             } else if apiRequest.isToSaveAnItem {
                 return Response.saveItem()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/DeleteAnItemTests.swift
+++ b/Tests iOS/DeleteAnItemTests.swift
@@ -25,6 +25,8 @@ class DeleteAnItemTests: XCTestCase {
                 return .myList()
             } else if apiRequest.isForArchivedContent {
                 return .archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/EditTagsTests.swift
+++ b/Tests iOS/EditTagsTests.swift
@@ -25,6 +25,8 @@ class EditTagsTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isToUpdateTag("rename tag 1") {
                 return Response.updateTag()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/FavoriteAnItemTests.swift
+++ b/Tests iOS/FavoriteAnItemTests.swift
@@ -28,6 +28,8 @@ class FavoriteAnItemTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/Fixtures/empty-tags.json
+++ b/Tests iOS/Fixtures/empty-tags.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "tags": {
+                "__typename": "[type-name-here]",
+                "edges": [],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": null,
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 0
+            }
+        }
+    }
+}

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -43,6 +43,8 @@ class HomeTests: XCTestCase {
                 return Response.delete()
             } else if apiRequest.isForRecommendationDetail {
                 return Response.recommendationDetail()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -377,6 +379,8 @@ extension HomeTests {
                 return Response.myList("list-for-web-view")
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/HomeWebViewTests.swift
+++ b/Tests iOS/HomeWebViewTests.swift
@@ -33,6 +33,8 @@ class HomeWebViewTests: XCTestCase {
                 return Response.saveItem()
             } else if apiRequest.isToArchiveAnItem {
                 return Response.archive()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/MyList/ArchiveFiltersTests.swift
+++ b/Tests iOS/MyList/ArchiveFiltersTests.swift
@@ -34,6 +34,8 @@ class ArchiveFiltersTests: XCTestCase {
                 return Response.favorite()
             } else if apiRequest.isToUnfavoriteAnItem {
                 return Response.unfavorite()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -27,6 +27,8 @@ class ArchiveTests: XCTestCase {
                 return Response.archivedContent()
             } else if apiRequest.isForItemDetail {
                 return Response.itemDetail()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -169,6 +171,8 @@ extension ArchiveTests {
                 return Response.myList("list-for-web-view")
             } else if apiRequest.isForArchivedContent {
                 return Response.myList("archived-web-view")
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/MyList/EmptyStateTests.swift
+++ b/Tests iOS/MyList/EmptyStateTests.swift
@@ -33,6 +33,8 @@ class EmptyStateTests: XCTestCase {
                 return Response.archive()
             } else if apiRequest.isToSaveAnItem {
                 return Response.saveItem()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/MyList/MyListFiltersTests.swift
+++ b/Tests iOS/MyList/MyListFiltersTests.swift
@@ -32,6 +32,8 @@ class MyListFiltersTests: XCTestCase {
                 return Response.favorite()
             } else if apiRequest.isToUnfavoriteAnItem {
                 return Response.unfavorite()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/MyList/MyListTests.swift
+++ b/Tests iOS/MyList/MyListTests.swift
@@ -28,6 +28,8 @@ class MyListTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -160,6 +162,8 @@ class MyListTests: XCTestCase {
                 return promise!.futureResult
             } else if apiRequest.isForMyListContent {
                 return Response.myList()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -256,6 +260,8 @@ class MyListTests: XCTestCase {
                 return Response.myList("list-with-archived-item")
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -285,6 +291,8 @@ class MyListTests: XCTestCase {
                 return promise.futureResult
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }
@@ -363,6 +371,8 @@ extension MyListTests {
                 return Response.myList("list-for-web-view")
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/PullToRefreshTests.swift
+++ b/Tests iOS/PullToRefreshTests.swift
@@ -26,6 +26,8 @@ class PullToRefreshTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -30,6 +30,8 @@ class ReportARecommendationTests: XCTestCase {
                 return Response.archive()
             } else if apiRequest.isForRecommendationDetail {
                 return Response.recommendationDetail()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/ShareAnItemTests.swift
+++ b/Tests iOS/ShareAnItemTests.swift
@@ -26,6 +26,8 @@ class ShareAnItemTests: XCTestCase {
                 return Response.myList()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/SignOutTests.swift
+++ b/Tests iOS/SignOutTests.swift
@@ -29,6 +29,8 @@ class SignOutTests: XCTestCase {
                 return Response.saveItem()
             } else if apiRequest.isToArchiveAnItem {
                 return Response.archive()
+            } else if apiRequest.isForTags {
+                return Response.emptyTags()
             } else {
                 fatalError("Unexpected request")
             }

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -78,6 +78,10 @@ struct ClientAPIRequest {
         contains("replaceSavedItemTags")
     }
 
+    var isForTags: Bool {
+        contains("Tags")
+    }
+
     func contains(_ string: String) -> Bool {
         requestBody?.contains(string) == true
     }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -78,6 +78,10 @@ extension Response {
         fixture(named: "list-with-tagged-item")
     }
 
+    static func emptyTags() -> Response {
+        fixture(named: "empty-tags")
+    }
+
     static func fixture(named fixtureName: String) -> Response {
         Response {
             Status.ok


### PR DESCRIPTION
## Summary
Adds logic to `FetchList` operation that will download all the user's tags on the initial sync (since subsequent tags will be sync'd as they're added).

## References 
https://getpocket.atlassian.net/browse/IN-866

## Implementation Details
- Add `TagsQuery` to Apollo codegen
- Adds some logic to paginate through all the user's tags in `FetchList`
- Updates `FetchListTests` to properly stub out requests for tags in all methods
- Update UI tests to stub out the request for tags as well

## Test Steps

Scenario: Tag shows up in tag filter menu
1. Create an tag with no associated items on a separate device
2. Log into the app for the first time
3. Navigate to My List
4. Tap "Tagged" in filter carousel
5. The tag created in Step 1 should be present

Scenario: Tag appears in Add Tag screen
1. Create an tag with no associated items on a separate device
2. Log into the app for the first time
3. Navigate to My List (make sure you have at least one item)
4. Tap overflow menu for item, Tap "Add tags"
5. The tag created in Step 1 should be present

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA