### PR TITLE
fix(bitrise): move back to larger machines for now

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -222,5 +222,5 @@ app:
       SKIP_APOLLO_CODEGEN: '1'
 meta:
   bitrise.io:
-    machine_type_id: g2.4core
+    machine_type_id: g2.12core
     stack: osx-xcode-14.0.x


### PR DESCRIPTION
## Summary
When we moved to smaller machines the tests got very flaky in our CI.  

For now, we have the approval to put this back and look into this at a later date.