### PR TITLE
build(xcode): Add Snowplow to SaveTo Scheme

### DIFF
--- a/Pocket.xcodeproj/xcshareddata/xcschemes/SaveToPocket.xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/SaveToPocket.xcscheme
@@ -71,6 +71,24 @@
             ReferencedContainer = "container:Pocket.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "disableSnowplow"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SNOWPLOW_IDENTIFIER"
+            value = "pocket-ios-next-dev"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SNOWPLOW_ENDPOINT"
+            value = "http://127.0.0.1:9090"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
## Summary
Add Snowplow Tracking endpoint and identifier to Save To Extension Scheme. This allows calls to be seen locally and in mini when navigating through the Save Extension.

## References 
N / A

## Implementation Details
Add environment variables to SaveToPocket scheme

## Test Steps
1. Set Scheme to SaveToPocket
2. Run app and save an item via the save extension
3. Verify calls are appearing
 
## PR Checklist:
- N / A Added Unit / UI tests
- [ x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
N / A