### PR TITLE
feat(deeplinks): save url

### DIFF
--- a/Pocket (iOS).entitlements
+++ b/Pocket (iOS).entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:getpocket.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.ideashower.ReadItLaterProAlphaNeue</string>

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-        "version" : "7.31.3"
+        "revision" : "5238cc5f12c2b75027730a54ecf632cf103daf21",
+        "version" : "7.31.4"
       }
     },
     {

--- a/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ArchivedItemsList/ArchivedItemsListViewModel.swift
@@ -563,7 +563,7 @@ extension ArchivedItemsListViewModel {
             return
         }
 
-        var contexts: [Context] = [
+        let contexts: [Context] = [
             ContentContext(url: url)
         ]
 

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItemsListViewModel.swift
@@ -396,7 +396,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             return
         }
 
-        var contexts: [Context] = [
+        let contexts: [Context] = [
             ContentContext(url: url)
         ]
 

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -81,4 +81,14 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         coordinator.setup(scene: scene)
     }
+
+    public func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let incomingURL = userActivity.webpageURL else {
+            return
+        }
+
+        let router = Router(source: Services.shared.source)
+        router.handle(url: incomingURL)
+    }
 }

--- a/PocketKit/Sources/PocketKit/Router.swift
+++ b/PocketKit/Sources/PocketKit/Router.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Network
+import Sync
+
+class Router {
+    private let source: Source
+
+    init(source: Source) {
+        self.source = source
+    }
+
+    func handle(url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            return
+        }
+
+        if components.path == "/add" {
+            guard let urlString = components.queryItems?.first(where: { $0.name == "url" })?.value,
+                  let url = URL(string: urlString)
+            else { return }
+
+            saveItem(url: url)
+        }
+    }
+
+    private func saveItem(url: URL) {
+        source.save(url: url)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/RouterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RouterTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import Sync
+@testable import PocketKit
+
+class RouterTests: XCTestCase {
+    private var space: Space!
+    private var source: MockSource!
+
+    override func setUpWithError() throws {
+        source = MockSource()
+        space = .testSpace()
+    }
+
+    override func tearDownWithError() throws {
+        try space.clear()
+    }
+
+    func subject(source: Source? = nil) -> Router {
+        Router(source: source ?? self.source)
+    }
+
+    func test_handleURL_forSavingURL_savesItem() throws {
+        source.stubSaveURL { _ in }
+        guard let url = URL(string: "https://getpocket.com/add?url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FDuck") else {
+            XCTFail("should not be nil")
+            return
+        }
+        let router = subject()
+        router.handle(url: url)
+        XCTAssertEqual(source.saveURLCall(at: 0)?.url.absoluteString, "https://en.wikipedia.org/wiki/Duck")
+    }
+}


### PR DESCRIPTION
## Summary
Add deep link support for saving a URL to Pocket. This only supports saving the URL as an item and not presenting it in reader or article view.

**Status:** waiting on confirmation if we can modify the AC as well as waiting for updated app association file PR to be in prod https://github.com/Pocket/dotcom-gateway/pull/93

## References 
IN-1094

## Implementation Details
Added `associated domain` in entitlements and created `Router` class to handle our deep-links. Currently, using 
`https://getpocket.com/app/read?url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FDuck` instead of format in `https://getpocket.com/add?url=*` for testing purposes as the app association file is not updated.

https://getpocket.com/.well-known/apple-app-site-association

## Test Steps
- [ ] WHEN I share a save URL to the Pocket iOS app using the format: https://getpocket.com/add?url=* (where * is an escaped URL)
THEN the Pocket iOS app opens
AND the URL is saved to Pocket

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
