### PR TITLE
IN-321: Add Tags to Save Extension

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -22,7 +22,7 @@ class SavedItemViewModel: ReadableViewModel {
     var presentedWebReaderURL: URL?
 
     @Published
-    var presentedAddTags: AddTagsViewModel?
+    var presentedAddTags: PocketAddTagsViewModel?
 
     @Published
     var sharedActivity: PocketActivity?
@@ -166,7 +166,7 @@ extension SavedItemViewModel {
     }
 
     private func showAddTagsView() {
-        presentedAddTags = AddTagsViewModel(
+        presentedAddTags = PocketAddTagsViewModel(
             item: item,
             source: source,
             saveAction: { [weak self] in

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -5,6 +5,7 @@ import Analytics
 import BackgroundTasks
 import SafariServices
 import SwiftUI
+import Textile
 
 protocol CompactHomeCoordinatorDelegate: AnyObject {
     func compactHomeCoordinatorDidSelectRecentSaves(_ coordinator: CompactHomeCoordinator)
@@ -249,7 +250,7 @@ class CompactHomeCoordinator: NSObject {
         viewController.present(UIAlertController(alert), animated: !isResetting)
     }
 
-    func present(_ viewModel: AddTagsViewModel?) {
+    func present(_ viewModel: PocketAddTagsViewModel?) {
         guard !isResetting, let viewModel = viewModel else { return }
         let hostingController = UIHostingController(rootView: AddTagsView(viewModel: viewModel))
         hostingController.modalPresentationStyle = .formSheet

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -4,12 +4,13 @@ import SafariServices
 import Analytics
 import Sync
 import Combine
+import Textile
 
 protocol ModalContentPresenting: AnyObject {
     func report(_ recommendation: Recommendation?)
     func present(_ url: URL?)
     func present(_ alert: PocketAlert?)
-    func present(_ viewModel: AddTagsViewModel?)
+    func present(_ viewModel: PocketAddTagsViewModel?)
     func present(_ readerSettings: ReaderSettings?, isPresenting: Bool?)
     func present(_ tagsFilterViewModel: TagsFilterViewModel?)
     func share(_ activity: PocketActivity?)
@@ -217,7 +218,7 @@ extension RegularMainCoordinator: ModalContentPresenting {
         splitController.setViewController(readerRoot, for: .secondary)
     }
 
-    func present(_ viewModel: AddTagsViewModel?) {
+    func present(_ viewModel: PocketAddTagsViewModel?) {
         guard !isResetting, let viewModel = viewModel else { return }
 
         let hostingController = UIHostingController(rootView: AddTagsView(viewModel: viewModel))

--- a/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMyListCoordinator.swift
@@ -149,7 +149,7 @@ extension RegularMyListCoordinator {
         delegate?.present(alert)
     }
 
-    private func present(viewModel: AddTagsViewModel?) {
+    private func present(viewModel: PocketAddTagsViewModel?) {
         delegate?.present(viewModel)
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -25,7 +25,7 @@ class ArchivedItemsListViewModel: ItemsListViewModel {
     var presentedAlert: PocketAlert?
 
     @Published
-    var presentedAddTags: AddTagsViewModel?
+    var presentedAddTags: PocketAddTagsViewModel?
 
     @Published
     var presentedTagsFilter: TagsFilterViewModel?
@@ -314,7 +314,7 @@ extension ArchivedItemsListViewModel {
 // MARK: - Tags
 extension ArchivedItemsListViewModel {
     private func showAddTagsView(item: SavedItem) {
-        presentedAddTags = AddTagsViewModel(
+        presentedAddTags = PocketAddTagsViewModel(
             item: item,
             source: source,
             saveAction: { [weak self] in

--- a/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactMyListContainerCoordinator.swift
@@ -2,6 +2,7 @@ import UIKit
 import Combine
 import SafariServices
 import SwiftUI
+import Textile
 
 class CompactMyListContainerCoordinator: NSObject {
     var viewController: UIViewController {
@@ -164,7 +165,7 @@ class CompactMyListContainerCoordinator: NSObject {
         viewController.present(UIAlertController(alert), animated: !isResetting)
     }
 
-    private func present(viewModel: AddTagsViewModel?) {
+    private func present(viewModel: PocketAddTagsViewModel?) {
         guard !isResetting, let viewModel = viewModel else { return }
         let hostingController = UIHostingController(rootView: AddTagsView(viewModel: viewModel))
         hostingController.modalPresentationStyle = .formSheet

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -21,7 +21,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     var presentedAlert: PocketAlert?
 
     @Published
-    var presentedAddTags: AddTagsViewModel?
+    var presentedAddTags: PocketAddTagsViewModel?
 
     @Published
     var presentedTagsFilter: TagsFilterViewModel?
@@ -492,7 +492,7 @@ extension SavedItemsListViewModel: SavedItemsControllerDelegate {
 // MARK: - Add Tags to an item
 extension SavedItemsListViewModel {
     private func showAddTagsView(item: SavedItem) {
-        presentedAddTags = AddTagsViewModel(
+        presentedAddTags = PocketAddTagsViewModel(
             item: item,
             source: source,
             saveAction: { [weak self] in

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -30,7 +30,9 @@ struct SettingsView: View {
                 Section(header: Text("Your Account").style(.settings.header)) {
                     SettingsRowButton(title: "Sign Out", titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
                 }
-                .alert("Are you sure?", isPresented: $model.isPresentingSignOutConfirm, actions: {
+                .alert("Are you sure?",
+                       isPresented: $model.isPresentingSignOutConfirm,
+                       actions: {
                     Button("Sign Out", role: .destructive) {
                         model.signOut()
                     }
@@ -38,7 +40,7 @@ struct SettingsView: View {
                     Text("You will be signed out of your account and any files that have been saved for offline viewing will be deleted.")
                 })
                 .textCase(nil)
-                
+
                 Section(header: Text("About & Support").style(.settings.header)) {
                     SettingsRowButton(title: "Help", icon: SFIconModel("questionmark.circle")) { model.isPresentingHelp.toggle() }
                         .sheet(isPresented: $model.isPresentingHelp) {

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -15,7 +15,7 @@ class PocketAddTagsViewModel: AddTagsViewModel {
         self.source = source
         self.saveAction = saveAction
 
-        tags = item.tags?.compactMap { $0 as? Tag }.map { $0.name ?? "" } ?? []
+        tags = item.tags?.compactMap { ($0 as? Tag)?.name } ?? []
     }
 
     func addTags() {

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -1,0 +1,30 @@
+import Combine
+import Sync
+import Textile
+
+class PocketAddTagsViewModel: AddTagsViewModel {
+    private let item: SavedItem
+    private let source: Source
+    private let saveAction: () -> Void
+
+    @Published
+    var tags: [String] = []
+
+    init(item: SavedItem, source: Source, saveAction: @escaping () -> Void) {
+        self.item = item
+        self.source = source
+        self.saveAction = saveAction
+
+        tags = item.tags?.compactMap { $0 as? Tag }.map { $0.name ?? "" } ?? []
+    }
+
+    func addTags() {
+        source.addTags(item: item, tags: tags)
+        saveAction()
+    }
+
+    func allOtherTags() -> [String]? {
+        let fetchedTags = source.retrieveTags(excluding: tags)
+        return fetchedTags?.compactMap { $0.name }
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -26,7 +26,7 @@ class LoggedOutViewModel {
             configuration.background.backgroundColor = UIColor(.ui.teal2)
             configuration.background.cornerRadius = 13
             configuration.contentInsets = NSDirectionalEdgeInsets(top: 13, leading: 0, bottom: 13, trailing: 0)
-            configuration.attributedTitle = AttributedString(NSAttributedString(string: "Log in to Pocket", style: .logIn))
+            configuration.attributedTitle = AttributedString(NSAttributedString(string: "Log in to Pocket", style: .buttonText))
             actionButtonConfiguration = configuration
         }
     }

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -28,7 +28,7 @@ class MainViewController: UIViewController {
                 viewModel: SavedItemViewModel(
                     appSession: appSession,
                     saveService: services.saveService,
-                    dismissTimer: Timer.TimerPublisher(interval: 2.1, runLoop: .main, mode: .default)
+                    dismissTimer: Timer.TimerPublisher(interval: 3.0, runLoop: .main, mode: .default)
                 )
             )
         }

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -15,7 +15,7 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
         self.retrieveAction = retrieveAction
         self.saveAction = saveAction
 
-        tags = item?.tags?.compactMap { $0 as? Tag }.map { $0.name ?? "" } ?? []
+        tags = item?.tags?.compactMap { ($0 as? Tag)?.name } ?? []
     }
 
     func addTags() {

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -1,0 +1,29 @@
+import Combine
+import Sync
+import Textile
+
+class SaveToAddTagsViewModel: AddTagsViewModel {
+    private let item: SavedItem?
+    private let retrieveAction: ([String]) -> [Tag]?
+    private let saveAction: ([String]) -> Void
+
+    @Published
+    var tags: [String] = []
+
+    init(item: SavedItem?, retrieveAction: @escaping ([String]) -> [Tag]?, saveAction: @escaping ([String]) -> Void) {
+        self.item = item
+        self.retrieveAction = retrieveAction
+        self.saveAction = saveAction
+
+        tags = item?.tags?.compactMap { $0 as? Tag }.map { $0.name ?? "" } ?? []
+    }
+
+    func addTags() {
+        saveAction(tags)
+    }
+
+    func allOtherTags() -> [String]? {
+        let fetchedTags = retrieveAction(tags)
+        return fetchedTags?.compactMap { $0.name }
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -48,7 +48,7 @@ class SavedItemViewModel {
             case .newItem(let savedItem):
                 self.savedItem = savedItem
                 infoViewModel = .newItem
-            case .taggedItem(_):
+            case .taggedItem:
                 break
             }
 

--- a/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
@@ -1,7 +1,7 @@
 import Textile
 
 extension Style {
-    static let logIn: Self = .header.sansSerif.h8.with(color: .ui.white)
+    static let buttonText: Self = .header.sansSerif.h8.with(color: .ui.white)
 
     static func coloredMainText(color: ColorAsset) -> Style {
         .header.sansSerif.h2.with(color: color).with { $0.with(lineHeight: .explicit(36)).with(verticalAlignment: .center) }

--- a/PocketKit/Sources/Sync/SaveService.swift
+++ b/PocketKit/Sources/Sync/SaveService.swift
@@ -1,10 +1,20 @@
 import Foundation
 
 public enum SaveServiceStatus {
-    case existingItem
-    case newItem
+    case existingItem(SavedItem)
+    case newItem(SavedItem)
+    case taggedItem(SavedItem)
+
+    var savedItem: SavedItem {
+        switch self {
+        case .existingItem(let savedItem), .newItem(let savedItem), .taggedItem(let savedItem):
+            return savedItem
+        }
+    }
 }
 
 public protocol SaveService {
     func save(url: URL) -> SaveServiceStatus
+    func retrieveTags(excluding tags: [String]) -> [Tag]?
+    func addTags(savedItem: SavedItem, tags: [String]) -> SaveServiceStatus
 }

--- a/PocketKit/Sources/Textile/Views/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/Textile/Views/Tags/AddTagsView.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 import UIKit
-import Textile
+import Combine
 
-struct AddTagsView: View {
-    enum Constants {
-        static let tagsHorizontalSpacing: CGFloat = 6
-        static let tagPadding: CGFloat = 4
-    }
+enum Constants {
+    static let tagsHorizontalSpacing: CGFloat = 6
+    static let tagPadding: CGFloat = 4
+}
+
+public struct AddTagsView<ViewModel>: View where ViewModel: AddTagsViewModel {
 
     @ObservedObject
-    var viewModel: AddTagsViewModel
+    var viewModel: ViewModel
 
     @State
     private var newTag: String = ""
@@ -20,7 +21,11 @@ struct AddTagsView: View {
     @FocusState
     private var isTextFieldFocused: Bool
 
-    var body: some View {
+    public init(viewModel: ViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
         GeometryReader { geometry in
             NavigationView {
                 VStack {
@@ -61,13 +66,12 @@ struct AddTagsView: View {
                 .animation(.easeInOut, value: viewModel.tags)
             }
         }
-
         .accessibilityIdentifier("add-tags")
     }
 
     struct InputTagsView: View {
         @ObservedObject
-        var viewModel: AddTagsViewModel
+        var viewModel: ViewModel
 
         @Namespace
         var animation
@@ -140,7 +144,7 @@ struct AddTagsView: View {
 
     struct OtherTagsView: View {
         @ObservedObject
-        var viewModel: AddTagsViewModel
+        var viewModel: ViewModel
 
         var body: some View {
             if let otherTags = viewModel.allOtherTags(), !otherTags.isEmpty {

--- a/PocketKit/Sources/Textile/Views/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/Textile/Views/Tags/AddTagsViewModel.swift
@@ -1,22 +1,16 @@
 import Combine
-import Sync
 
-class AddTagsViewModel: ObservableObject {
-    private let item: SavedItem
-    private let source: Source
-    private let saveAction: () -> Void
+public protocol AddTagsViewModel: ObservableObject {
+    var placeholderText: String { get }
+    var emptyStateText: String { get }
+    var tags: [String] { get set }
+    func addTag(with tag: String) -> Bool
+    func addTags()
+    func allOtherTags() -> [String]?
+    func removeTag(with tag: String)
+}
 
-    @Published
-    var tags: [String] = []
-
-    init(item: SavedItem, source: Source, saveAction: @escaping () -> Void) {
-        self.item = item
-        self.source = source
-        self.saveAction = saveAction
-
-        tags = item.tags?.compactMap { $0 as? Tag }.map { $0.name ?? "" } ?? []
-    }
-
+public extension AddTagsViewModel {
     var placeholderText: String {
         "Enter tag name..."
     }
@@ -33,16 +27,6 @@ class AddTagsViewModel: ObservableObject {
         }
         tags.append(tagName)
         return true
-    }
-
-    func addTags() {
-        source.addTags(item: item, tags: tags)
-        saveAction()
-    }
-
-    func allOtherTags() -> [String]? {
-        let fetchedTags = source.retrieveTags(excluding: tags)
-        return fetchedTags?.compactMap { $0.name }
     }
 
     func removeTag(with tag: String) {

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Sync
 @testable import PocketKit
 
-class AddTagsViewModelTests: XCTestCase {
+class PocketAddTagsViewModelTests: XCTestCase {
     private var source: MockSource!
     private var space: Space!
 
@@ -17,8 +17,8 @@ class AddTagsViewModelTests: XCTestCase {
         try space.clear()
     }
 
-    private func subject(item: SavedItem, source: Source? = nil, saveAction: @escaping () -> Void) -> AddTagsViewModel {
-        AddTagsViewModel(item: item, source: source ?? self.source, saveAction: saveAction)
+    private func subject(item: SavedItem, source: Source? = nil, saveAction: @escaping () -> Void) -> PocketAddTagsViewModel {
+        PocketAddTagsViewModel(item: item, source: source ?? self.source, saveAction: saveAction)
     }
 
     func test_addTag_withValidName_updatesTags() {

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import Sync
+
+@testable import Sync
+@testable import SaveToPocketKit
+
+class SaveToAddTagsViewModelTests: XCTestCase {
+    private var space: Space!
+
+    override func setUp() {
+        space = .testSpace()
+    }
+
+    override func tearDown() async throws {
+        try space.clear()
+    }
+
+    private func subject(item: SavedItem, retrieveAction: @escaping ([String]) -> [Tag]?, saveAction: @escaping ([String]) -> Void) -> SaveToAddTagsViewModel {
+        SaveToAddTagsViewModel(item: item, retrieveAction: retrieveAction, saveAction: saveAction)
+    }
+
+    func test_addTag_withValidName_updatesTags() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { _ in }
+        viewModel.tags = ["tag 1"]
+        let isValidTag = viewModel.addTag(with: "tag 2")
+
+        XCTAssertTrue(isValidTag)
+        XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2"])
+    }
+
+    func test_addTag_withAlreadyExistingName_doesNotUpdateTags() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { _ in }
+        viewModel.tags = ["tag 1"]
+        let isValidTag = viewModel.addTag(with: "tag 1")
+
+        XCTAssertFalse(isValidTag)
+        XCTAssertEqual(viewModel.tags, ["tag 1"])
+    }
+
+    func test_addTag_withWhitespaceName_doesNotUpdateTags() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { _ in }
+        viewModel.tags = ["tag 1"]
+        let isValidTag = viewModel.addTag(with: "  ")
+
+        XCTAssertFalse(isValidTag)
+        XCTAssertEqual(viewModel.tags, ["tag 1"])
+    }
+
+    func test_addTags_delegatesToSaveServiceAndCallsSaveAction() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { tags in
+            XCTAssert(true, "expect call to save action")
+            var tags: [Tag] = []
+            for index in 1...2 {
+                let tag: Tag = self.space.new()
+                tag.name = "tag \(index)"
+                tags.append(tag)
+            }
+            item.tags = NSOrderedSet(array: tags.compactMap { $0 })
+        }
+
+        viewModel.addTags()
+        XCTAssertEqual(item.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"])
+    }
+
+    func test_allOtherTags_retrievesValidTagNames() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let viewModel = subject(
+            item: item,
+            retrieveAction: { _ in
+            var tags: [Tag] = []
+            for index in 2...3 {
+                let tag: Tag = self.space.new()
+                tag.name = "tag \(index)"
+                tags.append(tag)
+            }
+            return tags
+        }) { _ in
+        }
+
+        guard let tags = viewModel.allOtherTags() else {
+            XCTFail("tags should not be nil")
+            return
+        }
+
+        XCTAssertEqual(tags, ["tag 2", "tag 3"])
+    }
+
+    func test_removeTag_withValidName_updatesTags() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { _ in }
+        viewModel.tags = ["tag 1", "tag 2", "tag 3"]
+        viewModel.removeTag(with: "tag 2")
+
+        XCTAssertEqual(viewModel.tags, ["tag 1", "tag 3"])
+    }
+
+    func test_removeTag_withNotExistingName_updatesTags() {
+        let item = space.buildSavedItem(tags: ["tag 1"])
+        let retrieveAction: ([String]) -> [Tag]? = { _ in
+            return nil
+        }
+        let viewModel = subject(item: item, retrieveAction: retrieveAction) { _ in }
+        viewModel.tags = ["tag 1", "tag 2", "tag 3"]
+        viewModel.removeTag(with: "tag 4")
+
+        XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2", "tag 3"])
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
@@ -8,7 +8,7 @@ class MockSaveService: SaveService {
 
 extension MockSaveService {
     private static let saveImpl = "CallImpl"
-    typealias SaveImpl = (URL) -> SaveServiceStatus
+    typealias SaveImpl = (URL) -> Sync.SaveServiceStatus
 
     struct SaveCall {
         let url: URL
@@ -22,12 +22,83 @@ extension MockSaveService {
         calls[Self.saveImpl]?[index] as? SaveCall
     }
 
-    func save(url: URL) -> SaveServiceStatus {
+    func save(url: URL) ->  Sync.SaveServiceStatus {
         guard let impl = implementations[Self.saveImpl] as? SaveImpl else {
             fatalError("\(Self.self).\(#function) is not stubbed")
         }
 
         calls[Self.saveImpl] = (calls[Self.saveImpl] ?? []) + [SaveCall(url: url)]
         return impl(url)
+    }
+}
+
+// MARK: - Retrieve Tags
+extension MockSaveService {
+    private static let retrieveTags = "retrieveTags"
+    typealias RetrieveTagsImpl = ([String]) -> [Tag]?
+
+    struct RetrieveTagsImplCall {
+        let tags: [String]
+    }
+
+    func stubRetrieveTags(impl: @escaping RetrieveTagsImpl) {
+        implementations[Self.retrieveTags] = impl
+    }
+
+    func retrieveTags(excluding tags: [String]) -> [Tag]? {
+        guard let impl = implementations[Self.retrieveTags] as? RetrieveTagsImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.retrieveTags] = (calls[Self.retrieveTags] ?? []) + [
+            RetrieveTagsImplCall(tags: tags)
+        ]
+
+        return impl(tags)
+    }
+
+    func retrieveTagsCall(at index: Int) -> RetrieveTagsImplCall? {
+        guard let calls = calls[Self.retrieveTags],
+              calls.count > index else {
+                  return nil
+              }
+
+        return calls[index] as? RetrieveTagsImplCall
+    }
+}
+
+// MARK: - Add Tags
+extension MockSaveService {
+    private static let addTags = "addTags"
+    typealias AddTagsImpl = (SavedItem, [String]?) -> SaveServiceStatus
+
+    struct AddTagsImplCall {
+        let savedItem: SavedItem
+        let tags: [String]?
+    }
+
+    func stubAddTags(impl: @escaping AddTagsImpl) {
+        implementations[Self.addTags] = impl
+    }
+
+    func addTags(savedItem: SavedItem, tags: [String]) -> SaveServiceStatus {
+        guard let impl = implementations[Self.addTags] as? AddTagsImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.addTags] = (calls[Self.addTags] ?? []) + [
+            AddTagsImplCall(savedItem: savedItem, tags: tags)
+        ]
+
+        return impl(savedItem, tags)
+    }
+
+    func addTagsCall(at index: Int) -> AddTagsImplCall? {
+        guard let calls = calls[Self.addTags],
+              calls.count > index else {
+                  return nil
+              }
+
+        return calls[index] as? AddTagsImplCall
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,0 +1,11 @@
+import Sync
+
+extension PersistentContainer {
+    static let testContainer = PersistentContainer(storage: .inMemory)
+}
+
+extension Space {
+    static func testSpace() -> Space {
+        Space(context: PersistentContainer.testContainer.viewContext)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -274,4 +274,3 @@ extension Space {
         }
     }
 }
-

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -1,0 +1,277 @@
+import Foundation
+@testable import Sync
+
+// MARK: - SavedItem
+extension Space {
+    @discardableResult
+    func createSavedItem(
+        remoteID: String = "saved-item-1",
+        url: String = "http://example.com/item-1",
+        isFavorite: Bool = false,
+        isArchived: Bool = false,
+        createdAt: Date = Date(),
+        archivedAt: Date? = nil,
+        cursor: String? = nil,
+        tags: [String]? = nil,
+        item: Item? = nil
+    ) throws -> SavedItem {
+        try context.performAndWait {
+            let savedItem = buildSavedItem(
+                remoteID: remoteID,
+                url: url,
+                isFavorite: isFavorite,
+                isArchived: isArchived,
+                createdAt: createdAt,
+                archivedAt: archivedAt,
+                cursor: cursor,
+                tags: tags,
+                item: item
+            )
+            try save()
+
+            return savedItem
+        }
+    }
+
+    @discardableResult
+    func buildSavedItem(
+        remoteID: String = "saved-item-1",
+        url: String = "http://example.com/item-1",
+        isFavorite: Bool = false,
+        isArchived: Bool = false,
+        createdAt: Date = Date(),
+        archivedAt: Date? = nil,
+        cursor: String? = nil,
+        tags: [String]? = nil,
+        item: Item? = nil
+    ) -> SavedItem {
+        context.performAndWait {
+            let savedItem: SavedItem = new()
+            let tags: [Tag]? = tags?.map { tag -> Tag in
+                let newTag: Tag = new()
+                newTag.name = tag
+                return newTag
+            }
+            savedItem.remoteID = remoteID
+            savedItem.isFavorite = isFavorite
+            savedItem.isArchived = isArchived
+            savedItem.createdAt = createdAt
+            savedItem.archivedAt = archivedAt
+            savedItem.url = URL(string: url)!
+            savedItem.cursor = cursor
+            savedItem.tags = NSOrderedSet(array: tags ?? [])
+            savedItem.item = item ?? new()
+
+            return savedItem
+        }
+    }
+
+    @discardableResult
+    func buildPendingSavedItem() -> SavedItem {
+        context.performAndWait {
+            let savedItem: SavedItem = new()
+            return savedItem
+        }
+    }
+}
+
+// MARK: - Item
+extension Space {
+    @discardableResult
+    func createItem(
+        remoteID: String = "item-1",
+        title: String = "Item 1",
+        givenURL: URL? = URL(string: "https://example.com/items/item-1"),
+        isArticle: Bool = true,
+        article: Article? = nil
+    ) throws -> Item {
+        try context.performAndWait {
+            let item = buildItem(
+                remoteID: remoteID,
+                title: title,
+                givenURL: givenURL,
+                isArticle: isArticle,
+                article: article
+            )
+            try save()
+
+            return item
+        }
+    }
+
+    @discardableResult
+    func buildItem(
+        remoteID: String = "item-1",
+        title: String = "Item 1",
+        givenURL: URL? = URL(string: "https://example.com/items/item-1"),
+        resolvedURL: URL? = nil,
+        isArticle: Bool = true,
+        article: Article? = nil
+    ) -> Item {
+        context.performAndWait {
+            let item: Item = new()
+            item.remoteID = remoteID
+            item.title = title
+            item.givenURL = givenURL
+            item.resolvedURL = resolvedURL
+            item.isArticle = isArticle
+            item.article = article
+
+            return item
+        }
+    }
+}
+
+// MARK: - SlateLineup
+extension Space {
+    @discardableResult
+    func createSlateLineup(
+        remoteID: String = "slate-lineup-1",
+        requestID: String = "slate-lineup-1-request",
+        experimentID: String = "slate-lineup-1-experiment",
+        slates: [Slate] = []
+    ) throws -> SlateLineup {
+        try context.performAndWait {
+            let slateLineup = buildSlateLineup(
+                remoteID: remoteID,
+                requestID: requestID,
+                experimentID: experimentID,
+                slates: slates
+            )
+
+            try save()
+            return slateLineup
+        }
+    }
+
+    @discardableResult
+    func buildSlateLineup(
+        remoteID: String = "slate-lineup-1",
+        requestID: String = "slate-lineup-1-request",
+        experimentID: String = "slate-lineup-1-experiment",
+        slates: [Slate] = []
+    ) -> SlateLineup {
+        context.performAndWait {
+            let lineup: SlateLineup = new()
+            lineup.remoteID = remoteID
+            lineup.requestID = requestID
+            lineup.experimentID = experimentID
+            lineup.slates = NSOrderedSet(array: slates)
+
+            return lineup
+        }
+    }
+}
+
+// MARK: - Slate
+extension Space {
+    @discardableResult
+    func createSlate(
+        experimentID: String = "slate-1-experiment",
+        remoteID: String = "slate-1",
+        name: String = "Slate 1",
+        requestID: String = "slate-1-request",
+        slateDescription: String = "The description of slate 1",
+        recommendations: [Recommendation] = []
+    ) throws -> Slate {
+        try context.performAndWait {
+            let slate = buildSlate(
+                experimentID: experimentID,
+                remoteID: remoteID,
+                name: name,
+                requestID: requestID,
+                slateDescription: slateDescription,
+                recommendations: recommendations
+            )
+
+            try save()
+            return slate
+        }
+    }
+
+    @discardableResult
+    func buildSlate(
+        experimentID: String = "slate-1-experiment",
+        remoteID: String = "slate-1",
+        name: String = "Slate 1",
+        requestID: String = "slate-1-request",
+        slateDescription: String = "The description of slate 1",
+        recommendations: [Recommendation] = []
+    ) -> Slate {
+        context.performAndWait {
+            let slate: Slate = new()
+            slate.experimentID = experimentID
+            slate.remoteID = remoteID
+            slate.name = name
+            slate.requestID = requestID
+            slate.slateDescription = slateDescription
+            slate.recommendations = NSOrderedSet(array: recommendations)
+
+            return slate
+        }
+    }
+}
+
+// MARK: - Recommendation
+extension Space {
+    @discardableResult
+    func createRecommendation(
+        remoteID: String = "slate-1-rec-1",
+        item: Item? = nil
+    ) throws -> Recommendation {
+        try context.performAndWait {
+            let recommendation = buildRecommendation(
+                remoteID: remoteID,
+                item: item
+            )
+
+            try save()
+            return recommendation
+        }
+    }
+
+    @discardableResult
+    func buildRecommendation(
+        remoteID: String = "slate-1-rec-1",
+        item: Item? = nil
+    ) -> Recommendation {
+        context.performAndWait {
+            let recommendation: Recommendation = new()
+            recommendation.remoteID = remoteID
+            recommendation.item = item
+
+            return recommendation
+        }
+    }
+}
+
+// MARK: - Image
+extension Space {
+    @discardableResult
+    func buildImage(
+        source: URL?,
+        isDownloaded: Bool = false
+    ) -> Image {
+        return context.performAndWait {
+            let image: Image = new()
+            image.source = source
+            image.isDownloaded = isDownloaded
+
+            return image
+        }
+    }
+
+    @discardableResult
+    func createImage(
+        source: URL?,
+        isDownloaded: Bool = false
+    ) throws -> Image {
+        return try context.performAndWait {
+            let image = buildImage(source: source, isDownloaded: isDownloaded)
+            try save()
+
+            return image
+        }
+    }
+}
+

--- a/PocketKit/Tests/SyncTests/Fixtures/add-tags.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/add-tags.json
@@ -1,0 +1,61 @@
+{
+    "data": {
+        "replaceSavedItemTags": [
+            {
+                "__typename": "[type-name-here]",
+                "remoteID": "saved-item-1",
+                "url": "https://example.com/item-1",
+                "_createdAt": 0,
+                "_deletedAt": null,
+                "archivedAt": null,
+                "isArchived": false,
+                "isFavorite": false,
+                "tags": [
+                    {
+                        "__typename": "Tag",
+                        "id": "id-1",
+                        "name": "tag-1"
+                    },
+                    {
+                        "__typename": "Tag",
+                        "id": "id-2",
+                        "name": "tag-2"
+                    }
+                ],
+                "item": {
+                    "__typename": "Item",
+                    "remoteID": "item-1",
+                    "givenUrl": "https://given.example.com/item-1",
+                    "resolvedUrl": "https://resolved.example.com/item-1",
+                    "title": "Item 1",
+                    "topImageUrl": "https://example.com/item-1/top-image.jpg",
+                    "domain": null,
+                    "language": "en",
+                    "timeToRead": 6,
+                    "marticle": [],
+                    "excerpt": "Cursus Aenean Elit",
+                    "datePublished": "2021-01-01 12:01:01",
+                    "authors": [],
+                    "domainMetadata": {
+                        "__typename": "[type-name-here]",
+                        "name": "WIRED",
+                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                    },
+                    "images": [
+                        {
+                            "__typename": "[type-name-here]",
+                            "height": 1,
+                            "width": 2,
+                            "src": "http://example.com/item-1/image-1.jpg",
+                            "imageId": 1
+                        }
+                    ],
+                    "isArticle": true,
+                    "hasImage": "HAS_IMAGES",
+                    "hasVideo": "HAS_VIDEOS",
+                    "syndicatedArticle": null
+                }
+            }
+        ]
+    }
+}

--- a/PocketKit/Tests/SyncTests/Fixtures/update-tags.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/update-tags.json
@@ -1,20 +1,16 @@
 {
     "data": {
-        "upsertSavedItem": {
+        "updateSavedItemRemoveTags": 
+        {
             "__typename": "[type-name-here]",
             "remoteID": "saved-item-1",
             "url": "https://example.com/item-1",
             "_createdAt": 0,
             "_deletedAt": null,
+            "archivedAt": null,
             "isArchived": false,
             "isFavorite": false,
-            "tags": [
-                {
-                    "__typename": "Tag",
-                    "id": "id-1",
-                    "name": "tag-1"
-                }
-            ],
+            "tags": [],
             "item": {
                 "__typename": "Item",
                 "remoteID": "item-1",
@@ -46,6 +42,7 @@
                 "isArticle": true,
                 "hasImage": "HAS_IMAGES",
                 "hasVideo": "HAS_VIDEOS",
+                "syndicatedArticle": null
             }
         }
     }

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -45,4 +45,42 @@ class SaveToPocketTests: XCTestCase {
 
         app.loggedOutView.wait()
     }
+
+    func test_userAddTags_showsConfirmationView() {
+        app.launch()
+
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        safari.launch()
+
+        safari.textFields["Address"].tap()
+        safari.typeText("http://localhost:8080/hello\n")
+        safari.staticTexts["Hello, world"].wait()
+        safari.toolbars.buttons["ShareButton"].tap()
+        let activityView = safari.descendants(matching: .other)["ActivityListView"].wait()
+
+        activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 1).tap()
+        safari.buttons["add-tags-button"].wait().tap()
+
+        let addTagsView = AddTagsViewElement(safari.otherElements["add-tags"])
+
+        addTagsView.wait()
+        addTagsView.newTagTextField.tap()
+        addTagsView.newTagTextField.typeText("Tag 1")
+        addTagsView.newTagTextField.typeText("\n")
+
+        addTagsView.tag(matching: "tag 1").wait()
+
+        server.routes.post("/graphql") { request, _ in
+            Response.savedItemWithTag()
+        }
+
+        addTagsView.saveButton.tap()
+        safari.staticTexts["Tags Added!"].wait()
+        safari.staticTexts["Tap to Dismiss"].tap()
+
+        safari.toolbars.buttons["ShareButton"].tap()
+        activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 1).tap()
+        safari.buttons["add-tags-button"].wait().tap()
+        addTagsView.tag(matching: "tag 1").wait()
+    }
 }


### PR DESCRIPTION
## Summary
Added the ability for users to add tags to a Saved Item via Save Extension

## References 
IN-321

## Implementation Details
* Move `AddTagsView` into the shared UI Component `Textile` and created a two view models (one for PocketKit and one for SaveTo Extension) which both conform to `AddTagsViewModel` protocol. Modified the `PocketSaveService` to be able to send the GraphQL mutations related to tags and update the saved item accordingly. Added a new `infoViewModel` called `.taggedItem` to show the user a confirmation view.
* Change the copy of existing item from `You've already saved this before. We'll move it to the top of your list.` to `You've already saved this. We'll move it to the top of your list.` as confirmed with product.
* Extended dismiss timer as it disappeared too quickly

## Test Steps
- [ ] Given that a user saves item to pocket using shared menu, 
and the user taps on Add Tags button, 
then the user should be able to view the Add Tags screen. 

- [ ] Given that sees the Add Tags view via shared extension, 
and the user interacts with it, 
then the behavior should be the same as general Add Tags feature.

- [ ] Given that a user saves a tag, 
then the user should view a confirmation page.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://user-images.githubusercontent.com/6743397/195681326-4f7ac0f0-fa34-4fd8-aaa4-b420dc6553a6.mp4

