### PR TITLE
draft-proposal-to-reduce-build-time

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -189,6 +189,9 @@
 		8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesCellElement.swift; sourceTree = "<group>"; };
 		8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTagsTests.swift; sourceTree = "<group>"; };
 		8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsViewElement.swift; sourceTree = "<group>"; };
+		D4309FEB28F5B07C00E1A2AE /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		D4309FEC28F5B08900E1A2AE /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
+		D4309FED28F5B0B500E1A2AE /* UITests-2.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-2.xctestplan"; sourceTree = "<group>"; };
 		F204A76027E22EC50010E155 /* SaveToPocket.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaveToPocket.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
@@ -264,6 +267,9 @@
 		166A81A32637406B0015AA1D = {
 			isa = PBXGroup;
 			children = (
+				D4309FED28F5B0B500E1A2AE /* UITests-2.xctestplan */,
+				D4309FEC28F5B08900E1A2AE /* UITests.xctestplan */,
+				D4309FEB28F5B07C00E1A2AE /* UnitTests.xctestplan */,
 				655C274E28B67ED20040AEAB /* README.md */,
 				166DF27827E9172800C03BF4 /* Pocket (iOS).entitlements */,
 				1624B85A268508180099B6EF /* PocketKit */,

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1300"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -42,6 +42,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests-2.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/UITests-2.xctestplan
+++ b/UITests-2.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "71CBD44E-2117-44AE-B032-6918B5B9C2E0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "AddTagsItemTests",
+        "ArchiveAnItemTests",
+        "ArchiveFiltersTests",
+        "ArchiveTests",
+        "BannerViewTests",
+        "DeleteAnItemTests",
+        "EditTagsTests",
+        "EmptyStateTests",
+        "FavoriteAnItemTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Pocket.xcodeproj",
+        "identifier" : "166A81BF2637406C0015AA1D",
+        "name" : "Tests iOS"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "A4EB5A67-4AB5-4BAF-934F-5BDCE7E091F6",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "HomeTests",
+        "HomeWebViewTests",
+        "MyListFiltersTests",
+        "MyListTests",
+        "PullToRefreshTests",
+        "ReportARecommendationTests",
+        "SaveToPocketTests",
+        "ShareAnItemTests",
+        "SignOutTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Pocket.xcodeproj",
+        "identifier" : "166A81BF2637406C0015AA1D",
+        "name" : "Tests iOS"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -1,0 +1,52 @@
+{
+  "configurations" : [
+    {
+      "id" : "D7A8561E-5086-4968-9C3A-9D568C5F3698",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "AnalyticsTests",
+        "name" : "AnalyticsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "PocketKitTests",
+        "name" : "PocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SaveToPocketKitTests",
+        "name" : "SaveToPocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SharedPocketKitTests",
+        "name" : "SharedPocketKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:PocketKit",
+        "identifier" : "SyncTests",
+        "name" : "SyncTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -258,16 +258,6 @@ workflows:
         - extract_to_path: '$BITRISE_SOURCE_DIR/PocketKit/Sources/Textile/Style/Typography/Fonts'
         - archive_url: '$BITRISEIO_BASE_FONTS_URL'
         title: Install fonts
-    - script@1:
-        title: Download latest schema
-        inputs:
-        - content: |
-            #!/usr/bin/env bash
-            # fail if any commands fails
-            set -e
-            cd PocketKit
-            swift run ApolloCodegen download-schema
-            swift run ApolloCodegen generate
     - file-downloader@1:
         inputs:
         - source: '$BITRISEIO_SECRETS_TEST_URL'
@@ -294,6 +284,11 @@ workflows:
             ls ./Users/vagrant/git/DerivedData
             mv ./Users/vagrant/git/* .
             ls -la
+            cd PocketKit
+            swift run ApolloCodegen download-schema
+            swift run ApolloCodegen generate
+
+            cd ..
             echo "-- test-without-building --"
             xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building
     - custom-test-results-export@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,9 +210,7 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
-            mv 'Tests iOS' TestsiOS
             ls
-            ls DerivedData/
             xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "test" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan UnitTests | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Compress Derived Data
@@ -225,13 +223,13 @@ workflows:
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
             "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
-            "$BITRISE_SOURCE_DIR/TestsiOS/" \
             "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
             "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
             "$BITRISE_SOURCE_DIR/UnitTests.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
+            "$BITRISE_SOURCE_DIR/Tests iOS/"
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
@@ -270,7 +268,7 @@ workflows:
             ls .
             ls ./Users/vagrant/git/
             ls ./Users/vagrant/git/DerivedData
-            cp -r ./Users/vagrant/git/TestsiOS/ .
+            #cp -r ./Users/vagrant/git/Tests\ iOS/ .
             mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,7 +29,9 @@ stages:
   build-test:
     workflows:
       # Run the test and qa build flow in parallel
-      - test: {}
+      - test_1: {}
+      - test_2: {}
+      - test_3: {}
       - qa-build: {}
   release-build:
     workflows:
@@ -190,7 +192,7 @@ workflows:
     after_run:
       - _upload_sentry
 
-  test:
+  test_1:
     steps:
       - file-downloader@1:
           inputs:
@@ -200,6 +202,39 @@ workflows:
       - xcode-test@4:
           inputs:
             - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
+            - test_plan: UITests
+      - deploy-to-bitrise-io@2: {}
+    before_run:
+      - _setup
+    after_run:
+      - _danger
+  test_2:
+    steps:
+      - file-downloader@1:
+          inputs:
+            - source: '$BITRISEIO_SECRETS_TEST_URL'
+            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+          title: Install test secrets.xcconfig
+      - xcode-test@4:
+          inputs:
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
+            - test_plan: UITests-2
+      - deploy-to-bitrise-io@2: {}
+    before_run:
+      - _setup
+    after_run:
+      - _danger
+  test_3:
+    steps:
+      - file-downloader@1:
+          inputs:
+            - source: '$BITRISEIO_SECRETS_TEST_URL'
+            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+          title: Install test secrets.xcconfig
+      - xcode-test@4:
+          inputs:
+            - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
+            - test_plan: UnitTests
       - deploy-to-bitrise-io@2: {}
     before_run:
       - _setup

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -227,8 +227,8 @@ workflows:
             "$BITRISE_SOURCE_DIR/UnitTests.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
+            "$BITRISE_SOURCE_DIR/Tests\ iOS/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
-            "$BITRISE_SOURCE_DIR/Tests\ iOS/"
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
@@ -259,9 +259,10 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            #ls ./Users/vagrant/git/Tests\ iOS/
+            ls .
+            ls ./Users/vagrant/git/
             #cp -r ./Users/vagrant/git/Tests\ iOS/* .
-            #mv ./Users/vagrant/git/* .
+            mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"
             xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -233,8 +233,7 @@ workflows:
             "$BITRISE_SOURCE_DIR/PushNotificationServiceExtension/" \
             "$BITRISE_SOURCE_DIR/PushNotificationStoryExtension/" \
             "$BITRISE_SOURCE_DIR/SaveToPocket/" \
-            "$BITRISE_SOURCE_DIR/Assets.xcassets/" \
-            "$BITRISE_SOURCE_DIR/DerivedData/"
+            "$BITRISE_SOURCE_DIR/Assets.xcassets/"
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -202,17 +202,6 @@ workflows:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
-    - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
-        title: Bitrise Test Plan Sharder
-        inputs:
-        - xcode_project: Pocket.xcodeproj
-        - target: Pocket
-        - shards: '3'
-        - scheme: Pocket (iOS)
-        - test_plan: UITests.xctestplan
-        - debug_mode: 'true'
-        - test_path: ''
-        - file_type: ".swift"
     - script@1.1:
         title: Build for Testing
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -36,7 +36,7 @@ stages:
       - test_1: {}
       #- test_2: {}
       #- test_3: {}
-      - qa-build: {}
+      #- qa-build: {}
   release-build:
     workflows:
       - release-build: {}
@@ -228,7 +228,7 @@ workflows:
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
-            "$BITRISE_SOURCE_DIR/Tests\ iOS"
+            "$BITRISE_SOURCE_DIR/Tests\ iOS/"
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,6 +210,7 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
+            cp -r Tests\ iOS DerivedData
             xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Compress Derived Data

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -243,6 +243,11 @@ workflows:
         inputs:
         - verbose: true
         - artifact_sources: build.*
+    - file-downloader@1:
+          inputs:
+            - source: '$BITRISEIO_SECRETS_TEST_URL'
+            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+          title: Install test secrets.xcconfig
     - script@1.1:
         title: Unzip
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -249,10 +249,30 @@ workflows:
         - verbose: true
         - artifact_sources: build.*
     - file-downloader@1:
-          inputs:
-            - source: '$BITRISEIO_SECRETS_TEST_URL'
-            - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
-          title: Install test secrets.xcconfig
+        inputs:
+        - source: '$BITRISEIO_SECRETS_XCCONFIG_URL'
+        - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+        title: Install production secrets.xcconfig
+    - resource-archive@2:
+        inputs:
+        - extract_to_path: '$BITRISE_SOURCE_DIR/PocketKit/Sources/Textile/Style/Typography/Fonts'
+        - archive_url: '$BITRISEIO_BASE_FONTS_URL'
+        title: Install fonts
+    - script@1:
+        title: Download latest schema
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            cd PocketKit
+            swift run ApolloCodegen download-schema
+            swift run ApolloCodegen generate
+    - file-downloader@1:
+        inputs:
+        - source: '$BITRISEIO_SECRETS_TEST_URL'
+        - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
+        title: Install test secrets.xcconfig
     - script@1.1:
         title: Unzip
         inputs:
@@ -272,7 +292,6 @@ workflows:
             ls .
             ls ./Users/vagrant/git/
             ls ./Users/vagrant/git/DerivedData
-            #cp -r ./Users/vagrant/git/Tests\ iOS/ .
             mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -197,63 +197,63 @@ workflows:
       - _upload_sentry
   configure_build:
     steps:
-      - file-downloader@1:
+    - file-downloader@1:
           inputs:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
-      - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
-          title: Bitrise Test Plan Sharder
-          inputs:
-          - xcode_project: Pocket.xcodeproj
-          - target: Pocket
-          - shards: '3'
-          - scheme: Pocket (iOS)
-          - test_plan: UITests.xctestplan
-          - debug_mode: 'true'
-          - test_path: ''
-          - file_type: ".swift"
-      - script@1.1:
-          title: Build for Testing
-          inputs:
-          - content: |
-              set -euxo pipefail
-              echo "-- build-for-testing --"
-              mkdir DerivedData
-              xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
-      - script@1.1:
-          title: Compress Derived Data
-          is_always_run: true
-          inputs:
-          - content: |
-              set -euxo pipefail
-              echo "-- compress --"
-              exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
-              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
-              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
-              "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
-              "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
-              "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
-              "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
-              "$BITRISE_SOURCE_DIR/xcodebuild.log" \
-              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
-              "$BITRISE_SOURCE_DIR/PocketKit/" \
-              "$BITRISE_SOURCE_DIR/Tests\ iOS"
-      - deploy-to-bitrise-io@2:
-          inputs:
-          - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
+    - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
+        title: Bitrise Test Plan Sharder
+        inputs:
+        - xcode_project: Pocket.xcodeproj
+        - target: Pocket
+        - shards: '3'
+        - scheme: Pocket (iOS)
+        - test_plan: UITests.xctestplan
+        - debug_mode: 'true'
+        - test_path: ''
+        - file_type: ".swift"
+    - script@1.1:
+        title: Build for Testing
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- build-for-testing --"
+            mkdir DerivedData
+            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
+    - script@1.1:
+        title: Compress Derived Data
+        is_always_run: true
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- compress --"
+            exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
+            "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
+            "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
+            "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
+            "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
+            "$BITRISE_SOURCE_DIR/xcodebuild.log" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
+            "$BITRISE_SOURCE_DIR/PocketKit/" \
+            "$BITRISE_SOURCE_DIR/Tests\ iOS"
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
     before_run:
       - _setup
     after_run:
       - _danger
   test_1:
     steps:
-      - git::https://github.com/bitrise-steplib/bitrise-step-artifact-pull.git@main:
+    - git::https://github.com/bitrise-steplib/bitrise-step-artifact-pull.git@main:
         title: Pull artifacts
         inputs:
         - verbose: true
         - artifact_sources: build.*
-      - script@1.1:
+    - script@1.1:
         title: Unzip
         inputs:
         - content: |
@@ -263,7 +263,7 @@ workflows:
             exec unzip "${BITRISE_ARTIFACT_PATHS}"
             echo "show dir"
             ls
-      - script@1.1:
+    - script@1.1:
         title: Test without Building
         inputs:
         - content: |
@@ -275,11 +275,11 @@ workflows:
             ls -la
             echo "-- test-without-building --"
             xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building
-      - custom-test-results-export@0:
+    - custom-test-results-export@0:
         inputs:
         - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
         - test_name: UITests
-      - deploy-to-bitrise-io@2: {}
+    - deploy-to-bitrise-io@2: {}
   test_2:
     steps:
       - file-downloader@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -214,34 +214,34 @@ workflows:
           - test_path: ''
           - file_type: ".swift"
       - script@1.1:
-        title: Build for Testing
-        inputs:
-        - content: |
-            set -euxo pipefail
-            echo "-- build-for-testing --"
-            mkdir DerivedData
-            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
+          title: Build for Testing
+          inputs:
+          - content: |
+              set -euxo pipefail
+              echo "-- build-for-testing --"
+              mkdir DerivedData
+              xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
       - script@1.1:
-        title: Compress Derived Data
-        is_always_run: true
-        inputs:
-        - content: |
-            set -euxo pipefail
-            echo "-- compress --"
-            exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
-            "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
-            "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
-            "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
-            "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
-            "$BITRISE_SOURCE_DIR/xcodebuild.log" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
-            "$BITRISE_SOURCE_DIR/PocketKit/" \
-            "$BITRISE_SOURCE_DIR/Tests\ iOS"
+          title: Compress Derived Data
+          is_always_run: true
+          inputs:
+          - content: |
+              set -euxo pipefail
+              echo "-- compress --"
+              exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
+              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
+              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
+              "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
+              "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
+              "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
+              "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
+              "$BITRISE_SOURCE_DIR/xcodebuild.log" \
+              "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
+              "$BITRISE_SOURCE_DIR/PocketKit/" \
+              "$BITRISE_SOURCE_DIR/Tests\ iOS"
       - deploy-to-bitrise-io@2:
-        inputs:
-        - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
+          inputs:
+          - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
     before_run:
       - _setup
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,7 +210,8 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
-            cp -r Tests\ iOS DerivedData
+            cp -r 'Tests iOS' DerivedData
+            ls DerivedData/
             xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Compress Derived Data
@@ -267,6 +268,7 @@ workflows:
             set -ex
             ls .
             ls ./Users/vagrant/git/
+            ls ./Users/vagrant/git/DerivedData
             #cp -r ./Users/vagrant/git/Tests\ iOS/* .
             mv ./Users/vagrant/git/* .
             ls -la

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -211,7 +211,7 @@ workflows:
             echo "-- build-for-testing --"
             mkdir DerivedData
             ls
-            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "test" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan UnitTests | xcpretty | tee xcodebuild_test.log
+            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "test" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan UnitTests | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Compress Derived Data
         is_always_run: true
@@ -221,7 +221,7 @@ workflows:
             echo "-- compress --"
             exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests iOS-Runner" \
             "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
             "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
             "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
@@ -229,7 +229,8 @@ workflows:
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
-            "$BITRISE_SOURCE_DIR/Tests iOS/"
+            "$BITRISE_SOURCE_DIR/Tests iOS/" \
+            "$BITRISE_SOURCE_DIR/DerivedData/
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,10 +210,10 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
-            cp -r 'Tests iOS' DerivedData/TestsiOS
-            cp -r 'Tests iOS' DerivedData
+            mv 'Tests iOS' TestsiOS
+            ls
             ls DerivedData/
-            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
+            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "test" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan UnitTests | xcpretty | tee xcodebuild_test.log
     - script@1.1:
         title: Compress Derived Data
         is_always_run: true
@@ -225,13 +225,12 @@ workflows:
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
             "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
-            "$BITRISE_SOURCE_DIR/DerivedData/TestsiOS/" \
+            "$BITRISE_SOURCE_DIR/TestsiOS/" \
             "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
             "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
             "$BITRISE_SOURCE_DIR/UnitTests.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
-            "$BITRISE_SOURCE_DIR/DerivedData/Tests\ iOS/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
     - deploy-to-bitrise-io@2:
         inputs:
@@ -271,7 +270,7 @@ workflows:
             ls .
             ls ./Users/vagrant/git/
             ls ./Users/vagrant/git/DerivedData
-            cp -r ./Users/vagrant/git/DerivedData/TestsiOS/* .
+            cp -r ./Users/vagrant/git/TestsiOS/ .
             mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -230,7 +230,11 @@ workflows:
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
             "$BITRISE_SOURCE_DIR/Tests iOS/" \
-            "$BITRISE_SOURCE_DIR/DerivedData/
+            "$BITRISE_SOURCE_DIR/PushNotificationServiceExtension/" \
+            "$BITRISE_SOURCE_DIR/PushNotificationStoryExtension/" \
+            "$BITRISE_SOURCE_DIR/SaveToPocket/"
+            "$BITRISE_SOURCE_DIR/Assets.xcassets/"
+            "$BITRISE_SOURCE_DIR/DerivedData/"
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -202,8 +202,20 @@ workflows:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
+    - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
+        title: Bitrise Test Plan Sharder
+        inputs:
+        - xcode_project: Pocket.xcodeproj
+        - target: Pocket (iOS)
+        - shards: '3'
+        - scheme: Pocket (iOS)
+        - test_plan: UITests.xctestplan
+        - debug_mode: 'true'
+        - test_path: ''
+        - file_type: ".swift"
     - script@1.1:
         title: Build for Testing
+        is_always_run: true
         inputs:
         - content: |
             set -euxo pipefail
@@ -234,7 +246,7 @@ workflows:
     before_run:
       - _setup
     after_run:
-      - _danger
+      #- _danger
   test_1:
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-artifact-pull.git@main:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -232,8 +232,8 @@ workflows:
             "$BITRISE_SOURCE_DIR/Tests iOS/" \
             "$BITRISE_SOURCE_DIR/PushNotificationServiceExtension/" \
             "$BITRISE_SOURCE_DIR/PushNotificationStoryExtension/" \
-            "$BITRISE_SOURCE_DIR/SaveToPocket/"
-            "$BITRISE_SOURCE_DIR/Assets.xcassets/"
+            "$BITRISE_SOURCE_DIR/SaveToPocket/" \
+            "$BITRISE_SOURCE_DIR/Assets.xcassets/" \
             "$BITRISE_SOURCE_DIR/DerivedData/"
     - deploy-to-bitrise-io@2:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -202,17 +202,6 @@ workflows:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
-    - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
-        title: Bitrise Test Plan Sharder
-        inputs:
-        - xcode_project: Pocket.xcodeproj
-        - target: Pocket (iOS)
-        - shards: '3'
-        - scheme: Pocket (iOS)
-        - test_plan: UITests.xctestplan
-        - debug_mode: 'true'
-        - test_path: ''
-        - file_type: ".swift"
     - script@1.1:
         title: Build for Testing
         is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,6 +210,7 @@ workflows:
             set -euxo pipefail
             echo "-- build-for-testing --"
             mkdir DerivedData
+            cp -r 'Tests iOS' DerivedData/TestsiOS
             cp -r 'Tests iOS' DerivedData
             ls DerivedData/
             xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
@@ -224,12 +225,13 @@ workflows:
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
             "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
+            "$BITRISE_SOURCE_DIR/DerivedData/TestsiOS/" \
             "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
             "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
             "$BITRISE_SOURCE_DIR/UnitTests.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
-            "$BITRISE_SOURCE_DIR/Tests\ iOS/" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Tests\ iOS/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
     - deploy-to-bitrise-io@2:
         inputs:
@@ -269,7 +271,7 @@ workflows:
             ls .
             ls ./Users/vagrant/git/
             ls ./Users/vagrant/git/DerivedData
-            #cp -r ./Users/vagrant/git/Tests\ iOS/* .
+            cp -r ./Users/vagrant/git/DerivedData/TestsiOS/* .
             mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -253,11 +253,6 @@ workflows:
         - source: '$BITRISEIO_SECRETS_XCCONFIG_URL'
         - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
         title: Install production secrets.xcconfig
-    - resource-archive@2:
-        inputs:
-        - extract_to_path: '$BITRISE_SOURCE_DIR/PocketKit/Sources/Textile/Style/Typography/Fonts'
-        - archive_url: '$BITRISEIO_BASE_FONTS_URL'
-        title: Install fonts
     - file-downloader@1:
         inputs:
         - source: '$BITRISEIO_SECRETS_TEST_URL'
@@ -287,8 +282,8 @@ workflows:
             cd PocketKit
             swift run ApolloCodegen download-schema
             swift run ApolloCodegen generate
-
             cd ..
+
             echo "-- test-without-building --"
             xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building
     - custom-test-results-export@0:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -224,7 +224,7 @@ workflows:
             "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
             "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
             "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
-            "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
+            "$BITRISE_SOURCE_DIR/UnitTests.xctestplan" \
             "$BITRISE_SOURCE_DIR/xcodebuild.log" \
             "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
             "$BITRISE_SOURCE_DIR/PocketKit/" \
@@ -259,9 +259,9 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            ls ./Users/vagrant/git/Tests\ iOS/
-            cp -r ./Users/vagrant/git/Tests\ iOS/* .
-            mv ./Users/vagrant/git/* .
+            #ls ./Users/vagrant/git/Tests\ iOS/
+            #cp -r ./Users/vagrant/git/Tests\ iOS/* .
+            #mv ./Users/vagrant/git/* .
             ls -la
             echo "-- test-without-building --"
             xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,7 +12,8 @@ pipelines:
   build-test-pipeline:
     stages:
       # Run the buld and test stage workflows
-      - build-test: {}
+      - build: {}
+      - test: {}
   app-store-pipeline:
     stages:
       # First Build the release build (app store build)
@@ -26,12 +27,15 @@ pipelines:
       # Run the steps to deploy to testflight internally
       - deploy-internal-testflight: {}
 stages:
-  build-test:
+  build:
+    workflows:
+      - configure_build: {}
+  test:
     workflows:
       # Run the test and qa build flow in parallel
       - test_1: {}
-      - test_2: {}
-      - test_3: {}
+      #- test_2: {}
+      #- test_3: {}
       - qa-build: {}
   release-build:
     workflows:
@@ -191,23 +195,91 @@ workflows:
       - _setup
     after_run:
       - _upload_sentry
-
-  test_1:
+  configure_build:
     steps:
       - file-downloader@1:
           inputs:
             - source: '$BITRISEIO_SECRETS_TEST_URL'
             - destination: '$BITRISE_SOURCE_DIR/Config/secrets.xcconfig'
           title: Install test secrets.xcconfig
-      - xcode-test@4:
+      - git::https://github.com/DamienBitrise/bitrise-test-plan-sharder.git@master:
+          title: Bitrise Test Plan Sharder
           inputs:
-            - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
-            - test_plan: UITests
-      - deploy-to-bitrise-io@2: {}
+          - xcode_project: Pocket.xcodeproj
+          - target: Pocket
+          - shards: '3'
+          - scheme: Pocket (iOS)
+          - test_plan: UITests.xctestplan
+          - debug_mode: 'true'
+          - test_path: ''
+          - file_type: ".swift"
+      - script@1.1:
+        title: Build for Testing
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- build-for-testing --"
+            mkdir DerivedData
+            xcodebuild "-project" "/Users/vagrant/git/Pocket.xcodeproj" "-scheme" "Pocket (iOS)" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 14,OS=latest" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_test.log
+      - script@1.1:
+        title: Compress Derived Data
+        is_always_run: true
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "-- compress --"
+            exec zip -0 -qr "${BITRISE_SOURCE_DIR}/DerivedData.zip" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Pocket.app" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/Tests\ iOS-Runner" \
+            "$BITRISE_SOURCE_DIR/Pocket.xcodeproj" \
+            "$BITRISE_SOURCE_DIR/UITests.xctestplan" \
+            "$BITRISE_SOURCE_DIR/UITests-2.xctestplan" \
+            "$BITRISE_SOURCE_DIR/Tests/UnitTests.xctestplan" \
+            "$BITRISE_SOURCE_DIR/xcodebuild.log" \
+            "$BITRISE_SOURCE_DIR/DerivedData/Build/Products/Debug_Test-iphonesimulator/" \
+            "$BITRISE_SOURCE_DIR/PocketKit/" \
+            "$BITRISE_SOURCE_DIR/Tests\ iOS"
+      - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "${BITRISE_SOURCE_DIR}/DerivedData.zip"
     before_run:
       - _setup
     after_run:
       - _danger
+  test_1:
+    steps:
+      - git::https://github.com/bitrise-steplib/bitrise-step-artifact-pull.git@main:
+        title: Pull artifacts
+        inputs:
+        - verbose: true
+        - artifact_sources: build.*
+      - script@1.1:
+        title: Unzip
+        inputs:
+        - content: |
+            set -euxo pipefail
+            echo "$BITRISE_ARTIFACT_PATHS"
+            echo "-- unzip -- "
+            exec unzip "${BITRISE_ARTIFACT_PATHS}"
+            echo "show dir"
+            ls
+      - script@1.1:
+        title: Test without Building
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+            ls ./Users/vagrant/git/Tests\ iOS/
+            cp -r ./Users/vagrant/git/Tests\ iOS/* .
+            mv ./Users/vagrant/git/* .
+            ls -la
+            echo "-- test-without-building --"
+            xcodebuild -project "Pocket.xcodeproj" -scheme "Pocket (iOS)" -resultBundlePath "xcodebuild.xcresult" -derivedDataPath "/Users/vagrant/git/DerivedData" -testPlan "UITests" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test-without-building
+      - custom-test-results-export@0:
+        inputs:
+        - search_pattern: "$BITRISE_SOURCE_DIR/xcodebuild.xcresult"
+        - test_name: UITests
+      - deploy-to-bitrise-io@2: {}
   test_2:
     steps:
       - file-downloader@1:


### PR DESCRIPTION
I have seen that the `test` workflow takes around 20mins. 
![Screenshot 2022-10-11 at 16 37 25](https://user-images.githubusercontent.com/1897507/195153003-7752ee7a-b7dd-446d-8e1c-aa475d5092a8.png)

The proposal is to split the UI tests into test plans, and run each test plan in parallel. 
We have a similar approach on [firefox](https://github.com/mozilla-mobile/firefox-ios/blob/e643b1577929d581c826587dd4d076e42d96def3/bitrise.yml#L15) that allowed us to reduce build time by ~40%.

