### PR TITLE
ci(swiftlint): SwiftLint Updates

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,17 +7,12 @@ disabled_rules: # rule identifiers to exclude from running
   # Disabled all default rules
   - block_based_kvo
   - closure_parameter_position
-  - compiler_protocol_init
-  - computed_accessors_order
   - custom_rules
   - cyclomatic_complexity
   - deployment_target
   - discouraged_direct_init
   - discarded_notification_center_observer
-  - duplicate_enum_cases
   - duplicate_imports
-  - duplicated_key_in_dictionary_literal
-  - dynamic_inline
   - fallthrough
   - file_length
   - for_where
@@ -27,9 +22,6 @@ disabled_rules: # rule identifiers to exclude from running
   - function_parameter_count
   - generic_type_name
   - identifier_name
-  - implicit_getter
-  - inclusive_language
-  - inert_defer
   - is_disjoint
   - legacy_hashing
   - legacy_random
@@ -79,8 +71,12 @@ opt_in_rules: # some rules are only opt-in
   # - redundant_type_annotation
   # Find all the available rules by running:
   # swiftlint rules
-
+  - anyobject_protocol
+  - array_init
+  - attributes
+  - capture_variable
   - closing_brace
+  - closure_spacing
   - contains_over_filter_count
   - contains_over_filter_is_empty
   - contains_over_first_not_nil
@@ -91,10 +87,10 @@ opt_in_rules: # some rules are only opt-in
   - empty_xctest_method
   - duplicate_imports
   - duplicate_enum_cases
+  - multiline_arguments_brackets
   - multiline_arguments
   - opening_brace
   - return_arrow_whitespace
-  - multiline_arguments_brackets
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build

--- a/PocketKit/Sources/PocketKit/Activity/CopyLinkActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/CopyLinkActivity.swift
@@ -24,7 +24,7 @@ class CopyLinkActivity: UIActivity {
     }
 
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
-        let first = activityItems.first(where: {$0 is URL})
+        let first = activityItems.first(where: { $0 is URL })
         return first != nil
     }
 

--- a/PocketKit/Sources/PocketKit/Activity/CopyLinkWithSelectionActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/CopyLinkWithSelectionActivity.swift
@@ -26,13 +26,13 @@ class CopyLinkWithSelectionActivity: UIActivity {
 
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
         let firstURL = activityItems.first(where: { $0 is URL })
-        let firstString  = activityItems.first(where: {  $0 is String })
+        let firstString  = activityItems.first(where: { $0 is String })
         return firstURL != nil && firstString != nil
     }
 
     override func prepare(withActivityItems activityItems: [Any]) {
         guard let link = activityItems.first(where: { $0 is URL }) as? URL,
-        let highlight = activityItems.first(where: { $0 is String}) as? String else {
+        let highlight = activityItems.first(where: { $0 is String }) as? String else {
             return
         }
 

--- a/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
@@ -44,11 +44,11 @@ class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, Art
     }
 
     var attributedContent: NSAttributedString? {
-        set {
-            textView.attributedText = newValue
-        }
         get {
             textView.attributedText
+        }
+        set {
+            textView.attributedText = newValue
         }
     }
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
@@ -27,7 +27,7 @@ class UnsupportedComponentPresenter: ArticleComponentPresenter {
     private func handleShowInWebReaderButtonTap() {
         readableViewModel?.showWebReader()
     }
-    
+
     private func handleArchiveArticleButtonTap() {
         readableViewModel?.archiveArticle()
     }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -6,7 +6,6 @@ import UIKit
 import Analytics
 
 class RecommendationViewModel: ReadableViewModel {
-    
     @Published
     private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
@@ -101,7 +100,7 @@ class RecommendationViewModel: ReadableViewModel {
     func showWebReader() {
         presentedWebReaderURL = url
     }
-    
+
     func archiveArticle() {
         archive()
     }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -66,7 +66,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     var authors: [ReadableAuthor]? {
-        recommendation.item?.authors?.compactMap { $0 as? Author}
+        recommendation.item?.authors?.compactMap { $0 as? Author }
     }
 
     var domain: String? {

--- a/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
@@ -70,7 +70,7 @@ public class AuthorizationClient {
                     continuation.resume(throwing: AuthorizationClient.Error.other(error))
                 } else if let url = url {
                     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                          let guid = components.queryItems?.first(where: {$0.name == "guid" })?.value,
+                          let guid = components.queryItems?.first(where: { $0.name == "guid" })?.value,
                           let token = components.queryItems?.first(where: { $0.name == "access_token" })?.value,
                           let userID = components.queryItems?.first(where: { $0.name == "id" })?.value else {
                               continuation.resume(throwing: AuthorizationClient.Error.invalidRedirect)

--- a/PocketKit/Sources/PocketKit/Banner/BannerView.swift
+++ b/PocketKit/Sources/PocketKit/Banner/BannerView.swift
@@ -139,7 +139,8 @@ extension BannerView {
         gestureRecognizer.addTarget(self, action: #selector(dismiss))
     }
 
-    @objc func dismiss() {
+    @objc
+    func dismiss() {
         guard let dismissAction = dismissAction else { return }
         dismissAction()
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -307,7 +307,7 @@ private extension UIConfigurationStateCustomKey {
 
 private extension UICellConfigurationState {
     var model: ItemsListItemCell.Model? {
-        set { self[.model] = newValue }
         get { return self[.model] as? ItemsListItemCell.Model }
+        set { self[.model] = newValue }
     }
 }

--- a/PocketKit/Sources/PocketKit/OnDismissHostingController.swift
+++ b/PocketKit/Sources/PocketKit/OnDismissHostingController.swift
@@ -14,7 +14,8 @@ class OnDismissHostingController<T: View>: UIHostingController<T> {
         }
     }
 
-    @MainActor @objc required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor @objc
+    required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
@@ -8,7 +8,8 @@ class ReaderSettingsViewController: OnDismissHostingController<ReaderSettingsVie
         )
     }
 
-    @MainActor @objc required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor @objc
+    required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/PocketKit/Sources/PocketKit/Settings/Components/PremiumRow.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/PremiumRow.swift
@@ -58,7 +58,7 @@ struct PremiumRow<Destination: View>: View {
                     SFIcon(SFIconModel("chevron.right", color: status.foreground))
                 }
                 .padding(.vertical, 5)
-                NavigationLink(destination: destination, isActive: $isActive) {EmptyView()}.hidden()
+                NavigationLink(destination: destination, isActive: $isActive) { EmptyView() }.hidden()
             }
         }.listRowBackground(status.background)
     }

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowLink.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowLink.swift
@@ -23,7 +23,7 @@ struct SettingsRowLink<Destination: View>: View {
                     SFIcon(icon)
                 }
                 .padding(.vertical, 5)
-                NavigationLink(destination: destination, isActive: $isActive) {EmptyView()}.hidden()
+                NavigationLink(destination: destination, isActive: $isActive) { EmptyView() }.hidden()
             }
         }
     }

--- a/PocketKit/Sources/SharedPocketKit/DeviceUtilities.swift
+++ b/PocketKit/Sources/SharedPocketKit/DeviceUtilities.swift
@@ -7,11 +7,9 @@ public class DeviceUtilities {
         case idfvUnavailable
 
         var errorDescription: String? {
-            get {
-                switch self {
-                case .idfvUnavailable:
-                    return "IDFV Identifier is currently unavailable"
-                }
+            switch self {
+            case .idfvUnavailable:
+                return "IDFV Identifier is currently unavailable"
             }
         }
     }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -57,10 +57,12 @@
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
+        <relationship name="savedItemUpdatedNotification" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItemUpdatedNotification" inverseName="savedItem" inverseEntity="SavedItemUpdatedNotification"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Tag" inverseName="savedItems" inverseEntity="Tag"/>
+        <relationship name="unresolvedSavedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UnresolvedSavedItem" inverseName="savedItem" inverseEntity="UnresolvedSavedItem"/>
     </entity>
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
-        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
+        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="savedItemUpdatedNotification" inverseEntity="SavedItem"/>
     </entity>
     <entity name="Slate" representedClassName="Slate" syncable="YES" codeGenerationType="class">
         <attribute name="experimentID" optional="YES" attributeType="String"/>
@@ -87,20 +89,6 @@
         <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
     </entity>
     <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES" codeGenerationType="class">
-        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem"/>
+        <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="unresolvedSavedItem" inverseEntity="SavedItem"/>
     </entity>
-    <elements>
-        <element name="Author" positionX="-9" positionY="144" width="128" height="89"/>
-        <element name="DomainMetadata" positionX="-63" positionY="36" width="128" height="14"/>
-        <element name="Image" positionX="-36" positionY="144" width="128" height="74"/>
-        <element name="Item" positionX="-45" positionY="99" width="128" height="314"/>
-        <element name="PersistentSyncTask" positionX="-36" positionY="144" width="128" height="59"/>
-        <element name="Recommendation" positionX="-18" positionY="162" width="128" height="74"/>
-        <element name="SavedItem" positionX="-63" positionY="-18" width="128" height="179"/>
-        <element name="SavedItemUpdatedNotification" positionX="-36" positionY="144" width="128" height="44"/>
-        <element name="Slate" positionX="-27" positionY="153" width="128" height="134"/>
-        <element name="SlateLineup" positionX="-36" positionY="144" width="128" height="89"/>
-        <element name="Tag" positionX="-36" positionY="144" width="128" height="74"/>
-        <element name="UnresolvedSavedItem" positionX="-36" positionY="144" width="128" height="44"/>
-    </elements>
 </model>

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -85,7 +85,7 @@ class SlateDetailViewModelTests: XCTestCase {
 
         let snapshotExpectation = expectation(description: "expected snapshot to update")
         viewModel.$snapshot.dropFirst().sink { snapshot in
-            defer { snapshotExpectation.fulfill()}
+            defer { snapshotExpectation.fulfill() }
 
             XCTAssertEqual(snapshot.sectionIdentifiers, [.slate(slate)])
             XCTAssertEqual(

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -322,7 +322,7 @@ extension PocketSaveServiceTests {
         wait(for: [performMutationCalled, notificationReceived], timeout: 1)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
-        XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name}, ["tag 1", "tag 2"] )
+        XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"] )
         XCTAssertEqual(unresolved[0].hasChanges, false)
     }
 
@@ -378,7 +378,7 @@ extension PocketSaveServiceTests {
         wait(for: [performMutationCalled, notificationReceived], timeout: 1)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
-        XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name}, [] )
+        XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, [] )
         XCTAssertEqual(unresolved[0].hasChanges, false)
     }
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -33,7 +33,7 @@ class PocketSourceTests: XCTestCase {
         osNotificationCenter = OSNotificationCenter(notifications: CFNotificationCenterGetDarwinNotifyCenter())
         subscriptions = []
 
-        lastRefresh.stubGetLastRefresh { nil}
+        lastRefresh.stubGetLastRefresh { nil }
 
         backgroundTaskManager.stubBeginTask { _, _ in return 0 }
         backgroundTaskManager.stubEndTask { _ in }


### PR DESCRIPTION
## Summary
Update swiftlint rules that have been voted on according to the SwiftLint Mozilla spreadsheet
https://docs.google.com/spreadsheets/d/1UY2rqwVFDbyJYj4oSnwSrdE4Fj2Wy-RhuH4AFaBUogY/edit#gid=841652337

## References 
IN-900

## Implementation Details
Added rules based on the spreadsheet mentioned above as some rules in the Firefox repo was not included even though it was voted on. This is due to a lot of changes and they treat them as errors vs warnings, so they haven't gotten a chance to integrate the rules. There were a couple of rules that still need to be added, but due to more changes - decide to postpone that for a future PR. 

With this work, we add the following:
  - anyobject_protocol
  - array_init
  - attributes
  - capture_variable
  - closure_spacing
  - compiler_protocol_init
  - computed_accessors_order
  - duplicate_enum_cases
  - duplicated_key_in_dictionary_literal
  - dynamic_inline
  - implicit_getter
  - inclusive_language
  - inert_defer
 
## Test Steps
* Build project and confirm that rules are enabled and no warnings associated with those rules

## PR Checklist:
- N/A Added Unit / UI tests 
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
