### PR TITLE
Scope `typeText` to entire app instead of a single text field

### DIFF
--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -66,12 +66,7 @@ class SaveToPocketTests: XCTestCase {
         // typeText is flakey and cannot type "Tag 1" 100% of the time
         addTagsView.wait()
         addTagsView.newTagTextField.tap()
-        addTagsView.newTagTextField.typeText("T")
-        addTagsView.newTagTextField.typeText("a")
-        addTagsView.newTagTextField.typeText("g")
-        addTagsView.newTagTextField.typeText(" ")
-        addTagsView.newTagTextField.typeText("1")
-        addTagsView.newTagTextField.typeText("\n")
+        safari.typeText("Tag 1\n")
 
         addTagsView.tag(matching: "tag 1").wait()
 


### PR DESCRIPTION
When typing, you can call `typeText` on the app in the foreground to make sure the keyboard is always available. If you try and type within a specific UI element, it's liable to fail if that element becomes obscured (sometimes by the keyboard itself)