### PR TITLE
fix(braze): versioning in the root project was different

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -46,12 +46,12 @@
 		3E8283A428B65ECF00C1DC4A /* SortMenuElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8283A328B65ECF00C1DC4A /* SortMenuElement.swift */; };
 		650FECCE28BA85F300A3CB0C /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650FECCD28BA85F300A3CB0C /* NotificationService.swift */; };
 		650FECD228BA85F300A3CB0C /* PushNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		65734C2628BA89B900730661 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = 65734C2528BA89B900730661 /* BrazeNotificationService */; };
+		65167B6F2909904200343FA8 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = 65167B6E2909904200343FA8 /* BrazeNotificationService */; };
+		65167B712909904200343FA8 /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = 65167B702909904200343FA8 /* BrazePushStory */; };
 		65EC272728BA8AD50075E1DF /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65EC272628BA8AD50075E1DF /* UserNotifications.framework */; };
 		65EC272928BA8AD50075E1DF /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */; };
 		65EC272C28BA8AD50075E1DF /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EC272B28BA8AD50075E1DF /* NotificationViewController.swift */; };
 		65EC273328BA8AD50075E1DF /* PushNotificationStoryExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		65EC273928BA8B120075E1DF /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = 65EC273828BA8B120075E1DF /* BrazePushStory */; };
 		8A289CD62899BD820030E5E0 /* BannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A289CD52899BD820030E5E0 /* BannerViewTests.swift */; };
 		8A3E3DBC2864DB0500483564 /* EmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3E3DBB2864DB0500483564 /* EmptyStateTests.swift */; };
 		8A3EAA5128AACC9500392057 /* AddTagsItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EAA5028AACC9500392057 /* AddTagsItemTests.swift */; };
@@ -233,7 +233,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65734C2628BA89B900730661 /* BrazeNotificationService in Frameworks */,
+				65167B6F2909904200343FA8 /* BrazeNotificationService in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,7 +242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				65EC272928BA8AD50075E1DF /* UserNotificationsUI.framework in Frameworks */,
-				65EC273928BA8B120075E1DF /* BrazePushStory in Frameworks */,
+				65167B712909904200343FA8 /* BrazePushStory in Frameworks */,
 				65EC272728BA8AD50075E1DF /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -488,7 +488,7 @@
 			);
 			name = PushNotificationServiceExtension;
 			packageProductDependencies = (
-				65734C2528BA89B900730661 /* BrazeNotificationService */,
+				65167B6E2909904200343FA8 /* BrazeNotificationService */,
 			);
 			productName = PushNotificationServiceExtension;
 			productReference = 650FECCB28BA85F300A3CB0C /* PushNotificationServiceExtension.appex */;
@@ -508,7 +508,7 @@
 			);
 			name = PushNotificationStoryExtension;
 			packageProductDependencies = (
-				65EC273828BA8B120075E1DF /* BrazePushStory */,
+				65167B702909904200343FA8 /* BrazePushStory */,
 			);
 			productName = PushNotificationStoryExtension;
 			productReference = 65EC272528BA8AD50075E1DF /* PushNotificationStoryExtension.appex */;
@@ -574,7 +574,7 @@
 			mainGroup = 166A81A32637406B0015AA1D;
 			packageReferences = (
 				167F8082264B011600D8F507 /* XCRemoteSwiftPackageReference "Sails" */,
-				65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
+				65167B6D2909904200343FA8 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
 			);
 			productRefGroup = 166A81B12637406C0015AA1D /* Products */;
 			projectDirPath = "";
@@ -1133,6 +1133,7 @@
 		650FECD428BA85F300A3CB0C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
@@ -1163,6 +1164,7 @@
 		650FECD528BA85F300A3CB0C /* Debug_Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_IDENTITY = "Apple Development: David Skuza (A7H8F4CPQQ)";
 				CODE_SIGN_STYLE = Manual;
@@ -1193,6 +1195,7 @@
 		650FECD628BA85F300A3CB0C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_IDENTITY = "Apple Distribution: Read It Later, Inc (EX3VH4YFCH)";
 				CODE_SIGN_STYLE = Manual;
@@ -1245,7 +1248,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story Development";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1275,7 +1278,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story App Store Distribution";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1305,7 +1308,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "iOS Next Push Story App Store Distribution";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -1450,12 +1453,12 @@
 				kind = branch;
 			};
 		};
-		65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
+		65167B6D2909904200343FA8 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
+			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.5.0;
+				minimumVersion = 5.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1470,14 +1473,14 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = PocketKit;
 		};
-		65734C2528BA89B900730661 /* BrazeNotificationService */ = {
+		65167B6E2909904200343FA8 /* BrazeNotificationService */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			package = 65167B6D2909904200343FA8 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
 			productName = BrazeNotificationService;
 		};
-		65EC273828BA8B120075E1DF /* BrazePushStory */ = {
+		65167B702909904200343FA8 /* BrazePushStory */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 65734C2328BA895B00730661 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			package = 65167B6D2909904200343FA8 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
 			productName = BrazePushStory;
 		};
 		F2687E7227E28F0F00E43F09 /* SaveToPocketKit */ = {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "eec5fe0bd84b553560b76334e832f8f124406749",
-        "version" : "5.5.1"
+        "revision" : "3481cf155516b5b223b8bcea71b74ff002db1625",
+        "version" : "5.6.0"
       }
     },
     {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/airbnb/lottie-ios.git", from: "3.4.3"),
         .package(url: "https://github.com/johnxnguyen/Down", .upToNextMinor(from: "0.11.0")),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", .upToNextMinor(from: "1.1.5")),
-        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMajor(from: "5.5.1"))
+        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMajor(from: "5.6.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
* Braze Push Service targets need braze included in the project root packages to work, but they need to be bumped when Package.swift is also bumped or it conflicts.
