### PR TITLE
fix(analytics): implement various missing analytics

### DIFF
--- a/PocketKit/Sources/Analytics/Context/UIContext.swift
+++ b/PocketKit/Sources/Analytics/Context/UIContext.swift
@@ -102,6 +102,12 @@ extension UIContext {
         case tagsSaveChanges = "tagsSaveChanges"
         case externalApp = "external_app"
         case saveExtension = "save_extension"
+        case sortFilterSheet = "sort_filter"
+        case sortByNewest = "sortByNewest"
+        case sortByOldest = "sortByOldest"
+        case sortByLongest = "sortByLongest"
+        case sortByShortest = "sortByShortest"
+        case navigationDrawer = "navigationDrawer"
     }
 }
 
@@ -156,6 +162,7 @@ extension UIContext {
         public let saves = UIContext(type: .list, hierarchy: 0, identifier: .saves)
         public let archive = UIContext(type: .list, hierarchy: 0, identifier: .archive)
         public let favorites = UIContext(type: .list, hierarchy: 0, identifier: .favorites)
+        public let sortFilterSheet = UIContext(type: .screen, identifier: .sortFilterSheet)
 
         public func item(index: UIIndex) -> UIContext {
             UIContext(type: .card, hierarchy: 0, identifier: .item, componentDetail: .itemRow, index: index)
@@ -196,6 +203,8 @@ extension UIContext {
     public static let saveExtension = SaveExtension()
 
     public static let reportDialog = UIContext(type: .dialog, identifier: .reportItem)
+
+    public static let navigationDrawer = UIContext(type: .screen, identifier: .navigationDrawer)
 
     public static func button(identifier: Identifier) -> UIContext {
         UIContext(

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -28,7 +28,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var url: URL? { get }
 
     func delete()
-    func showWebReader()
+    func openExternally(url: URL?)
     func archiveArticle()
     func fetchDetailsIfNeeded()
     func externalActions(for url: URL) -> [ItemAction]
@@ -42,7 +42,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
 
 extension ReadableViewModel {
     func readableViewController(_ controller: ReadableViewController, openURL url: URL) {
-        open(url: url)
+        openExternally(url: url)
     }
 
     func readableViewController(_ controller: ReadableViewController, shareWithAdditionalText text: String?) {
@@ -58,9 +58,16 @@ extension ReadableViewModel {
         isPresentingReaderSettings = true
     }
 
-    func open(url: URL) {
-        trackOpen(url: url)
+    func openExternally(url: URL?) {
         presentedWebReaderURL = url
+
+        if let url = url {
+            trackOpen(url: url)
+        }
+    }
+
+    func showWebReader() {
+        openExternally(url: url)
     }
 
     private func trackOpen(url: URL) {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -97,10 +97,6 @@ class RecommendationViewModel: ReadableViewModel {
         _events.send(.delete)
     }
 
-    func showWebReader() {
-        presentedWebReaderURL = url
-    }
-
     func archiveArticle() {
         archive()
     }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -97,10 +97,6 @@ class SavedItemViewModel: ReadableViewModel {
         _events.send(.delete)
     }
 
-    func showWebReader() {
-        presentedWebReaderURL = url
-    }
-
     func archiveArticle() {
         archive()
     }

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -48,7 +48,10 @@ class RegularMainCoordinator: NSObject {
         splitController = UISplitViewController(style: .doubleColumn)
         splitController.displayModeButtonVisibility = .automatic
 
-        sidebarViewController = NavigationSidebarViewController(model: model)
+        sidebarViewController = NavigationSidebarViewController(
+            model: model,
+            tracker: tracker.childTracker(hosting: .navigationDrawer)
+        )
         navigationSidebar = UINavigationController(rootViewController: sidebarViewController)
 
         saves = RegularSavesCoordinator(model: model.saves)

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -396,8 +396,12 @@ extension ArchivedItemsListViewModel {
 
         if item.shouldOpenInWebView {
             selectedItem = .webView(readable)
+
+            trackContentOpen(destination: .external, item: item)
         } else {
             selectedItem = .readable(readable)
+
+            trackContentOpen(destination: .internal, item: item)
         }
     }
 
@@ -481,7 +485,7 @@ extension ArchivedItemsListViewModel {
             guard let sender = sender else { return }
             presentedSortFilterViewModel = SortMenuViewModel(
                 source: source,
-                tracker: tracker.childTracker(hosting: .saves.saves),
+                tracker: tracker.childTracker(hosting: .saves.sortFilterSheet),
                 listOptions: listOptions,
                 sender: sender,
                 listOfSortMenuOptions: [.newest, .oldest]
@@ -551,6 +555,19 @@ extension ArchivedItemsListViewModel {
         }
 
         let event = SnowplowEngagement(type: .general, value: nil)
+        tracker.track(event: event, contexts)
+    }
+
+    private func trackContentOpen(destination: ContentOpenEvent.Destination, item: SavedItem) {
+        guard let url = item.bestURL else {
+            return
+        }
+
+        var contexts: [Context] = [
+            ContentContext(url: url)
+        ]
+
+        let event = ContentOpenEvent(destination: destination, trigger: .click)
         tracker.track(event: event, contexts)
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -391,6 +391,19 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         tracker.track(event: event, contexts)
     }
 
+    private func trackContentOpen(destination: ContentOpenEvent.Destination, item: SavedItem) {
+        guard let url = item.bestURL else {
+            return
+        }
+
+        var contexts: [Context] = [
+            ContentContext(url: url)
+        ]
+
+        let event = ContentOpenEvent(destination: destination, trigger: .click)
+        tracker.track(event: event, contexts)
+    }
+
     private func trackButton(item: SavedItem, identifier: UIContext.Identifier) {
         guard let url = item.bestURL else {
             return
@@ -447,8 +460,12 @@ extension SavedItemsListViewModel {
 
         if savedItem.shouldOpenInWebView {
             selectedItem = .webView(readable)
+
+            trackContentOpen(destination: .external, item: savedItem)
         } else {
             selectedItem = .readable(readable)
+
+            trackContentOpen(destination: .internal, item: savedItem)
         }
     }
 
@@ -496,7 +513,7 @@ extension SavedItemsListViewModel {
             guard let sender = sender else { return }
             presentedSortFilterViewModel = SortMenuViewModel(
                 source: source,
-                tracker: tracker.childTracker(hosting: .saves.saves),
+                tracker: tracker.childTracker(hosting: .saves.sortFilterSheet),
                 listOptions: listOptions,
                 sender: sender
             )

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
@@ -55,5 +55,23 @@ extension SortMenuViewModel {
         }
 
         listOptions.selectedSortOption = row
+        track(sortOption: row)
+    }
+
+    private func track(sortOption: SortOption) {
+        let selection = UIContext(type: .button, identifier: sortOption.uiContextIdentifier)
+        let event = SnowplowEngagement(type: .general, value: nil)
+        tracker.track(event: event, [selection])
+    }
+}
+
+extension SortOption {
+    var uiContextIdentifier: UIContext.Identifier {
+        switch self {
+        case .newest: return .sortByNewest
+        case .oldest: return .sortByOldest
+        case .longestToRead: return .sortByLongest
+        case .shortestToRead: return .sortByShortest
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarViewController.swift
+++ b/PocketKit/Sources/PocketKit/Navigation/NavigationSidebarViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Combine
 import Textile
+import Analytics
 
 private extension Style {
     static let title: Style = .header.sansSerif.h8
@@ -87,10 +88,12 @@ class NavigationSidebarViewController: UIViewController {
         collectionViewLayout: layout
     )
     private let model: MainViewModel
+    private let tracker: Tracker
     private var subscriptions: Set<AnyCancellable> = []
 
-    init(model: MainViewModel) {
+    init(model: MainViewModel, tracker: Tracker) {
         self.model = model
+        self.tracker = tracker
         super.init(nibName: nil, bundle: nil)
 
         self.title = "Pocket"
@@ -111,6 +114,13 @@ class NavigationSidebarViewController: UIViewController {
 
     override func loadView() {
         view = collectionView
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        let event = ImpressionEvent(component: .screen, requirement: .instant)
+        tracker.track(event: event, nil)
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

This pull request fixes various missing analytics. The following have been implemented:

- `content_open` when opening web view from the reader
- `engagement` when selecting a sort / filter option
- `content_open` when opening items from saves or archive
- `impression` when opening the navigation sidebar is opened on iPad

## References 

IN-1111

## Test Steps

- [ ] Verify against Snowplow Micro
- [x] Verify with Analytics

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
