### PR TITLE
feat(tags): auto-dismiss on adding tags [IN-925]

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -43,7 +43,7 @@ class SavedItemViewController: UIViewController {
 
         addTagsButton.addAction(UIAction { [weak self] _ in
             self?.viewModel.cancelDismissTimer()
-            self?.viewModel.showAddTagsView()
+            self?.viewModel.showAddTagsView(from: self?.extensionContext)
         }, for: .primaryActionTriggered)
     }
 

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -72,20 +72,20 @@ class SavedItemViewModel {
         }
     }
 
-    func showAddTagsView() {
+    func showAddTagsView(from context: ExtensionContext?) {
         presentedAddTags = SaveToAddTagsViewModel(
             item: savedItem,
             retrieveAction: { [weak self] tags in
                 self?.retrieveTags(excluding: tags)
             },
             saveAction: { [weak self] tags in
-                self?.addTags(tags: tags)
+                self?.addTags(tags: tags, from: context)
             }
         )
         track(context: .saveExtension.addTagsButton)
     }
 
-    func addTags(tags: [String]) {
+    func addTags(tags: [String], from context: ExtensionContext?) {
         guard let savedItem = savedItem else { return }
         let result = saveService.addTags(savedItem: savedItem, tags: tags)
         if case let .taggedItem(savedItem) = result {
@@ -94,6 +94,7 @@ class SavedItemViewModel {
 
             track(context: .saveExtension.addTagsDone)
         }
+        finish(context: context)
     }
 
     func retrieveTags(excluding tags: [String]) -> [Tag]? {

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -90,6 +90,7 @@ class SavedItemViewModel {
         let result = saveService.addTags(savedItem: savedItem, tags: tags)
         if case let .taggedItem(savedItem) = result {
             self.savedItem = savedItem
+            infoViewModel = .taggedItem
 
             track(context: .saveExtension.addTagsDone)
         }
@@ -185,6 +186,15 @@ private extension InfoView.Model {
         attributedText: NSAttributedString(
             string: "Pocket couldn't save this link",
             style: .mainTextError
+        ),
+        attributedDetailText: nil
+    )
+
+    static let taggedItem = InfoView.Model(
+        style: .default,
+        attributedText: NSAttributedString(
+            string: "Tags Added!",
+            style: .mainText
         ),
         attributedDetailText: nil
     )

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -90,7 +90,6 @@ class SavedItemViewModel {
         let result = saveService.addTags(savedItem: savedItem, tags: tags)
         if case let .taggedItem(savedItem) = result {
             self.savedItem = savedItem
-            infoViewModel = .taggedItem
 
             track(context: .saveExtension.addTagsDone)
         }
@@ -179,15 +178,6 @@ private extension InfoView.Model {
             string: "You've already saved this. We'll move it to the top of your list.",
             style: .detailText
         )
-    )
-
-    static let taggedItem = InfoView.Model(
-        style: .default,
-        attributedText: NSAttributedString(
-            string: "Tags Added!",
-            style: .mainText
-        ),
-        attributedDetailText: nil
     )
 
     static let error = InfoView.Model(

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -279,8 +279,7 @@ extension SavedItemViewModelTests {
         viewModel.addTags(tags: ["tag 1"], from: context)
         let infoViewModelChanged = expectation(description: "infoViewModelChanged")
         let subscription = viewModel.$infoViewModel.sink { model in
-            defer { infoViewModelChanged.fulfill() }
-            XCTAssertEqual(model.attributedText.string, "Tags Added!")
+            do { infoViewModelChanged.fulfill() }
         }
 
         wait(for: [infoViewModelChanged], timeout: 1)

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -254,7 +254,11 @@ extension SavedItemViewModelTests {
             XCTAssertNotNil(viewModel)
         }
 
-        viewModel.showAddTagsView()
+        let extensionItem = MockExtensionItem(itemProviders: [])
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
+        viewModel.showAddTagsView(from: context)
 
         wait(for: [expectAddTags], timeout: 1)
         subscription.cancel()
@@ -268,7 +272,11 @@ extension SavedItemViewModelTests {
             return .taggedItem(item)
         }
 
-        viewModel.addTags(tags: ["tag 1"])
+        let extensionItem = MockExtensionItem(itemProviders: [])
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
+        viewModel.addTags(tags: ["tag 1"], from: context)
         let infoViewModelChanged = expectation(description: "infoViewModelChanged")
         let subscription = viewModel.$infoViewModel.sink { model in
             defer { infoViewModelChanged.fulfill() }

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -75,8 +75,6 @@ class SaveToPocketTests: XCTestCase {
         }
 
         addTagsView.saveButton.tap()
-        safari.staticTexts["Tags Added!"].wait()
-        safari.staticTexts["Tap to Dismiss"].tap()
 
         safari.toolbars.buttons["ShareButton"].tap()
         activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 1).tap()


### PR DESCRIPTION
## Summary
* Auto-dismiss the save to pocket modal when adding tags

## References 
* [IN-925](https://getpocket.atlassian.net/jira/software/projects/IN/boards/80?selectedIssue=IN-925)

## Implementation Details
* added `finish()` and `context` to `addTags` in `SavedItemViewModel`

## Test Steps
* navigate to another app
* share an article to pocket
* when the pop-up shows, click add tag
* add a tag
* should dismiss

* navigate to another app
* share an article to pocket
* when the pop-up shows, click add tag
* cancel
* should take you to initial modal

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
