### PR TITLE
feat(snowplow): Add Auto Screen View Tracking [IN-832]

### DIFF
--- a/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
@@ -22,8 +22,8 @@ public class PocketSnowplowTracker: SnowplowTracker {
         trackerConfiguration.platformContext = true
         trackerConfiguration.geoLocationContext = false
         trackerConfiguration.sessionContext = false
-        trackerConfiguration.screenContext = false
-        trackerConfiguration.screenViewAutotracking = false
+        trackerConfiguration.screenContext = true
+        trackerConfiguration.screenViewAutotracking = true
         trackerConfiguration.lifecycleAutotracking = false
         trackerConfiguration.installAutotracking = false
         trackerConfiguration.exceptionAutotracking = false


### PR DESCRIPTION
## Summary
Enable Automatic View Tracking in Snowplow

## References 
IN-832

## Implementation Details
Added Screen View Tracking which is composed of 2 settings:
* `screenViewAutotracking`: the tracker automatically tracks each screen change (triggered by viewDidAppear in a ViewController) using a ScreenView event
```
    "data": {
      "schema": "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0",
      "data": {
        "id": "B4C81E97-4835-49D1-A540-76CFF0025BCB",
        "previousName": "UINavigationController",
        "previousType": "SplitView",
        "name": "PocketKit.HomeViewController",
        "type": "SplitView",
        "previousId": "B8132DD0-92CD-453A-B4C1-0563BE17F229"
      }
    }
```

Note: Some of the automatic capture are inconsistent with our manual calls. This is due to our calls being triggered prior to the `viewDidAppear`

* `screenContext`: the tracker attaches a Screen entity to all the events tracked by the tracker reporting the last (and probably current) screen visible on device when the event was tracked.

```
      {
        "schema": "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0",
        "data": {
          "topViewController": "UISplitViewController",
          "id": "F1F46C4B-8C8C-491F-8C67-03CF40538A65",
          "name": "PocketKit.HomeViewController",
          "type": "SplitView",
          "viewController": "PocketKit.HomeViewController"
        }
      }
```

More info: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/#screen-view-tracking

## Test Steps
1. Navigate between Home and Settings Tab
2. Verify differences in the calls are similar to the json files attached to this PR in Analytics.zip 

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Analytics 
Both files are calls triggered from switching from Home Tab to Settings Tab and back to Home
**automatictracking.json:** calls without changes 
**noautomatictracking.json:** calls with changes associated in this PR

[Analytics.zip](https://github.com/Pocket/pocket-ios/files/9872718/Analytics.zip)
