### PR TITLE
fix(settings): Fix Background Color [IN-864]

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -48,9 +48,19 @@ class CompactMainCoordinator: NSObject {
         account.viewController.tabBarItem.selectedImage = UIImage(asset: .tabSettingsSelected)
 
         tabBarController = UITabBarController()
-        tabBarController.tabBar.barTintColor = UIColor(.ui.white1)
-        tabBarController.tabBar.tintColor = UIColor(.ui.grey1)
-        tabBarController.tabBar.unselectedItemTintColor = UIColor(.ui.grey1)
+        let appearance = UITabBarAppearance()
+        let tabBar = tabBarController.tabBar
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor(.ui.white1)
+        appearance.compactInlineLayoutAppearance.normal.iconColor = UIColor(.ui.grey1)
+        appearance.compactInlineLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor(.ui.grey1)]
+        appearance.stackedLayoutAppearance.normal.iconColor = UIColor(.ui.grey1)
+        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor(.ui.grey1)]
+        appearance.inlineLayoutAppearance.normal.iconColor = UIColor(.ui.grey1)
+        appearance.inlineLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor(.ui.grey1)]
+        tabBar.standardAppearance = appearance
+        tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+
         tabBarController.viewControllers = [
             home.viewController,
             myList.viewController,

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import Textile
 
 class SettingsViewController: UIHostingController<SettingsView> {
-   override init(rootView: SettingsView) {
+    override init(rootView: SettingsView) {
         super.init(rootView: rootView)
 
-        UITableView.appearance(whenContainedInInstancesOf: [Self.self]).backgroundColor = UIColor(.ui.grey7)
+        UITableView.appearance(whenContainedInInstancesOf: [Self.self]).backgroundColor = .clear
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -20,12 +20,30 @@ struct SettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Form {
-//                Section(header: Text("Your Account").style(.settings.header)) {
-//                    PremiumRow(status: .notSubscribed, destination: EmptyView())
-//                    SettingsRowLink(title: "Reset Password", destination: EmptyView())
-//                    SettingsRowLink(title: "Delete Account", destination: EmptyView())
-//                }.textCase(nil)
+            if #available(iOS 16.0, *) {
+                SettingsForm(model: model)
+                    .scrollContentBackground(.hidden)
+                    .background(Color(.ui.white1))
+            } else {
+                SettingsForm(model: model)
+                    .background(Color(.ui.white1))
+            }
+        }
+        .navigationBarTitle("Settings", displayMode: .large)
+    }
+}
+
+struct SettingsForm: View {
+    @ObservedObject
+    var model: AccountViewModel
+    var body: some View {
+        Form {
+            Group {
+                //                Section(header: Text("Your Account").style(.settings.header)) {
+                //                    PremiumRow(status: .notSubscribed, destination: EmptyView())
+                //                    SettingsRowLink(title: "Reset Password", destination: EmptyView())
+                //                    SettingsRowLink(title: "Delete Account", destination: EmptyView())
+                //                }.textCase(nil)
 
                 Section(header: Text("Your Account").style(.settings.header)) {
                     SettingsRowButton(title: "Sign Out", titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
@@ -60,7 +78,7 @@ struct SettingsView: View {
 
                 }.textCase(nil)
             }
+            .listRowBackground(Color(.ui.grey7))
         }
-        .navigationBarTitle("Settings", displayMode: .large)
     }
 }

--- a/PocketKit/Sources/Textile/Views/SFIcon/SFIconModel.swift
+++ b/PocketKit/Sources/Textile/Views/SFIcon/SFIconModel.swift
@@ -9,7 +9,7 @@ public class SFIconModel: ObservableObject {
     var rotation: CGFloat
     var color: Color
 
-    public init(_ systemImage: String, size: CGFloat = 18, weight: Font.Weight = .regular, rotation: CGFloat = 0, color: Color = Color(.ui.black)) {
+    public init(_ systemImage: String, size: CGFloat = 18, weight: Font.Weight = .regular, rotation: CGFloat = 0, color: Color = Color(.ui.black1)) {
         self.systemImage = systemImage
         self.size = size
         self.weight = weight


### PR DESCRIPTION
## Summary
Note: In draft - waiting on confirmation from design

* Updates Settings background color to match Saves/Home background color
* Updates icon to match text in Dark Mode

## References 
IN-864

## Implementation Details
There has been a change in how to modify the color of the background of a List / Form natively in SwiftUI for iOS 16. Updated the code to utilize this new way as well update the colors so that it looks similar in iOS 15.
https://sarunw.com/posts/swiftui-list-background-color/#how-to-hide-swiftui-list-background

Also, had to change how we are implementing the tab bar style by using the new APIs in changing its appearance.

## Test Steps
1. Navigate to Settings
2. Verify background color is consistent across tabs and devices 

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
|Light Mode|Dark Mode|
|------|-----|
|![Light Mode](https://user-images.githubusercontent.com/6743397/197564754-348c44d2-38e3-4a20-b2ab-964464aebf9a.png)|![Dark Mode](https://user-images.githubusercontent.com/6743397/197564751-57648a2d-5830-4dbd-91d2-a5169b3bacd4.png)|