### PR TITLE
feat(tags): Analytics for Add Tags [IN-151]

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -43,10 +43,9 @@ let package = Package(
             name: "PocketKitTests",
             dependencies: ["PocketKit", "SharedPocketKit"]
         ),
-
         .target(
             name: "SaveToPocketKit",
-            dependencies: ["SharedPocketKit", "Textile", "Sync"]
+            dependencies: ["SharedPocketKit", "Textile", "Sync", "Analytics"]
         ),
         .testTarget(
             name: "SaveToPocketKitTests",
@@ -89,7 +88,6 @@ let package = Package(
             dependencies: ["Sync"],
             resources: [.copy("Fixtures")]
         ),
-
         .target(
             name: "PocketGraph",
             dependencies: [

--- a/PocketKit/Sources/Analytics/Context/UIContext.swift
+++ b/PocketKit/Sources/Analytics/Context/UIContext.swift
@@ -13,19 +13,22 @@ public struct UIContext: Context {
     let identifier: Identifier
     let componentDetail: ComponentDetail?
     let index: UIIndex?
+    let label: Label?
 
     public init(
         type: UIType,
         hierarchy: UIHierarchy = 0,
         identifier: Identifier,
         componentDetail: ComponentDetail? = nil,
-        index: UIIndex? = nil
+        index: UIIndex? = nil,
+        label: Label? = nil
     ) {
         self.type = type
         self.hierarchy = hierarchy
         self.identifier = identifier
         self.componentDetail = componentDetail
         self.index = index
+        self.label = label
     }
 
     func with(hierarchy: UIHierarchy) -> UIContext {
@@ -34,7 +37,8 @@ public struct UIContext: Context {
             hierarchy: hierarchy,
             identifier: identifier,
             componentDetail: componentDetail,
-            index: index
+            index: index,
+            label: label
         )
     }
 }
@@ -46,6 +50,7 @@ private extension UIContext {
         case identifier
         case componentDetail = "component_detail"
         case index
+        case label
     }
 }
 
@@ -71,6 +76,9 @@ extension UIContext {
         case item
         case articleLink = "article_link"
         case switchToWebView = "switch_to_web_view"
+        case itemOverflow = "itemOverflow"
+        case itemEditTags = "itemEditTags"
+        case itemAddTags = "item_add_tags"
         case itemDelete = "item_delete"
         case itemArchive = "item_archive"
         case itemFavorite = "item_favorite"
@@ -92,6 +100,8 @@ extension UIContext {
         case tagsOverflow = "tagsOverflow"
         case tagsDelete = "tagsDelete"
         case tagsSaveChanges = "tagsSaveChanges"
+        case externalApp = "external_app"
+        case saveExtension = "save_extension"
     }
 }
 
@@ -99,6 +109,16 @@ extension UIContext {
     public enum ComponentDetail: String, Encodable {
         case itemRow = "item_row"
         case homeCard = "discover_tile"
+        case overlay = "overlay"
+        case addTags = "add_tags"
+        case addTagsDone = "add_tags_done"
+    }
+}
+
+extension UIContext {
+    public enum Label: String, Encodable {
+        case saveToPocket = "Save to Pocket"
+        case tagsAdded = "Tags Added"
     }
 }
 
@@ -160,12 +180,20 @@ extension UIContext {
         }
     }
 
+    public struct SaveExtension {
+        public let screen = UIContext(type: .screen, hierarchy: 0, identifier: .externalApp)
+        public let saveDialog = UIContext(type: .dialog, hierarchy: 0, identifier: .saveExtension, componentDetail: .overlay, label: .saveToPocket)
+        public let addTagsButton = UIContext(type: .button, hierarchy: 0, identifier: .saveExtension, componentDetail: .addTags)
+        public let addTagsDone = UIContext(type: .button, hierarchy: 0, identifier: .saveExtension, componentDetail: .addTagsDone, label: .tagsAdded)
+    }
+
     public static let loggedOut = LoggedOut()
     public static let home = Home()
     public static let saves = Saves()
     public static let account = Account()
     public static let articleView = ArticleView()
     public static let slateDetail = SlateDetail()
+    public static let saveExtension = SaveExtension()
 
     public static let reportDialog = UIContext(type: .dialog, identifier: .reportItem)
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -169,6 +169,7 @@ extension SavedItemViewModel {
                 self?.fetchDetailsIfNeeded()
             }
         )
+        track(identifier: .itemAddTags)
     }
 
     private func saveExternalURL(_ url: URL) {

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -242,6 +242,15 @@ extension ArchivedItemsListViewModel {
         ]
     }
 
+    func trackOverflow(for itemID: ItemIdentifier) -> UIAction? {
+        guard let item = savedItem(itemID) else {
+            return nil
+        }
+        return UIAction(title: "", handler: { [weak self] _ in
+            self?.trackButton(item: item, identifier: .itemOverflow)
+        })
+    }
+
     func trailingSwipeActions(for objectID: ItemIdentifier) -> [ItemContextualAction] {
         guard let item = savedItem(objectID) else {
             return []
@@ -321,6 +330,8 @@ extension ArchivedItemsListViewModel {
                 self?.archiveService.fetch()
             }
         )
+
+        trackButton(item: item, identifier: .itemEditTags)
     }
 
     func tagModel(with name: String) -> SelectedTagChipModel {
@@ -533,6 +544,20 @@ extension ArchivedItemsListViewModel {
         if selectedFilters.contains(.favorites) {
             contexts.insert(UIContext.saves.favorites, at: 0)
         }
+
+        let event = SnowplowEngagement(type: .general, value: nil)
+        tracker.track(event: event, contexts)
+    }
+
+    private func trackButton(item: SavedItem, identifier: UIContext.Identifier) {
+        guard let url = item.bestURL else {
+            return
+        }
+
+        let contexts: [Context] = [
+            UIContext.button(identifier: identifier),
+            ContentContext(url: url)
+        ]
 
         let event = SnowplowEngagement(type: .general, value: nil)
         tracker.track(event: event, contexts)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemCell.swift
@@ -225,6 +225,7 @@ extension ItemsListItemCell {
         let favoriteAction: ItemAction?
         let overflowActions: [ItemAction]
         let filterByTagAction: UIAction?
+        let trackOverflow: UIAction?
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -274,6 +275,10 @@ extension ItemsListItemCell {
 
         let menuActions = state.model?.overflowActions.compactMap(UIAction.init) ?? []
         menuButton.menu = UIMenu(children: menuActions)
+
+        if let trackAction = state.model?.trackOverflow {
+            menuButton.addAction(trackAction, for: .menuActionTriggered)
+        }
 
         thumbnailView.image = nil
         guard let thumbnailURL = state.model?.thumbnailURL else {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -237,7 +237,8 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
                 shareAction: nil,
                 favoriteAction: nil,
                 overflowActions: [],
-                filterByTagAction: nil
+                filterByTagAction: nil,
+                trackOverflow: nil
             )
 
             return
@@ -252,7 +253,8 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             shareAction: model.shareAction(for: objectID),
             favoriteAction: model.favoriteAction(for: objectID),
             overflowActions: model.overflowActions(for: objectID),
-            filterByTagAction: model.filterByTagAction()
+            filterByTagAction: model.filterByTagAction(),
+            trackOverflow: model.trackOverflow(for: objectID)
         )
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -94,6 +94,7 @@ protocol ItemsListViewModel: AnyObject {
     func selectCell(with: ItemsListCell<ItemIdentifier>, sender: Any?)
 
     func filterByTagAction() -> UIAction?
+    func trackOverflow(for objectID: ItemIdentifier) -> UIAction?
     func shareAction(for objectID: ItemIdentifier) -> ItemAction?
     func favoriteAction(for objectID: ItemIdentifier) -> ItemAction?
     func overflowActions(for objectID: ItemIdentifier) -> [ItemAction]

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -28,7 +28,9 @@ class MainViewController: UIViewController {
                 viewModel: SavedItemViewModel(
                     appSession: appSession,
                     saveService: services.saveService,
-                    dismissTimer: Timer.TimerPublisher(interval: 3.0, runLoop: .main, mode: .default)
+                    dismissTimer: Timer.TimerPublisher(interval: 3.0, runLoop: .main, mode: .default),
+                    tracker: Services.shared.tracker.childTracker(hosting: .saveExtension.screen),
+                    consumerKey: Keys.shared.pocketApiConsumerKey
                 )
             )
         }

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -2,12 +2,14 @@ import Foundation
 import Sync
 import SharedPocketKit
 import Combine
+import Analytics
 
 struct Services {
     static let shared = Services()
 
     let appSession: AppSession
     let saveService: PocketSaveService
+    let tracker: Tracker
 
     private let persistentContainer: PersistentContainer
 
@@ -16,6 +18,9 @@ struct Services {
         persistentContainer = .init(storage: .shared)
 
         appSession = AppSession()
+
+        let snowplow = PocketSnowplowTracker()
+        tracker = PocketTracker(snowplow: snowplow)
 
         saveService = PocketSaveService(
             space: persistentContainer.rootSpace,

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Analytics
 import SharedPocketKit
 import Sync
 
@@ -9,17 +10,23 @@ class SavedItemViewModelTests: XCTestCase {
     private var appSession: AppSession!
     private var saveService: MockSaveService!
     private var dismissTimer: Timer.TimerPublisher!
+    private var tracker: MockTracker!
+    private var consumerKey: String!
     private var space: Space!
 
     private func subject(
         appSession: AppSession? = nil,
         saveService: SaveService? = nil,
-        dismissTimer: Timer.TimerPublisher? = nil
+        dismissTimer: Timer.TimerPublisher? = nil,
+        tracker: Tracker? = nil,
+        consumerKey: String? = nil
     ) -> SavedItemViewModel {
         SavedItemViewModel(
             appSession: appSession ?? self.appSession,
             saveService: saveService ?? self.saveService,
-            dismissTimer: dismissTimer ?? self.dismissTimer
+            dismissTimer: dismissTimer ?? self.dismissTimer,
+            tracker: tracker ?? self.tracker,
+            consumerKey: consumerKey ?? self.consumerKey
         )
     }
 
@@ -29,6 +36,8 @@ class SavedItemViewModelTests: XCTestCase {
         appSession = AppSession(keychain: MockKeychain())
         saveService = MockSaveService()
         dismissTimer = Timer.TimerPublisher(interval: 0, runLoop: .main, mode: .default)
+        tracker = MockTracker()
+        consumerKey = "test-key"
         space = .testSpace()
 
         let savedItem = SavedItem()

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Analytics
+
+class MockTracker: Tracker {
+    struct TrackCall {
+        let event: Event
+        let contexts: [Context]?
+    }
+
+    private var persistentContexts: [Context] = []
+
+    private(set) var trackCalls = Calls<TrackCall>()
+
+    func addPersistentContext(_ context: Context) {
+
+    }
+
+    func resetPersistentContexts(_ contexts: [Context]) {
+        persistentContexts = []
+    }
+
+    func track<T: Event>(event: T, _ contexts: [Context]?) {
+        trackCalls.add(TrackCall(event: event, contexts: contexts))
+    }
+
+    func childTracker(with contexts: [Context]) -> Tracker {
+        NoopTracker()
+    }
+}
+
+struct MockEvent: Event {
+    static var schema = "mock-event"
+
+    let value: Int
+}
+
+struct MockContext: Context {
+    static var schema = "mock-context"
+
+    let value: String
+}


### PR DESCRIPTION
## Summary
Track engagement event when adding tag(s) + save extension
```
Two engagement events for Add Tags Flow:
* When a user views an item in My List and goes to overflow menu and taps on Add Tag button
* When a user views an item in Reader and taps the Tag button from the overflow menu

Three engagement events for Save Extension:
* User taps share button and add To Pocket
* User clicks add tags option.
* User adds the relevant tags and then clicks Done.
```

## References 
IN-151

## Implementation Details
Added PocketTracker to be used in the Save Extension and track general add tags call

## Test Steps
1. Follow the testing steps in this doc to setup snowplow locally:
https://getpocket.atlassian.net/wiki/spaces/PFC/pages/2779447327/Testing+Analytics+for+iOS+Next
2. Use steps here to trigger calls: https://getpocket.atlassian.net/wiki/spaces/PFC/pages/2559836224/iOS+Next+Analytics#%235---engagement-events-in-Add-Tags-flow
3. Verify that calls match the ones in the zip file attached3. 

Note: To test the save extension calls, you may need to add the arguments to the SaveTo scheme. 

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Analytics Calls
[Analytics.zip](https://github.com/Pocket/pocket-ios/files/9861447/Analytics.zip)
