### PR TITLE
ci(tests): laggy reader test fix

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "c3c19e29f775ee95b77aa3168f3e2fd6c20deba6",
-        "version" : "7.31.3"
+        "revision" : "5238cc5f12c2b75027730a54ecf632cf103daf21",
+        "version" : "7.31.4"
       }
     },
     {

--- a/Tests iOS/MyList/SavesTests.swift
+++ b/Tests iOS/MyList/SavesTests.swift
@@ -226,12 +226,13 @@ class SavesTests: XCTestCase {
         ]
 
         for expectedString in expectedContent {
-            let cell = app
-                .readerView
-                .cell(containing: expectedString)
-                .wait()
-
-            app.readerView.scrollCellToTop(cell)
+            guard app.readerView.cell(containing: expectedString).isHittable else {
+                app.readerView.element.swipeUp()
+                let cell = app.readerView.cell(containing: expectedString)
+                app.readerView.scrollCellToTop(cell)
+                XCTAssertTrue(cell.exists)
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
test_tappingItem_displaysNativeReaderView in SavesTests.swift has this strange behavior where it's spending a lot of extra time scrolling the Reader UI. The test isn't currently breaking but it's using a lot of extra time so I'll add this as something to look into and fix as part of the Flakey tests work.

## References 
Jira ticket https://getpocket.atlassian.net/browse/IN-950

## Implementation Details
I'm going to change how the elements are found and scrolled to in order to fix this.

## Test Steps
The test should take much less time to complete after the changes.

## Screenshots
Gif in Slack:
https://pocket.slack.com/archives/C01UH57EJKD/p1670535231375889