### PR TITLE
IN-743 added share to Home and Slates

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -121,10 +121,10 @@ class CompactHomeCoordinator: NSObject {
         viewModel.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &slateDetailSubscriptions)
-        
+
         viewModel.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
-        }.store(in: &subscriptions)
+        }.store(in: &slateDetailSubscriptions)
     }
 
     func show(_ recommendation: RecommendationViewModel?) {

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -121,6 +121,10 @@ class CompactHomeCoordinator: NSObject {
         viewModel.$presentedWebReaderURL.sink { [weak self] url in
             self?.present(url: url)
         }.store(in: &slateDetailSubscriptions)
+        
+        viewModel.$sharedActivity.sink { [weak self] activity in
+            self?.present(activity: activity)
+        }.store(in: &subscriptions)
     }
 
     func show(_ recommendation: RecommendationViewModel?) {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -522,6 +522,9 @@ extension HomeViewModel {
         }
 
         return [
+            .share { [weak self] sender in
+                self?.sharedActivity = PocketItemActivity(url: recommendation.item?.bestURL, sender: sender)
+            },
             .report { [weak self] _ in
                 self?.report(recommendation, at: indexPath)
             }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -19,6 +19,9 @@ class SlateDetailViewModel {
 
     @Published
     var selectedRecommendationToReport: Recommendation?
+    
+    @Published
+    var sharedActivity: PocketActivity?
 
     var slateName: String? {
         slate.name
@@ -142,6 +145,9 @@ extension SlateDetailViewModel {
         return HomeRecommendationCellViewModel(
             recommendation: recommendation,
             overflowActions: [
+                .share { [weak self] sender in
+                    self?.sharedActivity = PocketItemActivity(url: recommendation.item?.bestURL, sender: sender)
+                },
                 .report { [weak self] _ in
                     self?.report(recommendation, at: indexPath)
                 }
@@ -299,6 +305,7 @@ extension SlateDetailViewModel {
 
     func clearSharedActivity() {
         selectedReadableViewModel?.clearSharedActivity()
+        sharedActivity = nil
     }
 
     func clearPresentedWebReaderURL() {

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -19,7 +19,7 @@ class SlateDetailViewModel {
 
     @Published
     var selectedRecommendationToReport: Recommendation?
-    
+
     @Published
     var sharedActivity: PocketActivity?
 

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -107,7 +107,7 @@ extension RegularHomeCoordinator {
 
         slate.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
-        }.store(in: &subscriptions)
+        }.store(in: &slateDetailSubscriptions)
 
         let slateDetailVC = SlateDetailViewController(model: slate)
         navigationController.pushViewController(slateDetailVC, animated: !isResetting)

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -104,6 +104,10 @@ extension RegularHomeCoordinator {
         slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &slateDetailSubscriptions)
+        
+        slate.$sharedActivity.sink { [weak self] activity in
+            self?.share(activity)
+        }.store(in: &subscriptions)
 
         let slateDetailVC = SlateDetailViewController(model: slate)
         navigationController.pushViewController(slateDetailVC, animated: !isResetting)

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -104,7 +104,7 @@ extension RegularHomeCoordinator {
         slate.$selectedRecommendationToReport.sink { [weak self] recommendation in
             self?.report(recommendation)
         }.store(in: &slateDetailSubscriptions)
-        
+
         slate.$sharedActivity.sink { [weak self] activity in
             self?.share(activity)
         }.store(in: &subscriptions)

--- a/Tests iOS/ShareAnItemTests.swift
+++ b/Tests iOS/ShareAnItemTests.swift
@@ -28,6 +28,8 @@ class ShareAnItemTests: XCTestCase {
                 return Response.archivedContent()
             } else if apiRequest.isForTags {
                 return Response.emptyTags()
+            } else if apiRequest.isForSlateDetail() {
+                return Response.slateDetail()
             } else {
                 fatalError("Unexpected request")
             }
@@ -73,6 +75,32 @@ class ShareAnItemTests: XCTestCase {
         app
             .shareButton.wait()
             .tap()
+
+        app.shareSheet.wait()
+    }
+
+    func test_shareFromHome_sharingARecommendation_sharingFromSlate() {
+        let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")
+
+        cell.overflowButton.wait().tap()
+        app.shareButton.wait().tap()
+
+        app.shareSheet.wait()
+    }
+
+    func test_shareFromHome_sharingARecommendation_sharingFromSlateDetails() {
+        app.launch()
+            .homeView
+            .sectionHeader("Slate 1")
+            .seeAllButton
+            .wait().tap()
+
+        let cell = app.slateDetailView
+            .recommendationCell("Slate 1, Recommendation 1")
+            .wait()
+
+        cell.overflowButton.wait().tap()
+        app.shareButton.wait().tap()
 
         app.shareSheet.wait()
     }


### PR DESCRIPTION
## Summary
* Adding a `Share` function to the home screen and the slates screen

## References 
* [IN-743](https://getpocket.atlassian.net/jira/software/projects/IN/boards/80/backlog?selectedIssue=IN-743)

## Implementation Details
* Added the `Share` function to the overflow menus for Home and Slates

## Test Steps
* While on Home, clicking on the overflow menu of any card should show a `share` function
* clicking on `share` would bring up a pop-up for sharing
* navigating to Slate Details (`See All` section) will also show an overflow menu with a `share` function
* clicking on `share` will also bring up a pop-up for sharing

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
<details>
<summary>Overflow videos</summary>

|Home|Slate|
|------|-----|
|![Home screen share](https://user-images.githubusercontent.com/111293209/194321837-01c675ca-83c5-47ec-9fec-ad2b905130ee.gif)|![Slate share](https://user-images.githubusercontent.com/111293209/194321840-44f2daa6-dc26-499d-8acb-31dfc66436bd.gif)|
</details>

