### PR TITLE
feat(refresh): Add Home Refresh Rule [IN-744]

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -80,7 +80,7 @@ class HomeViewController: UIViewController {
         collectionView.delegate = self
 
         let action = UIAction { [weak self] _ in
-            self?.handleRefresh()
+            self?.handleRefresh(isForced: true)
         }
 
         collectionView.refreshControl = UIRefreshControl(frame: .zero, primaryAction: action)
@@ -126,8 +126,8 @@ class HomeViewController: UIViewController {
         handleRefresh()
     }
 
-    private func handleRefresh() {
-        model.refresh { [weak self] in
+    private func handleRefresh(isForced: Bool = false) {
+        model.refresh(isForced: isForced) { [weak self] in
             DispatchQueue.main.async {
                 if self?.collectionView.refreshControl?.isRefreshing == true {
                     self?.collectionView.refreshControl?.endRefreshing()

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -29,7 +29,8 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                     home: HomeViewModel(
                         source: Services.shared.source,
                         tracker: Services.shared.tracker.childTracker(hosting: .home.screen),
-                        networkPathMonitor: NWPathMonitor()
+                        networkPathMonitor: NWPathMonitor(),
+                        homeRefreshCoordinator: Services.shared.homeRefreshCoordinator
                     ),
                     account: AccountViewModel(appSession: Services.shared.appSession)
                 ),

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -1,0 +1,56 @@
+import Foundation
+import UIKit
+import Combine
+import Sync
+
+protocol HomeRefreshCoordinatorProtocol {
+    func refresh(isForced: Bool, _ completion: @escaping () -> Void)
+}
+
+class HomeRefreshCoordinator: HomeRefreshCoordinatorProtocol {
+    static let dateLastRefreshKey = "HomeRefreshCoordinator.dateLastRefreshKey"
+    private let notificationCenter: NotificationCenter
+    private let userDefaults: UserDefaults
+    private let source: Source
+    private let minimumRefreshInterval: TimeInterval
+    private var subscriptions: [AnyCancellable] = []
+    private var isRefreshing: Bool = false
+
+    init(notificationCenter: NotificationCenter, userDefaults: UserDefaults, source: Source, minimumRefreshInterval: TimeInterval = 12 * 60 * 60) {
+        self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
+        self.minimumRefreshInterval = minimumRefreshInterval
+        self.source = source
+
+        self.notificationCenter.publisher(for: UIScene.willEnterForegroundNotification, object: nil).sink { [weak self] _ in
+            self?.refresh { }
+        }.store(in: &subscriptions)
+    }
+
+    func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
+        if shouldRefresh(isForced: isForced), !isRefreshing {
+            Task {
+                do {
+                    isRefreshing = true
+                    try await source.fetchSlateLineup(HomeViewModel.lineupIdentifier)
+                    userDefaults.setValue(Date(), forKey: Self.dateLastRefreshKey)
+                    Crashlogger.breadcrumb(category: "refresh", level: .info, message: "Home Refresh Occur")
+                } catch {
+                    Crashlogger.capture(error: error)
+                }
+                completion()
+                isRefreshing = false
+            }
+        }
+    }
+
+    private func shouldRefresh(isForced: Bool = false) -> Bool {
+        guard let lastActiveTimestamp = userDefaults.object(forKey: Self.dateLastRefreshKey) as? Date else {
+            return true
+        }
+
+        let timeSinceLastRefresh = Date().timeIntervalSince(lastActiveTimestamp)
+
+        return timeSinceLastRefresh >= minimumRefreshInterval || isForced
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -21,6 +21,7 @@ struct Services {
     let tracker: Tracker
     let sceneTracker: SceneTracker
     let refreshCoordinator: RefreshCoordinator
+    let homeRefreshCoordinator: HomeRefreshCoordinator
     let authClient: AuthorizationClient
     let imageManager: ImageManager
     let notificationService: PushNotificationService
@@ -65,6 +66,12 @@ struct Services {
         refreshCoordinator = RefreshCoordinator(
             notificationCenter: .default,
             taskScheduler: BGTaskScheduler.shared,
+            source: source
+        )
+
+        homeRefreshCoordinator = HomeRefreshCoordinator(
+            notificationCenter: .default,
+            userDefaults: userDefaults,
             source: source
         )
 

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+import Sync
+import Combine
+
+@testable import PocketKit
+
+class HomeRefreshCoordinatorTests: XCTestCase {
+    private var notificationCenter: NotificationCenter!
+    private var userDefaults: UserDefaults!
+    private var source: MockSource!
+    private var subscriptions: Set<AnyCancellable>!
+
+    override func setUpWithError() throws {
+        notificationCenter = NotificationCenter()
+        userDefaults = UserDefaults()
+        source = MockSource()
+        subscriptions = []
+    }
+
+    override func tearDownWithError() throws {
+        userDefaults.removeObject(forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+    }
+
+    func subject(
+        notificationCenter: NotificationCenter? = nil,
+        userDefaults: UserDefaults? = nil,
+        source: Source? = nil,
+        minimumRefreshInterval: TimeInterval = 12 * 60 * 60
+    ) -> HomeRefreshCoordinator {
+        HomeRefreshCoordinator(
+            notificationCenter: notificationCenter ?? self.notificationCenter,
+            userDefaults: userDefaults ?? self.userDefaults,
+            source: source ?? self.source,
+            minimumRefreshInterval: minimumRefreshInterval
+        )
+    }
+
+    func test_firstRefresh_setsUserDefaults() {
+        XCTAssertNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
+        source.stubFetchSlateLineup { _ in }
+
+        let expectRefresh = expectation(description: "Refresh home")
+
+        let coordinator = subject()
+
+        coordinator.refresh {
+            expectRefresh.fulfill()
+        }
+        wait(for: [expectRefresh], timeout: 1)
+        XCTAssertNotNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
+    }
+
+    func test_coordinator_whenDataIsNotStale_doesNotRefreshHome() {
+        let date = Date()
+        userDefaults.setValue(date, forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+        XCTAssertNotNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
+        source.stubFetchSlateLineup { _ in }
+
+        let coordinator = subject()
+        coordinator.refresh {
+            XCTFail("Should not have refreshed")
+        }
+        XCTAssertEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
+    }
+
+    func test_coordinator_whenDataIsStale_refreshesHome() {
+        let date = Calendar.current.date(byAdding: .hour, value: -12, to: Date())
+        userDefaults.setValue(date, forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+        XCTAssertNotNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
+        source.stubFetchSlateLineup { _ in }
+
+        let coordinator = subject()
+
+        let expectRefresh = expectation(description: "Refresh home")
+        coordinator.refresh {
+            expectRefresh.fulfill()
+        }
+        wait(for: [expectRefresh], timeout: 1)
+        XCTAssertNotEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
+    }
+
+    func test_coordinator_whenForceRefresh_refreshesHome() {
+        let date = Date()
+        userDefaults.setValue(date, forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+        XCTAssertNotNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
+        source.stubFetchSlateLineup { _ in }
+
+        let expectRefresh = expectation(description: "Refresh home")
+
+        let coordinator = subject()
+
+        coordinator.refresh(isForced: true) {
+            expectRefresh.fulfill()
+        }
+        wait(for: [expectRefresh], timeout: 1)
+    }
+
+    func test_refresh_delegatesToSource() {
+        let fetchExpectation = expectation(description: "expected to fetch slate lineup")
+        source.stubFetchSlateLineup { _ in fetchExpectation.fulfill() }
+
+        let coordinator = subject()
+
+        coordinator.refresh(isForced: true) { }
+        wait(for: [fetchExpectation], timeout: 2)
+
+        XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
+    }
+
+    func test_coordinator_whenEnterForeground_whenDataIsNotStale_doesNotRefreshHome() {
+        source.stubFetchSlateLineup { _ in
+            XCTFail("Should not fetch slate lineup")
+        }
+        let date = Date()
+        userDefaults.setValue(date, forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+
+        let coordinator = subject()
+        notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
+
+        XCTAssertEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
+    }
+
+    func test_coordinator_whenEnterForeground_whenDataIsStale_refreshesHome() {
+        let fetchExpectation = expectation(description: "expected to fetch slate lineup")
+        source.stubFetchSlateLineup { _ in fetchExpectation.fulfill() }
+        let date = Calendar.current.date(byAdding: .hour, value: -12, to: Date())
+        userDefaults.setValue(date, forKey: HomeRefreshCoordinator.dateLastRefreshKey)
+
+        let coordinator = subject()
+        notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
+
+        wait(for: [fetchExpectation], timeout: 2)
+        XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
+        XCTAssertNotEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockHomeRefreshCoordinator.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockHomeRefreshCoordinator.swift
@@ -1,0 +1,40 @@
+@testable import PocketKit
+
+class MockHomeRefreshCoordinator: HomeRefreshCoordinatorProtocol {
+    private var implementations: [String: Any] = [:]
+    private var calls: [String: [Any]] = [:]
+}
+
+extension MockHomeRefreshCoordinator {
+    private static let refresh = "refresh"
+    typealias RefreshImpl = (Bool, () -> Void) -> Void
+
+    struct RefreshCall {
+        let isForced: Bool
+        let completion: () -> Void
+    }
+
+    func stubRefresh(impl: @escaping RefreshImpl) {
+        implementations[Self.refresh] = impl
+    }
+
+    func refresh(isForced: Bool, _ completion: @escaping () -> Void) {
+        guard let impl = implementations[Self.refresh] as? RefreshImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.refresh] = (calls[Self.refresh] ?? []) + [
+            RefreshCall(isForced: isForced, completion: completion)
+        ]
+
+        impl(isForced, completion)
+    }
+
+    func refreshCall(at index: Int) -> RefreshCall? {
+        guard let calls = calls[Self.refresh], calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? RefreshCall
+    }
+}


### PR DESCRIPTION
## Summary
Add Home Refresh Rule so that when user opens app, it does not automatically refresh unless last refresh is >= 12 hours

## References 
IN-744

## Implementation Details
Added `HomeRefreshCoordinator` that uses user defaults to capture the timestamp of a refresh. Modify `refresh` in `HomeViewModel` to use this coordinator as well. 

## Test Steps
- [ ] WHEN I open the app
AND 12+ hours have elapsed since Home was last refreshed
THEN Home should automatically refresh
- [ ] WHEN I open the app
AND < 12 hours have elapsed since Home was last refreshed
THEN Home should not automatically refresh
- [ ] IF I am on the Home screen
AND I pull to refresh
AND 12+ hours have elapsed since Home was last refreshed
THEN Home should refresh
- [ ] IF I am on the Home screen
AND I pull to refresh
AND < 12 hours have elapsed since Home was last refreshed
THEN Home should refresh

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA