### PR TITLE
IN 876 - top level archive

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
@@ -27,4 +27,8 @@ class UnsupportedComponentPresenter: ArticleComponentPresenter {
     private func handleShowInWebReaderButtonTap() {
         readableViewModel?.showWebReader()
     }
+    
+    private func handleArchiveArticleButtonTap() {
+        readableViewModel?.archiveArticle()
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -29,6 +29,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
 
     func delete()
     func showWebReader()
+    func archiveArticle()
     func fetchDetailsIfNeeded()
     func externalActions(for url: URL) -> [ItemAction]
     func clearPresentedWebReaderURL()

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -6,6 +6,7 @@ import UIKit
 import Analytics
 
 class RecommendationViewModel: ReadableViewModel {
+    
     @Published
     private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
@@ -99,6 +100,10 @@ class RecommendationViewModel: ReadableViewModel {
 
     func showWebReader() {
         presentedWebReaderURL = url
+    }
+    
+    func archiveArticle() {
+        archive()
     }
 
     func fetchDetailsIfNeeded() {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -100,7 +100,7 @@ class SavedItemViewModel: ReadableViewModel {
     func showWebReader() {
         presentedWebReaderURL = url
     }
-    
+
     func archiveArticle() {
         archive()
     }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -100,6 +100,10 @@ class SavedItemViewModel: ReadableViewModel {
     func showWebReader() {
         presentedWebReaderURL = url
     }
+    
+    func archiveArticle() {
+        archive()
+    }
 
     func fetchDetailsIfNeeded() {
         guard item.item?.article == nil else {
@@ -132,18 +136,10 @@ extension SavedItemViewModel {
             favoriteAction = .favorite { [weak self] _ in self?.favorite() }
         }
 
-        let archiveAction: ItemAction
-        if item.isArchived {
-            archiveAction = .moveToMyList { [weak self] _ in self?.moveToMyList() }
-        } else {
-            archiveAction = .archive { [weak self] _ in self?.archive() }
-        }
-
         _actions = [
             .displaySettings { [weak self] _ in self?.displaySettings() },
             favoriteAction,
             .addTags { [weak self] _ in self?.showAddTagsView() },
-            archiveAction,
             .delete { [weak self] _ in self?.confirmDelete() },
             .share { [weak self] _ in self?.share() }
         ]

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -153,6 +153,15 @@ class CompactHomeCoordinator: NSObject {
         recommendation.$selectedRecommendationToReport.sink { [weak self] selected in
             self?.report(selected)
         }.store(in: &readerSubscriptions)
+
+        recommendation.events.sink { [weak self] event in
+            switch event {
+                case .contentUpdated:
+                    break
+                case .archive, .delete:
+                    self?.navigationController.popViewController(animated: true)
+            }
+        }.store(in: &readerSubscriptions)
     }
 
     func show(_ savedItem: SavedItemViewModel) {
@@ -181,6 +190,15 @@ class CompactHomeCoordinator: NSObject {
 
         savedItem.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(addTagsViewModel)
+        }.store(in: &readerSubscriptions)
+
+        savedItem.events.sink { [weak self] event in
+            switch event {
+            case .contentUpdated:
+                break
+            case .archive, .delete:
+                self?.navigationController.popViewController(animated: true)
+            }
         }.store(in: &readerSubscriptions)
     }
 

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -21,6 +21,7 @@ class ReadableHostViewController: UIViewController {
         title = nil
         navigationItem.largeTitleDisplayMode = .never
         hidesBottomBarWhenPushed = true
+        
 
         navigationItem.rightBarButtonItems = [
             moreButtonItem,
@@ -29,6 +30,12 @@ class ReadableHostViewController: UIViewController {
                 style: .plain,
                 target: self,
                 action: #selector(showWebView)
+            ),
+            UIBarButtonItem(
+                image: UIImage(asset: .archive),
+                style: .plain,
+                target: self,
+                action: #selector(archiveArticle)
             )
         ]
 
@@ -76,6 +83,11 @@ class ReadableHostViewController: UIViewController {
     @objc
     private func showWebView() {
         readableViewModel.showWebReader()
+    }
+    
+    @objc
+    private func archiveArticle() {
+        readableViewModel.archiveArticle()
     }
 
     var popoverAnchor: UIBarButtonItem? {

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -21,7 +21,14 @@ class ReadableHostViewController: UIViewController {
         title = nil
         navigationItem.largeTitleDisplayMode = .never
         hidesBottomBarWhenPushed = true
-        
+
+        let archiveNavButton = UIBarButtonItem(
+            image: UIImage(asset: .archive),
+            style: .plain,
+            target: self,
+            action: #selector(archiveArticle)
+        )
+        archiveNavButton.accessibilityIdentifier = "archiveNavButton"
 
         navigationItem.rightBarButtonItems = [
             moreButtonItem,
@@ -31,12 +38,7 @@ class ReadableHostViewController: UIViewController {
                 target: self,
                 action: #selector(showWebView)
             ),
-            UIBarButtonItem(
-                image: UIImage(asset: .archive),
-                style: .plain,
-                target: self,
-                action: #selector(archiveArticle)
-            )
+            archiveNavButton
         ]
 
         readableViewModel.actions.receive(on: DispatchQueue.main).sink { [weak self] actions in
@@ -84,7 +86,7 @@ class ReadableHostViewController: UIViewController {
     private func showWebView() {
         readableViewModel.showWebReader()
     }
-    
+
     @objc
     private func archiveArticle() {
         readableViewModel.archiveArticle()

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -147,6 +147,15 @@ extension RegularHomeCoordinator {
 
         let readableVC = ReadableHostViewController(readableViewModel: readable)
         navigationController.pushViewController(readableVC, animated: !isResetting)
+
+        readable.events.sink { [weak self] event in
+            switch event {
+                case .contentUpdated:
+                    break
+                case .archive, .delete:
+                    self?.navigationController.popViewController(animated: true)
+            }
+        }.store(in: &readerSubscriptions)
     }
 
     private func show(_ readable: RecommendationViewModel?) {
@@ -177,6 +186,15 @@ extension RegularHomeCoordinator {
 
         let viewController = ReadableHostViewController(readableViewModel: readable)
         navigationController.pushViewController(viewController, animated: !isResetting)
+
+        readable.events.sink { [weak self] event in
+            switch event {
+                case .contentUpdated:
+                    break
+                case .archive, .delete:
+                    self?.navigationController.popViewController(animated: true)
+            }
+        }.store(in: &readerSubscriptions)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -45,7 +45,7 @@ class SavedItemViewModelTests: XCTestCase {
             let viewModel = subject(item: space.buildSavedItem(isFavorite: false, isArchived: false))
             XCTAssertEqual(
                 viewModel._actions.map(\.title),
-                ["Display Settings", "Favorite", "Add Tags", "Archive", "Delete", "Share"]
+                ["Display Settings", "Favorite", "Add Tags", "Delete", "Share"]
             )
         }
 
@@ -54,7 +54,7 @@ class SavedItemViewModelTests: XCTestCase {
             let viewModel = subject(item: space.buildSavedItem(isFavorite: true, isArchived: true))
             XCTAssertEqual(
                 viewModel._actions.map(\.title),
-                ["Display Settings", "Unfavorite", "Add Tags", "Move to My List", "Delete", "Share"]
+                ["Display Settings", "Unfavorite", "Add Tags", "Delete", "Share"]
             )
         }
     }
@@ -66,13 +66,13 @@ class SavedItemViewModelTests: XCTestCase {
         item.isFavorite = true
         XCTAssertEqual(
             viewModel._actions.map(\.title),
-            ["Display Settings", "Unfavorite", "Add Tags", "Move to My List", "Delete", "Share"]
+            ["Display Settings", "Unfavorite", "Add Tags", "Delete", "Share"]
         )
 
         item.isArchived = false
         XCTAssertEqual(
             viewModel._actions.map(\.title),
-            ["Display Settings", "Unfavorite", "Add Tags", "Archive", "Delete", "Share"]
+            ["Display Settings", "Unfavorite", "Add Tags", "Delete", "Share"]
         )
     }
 
@@ -203,45 +203,6 @@ class SavedItemViewModelTests: XCTestCase {
         viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
 
         wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
-    }
-
-    func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
-        let item = space.buildSavedItem(isArchived: false)
-        let viewModel = subject(item: item)
-
-        let expectArchive = expectation(description: "expect source.archive(_:)")
-        source.stubArchiveSavedItem { archivedItem in
-            defer { expectArchive.fulfill() }
-            XCTAssertTrue(archivedItem === item)
-        }
-
-        let expectArchiveEvent = expectation(description: "expect archive event")
-        viewModel.events.sink { event in
-            guard case .archive = event else {
-                XCTFail("Received unexpected event: \(event)")
-                return
-            }
-
-            expectArchiveEvent.fulfill()
-        }.store(in: &subscriptions)
-
-        viewModel.invokeAction(title: "Archive")
-        wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
-    }
-
-    func test_reAdd_sendsRequestToSource_AndRefreshes() {
-        let item = space.buildSavedItem(isArchived: true)
-        let expectUnarchive = expectation(description: "expect source.unarchive(_:)")
-
-        source.stubUnarchiveSavedItem { unarchivedItem in
-            defer { expectUnarchive.fulfill() }
-            XCTAssertTrue(unarchivedItem === item)
-        }
-
-        let viewModel = subject(item: item)
-        viewModel.invokeAction(title: "Move to My List")
-
-        wait(for: [expectUnarchive], timeout: 1)
     }
 
     func test_share_updatesSharedActivity() {

--- a/Tests iOS/ArchiveAnItemTests.swift
+++ b/Tests iOS/ArchiveAnItemTests.swift
@@ -115,14 +115,10 @@ class ArchiveAnItemTests: XCTestCase {
             return Response.archive()
         }
 
-        app
-            .readerView
-            .readerToolbar
-            .moreButton
-            .wait()
-            .tap()
-
-        app.archiveButton.wait().tap()
+        let archiveNavButton = XCUIApplication().buttons["archiveNavButton"]
+        XCTAssert(archiveNavButton.exists)
+        archiveNavButton.wait().tap()
+        app.myListView.wait()
 
         wait(for: [expectRequest], timeout: 1)
         listView.wait()
@@ -150,7 +146,7 @@ class ArchiveAnItemTests: XCTestCase {
 
         let archiveNavButton = XCUIApplication().buttons["archiveNavButton"]
         XCTAssert(archiveNavButton.exists)
-        archiveNavButton.tap()
+        archiveNavButton.wait().tap()
         app.homeView.wait()
 
         wait(for: [expectRequest], timeout: 1)


### PR DESCRIPTION
## Summary
* added archive to top level of Reader view

## References 
* [IN 876](https://getpocket.atlassian.net/jira/software/projects/IN/boards/80?selectedIssue=IN-876)

## Implementation Details
* Added coordinator handlers for CompactHome and RegularHome
* removed overflow menu archive
* added navigation item for archive

## Test Steps
* Go to home
* select an article with reader
* archive should be visible in top navigation menu (left of Safari)
* click archive
* should archive the item and bring you back to home
* go to my list
* select an article with reader
* archive should be visible in top navigation menu
* click archive
* should archive the item and bring you back to my list

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
<details>

<img width="430" alt="image" src="https://user-images.githubusercontent.com/111293209/195101149-d33d669a-11f9-4368-bb8d-518ffd05ebca.png">
</details>