### PR TITLE
feat(premium): fetch user status [IN-979]

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "3481cf155516b5b223b8bcea71b74ff002db1625",
-        "version" : "5.6.0"
+        "revision" : "aeb3213fcabcd95f4c4831d895eb01a60db26b87",
+        "version" : "5.6.2"
       }
     },
     {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -79,7 +79,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Apollo", package: "apollo-ios"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
-                "PocketGraph"
+                "PocketGraph",
+                "SharedPocketKit"
             ],
             resources: [.process("PocketModel.xcdatamodeld")]
         ),

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
@@ -11,6 +11,7 @@ public class FetchSavesQuery: GraphQLQuery {
       query FetchSaves($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
         userByToken(token: $token) {
           __typename
+          isPremium
           savedItems(pagination: $pagination, filter: $savedItemsFilter) {
             __typename
             totalCount
@@ -75,12 +76,15 @@ public class FetchSavesQuery: GraphQLQuery {
 
       public static var __parentType: ParentType { PocketGraph.Objects.User }
       public static var __selections: [Selection] { [
+        .field("isPremium", Bool?.self),
         .field("savedItems", SavedItems?.self, arguments: [
           "pagination": .variable("pagination"),
           "filter": .variable("savedItemsFilter")
         ]),
       ] }
 
+      /// The user's premium status
+      public var isPremium: Bool? { __data["isPremium"] }
       /// Get a general paginated listing of all SavedItems for the user
       public var savedItems: SavedItems? { __data["savedItems"] }
 

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/list.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/list.graphql
@@ -22,6 +22,7 @@ fragment TagParts on Tag {
 
 query FetchSaves($token: String!, $pagination: PaginationInput, $savedItemsFilter: SavedItemsFilter) {
   userByToken(token: $token) {
+    isPremium
     savedItems(pagination: $pagination, filter: $savedItemsFilter) {
       totalCount
       pageInfo {

--- a/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
@@ -6,13 +6,16 @@ class SignOutOnFirstLaunch {
     static let hasAppBeenLaunchedPreviouslyKey = "hasAppBeenLaunchedPreviously"
 
     private let appSession: AppSession
+    private let user: User
     private let userDefaults: UserDefaults
 
     init(
         appSession: AppSession,
+        user: User,
         userDefaults: UserDefaults
     ) {
         self.appSession = appSession
+        self.user = user
         self.userDefaults = userDefaults
     }
 
@@ -30,6 +33,7 @@ class SignOutOnFirstLaunch {
             return
         }
 
+        user.clear()
         appSession.currentSession = nil
         hasAppBeenLaunchedPreviously = true
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -131,7 +131,7 @@ class HomeViewModel {
 
         networkPathMonitor.updateHandler = { [weak self] path in
             if path.status == .satisfied {
-                self?.refresh { }
+                self?.refresh(isForced: true) { }
             }
         }
     }

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -16,6 +16,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     private let refreshCoordinator: RefreshCoordinator
     private let appSession: AppSession
     internal let notificationService: PushNotificationService
+    private let user: User
 
     convenience override init() {
         self.init(services: Services.shared)
@@ -28,6 +29,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.refreshCoordinator = services.refreshCoordinator
         self.appSession = services.appSession
         self.notificationService = services.notificationService
+        self.user = services.user
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -57,6 +59,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
 
         SignOutOnFirstLaunch(
             appSession: appSession,
+            user: user,
             userDefaults: firstLaunchDefaults
         ).signOutOnFirstLaunch()
 

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -32,7 +32,10 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                         networkPathMonitor: NWPathMonitor(),
                         homeRefreshCoordinator: Services.shared.homeRefreshCoordinator
                     ),
-                    account: AccountViewModel(appSession: Services.shared.appSession)
+                    account: AccountViewModel(
+                        appSession: Services.shared.appSession,
+                        user: Services.shared.user
+                    )
                 ),
                 source: Services.shared.source,
                 tracker: Services.shared.tracker

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -16,6 +16,7 @@ struct Services {
     let userDefaults: UserDefaults
     let firstLaunchDefaults: UserDefaults
     let appSession: AppSession
+    let user: User
     let urlSession: URLSessionProtocol
     let source: Sync.Source
     let tracker: Tracker
@@ -45,12 +46,14 @@ struct Services {
             consumerKey: Keys.shared.pocketApiConsumerKey,
             authenticationSessionFactory: ASWebAuthenticationSession.init
         )
+        user = PocketUser(userDefaults: userDefaults)
 
         let snowplow = PocketSnowplowTracker()
         tracker = PocketTracker(snowplow: snowplow)
 
         source = PocketSource(
             space: persistentContainer.rootSpace,
+            user: user,
             sessionProvider: appSession,
             consumerKey: Keys.shared.pocketApiConsumerKey,
             defaults: userDefaults,

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -7,14 +7,17 @@ import SwiftUI
 
 class AccountViewModel: ObservableObject {
     private let appSession: AppSession
+    private let user: User
 
-    init(appSession: AppSession) {
+    init(appSession: AppSession, user: User) {
         self.appSession = appSession
+        self.user = user
     }
 
     func signOut() {
         // Post that we logged out to the rest of the app using the old session
         NotificationCenter.default.post(name: .userLoggedOut, object: appSession.currentSession)
+        user.clear()
         appSession.currentSession = nil
     }
 

--- a/PocketKit/Sources/SharedPocketKit/Keychain.swift
+++ b/PocketKit/Sources/SharedPocketKit/Keychain.swift
@@ -7,9 +7,7 @@ import Foundation
 public protocol Keychain {
     func add(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
     func update(query: CFDictionary, attributes: CFDictionary) -> OSStatus
-
     func delete(query: CFDictionary) -> OSStatus
-
     func copyMatching(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
 }
 

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftUI
+
+public enum Status: String {
+    case premium = "premium"
+    case free = "free"
+    case unknown = "unknown"
+}
+
+public protocol User {
+    func setPremiumStatus(_ isPremium: Bool)
+    func clear()
+}
+
+public class PocketUser: User {
+    static let userStatusKey = "User.statusKey"
+
+    @AppStorage
+    public var status: Status?
+
+    public init(status: Status = .unknown, userDefaults: UserDefaults) {
+        _status = AppStorage(Self.userStatusKey, store: userDefaults)
+    }
+
+    public func setPremiumStatus(_ isPremium: Bool) {
+        status = isPremium ? .premium : .free
+    }
+
+    public func clear() {
+        status = .unknown
+    }
+}

--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -2,8 +2,10 @@ import Foundation
 import Apollo
 import Combine
 import PocketGraph
+import SharedPocketKit
 
 class FetchList: SyncOperation {
+    private let user: User
     private let token: String
     private let apollo: ApolloClientProtocol
     private let space: Space
@@ -13,6 +15,7 @@ class FetchList: SyncOperation {
     private let lastRefresh: LastRefresh
 
     init(
+        user: User,
         token: String,
         apollo: ApolloClientProtocol,
         space: Space,
@@ -21,6 +24,7 @@ class FetchList: SyncOperation {
         maxItems: Int,
         lastRefresh: LastRefresh
     ) {
+        self.user = user
         self.token = token
         self.apollo = apollo
         self.space = space
@@ -61,6 +65,9 @@ class FetchList: SyncOperation {
 
         repeat {
             let result = try await fetchPage(pagination)
+            if let isPremium = result.data?.userByToken?.isPremium as? Bool {
+                user.setPremiumStatus(isPremium)
+             }
 
             if case .started = initialDownloadState.value,
                let totalCount = result.data?.userByToken?.savedItems?.totalCount,

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -3,9 +3,11 @@ import Apollo
 import Combine
 import CoreData
 import PocketGraph
+import SharedPocketKit
 
 protocol SyncOperationFactory {
     func fetchList(
+        user: User,
         token: String,
         apollo: ApolloClientProtocol,
         space: Space,
@@ -38,6 +40,7 @@ protocol SyncOperationFactory {
 
 class OperationFactory: SyncOperationFactory {
     func fetchList(
+        user: User,
         token: String,
         apollo: ApolloClientProtocol,
         space: Space,
@@ -47,6 +50,7 @@ class OperationFactory: SyncOperationFactory {
         lastRefresh: LastRefresh
     ) -> SyncOperation {
         return FetchList(
+            user: user,
             token: token,
             apollo: apollo,
             space: space,

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -7,6 +7,7 @@ import Apollo
 import Combine
 import Network
 import PocketGraph
+import SharedPocketKit
 
 public typealias SyncEvents = PassthroughSubject<SyncEvent, Never>
 
@@ -19,6 +20,7 @@ public class PocketSource: Source {
     public var initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>
 
     private let space: Space
+    private let user: User
     private let apollo: ApolloClientProtocol
     private let lastRefresh: LastRefresh
     private let slateService: SlateService
@@ -38,6 +40,7 @@ public class PocketSource: Source {
 
     public convenience init(
         space: Space,
+        user: User,
         sessionProvider: SessionProvider,
         consumerKey: String,
         defaults: UserDefaults,
@@ -50,6 +53,7 @@ public class PocketSource: Source {
 
         self.init(
             space: space,
+            user: user,
             apollo: apollo,
             operations: OperationFactory(),
             lastRefresh: UserDefaultsLastRefresh(defaults: defaults),
@@ -65,6 +69,7 @@ public class PocketSource: Source {
 
     init(
         space: Space,
+        user: User,
         apollo: ApolloClientProtocol,
         operations: SyncOperationFactory,
         lastRefresh: LastRefresh,
@@ -75,6 +80,7 @@ public class PocketSource: Source {
         osNotificationCenter: OSNotificationCenter
     ) {
         self.space = space
+        self.user = user
         self.apollo = apollo
         self.operations = operations
         self.lastRefresh = lastRefresh
@@ -184,6 +190,7 @@ extension PocketSource {
         }
 
         let operation = operations.fetchList(
+            user: user,
             token: token,
             apollo: apollo,
             space: space,
@@ -473,6 +480,7 @@ extension PocketSource {
             case .fetchList(let maxItems):
                 guard let token = sessionProvider.session?.accessToken else { return }
                 let operation = operations.fetchList(
+                    user: user,
                     token: token,
                     apollo: apollo,
                     space: space,

--- a/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import SharedPocketKit
+
+class PocketUserTests: XCTestCase {
+    private var userDefaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        userDefaults = UserDefaults(suiteName: "PocketUserTests")
+    }
+
+    override func tearDownWithError() throws {
+        UserDefaults.standard.removePersistentDomain(forName: "PocketUserTests")
+    }
+
+    func subject(
+        userDefaults: UserDefaults? = nil
+    ) -> PocketUser {
+        return PocketUser(
+            userDefaults: userDefaults ?? self.userDefaults
+        )
+    }
+
+    func test_setStatus_withPremiumTrue_setsPremiumStatus() {
+        let user = subject()
+        user.setPremiumStatus(true)
+        XCTAssertEqual(user.status, .premium)
+    }
+
+    func test_setStatus_withPremiumFalse_setsFreeStatus() {
+        let user = subject()
+        user.setPremiumStatus(false)
+        XCTAssertEqual(user.status, .free)
+    }
+
+    func test_clear_setsLoggedOutStatus() {
+        let user = subject()
+        user.clear()
+        XCTAssertEqual(user.status, .unknown)
+    }
+}

--- a/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/duplicate-list.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 1,

--- a/PocketKit/Tests/SyncTests/Fixtures/empty-list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/empty-list.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 0,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-1.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,

--- a/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/paginated-list-2.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,

--- a/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/updated-item.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 1,

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -10,7 +10,7 @@ extension PocketSourceTests {
 
     func test_enqueueingOperations_whenNetworkPathIsUnsatisfied_doesNotExecuteOperations() {
         sessionProvider.session = MockSession()
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation {
                 XCTFail("Operation should not be executed while network path is unsatisfied")
             }
@@ -33,7 +33,7 @@ extension PocketSourceTests {
         }
 
         let expectFetchList = expectation(description: "execute the fetch list operation")
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation {
                 expectFetchList.fulfill()
             }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
@@ -8,7 +8,7 @@ extension PocketSourceTests {
         sessionProvider.session = MockSession()
 
         let fetchList = expectation(description: "fetchList operation executed")
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation { fetchList.fulfill() }
         }
 
@@ -42,7 +42,7 @@ extension PocketSourceTests {
         source.drain { done.fulfill() }
         wait(for: [done], timeout: 1)
 
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             XCTFail("Operation should not be re-created after succeeding")
             return TestSyncOperation { }
         }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -7,11 +7,13 @@ import CoreData
 import Apollo
 import PocketGraph
 import Combine
+import SharedPocketKit
 
 @testable import Sync
 
 class PocketSourceTests: XCTestCase {
     var space: Space!
+    var user: MockUser!
     var apollo: MockApolloClient!
     var operations: MockOperationFactory!
     var lastRefresh: MockLastRefresh!
@@ -24,6 +26,7 @@ class PocketSourceTests: XCTestCase {
 
     override func setUpWithError() throws {
         space = .testSpace()
+        user = MockUser()
         apollo = MockApolloClient()
         operations = MockOperationFactory()
         lastRefresh = MockLastRefresh()
@@ -48,6 +51,7 @@ class PocketSourceTests: XCTestCase {
 
     func subject(
         space: Space? = nil,
+        user: User? = nil,
         apollo: ApolloClientProtocol? = nil,
         operations: OperationFactory? = nil,
         lastRefresh: LastRefresh? = nil,
@@ -58,6 +62,7 @@ class PocketSourceTests: XCTestCase {
     ) -> PocketSource {
         PocketSource(
             space: space ?? self.space,
+            user: user ?? self.user,
             apollo: apollo ?? self.apollo,
             operations: operations ?? self.operations,
             lastRefresh: lastRefresh ?? self.lastRefresh,
@@ -73,7 +78,7 @@ class PocketSourceTests: XCTestCase {
         let session = MockSession()
         sessionProvider.session = session
         let expectationToRunOperation = expectation(description: "Run operation")
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation {
                 expectationToRunOperation.fulfill()
             }
@@ -89,7 +94,7 @@ class PocketSourceTests: XCTestCase {
 
     func test_refreshWithCompletion_callsCompletionWhenFinished() {
         sessionProvider.session = MockSession()
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation { }
         }
 
@@ -105,7 +110,7 @@ class PocketSourceTests: XCTestCase {
 
     func test_refresh_whenTokenIsNil_callsCompletion() {
         sessionProvider.session = nil
-        operations.stubFetchList { _, _, _, _, _, _ in
+        operations.stubFetchList { _, _, _, _, _, _, _  in
             TestSyncOperation { }
         }
 

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -3,6 +3,7 @@ import Apollo
 import ApolloAPI
 import Combine
 import CoreData
+import SharedPocketKit
 
 @testable import Sync
 
@@ -14,6 +15,7 @@ class MockOperationFactory: SyncOperationFactory {
 // MARK: - fetchList
 extension MockOperationFactory {
     typealias FetchListImpl = (
+        User,
         String,
         ApolloClientProtocol,
         Space,
@@ -23,6 +25,7 @@ extension MockOperationFactory {
     ) -> SyncOperation
 
     struct FetchListCall {
+        let user: User
         let token: String
         let apollo: ApolloClientProtocol
         let space: Space
@@ -37,6 +40,7 @@ extension MockOperationFactory {
     }
 
     func fetchList(
+        user: User,
         token: String,
         apollo: ApolloClientProtocol,
         space: Space,
@@ -51,6 +55,7 @@ extension MockOperationFactory {
 
         calls["fetchList"] = (calls["fetchList"] ?? []) + [
             FetchListCall(
+                user: user,
                 token: token,
                 apollo: apollo,
                 space: space,
@@ -61,7 +66,7 @@ extension MockOperationFactory {
             )
         ]
 
-        return impl(token, apollo, space, events, initialDownloadState, maxItems)
+        return impl(user, token, apollo, space, events, initialDownloadState, maxItems)
     }
 
     func fetchListCall(at index: Int) -> FetchListCall? {

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -1,0 +1,65 @@
+import SharedPocketKit
+
+class MockUser: User {
+    private var implementations: [String: Any] = [:]
+    private var calls: [String: [Any]] = [:]
+}
+
+// MARK: - Set Status
+extension MockUser {
+    private static let setStatus = "setStatus"
+    typealias SetStatusImpl = (Bool) -> Void
+
+    struct SetStatusCall {
+        let isPremium: Bool
+    }
+
+    func stubSetStatus(impl: @escaping SetStatusImpl) {
+        implementations[Self.setStatus] = impl
+    }
+
+    func setPremiumStatus(_ isPremium: Bool) {
+        guard let impl = implementations[Self.setStatus] as? SetStatusImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.setStatus] = (calls[Self.setStatus] ?? []) + [
+            SetStatusCall(isPremium: isPremium)
+        ]
+
+        impl(isPremium)
+    }
+
+    func setStatusCall(at index: Int) -> SetStatusCall? {
+        guard let calls = calls[Self.setStatus],
+              calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? SetStatusCall
+    }
+}
+
+// MARK: - Clear
+extension MockUser {
+    private static let clear = "clear"
+    typealias ClearImpl = () -> Void
+
+    struct ClearCall { }
+
+    func stubClear(impl: @escaping ClearImpl) {
+        implementations[Self.clear] = impl
+    }
+
+    func clear() {
+        guard let impl = implementations[Self.clear] as? ClearImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.clear] = (calls[Self.clear] ?? []) + [
+            ClearCall()
+        ]
+
+        impl()
+    }
+}

--- a/Tests iOS/Fixtures/initial-list-recent-saves.json
+++ b/Tests iOS/Fixtures/initial-list-recent-saves.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,

--- a/Tests iOS/Fixtures/initial-list.json
+++ b/Tests iOS/Fixtures/initial-list.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,

--- a/Tests iOS/Fixtures/list-for-web-view.json
+++ b/Tests iOS/Fixtures/list-for-web-view.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/Tests iOS/Fixtures/list-with-archived-item.json
+++ b/Tests iOS/Fixtures/list-with-archived-item.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/Tests iOS/Fixtures/list-with-unarchived-item.json
+++ b/Tests iOS/Fixtures/list-with-unarchived-item.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 1,

--- a/Tests iOS/Fixtures/saves-loading-page-1.json
+++ b/Tests iOS/Fixtures/saves-loading-page-1.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/Tests iOS/Fixtures/saves-loading-page-2.json
+++ b/Tests iOS/Fixtures/saves-loading-page-2.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 3,

--- a/Tests iOS/Fixtures/updated-list.json
+++ b/Tests iOS/Fixtures/updated-list.json
@@ -2,6 +2,7 @@
     "data": {
         "userByToken": {
             "__typename": "[type-name-here]",
+            "isPremium": true,
             "savedItems": {
                 "__typename": "[type-name-here]",
                 "totalCount": 2,


### PR DESCRIPTION
## Summary
Fetch user premium status on sign-in by using `isPremium` field from GraphQL 

## References 
IN-979

## Implementation Details
* Added `isPremium` field to `userByToken` query that gets called when we are Fetching Saves
* Created new class `User` which stores the users status via @AppStorage
* Pass in the `user` to our `FetchList` in order to `setPremiumStatus`
* Add tests and create mocks for user class

## Test Steps
- [ ] WHEN I sign into the app,
THEN request my premium status
THEN store the premium status

- [ ] WHEN the application is launched 
AND a sync request is made (including for user’s premium status)
THEN store the premium status

- [ ] WHEN the user quits the application after launching
THEN the premium status should persist without another request

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
