### PR TITLE
Better error logging when max retries are exceeded

### DIFF
--- a/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
@@ -61,7 +61,12 @@ class RetriableOperation: AsyncOperation {
 
     private func _retry(_ error: Error?) {
         guard retries < 2 else {
-            Crashlogger.capture(message: "Retriable operation \"\(operation)\" exceeded maximum number of retries")
+            Crashlogger.breadcrumb(
+                category: "sync",
+                level: .error,
+                message: "Retriable operation \"\(operation)\" exceeded maximum number of retries"
+            )
+
             if let error = error {
                 Crashlogger.capture(error: error)
             }


### PR DESCRIPTION
Log breadcrumb instead of capturing a message so the error details are associated to the sentry error.