### PR TITLE
feat(search): display search results (IN-894)

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "braze-swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/braze-inc/braze-swift-sdk.git",
+      "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "2a4c863027f716e088175bcf71b0b2d7bfb9d46f",
-        "version" : "5.8.0"
+        "revision" : "7afd6e0ac0bf59fcf9918e243298114888581ee2",
+        "version" : "5.6.4"
       }
     },
     {
@@ -73,15 +73,6 @@
       }
     },
     {
-      "identity" : "sdwebimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SDWebImage/SDWebImage.git",
-      "state" : {
-        "revision" : "3312bf5e67b52fbce7c3caf431b0cda721a9f7bb",
-        "version" : "5.14.2"
-      }
-    },
-    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
@@ -131,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
+        "version" : "1.0.3"
       }
     },
     {
@@ -140,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "7e3b50b38e4e66f31db6cf4a784c6af148bac846",
-        "version" : "2.46.0"
+        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
+        "version" : "2.45.0"
       }
     },
     {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemDetails.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemDetails.swift
@@ -1,15 +1,14 @@
 import SwiftUI
 
 struct ItemDetails: View {
-    var title: String
-    var detail: String
+    private let constants = ListItem.Constants.self
+    private let title: String
+    private let detail: String
 
     init(attributedTitle: NSAttributedString, attributedDetail: NSAttributedString) {
         self.title = attributedTitle.string
         self.detail = attributedDetail.string
     }
-
-    let constants = ListItem.Constants.self
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -22,7 +21,7 @@ struct ItemDetails: View {
                 .style(.listItem.detail)
                 .lineLimit(constants.detail.maxLines)
         }
-        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .leading)
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
         .padding([.bottom, .trailing], constants.objectSpacing)
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemTags.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemTags.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 
 struct ItemTags: View {
+    private let constants = ListItem.Constants.tags.self
     var tags: [NSAttributedString]?
     var tagCount: NSAttributedString?
-
-    let constants = ListItem.Constants.tags.self
 
     var body: some View {
         if let tags = tags {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
@@ -8,7 +8,7 @@ struct OverflowMenu: View {
     var trailingPadding: Bool = false
 
     var body: some View {
-        if overflowActions.isEmpty {
+        if !overflowActions.isEmpty {
             Menu {
                 ForEach(overflowActions, id: \.self) { action in
                     Button {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
@@ -3,30 +3,28 @@ import Textile
 import Kingfisher
 
 struct ListItem: View {
-    var model: ItemsListItemCell.Model
+    var model: SearchItem
 
     let constants = Constants.self
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: 0) {
-                ItemDetails(attributedTitle: model.attributedTitle, attributedDetail: model.attributedDetail)
+                ItemDetails(attributedTitle: model.title, attributedDetail: model.detail)
 
                 KFImage(model.thumbnailURL)
-                    .frame(width: constants.image.width, height: constants.image.height, alignment: .trailing)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: constants.image.width, height: constants.image.height, alignment: .center)
                     .cornerRadius(constants.image.cornerRadius)
             }
 
             HStack(alignment: .center, spacing: constants.tags.horizontalSpacing) {
-                ItemTags(tags: model.attributedTags, tagCount: model.attributedTagCount)
-
+                ItemTags(tags: model.tags, tagCount: model.tagCount)
                 Spacer()
-
                 ActionButton(model.favoriteAction)
-
                 ActionButton(model.shareAction)
-
-                OverflowMenu(overflowActions: model.overflowActions, trackOverflow: model.swiftUITrackOverflow, trailingPadding: false)
+                OverflowMenu(overflowActions: model.overflowActions, trackOverflow: model.trackOverflow, trailingPadding: false)
             }
         }
         .padding(.vertical, constants.verticalPadding)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchItem.swift
@@ -1,28 +1,55 @@
+import Foundation
+import UIKit
 import PocketGraph
 
-// TODO: To be fleshed out when we work on displaying search results
 struct SearchItem {
     private let item: ItemsListItem
+    private let itemPresenter: ItemsListItemPresenter
 
     init(item: ItemsListItem) {
         self.item = item
+        self.itemPresenter = ItemsListItemPresenter(item: item)
     }
 
     var id: String? {
         item.id
     }
 
-    var title: String {
-        [
-            item.title,
-            item.bestURL?.absoluteString
-        ]
-            .compactMap { $0 }
-            .first { !$0.isEmpty } ?? ""
+    var title: NSAttributedString {
+        itemPresenter.attributedTitle
     }
 
-    var detail: String? {
-        guard let tagNames = item.tagNames?.joined(separator: " "), !tagNames.isEmpty else { return nil }
-        return "Tags: \(tagNames)"
+    var detail: NSAttributedString {
+        itemPresenter.attributedDetail
+    }
+
+    var tags: [NSAttributedString]? {
+        itemPresenter.attributedTags
+    }
+
+    var tagCount: NSAttributedString? {
+        itemPresenter.attributedTagCount
+    }
+
+    var thumbnailURL: URL? {
+        itemPresenter.thumbnailURL
+    }
+
+    var shareAction: ItemAction {
+        ItemAction.share { _ in print("Share button tapped!") }
+    }
+
+    var favoriteAction: ItemAction {
+        ItemAction.favorite { _ in print("Favorite button tapped!") }
+    }
+
+    var overflowActions: [ItemAction] {
+        [ItemAction.addTags { _ in print("Add tags button tapped!") }, ItemAction.archive { _ in print("Archive button tapped!") }, ItemAction.delete { _ in print("Delete button tapped!") }]
+    }
+
+    var trackOverflow: ItemAction {
+        ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
+            print("Overflow button tapped!")
+        })
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItemParts+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItemParts+ItemsListItem.swift
@@ -28,7 +28,7 @@ extension SearchSavedItemParts: ItemsListItem {
     }
 
     var domainMetadata: ItemsListItemDomainMetadata? {
-        item.asItem?.domainMetadata as? ItemsListItemDomainMetadata
+        item.asItem?.domainMetadata
     }
 
     var timeToRead: Int? {
@@ -47,3 +47,5 @@ extension SearchSavedItemParts: ItemsListItem {
         self.tags?.compactMap { $0.name }
     }
 }
+
+extension SearchSavedItemParts.Item.AsItem.DomainMetadata: ItemsListItemDomainMetadata { }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -7,9 +7,7 @@ struct SearchView: View {
     var showTempResultsView: Bool = false
 
     var body: some View {
-        if showTempResultsView {
-            TempResultsView(viewModel: viewModel)
-        } else if let results = viewModel.searchResults, !results.isEmpty {
+        if let results = viewModel.searchResults, !results.isEmpty {
             ResultsView(results: results)
         } else if viewModel.showRecentSearches == true, !viewModel.recentSearches.isEmpty {
             RecentSearchView(recentSearches: viewModel.recentSearches)
@@ -19,103 +17,20 @@ struct SearchView: View {
     }
 }
 
-struct TempResultsView: View {
-    @ObservedObject
-    var viewModel: SearchViewModel
-
-    let listItemViewModel: ItemsListItemCell.Model = ItemsListItemCell.Model(
-        attributedTitle: NSAttributedString(string: "This is the title lorem ipsum dolor sit amet"),
-        attributedDetail: NSAttributedString(string: "Detail Details Daily"),
-        attributedTags: [NSAttributedString(string: "Tag 1"), NSAttributedString(string: "Tag 2")],
-        attributedTagCount: NSAttributedString(string: "+3"),
-        thumbnailURL: URL(string: "https://github.com/onevcat/Kingfisher/blob/master/images/kingfisher-1.jpg?raw=true"),
-        shareAction: ItemAction.share { _ in print("Share button tapped!") },
-        favoriteAction: ItemAction.favorite { _ in print("Favorite button tapped!") },
-        overflowActions: [ItemAction.addTags { _ in print("Add tags button tapped!") }, ItemAction.archive { _ in print("Archive button tapped!") }, ItemAction.delete { _ in print("Delete button tapped!") }],
-        filterByTagAction: nil,
-        trackOverflow: nil,
-        swiftUITrackOverflow: ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
-            print("Overflow button tapped!")
-        })
-    )
-    let listItemViewModelOneTag: ItemsListItemCell.Model = ItemsListItemCell.Model(
-        attributedTitle: NSAttributedString(string: "This is the title lorem ipsum dolor sit amet"),
-        attributedDetail: NSAttributedString(string: "Detail Details Daily"),
-        attributedTags: [NSAttributedString(string: "Tag 1")],
-        attributedTagCount: nil,
-        thumbnailURL: URL(string: "https://github.com/onevcat/Kingfisher/blob/master/images/kingfisher-1.jpg?raw=true"),
-        shareAction: ItemAction.share { _ in print("Share button tapped!") },
-        favoriteAction: ItemAction.favorite { _ in print("Favorite button tapped!") },
-        overflowActions: [ItemAction.addTags { _ in print("Add tags button tapped!") }, ItemAction.archive { _ in print("Archive button tapped!") }, ItemAction.delete { _ in print("Delete button tapped!") }],
-        filterByTagAction: nil,
-        trackOverflow: nil,
-        swiftUITrackOverflow: ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
-            print("Overflow button tapped!")
-        })
-    )
-
-    let listItemViewModelNoTag: ItemsListItemCell.Model = ItemsListItemCell.Model(
-        attributedTitle: NSAttributedString(string: "This is the title lorem ipsum dolor sit amet"),
-        attributedDetail: NSAttributedString(string: "Detail Details Daily"),
-        attributedTags: nil,
-        attributedTagCount: nil,
-        thumbnailURL: URL(string: "https://github.com/onevcat/Kingfisher/blob/master/images/kingfisher-1.jpg?raw=true"),
-        shareAction: ItemAction.share { _ in print("Share button tapped!") },
-        favoriteAction: ItemAction.favorite { _ in print("Favorite button tapped!") },
-        overflowActions: [ItemAction.addTags { _ in print("Add tags button tapped!") }, ItemAction.archive { _ in print("Archive button tapped!") }, ItemAction.delete { _ in print("Delete button tapped!") }],
-        filterByTagAction: nil,
-        trackOverflow: nil,
-        swiftUITrackOverflow: ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
-            print("Overflow button tapped!")
-        })
-    )
-
-    var body: some View {
-        List {
-            // only renders cell if view
-            ListItem(model: listItemViewModelNoTag)
-            ListItem(model: listItemViewModel)
-            ListItem(model: listItemViewModelOneTag)
-            ListItem(model: listItemViewModelNoTag)
-            ListItem(model: listItemViewModelNoTag)
-
-            ForEach(1..<10) {_ in
-                ListItem(model: listItemViewModel)
-            }
-        }.listStyle(.plain)
-    }
-}
-
+// MARK: - Search Results Component
 struct ResultsView: View {
     var results: [SearchItem]
     var body: some View {
         List {
             ForEach(results, id: \.id) { item in
                 HStack {
-                    // TODO: Fix Displaying Search Results
-                    ItemDetail(title: item.title, detail: item.detail ?? "")
+                    ListItem(model: item)
                     Spacer()
                 }
-                .padding(.vertical)
             }
         }
         .listStyle(.plain)
         .accessibilityIdentifier("search-results")
-    }
-}
-
-struct ItemDetail: View {
-    var title: String
-    var detail: String
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .style(.search.row.default)
-            Text(detail)
-                .style(.search.row.default)
-        }
-        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .leading)
-        .padding([.bottom, .trailing])
     }
 }
 
@@ -129,6 +44,7 @@ struct SearchEmptyView: View {
     }
 }
 
+// MARK: - Recent Searches Component
 struct RecentSearchView: View {
     var recentSearches: [String]
 

--- a/PocketKit/Tests/PocketKitTests/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SearchViewModelTests.swift
@@ -135,7 +135,7 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateSearchResults(with: term)
 
-        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title }, ["search-term"])
+        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title.string }, ["search-term"])
         XCTAssertNil(viewModel.emptyState)
     }
 
@@ -184,7 +184,7 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateSearchResults(with: term)
 
-        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title }, ["search-term"])
+        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title.string }, ["search-term"])
         XCTAssertNil(viewModel.emptyState)
     }
 
@@ -324,13 +324,13 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return savedItems }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.count == 2)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.count, 2)
 
         source.stubSearchItems { _ in return [] }
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -350,13 +350,13 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return savedItems }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.count == 2)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.count, 2)
 
         source.stubSearchItems { _ in return [] }
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -377,13 +377,13 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return savedItems }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.count == 2)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.count, 2)
 
         source.stubSearchItems { _ in return [] }
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -404,13 +404,13 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return savedItems }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.count == 2)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.count, 2)
 
         source.stubSearchItems { _ in return [] }
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -430,14 +430,14 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return [] }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
-        results = viewModel.searchItems(with: "test")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "test")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -457,16 +457,16 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return savedItems }
 
         let viewModel = subject()
-        var results = viewModel.searchItems(with: "test")
-        XCTAssertTrue(results.count == 2)
+        viewModel.submitLocalSearch(with: "test")
+        XCTAssertEqual(viewModel.searchResults?.count, 2)
 
         source.stubSearchItems { _ in return [] }
 
-        results = viewModel.searchItems(with: "saved")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "saved")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
-        results = viewModel.searchItems(with: "none")
-        XCTAssertTrue(results.isEmpty)
+        viewModel.submitLocalSearch(with: "none")
+        XCTAssertEqual(viewModel.searchResults?.isEmpty, true)
 
         try space.clear()
     }
@@ -477,10 +477,10 @@ class SearchViewModelTests: XCTestCase {
         source.stubSearchItems { _ in return [] }
 
         let viewModel = subject()
-        _ = viewModel.searchItems(with: "test")
+        viewModel.submitLocalSearch(with: "test")
         XCTAssertTrue(source.searchSavesCall(at: 0)?.searchTerm == "test")
 
-        _ = viewModel.searchItems(with: "none")
+        viewModel.submitLocalSearch(with: "none")
         XCTAssertTrue(source.searchSavesCall(at: 1)?.searchTerm == "none")
     }
 }


### PR DESCRIPTION
## Summary
Display search results using SwiftUI cells. This PR purely handles the visuals and additional logic / tests to complete the search feature will be addressed in future tickets.

## References 
IN-894

## Implementation Details
Used `ItemsListItemPresenter` to hold the logic for the data we need to present the items in search view (i.e. title, detail). This presenter will be a property on `SearchItem`. By doing so, we will use `NSAttributedString` types even though we only care about strings in SwiftUI . When we move towards SwiftUI  we can replace the attributed strings with just String, but for now we can access them via `attributedString.string`. 

## Test Steps
- [ ] WHEN I have submitted a search
AND there are 1+ search results
THEN the search results display in a list

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
|Saves Free User|All Items Premium User|
|------|-----|
|![Saves](https://user-images.githubusercontent.com/6743397/208963737-bce9ffd7-da80-4aae-831e-62102201398e.png)|![All Items](https://user-images.githubusercontent.com/6743397/208962187-0ebe70c1-3b36-461a-b135-509f597e18d9.png)|
