### PR TITLE
fix(tags): Download All Tags [IN-866]

### DIFF
--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -77,7 +77,7 @@ class FetchList: SyncOperation {
 
     private func fetchTags() async throws {
         var shouldFetchNextPage = true
-        var pagination = PaginationInput()
+        var pagination = PaginationInput(first: .null)
 
         while shouldFetchNextPage {
             let query = TagsQuery(pagination: .init(pagination))


### PR DESCRIPTION
## Summary
Fix issue where tags were not all downloading after a user adds a tag on a different device and then signs in and view tags on another device.

## References 
IN-866

## Implementation Details
Made changes to how we are passing in the input values in our GraphQL query for PaginationInput. We may want to handle the case in which we don't pass any input values and throw an error or return default via backend, but making this fix for now.

See slack convo here: https://pocket.slack.com/archives/C01VDFM30J2/p1666800998893259

## Test Steps
1. Sign out of pocket
2. Add new tag to oldest Archive item on Web
3. Sign into Pocket
4. Navigate to Saves on iOS 
5. Tap on Add Tags + Filter Tags
6. Verify that new tag appears

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA