### PR TITLE
fix(sentry): add breadcrumbs to authclient errors

### DIFF
--- a/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/AuthorizationClient.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import AuthenticationServices
+import Sync
 
 public class AuthorizationClient {
     typealias AuthenticationSessionFactory = (URL, String?, @escaping ASWebAuthenticationSession.CompletionHandler) -> AuthenticationSession
@@ -67,6 +68,7 @@ public class AuthorizationClient {
         return try await withCheckedThrowingContinuation { continuation in
             var session = authenticationSessionFactory(requestURL, requestRedirect) { url, error in
                 if let error = error {
+                    Crashlogger.breadcrumb(category: "auth", level: .error, message: "Error: \(error.localizedDescription) with url \(String(describing: url))")
                     continuation.resume(throwing: AuthorizationClient.Error.other(error))
                 } else if let url = url {
                     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -173,11 +173,13 @@ class LoggedOutViewModel: ObservableObject {
                     // but the other errors should never occur, so they should be captured.
                     switch nested.code {
                     case .presentationContextInvalid, .presentationContextNotProvided:
+                        Crashlogger.breadcrumb(category: "auth", level: .error, message: "ASWebAuthenticationSessionError: \(nested.localizedDescription)")
                         Crashlogger.capture(error: nested)
                     default:
                         return
                     }
                 } else {
+                    Crashlogger.breadcrumb(category: "auth", level: .error, message: "Error: \(nested.localizedDescription)")
                     Crashlogger.capture(error: error)
                 }
             }


### PR DESCRIPTION
## Summary
Add Breadcrumbs to Authorization Client.

Sentry Issue: [IOS-NEXT-7C](https://sentry.io/organizations/pocket/issues/3574089481/?referrer=jira_integration)
`PocketKit.AuthorizationClient.Error: Code: 3`

## References 
IN-983

## Implementation Details
Add breadcrumbs to retrieve more details for errors. I think the error message is due to this following error, where Code: 3 refers to `presentationContextInvalid` (ignore highlight)

![image](https://user-images.githubusercontent.com/6743397/207970964-f25c4da2-b43a-41ba-b997-2af2e4b75032.png)

## Test Steps
N / A. I don't know how to test these errors, but just verify that we receive more Information in Sentry.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
