### PR TITLE
Disable landscape orientation of Settings on iPhones

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -11,6 +11,11 @@ class SettingsViewController: UIHostingController<SettingsView> {
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard traitCollection.userInterfaceIdiom == .phone else { return .all }
+        return .portrait
+    }
 }
 
 struct SettingsView: View {


### PR DESCRIPTION
## Summary

Disable landscape orientation of Settings on iPhones

## References 
IN-923

## Implementation Details

The general pattern for disabling landscape across the app (as implemented for this app, specifically)  is:
1. Find a top-level navigation controller, assign its delegate, implementing `navigationControllerSupportedInterfaceOrientations(_:)` to return the supported interface orientations of its visible view controller.
2. Override `supportedInterfaceOrientations` on a view controller (that can be visible within a navigation controller) to return the correct orientations based on device idiom. For all screens (aside from the reader), this is `.all` on pad, `.portrait` on phone.

This pull request showcases the implementation of overriding the orientations in a given view controller. To see how this all connects, see [CompactAccountCoordinator.swift](https://github.com/Pocket/pocket-ios/blob/develop/PocketKit/Sources/PocketKit/Settings/CompactAccountCoordinator.swift).

## Test Steps

- Open the Settings screen on iPhone
- Rotate to landscape
- The screen should remain in portrait

- Open the Settings screen on iPad
- Rotate to landscape
- The screen should rotate with the device

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
