### PR TITLE
ci(tests): update tests plans

### DIFF
--- a/UITests-2.xctestplan
+++ b/UITests-2.xctestplan
@@ -77,11 +77,11 @@
         "EditTagsTests",
         "EmptyStateTests",
         "FavoriteAnItemTests",
-        "MyListFiltersTests",
-        "MyListTests",
         "PullToRefreshTests",
         "ReportARecommendationTests",
         "SaveToPocketTests",
+        "SavesFiltersTests",
+        "SavesTests",
         "ShareAnItemTests",
         "SignOutTests"
       ],

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -70,11 +70,11 @@
       "skippedTests" : [
         "HomeTests",
         "HomeWebViewTests",
-        "MyListFiltersTests",
-        "MyListTests",
         "PullToRefreshTests",
         "ReportARecommendationTests",
         "SaveToPocketTests",
+        "SavesFiltersTests",
+        "SavesTests",
         "ShareAnItemTests",
         "SignOutTests"
       ],


### PR DESCRIPTION
## Summary
Update test plans so that `SavesTests` and `SavesFilterTests` only run for `AllTests` plan and `UITests-3` plan

## References 
Slack convo: https://pocket.slack.com/archives/C01UH57EJKD/p1669998489687399

## Implementation Details
Remove MyList test plans and add Saves test plans where necessary

## Test Steps
1. Navigate to test plans
2. Verify tests are located in the correct test plans 

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
