### PR TITLE
IN-508-Sort by longest and shortest time to read for Saved Item List only, exclude in Archive list

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -435,7 +435,7 @@ extension ArchivedItemsListViewModel {
     }
 
     func applySorting() {
-        if listOptions.selectedSort == .oldest {
+        if listOptions.selectedSortOption == .oldest {
             archiveService.selectedSortOption = .ascending
         } else {
             archiveService.selectedSortOption = .descending
@@ -456,7 +456,8 @@ extension ArchivedItemsListViewModel {
                 source: source,
                 tracker: tracker.childTracker(hosting: .myList.myList),
                 listOptions: listOptions,
-                sender: sender
+                sender: sender,
+                listOfSortMenuOptions: [.newest, .oldest]
             )
 
         default:

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -435,8 +435,20 @@ extension SavedItemsListViewModel {
     }
 
     private func applySorting() {
-        let sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.createdAt, ascending: (listOptions.selectedSort == .oldest))
-        self.itemsController.sortDescriptors = [sortDescriptorTemp]
+        var sortDescriptorTemp: NSSortDescriptor?
+
+        switch listOptions.selectedSortOption {
+        case .longestToRead, .shortestToRead:
+            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.item?.timeToRead, ascending: (listOptions.selectedSortOption == .shortestToRead))
+        case .newest, .oldest:
+            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.createdAt, ascending: (listOptions.selectedSortOption == .oldest))
+        }
+
+        guard let sortDescriptor = sortDescriptorTemp else {
+            assertionFailure("sortDescriptorTemp can not be nil!")
+            return
+        }
+        self.itemsController.sortDescriptors = [sortDescriptor]
     }
 
     private func handleFilterSelection(with filter: ItemsListFilter, sender: Any? = nil) {

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuModel.swift
@@ -7,4 +7,6 @@ enum SortSection: String, Hashable, CaseIterable {
 enum SortOption: String, Hashable {
     case newest = "Newest saved"
     case oldest = "Oldest saved"
+    case shortestToRead = "Shortest to read"
+    case longestToRead = "Longest to read"
 }

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
@@ -2,6 +2,11 @@ import UIKit
 import Sync
 import Analytics
 
+enum SortMenuSourceView {
+    case savedList
+    case archiveList
+}
+
 class SortMenuViewModel {
 
     typealias Snapshot = NSDiffableDataSourceSnapshot<SortSection, SortOption>
@@ -11,20 +16,28 @@ class SortMenuViewModel {
     private let source: Source
     private let tracker: Tracker
     private let listOptions: ListOptions
+    private let listOfSortMenuOptions: [SortOption]
     let sender: Any
 
-    init(source: Source, tracker: Tracker, listOptions: ListOptions, sender: Any) {
+    init(
+        source: Source,
+        tracker: Tracker,
+        listOptions: ListOptions,
+        sender: Any,
+        listOfSortMenuOptions: [SortOption] = [.newest, .oldest, .shortestToRead, .longestToRead]
+    ) {
         self.source = source
         self.tracker = tracker
         self.listOptions = listOptions
         self.sender = sender
+        self.listOfSortMenuOptions = listOfSortMenuOptions
         buildSnapshot()
     }
 
     func buildSnapshot() {
         var snapshotTemp: NSDiffableDataSourceSnapshot<SortSection, SortOption> = .init()
         snapshotTemp.appendSections([.sortBy])
-        snapshotTemp.appendItems([.newest, .oldest], toSection: .sortBy)
+        snapshotTemp.appendItems(listOfSortMenuOptions, toSection: .sortBy)
         snapshot = snapshotTemp
     }
 }
@@ -32,13 +45,19 @@ class SortMenuViewModel {
 extension SortMenuViewModel {
 
     func cellViewModel(for row: SortOption) -> SortMenuViewCell.Model {
+
         return .init(
             sortOption: row,
-            isSelected: (listOptions.selectedSort == row)
+            isSelected: listOptions.selectedSortOption == row
         )
     }
 
     func select(row: SortOption) {
-        listOptions.selectedSort = row
+
+        guard listOfSortMenuOptions.contains(row) else {
+            return
+        }
+
+        listOptions.selectedSortOption = row
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
@@ -1,7 +1,68 @@
 import SwiftUI
 import Sync
+import Combine
+
+protocol ListOptionsHolder: AnyObject {
+    var selectedSortOption: SortOption { get set }
+    var publisher: AnyPublisher<Void, Never> { get }
+}
 
 class ListOptions: ObservableObject {
-    @AppStorage("listSelectedSort")
-    var selectedSort: SortOption  = .newest
+    static let saved = ListOptions(holder: SavedListOptions())
+    static let archived = ListOptions(holder: ArchiveListOptions())
+
+    private let holder: any ListOptionsHolder
+    private var cancellable: AnyCancellable?
+
+    init(holder: any ListOptionsHolder) {
+        self.holder = holder
+        self.cancellable = holder.publisher.sink {
+            self.objectWillChange.send()
+        }
+    }
+
+    var selectedSortOption: SortOption {
+        get {
+            holder.selectedSortOption
+        }
+        set {
+            holder.selectedSortOption = newValue
+        }
+    }
+}
+
+class SavedListOptions: ObservableObject, ListOptionsHolder {
+    @AppStorage("listSelectedSortForSaved")
+    var selectedSortOption: SortOption  = .newest
+
+    private var cancellable: AnyCancellable?
+    private let _publisher: PassthroughSubject<Void, Never>
+    var publisher: AnyPublisher<Void, Never> {
+        _publisher.eraseToAnyPublisher()
+    }
+
+    init() {
+        _publisher = .init()
+        cancellable = objectWillChange.sink { [weak self] in
+            self?._publisher.send()
+        }
+    }
+}
+
+class ArchiveListOptions: ObservableObject, ListOptionsHolder {
+    @AppStorage("listSelectedSortForArchive")
+    var selectedSortOption: SortOption  = .newest
+
+    private var cancellable: AnyCancellable?
+    private let _publisher: PassthroughSubject<Void, Never>
+    var publisher: AnyPublisher<Void, Never> {
+        _publisher.eraseToAnyPublisher()
+    }
+
+    init() {
+        _publisher = .init()
+        cancellable = objectWillChange.sink { [weak self] in
+            self?._publisher.send()
+        }
+    }
 }

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -18,12 +18,12 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                         savedItemsList: SavedItemsListViewModel(
                             source: Services.shared.source,
                             tracker: Services.shared.tracker.childTracker(hosting: .myList.myList),
-                            listOptions: ListOptions()
+                            listOptions: .saved
                         ),
                         archivedItemsList: ArchivedItemsListViewModel(
                             source: Services.shared.source,
                             tracker: Services.shared.tracker.childTracker(hosting: .myList.archive),
-                            listOptions: ListOptions()
+                            listOptions: .archived
                         )
                     ),
                     home: HomeViewModel(

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
@@ -19,6 +19,7 @@ class ArchivedItemsListViewModelTests: XCTestCase {
     var archiveService: MockArchiveService!
     var subscriptions: Set<AnyCancellable> = []
     var listOptions: ListOptions!
+    var viewModel: ArchivedItemsListViewModel!
 
     override func setUp() {
         self.source = MockSource()
@@ -26,7 +27,7 @@ class ArchivedItemsListViewModelTests: XCTestCase {
         self.networkMonitor = MockNetworkPathMonitor()
         self.archiveService = MockArchiveService()
         self.space = .testSpace()
-        listOptions = ListOptions()
+        listOptions = .archived
 
         source.stubMakeArchiveService { self.archiveService }
     }
@@ -53,9 +54,8 @@ class ArchivedItemsListViewModelTests: XCTestCase {
     func test_applySortingOnMyListArchivedItems() throws {
 
         // When selected sort is newest
-        let listOptionsToPass = ListOptions()
-        listOptionsToPass.selectedSort = .newest
-        let viewModel = subject(listOptions: listOptionsToPass)
+        listOptions.selectedSortOption = .newest
+        let viewModel = subject()
 
         XCTAssertTrue(archiveService.selectedSortOption == .descending)
 
@@ -65,7 +65,7 @@ class ArchivedItemsListViewModelTests: XCTestCase {
         }
 
         // When selected sort is oldest
-        listOptionsToPass.selectedSort = .oldest
+        listOptions.selectedSortOption = .oldest
 
         wait(for: [refreshCalled], timeout: 1)
         XCTAssertTrue(archiveService.selectedSortOption == .ascending)

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -20,8 +20,8 @@ class SavedItemsListViewModelTests: XCTestCase {
         space = .testSpace()
         subscriptions = []
         itemsController = MockSavedItemsController()
-        listOptions = ListOptions()
-        listOptions.selectedSort = .newest
+        listOptions = .saved
+        listOptions.selectedSortOption = .newest
 
         itemsController.stubIndexPathForObject { _ in IndexPath(item: 0, section: 0) }
         source.stubMakeItemsController {
@@ -71,7 +71,7 @@ class SavedItemsListViewModelTests: XCTestCase {
             snapshotSent.fulfill()
         }.store(in: &subscriptions)
 
-        listOptions.selectedSort = .oldest
+        listOptions.selectedSortOption = .oldest
 
         wait(for: [snapshotSent], timeout: 1)
     }

--- a/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
@@ -15,33 +15,41 @@ class SortMenuViewModelTests: XCTestCase {
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
-        listOptions = ListOptions()
-        listOptions.selectedSort = .newest
+        listOptions = .saved
+        listOptions.selectedSortOption = .newest
     }
 
     override func tearDown() {
         subscriptions = []
     }
 
-    private func subject(source: Source? = nil, tracker: Tracker? = nil, listOptions: ListOptions? = nil) -> SortMenuViewModel {
+    private func subject(
+        source: Source? = nil,
+        tracker: Tracker? = nil,
+        listOptions: ListOptions? = nil,
+        listOfSortMenuOptions: [SortOption] = [.newest, .oldest, .shortestToRead, .longestToRead]
+    ) -> SortMenuViewModel {
         return SortMenuViewModel(
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             listOptions: listOptions ?? self.listOptions,
-            sender: UIView()
+            sender: UIView(),
+            listOfSortMenuOptions: listOfSortMenuOptions
         )
     }
 
-    func test_snapshot_containsAllSortOptions() {
-        let sortMenuVM = subject()
+    func test_snapshot_containsAllSortOptionsForSavedItemsList() {
+        let sortMenuVM = subject(
+            listOfSortMenuOptions: [.newest, .oldest, .shortestToRead, .longestToRead]
+        )
         sortMenuVM.$snapshot.sink { snapshot in
             XCTAssertEqual(snapshot.sectionIdentifiers, [.sortBy])
-            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .sortBy), [.newest, .oldest])
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .sortBy), [.newest, .oldest, .shortestToRead, .longestToRead])
         }.store(in: &subscriptions)
     }
 
     func test_cellViewModel_whenSortOptionIsSelected_returnsViewModelWithIsSelectedSetToTrue() {
-
+        listOptions.selectedSortOption = .newest
         let sortMenuVM = subject()
         let sortCellModel = sortMenuVM.cellViewModel(for: SortOption.newest)
 
@@ -58,14 +66,20 @@ class SortMenuViewModelTests: XCTestCase {
         XCTAssertEqual(sortCellModel.isSelected, false)
     }
 
-    func test_select_setsTheSelectedSortOnListOptions() {
+    func test_select_setsTheSelectedSortOnListOptionsForSavedList() {
 
-        listOptions.selectedSort = .oldest
+        listOptions.selectedSortOption = .oldest
         let sortMenuVM = subject()
-        XCTAssert(listOptions.selectedSort == .oldest)
+        XCTAssert(listOptions.selectedSortOption == .oldest)
 
         sortMenuVM.select(row: .newest)
+        XCTAssert(listOptions.selectedSortOption == .newest)
 
-        XCTAssert(listOptions.selectedSort == .newest)
+        sortMenuVM.select(row: .shortestToRead)
+        XCTAssert(listOptions.selectedSortOption == .shortestToRead)
+
+        sortMenuVM.select(row: .longestToRead)
+        XCTAssert(listOptions.selectedSortOption == .longestToRead)
+
     }
 }


### PR DESCRIPTION
## Summary
- IN-508-Sort by longest and shortest time to read for Saved Item List
- Remove/exclude 'Shortest time to read' & 'Longest time to read' options for Archive item list
- Two separate ListOptions properties for Saved & Archive: This does mean, sorting selection of Saved and Archive list will be independent and will not have impact on each other.
- List Options: For saved & archive lists, the both properties of ListOptions were observed parallel when only 1 need events to be notified. Changes are done in ListOptions class to accommodate the optimization so only 1 ListOption listen and notified when needed at a time since user will either be on Saved List or Archive List.


## References 
[IN-508](https://getpocket.atlassian.net/browse/IN-508)

## Implementation Details
Consuming SortMenu to add and implement sort options - 'Shortest time to read' and 'Longest time to read'  for Saved items List.


## Test Steps
- [x] Given I have opened the Pocket app,
when I view the My List tab and it shows saved items in All and Favorite.
then I should be able to click on 'Sort/Filter' menu and apply sorting by choosing 'Shortest to read'. Saved items should sort by 'Shortest time to read' saved items.

- [x] Given I have opened the Pocket app,
when I view the My List tab and it shows saved items in All and Favorite.
then I should be able to click on 'Sort/Filter' menu and apply sorting by choosing 'Longest to read'. Saved items should sort by 'Longest time to read' saved items.

- [x] Given I have opened the Pocket app,
when I view the My List tab and it shows saved items in All and Favorite.
I should be able to click on 'Sort/Filter' menu and apply sorting by choosing 'Shortest to read'. Saved items should sort by 'Shortest time to read' saved items.
then If I close or terminate the app and come back to My List, it should show the saved items list as per last selected sorting option and when tap on 'Sort/Filter', by default the last option (Shortest to read) should be selected/highlighted.

- [x] Given I have opened the Pocket app,
when I view the My List tab and it shows saved items.
then I should be able to click on 'Sort/Filter' menu and apply sorting by choosing 'Oldest'. Saved Items should sort by 'Oldest' saved items.
Now, If I switch to Archive List,
then I should be able to click on 'Sort/Filter' menu and 'Oldest' sorting should not be pre-selected. Archive Items should be sort by 'Newest' as default.


## PR Checklist:
- [X] Added Unit / UI tests
- [X] Self Review (review, clean up, documentation, run tests)
- [X] Basic Self QA

## Screenshots
| Initial State (by default Newest)        | Sort Menu (Newest To Shortest Selection)           | Saved List (selected: Shortest to read)  | Sort Menu (Longest to Shortest Selection) |        Saved List (selected: Longest to read) 
|-------------|-------------|-----|------|------|
| ![Newest](https://user-images.githubusercontent.com/110417980/194581454-8207de17-588f-4d8d-a081-58a06867b3f3.png) | ![NewestToShortest](https://user-images.githubusercontent.com/110417980/194581907-b4d5bef0-62dc-408c-8f98-7c9aa42017d3.png) | ![Shortest](https://user-images.githubusercontent.com/110417980/194582053-ea160bbf-e17d-460f-973f-f2c56b717800.png) | ![Shortest to Longest](https://user-images.githubusercontent.com/110417980/194582290-9d453f7a-f47e-484a-86ed-bbcce4f06636.png) | ![Longest](https://user-images.githubusercontent.com/110417980/194584389-23e27c6e-e513-4ad6-9a21-d6c8ec670219.png) |



![My Movie](https://user-images.githubusercontent.com/110417980/195654419-d2e43446-f924-4ef5-8b3a-77f31d9f7a6c.gif)


