### PR TITLE
build(graphql): generate updated schema

### DIFF
--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateLineupQuery.graphql.swift
@@ -49,7 +49,7 @@ public class GetSlateLineupQuery: GraphQLQuery {
 
     public static var __parentType: ParentType { PocketGraph.Objects.Query }
     public static var __selections: [Selection] { [
-      .field("getSlateLineup", GetSlateLineup?.self, arguments: [
+      .field("getSlateLineup", GetSlateLineup.self, arguments: [
         "slateLineupId": .variable("lineupID"),
         "recommendationCount": .variable("maxRecommendations")
       ]),
@@ -57,7 +57,7 @@ public class GetSlateLineupQuery: GraphQLQuery {
 
     /// Request a specific `SlateLineup` by id
     @available(*, deprecated, message: "Please use queries specific to the surface ex. setMomentSlate. If a named query for your surface does not yet exit please reach out to the Data Products team and they will happily provide you with a named query.")
-    public var getSlateLineup: GetSlateLineup? { __data["getSlateLineup"] }
+    public var getSlateLineup: GetSlateLineup { __data["getSlateLineup"] }
 
     /// GetSlateLineup
     ///

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateQuery.graphql.swift
@@ -40,7 +40,7 @@ public class GetSlateQuery: GraphQLQuery {
 
     public static var __parentType: ParentType { PocketGraph.Objects.Query }
     public static var __selections: [Selection] { [
-      .field("getSlate", GetSlate?.self, arguments: [
+      .field("getSlate", GetSlate.self, arguments: [
         "slateId": .variable("slateID"),
         "recommendationCount": .variable("recommendationCount")
       ]),
@@ -48,7 +48,7 @@ public class GetSlateQuery: GraphQLQuery {
 
     /// Request a specific `Slate` by id
     @available(*, deprecated, message: "Please use queries specific to the surface ex. setMomentSlate. If a named query for your surface does not yet exit please reach out to the Data Products team and they will happily provide you with a named query.")
-    public var getSlate: GetSlate? { __data["getSlate"] }
+    public var getSlate: GetSlate { __data["getSlate"] }
 
     /// GetSlate
     ///

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -34,7 +34,7 @@ class APISlateService: SlateService {
         let query = GetSlateQuery(slateID: slateID, recommendationCount: 25)
 
         guard let remote = try await apollo.fetch(query: query)
-            .data?.getSlate?.fragments.slateParts else {
+            .data?.getSlate.fragments.slateParts else {
             return
         }
 


### PR DESCRIPTION
## Summary

Update the GraphQL schema and auto-generated code to include changes to the `getSlateLineup` and `getSlate` queries. This change made the return type of these queries non-optional, which we then had to reflect in our usage of these queries in `Sync`.

## Implementation Details
 
The commands (in our README) to redownload and regenerate code based on our GraphQL schema were called.
