### PR TITLE
IN-770  Added the confirmation step, to verify the user really wants …

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -19,4 +19,5 @@ class AccountViewModel: ObservableObject {
     @Published var isPresentingHelp = false
     @Published var isPresentingTerms = false
     @Published var isPresentingPrivacy = false
+    @Published var isPresentingSignOutConfirm = false
 }

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -28,9 +28,17 @@ struct SettingsView: View {
 //                }.textCase(nil)
 
                 Section(header: Text("Your Account").style(.settings.header)) {
-                    SettingsRowButton(title: "Sign Out", titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.signOut() }
-                }.textCase(nil)
-
+                    SettingsRowButton(title: "Sign Out", titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
+                }
+                .alert("Are you sure?", isPresented: $model.isPresentingSignOutConfirm, actions: {
+                    Button("Sign Out", role: .destructive) {
+                        model.signOut()
+                    }
+                }, message: {
+                    Text("You will be signed out of your account and any files that have been saved for offline viewing will be deleted.")
+                })
+                .textCase(nil)
+                
                 Section(header: Text("About & Support").style(.settings.header)) {
                     SettingsRowButton(title: "Help", icon: SFIconModel("questionmark.circle")) { model.isPresentingHelp.toggle() }
                         .sheet(isPresented: $model.isPresentingHelp) {


### PR DESCRIPTION
…to sign out.

## Summary
* Adds a confirmation dialog box when a user taps sign out.

## References 
* [Add Log Out Setting Ticket](https://getpocket.atlassian.net/browse/IN-770)

## Implementation Details
* Added isPresentingSignOutConfirm to AccountViewModel
* Added alert to SettingsView

## Test Steps
* Tap sign out in settings and tap sign out in the confirmation pop up also tap cancel to test that too
* Repeat in dark mode

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPhone 14 Pro](https://user-images.githubusercontent.com/8561013/194185768-ad64d269-46fb-45b1-92b7-603406fedbc0.png)
![Simulator Screen Shot - iPhone 14 Pro](https://user-images.githubusercontent.com/8561013/194185660-2c95ef27-8520-488b-af54-c838789f7856.png)
