### PR TITLE
ci(swiftlint): add custom rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ disabled_rules: # rule identifiers to exclude from running
   # Disabled all default rules
   - block_based_kvo
   - closure_parameter_position
-  - custom_rules
   - cyclomatic_complexity
   - deployment_target
   - discouraged_direct_init
@@ -90,6 +89,13 @@ opt_in_rules: # some rules are only opt-in
   - return_arrow_whitespace
   - unused_import
   - yoda_condition
+
+custom_rules:
+  redundant_internal_acl:
+    name: "Redundant Internal Access Level"
+    regex: "internal func"
+    message: "Internal by default; no need to explicitly mark it as such"
+    severity: warning
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -214,7 +214,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         })
     }
 
-    func favoriteAction(for objectID: NSManagedObjectID) -> ItemAction? {
+    internal func favoriteAction(for objectID: NSManagedObjectID) -> ItemAction? {
         guard let item = bareItem(with: objectID) else {
             return nil
         }


### PR DESCRIPTION
## Summary
Draft PR to demonstrate custom rule. Included an example. Issue with this is that it triggers even in cases when we want it to be explicit, but we can always disable this rule for this cases. Open for team discussion!

Custom Rule is related to this:
https://github.com/Pocket/pocket-ios/wiki/Pocket-Swift-Style-Guide#internal-by-default

## References 
N / A

## Test Steps
Pull down this branch and confirm that the warning appears when explicitly adding internal to a function. 

## Screenshots
![image](https://user-images.githubusercontent.com/6743397/202227889-5b5853b7-1489-4412-9688-b19137af4337.png)