### PR TITLE
ci(swiftlint): Update Rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,6 @@ disabled_rules: # rule identifiers to exclude from running
   - deployment_target
   - discouraged_direct_init
   - discarded_notification_center_observer
-  - duplicate_imports
   - fallthrough
   - file_length
   - for_where
@@ -48,8 +47,6 @@ disabled_rules: # rule identifiers to exclude from running
   - unused_closure_parameter
   - unused_control_flow_label
   - unused_enumerated
-  - unused_optional_binding
-  - unused_setter_value
   - valid_ibinspectable
   - vertical_parameter_alignment
   - weak_delegate
@@ -91,6 +88,8 @@ opt_in_rules: # some rules are only opt-in
   - multiline_arguments
   - opening_brace
   - return_arrow_whitespace
+  - unused_import
+  - yoda_condition
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
@@ -6,7 +6,6 @@ import Textile
 import Sync
 import Combine
 import Foundation
-import Sync
 import Analytics
 import CoreData
 import UIKit

--- a/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ArchivedItemsListViewModelTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Sync
 import Combine
 import Network
 import Analytics

--- a/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Sync
 
 @testable import Sync
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Sync
 import Analytics
 import Combine
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import Analytics
-import Sync
 import Combine
 
 @testable import Sync

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Sync
 import Combine
 import Analytics
 import CoreData

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Sync
 
 @testable import Sync
 @testable import SaveToPocketKit

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Analytics
 import SharedPocketKit
-import Sync
 
 @testable import Sync
 @testable import SaveToPocketKit

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Fixture.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Fixture.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Apollo
 import ApolloAPI
-import Sync
 
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Apollo
 import PocketGraph
-import Sync
 
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/Support/Fixture.swift
+++ b/PocketKit/Tests/SyncTests/Support/Fixture.swift
@@ -5,7 +5,6 @@
 import Foundation
 import Apollo
 import ApolloAPI
-import Sync
 
 @testable import Sync
 


### PR DESCRIPTION
## Summary
Update swiftlint rules that have been voted on according to the SwiftLint Mozilla spreadsheet
https://docs.google.com/spreadsheets/d/1UY2rqwVFDbyJYj4oSnwSrdE4Fj2Wy-RhuH4AFaBUogY/edit#gid=841652337

## References 
IN-995

## Implementation Details
With this work, we add the following:
- duplicate_imports
- unused_optional_binding
- unused_setter_value
- unused_import
- yoda_condition

There are four more rules that we need to implement, which may need a discussion so will save it for the next round.

## Test Steps
Build project and confirm that rules are enabled and no warnings associated with those rules

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
