### PR TITLE
feat(migration): migrate legacy user sessions to new session type

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "rncryptor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RNCryptor/RNCryptor.git",
+      "state" : {
+        "revision" : "5e3bbf44f08bf90049537cb8902d8f4fa911a79a",
+        "version" : "5.1.0"
+      }
+    },
+    {
       "identity" : "sails",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jacobsimeon/Sails.git",

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.1.3"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.4.0"),
-        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "5.11.2")
+        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "5.11.2"),
+        .package(url: "https://github.com/RNCryptor/RNCryptor.git", .upToNextMajor(from: "5.0.0"))
     ],
     targets: [
         .target(
@@ -53,7 +54,10 @@ let package = Package(
         ),
 
         .target(
-            name: "SharedPocketKit"
+            name: "SharedPocketKit",
+            dependencies: [
+                "RNCryptor"
+            ]
         ),
         .testTarget(
             name: "SharedPocketKitTests",

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -81,6 +81,23 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         }
         Textiles.initialize()
 
+        do {
+            let migration = LegacyUserMigration(
+                userDefaults: userDefaults,
+                encryptedStore: PocketEncryptedStore(),
+                appSession: appSession
+            )
+
+            let attempted = try migration.perform()
+            if attempted {
+                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
+            } else {
+                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
+            }
+        } catch {
+            Crashlogger.capture(error: error)
+        }
+
         return true
     }
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -81,20 +81,27 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         }
         Textiles.initialize()
 
-        do {
-            let migration = LegacyUserMigration(
-                userDefaults: userDefaults,
-                encryptedStore: PocketEncryptedStore(),
-                appSession: appSession
-            )
+        let legacyUserMigration = LegacyUserMigration(
+            userDefaults: userDefaults,
+            encryptedStore: PocketEncryptedStore(),
+            appSession: appSession
+        )
 
-            let attempted = try migration.perform()
+        do {
+            let attempted = try legacyUserMigration.perform()
             if attempted {
                 Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
             } else {
                 Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
+        } catch LegacyUserMigrationError.missingStore {
+            Crashlogger.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
+            // Since we don't have a store, we can skip any further attempts at running this migration.
+            legacyUserMigration.forceSkip()
         } catch {
+            // All errors are something we can't resolve client-side, so we don't want to re-attempt
+            // on further launches.
+            legacyUserMigration.forceSkip()
             Crashlogger.capture(error: error)
         }
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -84,25 +84,26 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         let legacyUserMigration = LegacyUserMigration(
             userDefaults: userDefaults,
             encryptedStore: PocketEncryptedStore(),
-            appSession: appSession
+            appSession: appSession,
+            groupID: Keys.shared.groupID
         )
 
         do {
             let attempted = try legacyUserMigration.perform()
             if attempted {
-                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
+                Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
             } else {
-                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
+                Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
         } catch LegacyUserMigrationError.missingStore {
-            Crashlogger.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
+            Log.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
             // Since we don't have a store, we can skip any further attempts at running this migration.
             legacyUserMigration.forceSkip()
         } catch {
             // All errors are something we can't resolve client-side, so we don't want to re-attempt
             // on further launches.
             legacyUserMigration.forceSkip()
-            Crashlogger.capture(error: error)
+            Log.capture(error: error)
         }
 
         return true

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -15,22 +15,31 @@ class MainViewController: UIViewController {
         Textiles.initialize()
 
         let appSession = services.appSession
+        let encryptedStore = PocketEncryptedStore()
+        let userDefaults = services.userDefaults
         let child: UIViewController
 
-        do {
-            let migration = LegacyUserMigration(
-                userDefaults: services.userDefaults,
-                encryptedStore: PocketEncryptedStore(),
-                appSession: appSession
-            )
+        let legacyUserMigration = LegacyUserMigration(
+            userDefaults: userDefaults,
+            encryptedStore: encryptedStore,
+            appSession: appSession
+        )
 
-            let attempted = try migration.perform()
+        do {
+            let attempted = try legacyUserMigration.perform()
             if attempted {
                 Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
             } else {
                 Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
+        } catch LegacyUserMigrationError.missingStore {
+            Crashlogger.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
+            // Since we don't have a store, we can skip any further attempts at running this migration.
+            legacyUserMigration.forceSkip()
         } catch {
+            // All errors are something we can't resolve client-side, so we don't want to re-attempt
+            // on further launches.
+            legacyUserMigration.forceSkip()
             Crashlogger.capture(error: error)
         }
 

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -17,6 +17,23 @@ class MainViewController: UIViewController {
         let appSession = services.appSession
         let child: UIViewController
 
+        do {
+            let migration = LegacyUserMigration(
+                userDefaults: services.userDefaults,
+                encryptedStore: PocketEncryptedStore(),
+                appSession: appSession
+            )
+
+            let attempted = try migration.perform()
+            if attempted {
+                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
+            } else {
+                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
+            }
+        } catch {
+            Crashlogger.capture(error: error)
+        }
+
         if appSession.currentSession == nil {
             Log.clearUser()
             child = LoggedOutViewController(

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -22,25 +22,26 @@ class MainViewController: UIViewController {
         let legacyUserMigration = LegacyUserMigration(
             userDefaults: userDefaults,
             encryptedStore: encryptedStore,
-            appSession: appSession
+            appSession: appSession,
+            groupID: Keys.shared.groupdId
         )
 
         do {
             let attempted = try legacyUserMigration.perform()
             if attempted {
-                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
+                Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
             } else {
-                Crashlogger.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
+                Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
         } catch LegacyUserMigrationError.missingStore {
-            Crashlogger.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
+            Log.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")
             // Since we don't have a store, we can skip any further attempts at running this migration.
             legacyUserMigration.forceSkip()
         } catch {
             // All errors are something we can't resolve client-side, so we don't want to re-attempt
             // on further launches.
             legacyUserMigration.forceSkip()
-            Crashlogger.capture(error: error)
+            Log.capture(error: error)
         }
 
         if appSession.currentSession == nil {

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -11,6 +11,7 @@ struct Services {
     let saveService: PocketSaveService
     let tracker: Tracker
     let firstLaunchDefaults: UserDefaults
+    let userDefaults: UserDefaults
 
     private let persistentContainer: PersistentContainer
 
@@ -33,5 +34,7 @@ struct Services {
             consumerKey: Keys.shared.pocketApiConsumerKey,
             expiringActivityPerformer: ProcessInfo.processInfo
         )
+
+        userDefaults = .standard
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+import RNCryptor
+
+public protocol LegacyEncryptedStore {
+    func decryptStore(securedBy password: String) throws -> Data?
+}
+
+public class PocketEncryptedStore: LegacyEncryptedStore {
+    private lazy var storeURL: URL? = {
+        let groupID = "group.com.ideashower.ReadItLaterPro"
+        let directory = "data"
+        let filename = "PKTSharedKeyStore.json"
+
+        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupID) else {
+            return nil
+        }
+
+        let filepath = url.appendingPathComponent(directory).appendingPathComponent("PKTSharedKeyStore").appendingPathExtension("json")
+
+        guard FileManager.default.fileExists(atPath: filepath.absoluteString) else {
+            return nil
+        }
+
+        return url
+    }()
+
+    public init() { }
+
+    public func decryptStore(securedBy password: String) throws -> Data? {
+        guard let storeURL = storeURL else {
+            throw LegacyUserMigrationError.missingStore
+        }
+
+        let data = try Data(contentsOf: storeURL)
+        return try RNCryptor.decrypt(data: data, withPassword: password)
+    }
+}

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
@@ -17,7 +17,7 @@ public class PocketEncryptedStore: LegacyEncryptedStore {
 
         let filepath = url.appendingPathComponent(directory).appendingPathComponent("PKTSharedKeyStore").appendingPathExtension("json")
 
-        guard FileManager.default.fileExists(atPath: filepath.absoluteString) else {
+        guard FileManager.default.fileExists(atPath: filepath.path) else {
             return nil
         }
 

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
@@ -21,7 +21,7 @@ public class PocketEncryptedStore: LegacyEncryptedStore {
             return nil
         }
 
-        return url
+        return filepath
     }()
 
     public init() { }

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+public enum LegacyUserMigrationError: Error, LocalizedError {
+    case missingKey
+    case missingStore
+    case failedDecryption(Error)
+    case missingData
+    case failedDeserialization(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingKey: return "Missing decryption key for legacy user migration"
+        case .missingStore: return "Missing file for legacy store"
+        case .failedDecryption(let error): return "Failed to decrypt store: \(error)"
+        case .missingData: return "Data is missing after decrypting store"
+        case .failedDeserialization(let error): return "Failed to deserialize data: \(error)"
+        }
+    }
+}
+
+public class LegacyUserMigration {
+    static let migrationKey = "com.mozilla.pocket.next.migration.legacyUser"
+    static let versionKey = "version"
+    static let decryptionKey = "kPKTCryptoKey"
+
+    private let userDefaults: UserDefaults
+    private let encryptedStore: LegacyEncryptedStore
+    private let appSession: AppSession
+
+    public init(
+        userDefaults: UserDefaults,
+        encryptedStore: LegacyEncryptedStore,
+        appSession: AppSession
+    ) {
+        self.userDefaults = userDefaults
+        self.encryptedStore = encryptedStore
+        self.appSession = appSession
+    }
+
+    @discardableResult
+    public func perform() throws -> Bool {
+        guard let password = userDefaults.string(forKey: Self.decryptionKey) else {
+            throw LegacyUserMigrationError.missingKey
+        }
+
+        let decryptedData: Data?
+        do {
+            decryptedData = try encryptedStore.decryptStore(securedBy: password)
+        } catch {
+            throw LegacyUserMigrationError.failedDecryption(error)
+        }
+
+        guard let decryptedData = decryptedData else {
+            throw LegacyUserMigrationError.missingData
+        }
+
+        let legacyStore: LegacyStore
+        do {
+            legacyStore = try JSONDecoder().decode(LegacyStore.self, from: decryptedData)
+        } catch {
+            throw LegacyUserMigrationError.failedDeserialization(error)
+        }
+
+        guard isRequired(version: legacyStore.version) else {
+            updateUserDefaults()
+            return false
+        }
+
+        appSession.currentSession = Session(
+            guid: legacyStore.guid,
+            accessToken: legacyStore.accessToken,
+            userIdentifier: legacyStore.userIdentifier
+        )
+
+        updateUserDefaults()
+        return true
+    }
+}
+
+extension LegacyUserMigration {
+    func isRequired(version: String) -> Bool {
+        // On a fresh install, the app will not have a "previous version", and
+        // thus will not be required to run. If the previous version is < 8,
+        // and we have not yet run the migration, then it is required.
+        return required(for: version) && !previouslyRun
+    }
+
+    private var previouslyRun: Bool {
+        userDefaults.bool(forKey: Self.migrationKey)
+    }
+
+    private func required(for version: String) -> Bool {
+        guard let majorComponent = version.components(separatedBy: ".").first,
+              let previousMajorComponent = Int(majorComponent),
+              previousMajorComponent < 8 else {
+            return false
+        }
+
+        return true
+    }
+
+    private func updateUserDefaults() {
+        if !userDefaults.bool(forKey: Self.migrationKey) {
+            userDefaults.set(true, forKey: Self.migrationKey)
+        }
+    }
+}
+
+private struct LegacyStore: Decodable {
+    let guid: String
+    let accessToken: String
+    let userIdentifier: String
+    let version: String
+
+    enum CodingKeys: String, CodingKey {
+        case guid
+        case accessToken
+        case userIdentifier = "uid"
+        case version
+    }
+}

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -46,6 +46,14 @@ public class LegacyUserMigration {
         let decryptedData: Data?
         do {
             decryptedData = try encryptedStore.decryptStore(securedBy: password)
+        } catch LegacyUserMigrationError.missingStore {
+            // Decryption can throw one of "two" errors - .missingStore, and
+            // the rethrow of the internal decryption. We want to
+            // forward the missing store to force-skip the
+            // migration as necessary, since the migration shouldn't
+            // have been attempted if there is no file on disk.
+            // It is likely that the user has a fresh install, then.
+            throw LegacyUserMigrationError.missingStore
         } catch {
             throw LegacyUserMigrationError.failedDecryption(error)
         }
@@ -74,6 +82,10 @@ public class LegacyUserMigration {
 
         updateUserDefaults()
         return true
+    }
+
+    public func forceSkip() {
+        updateUserDefaults()
     }
 }
 

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -130,7 +130,7 @@ extension LegacyUserMigration {
     }
 
     private var keychainPassword: String? {
-        LegacyPasswordRetriever(keychain: keychain, groupID: groupID).password
+        LegacyPasswordRetriever(groupID: groupID, key: Self.decryptionKey).password
     }
 
     private var userDefaultsPassword: String? {
@@ -155,24 +155,7 @@ private struct LegacyStore: Decodable {
 private class LegacyPasswordRetriever {
     let password: String?
 
-    init(keychain: Keychain, groupID: String) {
-        let query: CFDictionary = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: "Pocket",
-            kSecAttrAccount: "encryption",
-            kSecAttrAccessGroup: groupID,
-            kSecReturnData: true
-        ] as CFDictionary
-
-        var result: AnyObject?
-        let status = keychain.copyMatching(query: query, result: &result)
-
-        guard status == errSecSuccess,
-              let password = result as? String else {
-            password = nil
-            return
-        }
-
-        self.password = password
+    init(groupID: String, key: String) {
+        password = UserDefaults(suiteName: groupID)?.string(forKey: key)
     }
 }

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import SharedPocketKit
+
+class BlankKeychain: Keychain {
+    func add(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        .zero
+    }
+
+    func update(query: CFDictionary, attributes: CFDictionary) -> OSStatus {
+        .zero
+    }
+
+    func delete(query: CFDictionary) -> OSStatus {
+        .zero
+    }
+
+    func copyMatching(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        .zero
+    }
+}
+
+class MockEncryptedStore: LegacyEncryptedStore {
+    typealias Impl = (String) throws -> Data?
+    private var impl: Impl?
+
+    func stubDecryptStore(_ impl: @escaping Impl) {
+        self.impl = impl
+    }
+
+    func decryptStore(securedBy password: String) throws -> Data? {
+        guard let impl = impl else {
+            fatalError("decryptedStore must be stubbed before use")
+        }
+
+        return try impl(password)
+    }
+}
+
+private enum MockError: Error {
+    case someError
+}
+
+class LegacyUserMigrationTests: XCTestCase {
+    private var userDefaults: UserDefaults!
+    private var encryptedStore: MockEncryptedStore!
+    private var appSession: AppSession!
+
+    private func subject(
+        userDefaults: UserDefaults? = nil,
+        encryptedStore: LegacyEncryptedStore? = nil,
+        appSession: AppSession? = nil
+    ) -> LegacyUserMigration {
+        return LegacyUserMigration(
+            userDefaults: userDefaults ?? self.userDefaults,
+            encryptedStore: encryptedStore ?? self.encryptedStore,
+            appSession: appSession ?? self.appSession
+        )
+    }
+
+    override func setUp() {
+        userDefaults = UserDefaults(suiteName: "LegacyUserMigrationTests")
+        encryptedStore = MockEncryptedStore()
+        appSession = AppSession(keychain: BlankKeychain())
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: "LegacyUserMigrationTests")
+    }
+}
+
+// MARK: - isRequired
+extension LegacyUserMigrationTests {
+    func test_isRequired_withPreviousVersionLessThan8_andNotRun_returnsTrue() {
+        let migration = subject()
+        XCTAssertTrue(migration.isRequired(version: "7.0.0"))
+    }
+
+    func test_isRequired_withPreviousVersionLessThan8_andRun_returnsFalse() {
+        userDefaults.set(true, forKey: LegacyUserMigration.migrationKey)
+        let migration = subject()
+        XCTAssertFalse(migration.isRequired(version: "7.0.0"))
+    }
+
+    func test_isRequired_withPreviousVersionGreaterThanOrEqualTo8_andNotRun_returnsFalse() {
+        var migration = subject()
+        XCTAssertFalse(migration.isRequired(version: "8.0.0"))
+
+        migration = subject()
+        XCTAssertFalse(migration.isRequired(version: "9.0.0"))
+    }
+
+    func test_isRequired_withPreviousVersionGreaterThanOrEqualTo8_andRun_returnsFalse() {
+        userDefaults.set(true, forKey: LegacyUserMigration.migrationKey)
+
+        var migration = subject()
+        XCTAssertFalse(migration.isRequired(version: "8.0.0"))
+    }
+}
+
+// MARK: - perform (requirements)
+extension LegacyUserMigrationTests {
+    func test_perform_whenNotRequired_doesNotThrowError() {
+        let migration = subject()
+        userDefaults.set(true, forKey: LegacyUserMigration.migrationKey)
+        userDefaults.set("key", forKey: LegacyUserMigration.decryptionKey)
+        encryptedStore.stubDecryptStore { key in
+            let correct: [String: Any] = [
+                "guid": "guid",
+                "accessToken": "accessToken",
+                "uid": "uid",
+                "version": "7.0.0"
+            ]
+
+            return try! JSONSerialization.data(withJSONObject: correct)
+        }
+
+        XCTAssertNoThrow(try migration.perform())
+    }
+
+    func test_perform_withMissingKey_throwsError() {
+        let migration = subject()
+
+        do {
+            try migration.perform()
+        } catch {
+            guard case LegacyUserMigrationError.missingKey = error else {
+                XCTFail("Incorrect error thrown")
+                return
+            }
+        }
+    }
+}
+
+// MARK: - perform (guid)
+// For these tests to correctly function, implement the same stub
+// for all keys (since guid is checked first)
+extension LegacyUserMigrationTests {
+    func test_perform_storeFailedDecryption_throwsError() {
+        let migration = subject()
+        userDefaults.set("key", forKey: "kPKTCryptoKey")
+        encryptedStore.stubDecryptStore { _ in
+            throw MockError.someError
+        }
+
+        do {
+            try migration.perform()
+        } catch {
+            guard case LegacyUserMigrationError.failedDecryption = error else {
+                XCTFail("Incorrect error thrown")
+                return
+            }
+        }
+    }
+
+    func test_perform_storeReturnedNilData_throwsError() {
+        let migration = subject()
+        userDefaults.set("key", forKey: "kPKTCryptoKey")
+        encryptedStore.stubDecryptStore { _ in
+            return nil
+        }
+
+        do {
+            try migration.perform()
+        } catch {
+            guard case LegacyUserMigrationError.missingData = error else {
+                XCTFail("Incorrect error thrown")
+                return
+            }
+        }
+    }
+
+    func test_perform_storeReturnedIncorrectData_throwsError() {
+        let migration = subject()
+        userDefaults.set("key", forKey: "kPKTCryptoKey")
+        encryptedStore.stubDecryptStore { _ in
+            let incorrect: [String: Any] = [
+                "guid": "guid"
+            ]
+
+            return try! JSONSerialization.data(withJSONObject: incorrect)
+        }
+
+        do {
+            try migration.perform()
+        } catch {
+            guard case LegacyUserMigrationError.failedDeserialization = error else {
+                XCTFail("Incorrect error thrown")
+                return
+            }
+        }
+    }
+}
+
+// MARK: - perform (passing)
+extension LegacyUserMigrationTests {
+    func test_perform_allValid_updatesAppSession() throws {
+        // Required to regenerate migration with updated infoDictionary since infoDictionary
+        // is a value type, and thus pass-by-copy
+        userDefaults.set("7.0.0", forKey: LegacyUserMigration.versionKey)
+        let migration = subject()
+
+        userDefaults.set("key", forKey: LegacyUserMigration.decryptionKey)
+        encryptedStore.stubDecryptStore { key in
+            let correct: [String: Any] = [
+                "guid": "guid",
+                "accessToken": "accessToken",
+                "uid": "uid",
+                "version": "7.0.0"
+            ]
+
+            return try! JSONSerialization.data(withJSONObject: correct)
+        }
+
+        try migration.perform()
+
+        XCTAssertEqual(appSession.currentSession?.guid, "guid")
+        XCTAssertEqual(appSession.currentSession?.accessToken, "accessToken")
+        XCTAssertEqual(appSession.currentSession?.userIdentifier, "uid")
+    }
+}

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -138,20 +138,6 @@ extension LegacyUserMigrationTests {
         }
     }
 
-    func test_perform_withKeyInKeychain_doesNotThrowError() {
-        keychain.copyMatchingResult = "password" as CFTypeRef
-        let migration = subject()
-        encryptedStore.stubDecryptStore { _ in return nil }
-
-        do {
-            try migration.perform()
-        } catch {
-            if case LegacyUserMigrationError.missingKey = error {
-                XCTFail("Key should exist; error should not be thrown")
-            }
-        }
-    }
-
     func test_perform_withKeyNotInKeychainAndInUserDefaults_doesNotThrowError() {
         userDefaults.set("password", forKey: LegacyUserMigration.decryptionKey)
 

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -44,23 +44,31 @@ class LegacyUserMigrationTests: XCTestCase {
     private var userDefaults: UserDefaults!
     private var encryptedStore: MockEncryptedStore!
     private var appSession: AppSession!
+    private var keychain: MockKeychain!
+    private var groupID: String!
 
     private func subject(
         userDefaults: UserDefaults? = nil,
         encryptedStore: LegacyEncryptedStore? = nil,
-        appSession: AppSession? = nil
+        appSession: AppSession? = nil,
+        keychain: Keychain? = nil,
+        groupID: String? = nil
     ) -> LegacyUserMigration {
         return LegacyUserMigration(
             userDefaults: userDefaults ?? self.userDefaults,
             encryptedStore: encryptedStore ?? self.encryptedStore,
-            appSession: appSession ?? self.appSession
+            appSession: appSession ?? self.appSession,
+            keychain: keychain ?? self.keychain,
+            groupID: groupID ?? self.groupID
         )
     }
 
     override func setUp() {
+        groupID = "group.com.mozilla.test"
         userDefaults = UserDefaults(suiteName: "LegacyUserMigrationTests")
         encryptedStore = MockEncryptedStore()
-        appSession = AppSession(keychain: BlankKeychain())
+        appSession = AppSession(keychain: BlankKeychain(), groupID: groupID)
+        keychain = MockKeychain()
     }
 
     override func tearDown() {
@@ -117,7 +125,7 @@ extension LegacyUserMigrationTests {
         XCTAssertNoThrow(try migration.perform())
     }
 
-    func test_perform_withMissingKey_throwsError() {
+    func test_perform_withMissingKeyInKeychainAndDefaults_throwsError() {
         let migration = subject()
 
         do {
@@ -126,6 +134,35 @@ extension LegacyUserMigrationTests {
             guard case LegacyUserMigrationError.missingKey = error else {
                 XCTFail("Incorrect error thrown")
                 return
+            }
+        }
+    }
+
+    func test_perform_withKeyInKeychain_doesNotThrowError() {
+        keychain.copyMatchingResult = "password" as CFTypeRef
+        let migration = subject()
+        encryptedStore.stubDecryptStore { _ in return nil }
+
+        do {
+            try migration.perform()
+        } catch {
+            if case LegacyUserMigrationError.missingKey = error {
+                XCTFail("Key should exist; error should not be thrown")
+            }
+        }
+    }
+
+    func test_perform_withKeyNotInKeychainAndInUserDefaults_doesNotThrowError() {
+        userDefaults.set("password", forKey: LegacyUserMigration.decryptionKey)
+
+        let migration = subject()
+        encryptedStore.stubDecryptStore { _ in return nil }
+
+        do {
+            try migration.perform()
+        } catch {
+            if case LegacyUserMigrationError.missingKey = error {
+                XCTFail("Key should exist; error should not be thrown")
             }
         }
     }


### PR DESCRIPTION
## Summary

As required, performs a migration of a legacy user session (guid, access token, and user identifier) from the legacy session store to the new keychain-based store.

## References 

IN-845

## Implementation Details

There are two main portions to this implementation:
1. Verify that the application _needs_ to run the migration
    - If the user's last known application version was < 8.x.x, and the migration had not yet been run
2. Perform the migration, either in the main app or the save extension.

For obtaining the previous version _as well as_ the legacy session information, we have to dig into an encrypted JSON file, stored in a shared directory (so that both the extension and application can read from it). We use `RNCryptor` to decrypt the data (from the JSON file), using a password stored in `UserDefaults`. To simplify deserialization, we create a `LegacyStore` type that represents the data we want to decrypt (specifically for that migration). 

We have to attempt to run the migration in two spots:
1. The main app
2. The save extension

The reason for also attempting to run within the save extension is that there is a possibility that the user updated the app (either explicitly or via automatic update), and opened the save extension prior to opening the main app. This way, one migration is synchronized across both targets.

## Test Steps

???

## PR Checklist:

- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA