### PR TITLE
feat(search): select search scopes

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -142,7 +142,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {
         guard let titles = searchBar.scopeButtonTitles else { return }
         searchBar.returnKeyType = .search
-        searchViewModel.updateScope(with: SearchScope(rawValue: titles[selectedScope]) ?? .saves)
+        searchViewModel.updateScope(with: SearchScope(rawValue: titles[selectedScope]) ?? .saves, searchTerm: searchBar.text)
     }
 
     func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
@@ -157,6 +157,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchViewModel.clear()
+        searchViewModel.clearCache()
     }
 
     func updateSearchScope() {

--- a/Tests iOS/Fixtures/search-list-all.json
+++ b/Tests iOS/Fixtures/search-list-all.json
@@ -1,0 +1,230 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-1",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-1",
+                                    "title": "Item 1",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-1/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-1/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-2",
+                                    "title": "Item 2",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-1/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-2/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-2/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-3",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": true,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-3",
+                                    "title": "Item 3",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-3/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-1/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": null,
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}

--- a/Tests iOS/Fixtures/search-list-archive.json
+++ b/Tests iOS/Fixtures/search-list-archive.json
@@ -1,0 +1,90 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-3",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": true,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-3",
+                                    "title": "Item 3",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-3/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-1/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": null,
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -28,8 +28,12 @@ class SearchTests: XCTestCase {
                 return Response.archivedContent()
             } else if apiRequest.isForTags {
                 return Response.emptyTags()
-            } else if apiRequest.isForSearch {
-                return Response.searchList()
+            } else if apiRequest.isForSearch(.saves) {
+                return Response.searchList(.saves)
+            } else if apiRequest.isForSearch(.archive) {
+                return Response.searchList(.archive)
+            } else if apiRequest.isForSearch(.all) {
+                return Response.searchList(.all)
             } else {
                 fatalError("Unexpected request")
             }
@@ -125,8 +129,8 @@ class SearchTests: XCTestCase {
     func test_submitSearch_forFreeUser_withArchive_showsResults() {
         server.routes.post("/graphql") { request, _ in
             let apiRequest = ClientAPIRequest(request)
-            if apiRequest.isForSearch {
-                return Response.searchList()
+            if apiRequest.isForSearch(.archive) {
+                return Response.searchList(.archive)
             } else {
                 return Response.saves("initial-list-free-user")
             }
@@ -137,7 +141,7 @@ class SearchTests: XCTestCase {
         searchField.tap()
         searchField.typeText("item\n")
         let searchView = app.saves.searchView.searchResultsView.wait()
-        XCTAssertEqual(searchView.cells.count, 2)
+        XCTAssertEqual(searchView.cells.count, 1)
     }
 
     func test_submitSearch_forPremiumUser_withSaves_showsResults() {
@@ -157,7 +161,7 @@ class SearchTests: XCTestCase {
         searchField.tap()
         searchField.typeText("item\n")
         let searchView = app.saves.searchView.searchResultsView.wait()
-        XCTAssertEqual(searchView.cells.count, 2)
+        XCTAssertEqual(searchView.cells.count, 1)
     }
 
     func test_submitSearch_forPremiumUser_withAllItems_showsResults() {
@@ -168,7 +172,23 @@ class SearchTests: XCTestCase {
         searchField.tap()
         searchField.typeText("item\n")
         let searchView = app.saves.searchView.searchResultsView.wait()
+        XCTAssertEqual(searchView.cells.count, 3)
+    }
+
+    func test_switchingScopes_showsResults() {
+        app.launch()
+        tapSearch()
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        let searchView = app.saves.searchView.searchResultsView.wait()
         XCTAssertEqual(searchView.cells.count, 2)
+
+        app.navigationBar.buttons["All Items"].wait().tap()
+        XCTAssertEqual(searchView.cells.count, 3)
+
+        app.navigationBar.buttons["Archive"].wait().tap()
+        XCTAssertEqual(searchView.cells.count, 1)
     }
 
     private func tapSearch(fromArchive: Bool = false) {

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Sails
+import SharedPocketKit
 
 struct ClientAPIRequest {
     private let request: Request
@@ -82,8 +83,15 @@ struct ClientAPIRequest {
         contains("Tags")
     }
 
-    var isForSearch: Bool {
-        contains("searchSavedItems")
+    func isForSearch(_ type: SearchScope) -> Bool {
+        switch type {
+        case .saves:
+            return contains("searchSavedItems") && contains("filter\":{\"status\":\"UNREAD\"}")
+        case .archive:
+            return contains("searchSavedItems") && contains("filter\":{\"status\":\"ARCHIVED\"}")
+        case .all:
+            return contains("searchSavedItems") && contains("filter\":{}")
+        }
     }
 
     func contains(_ string: String) -> Bool {

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Sails
+import SharedPocketKit
 
 extension Response {
     static func saves(_ fixtureName: String = "initial-list") -> Response {
@@ -82,8 +83,15 @@ extension Response {
         fixture(named: "empty-tags")
     }
 
-    static func searchList() -> Response {
-        fixture(named: "search-list")
+    static func searchList(_ type: SearchScope) -> Response {
+        switch type {
+        case .saves:
+            return fixture(named: "search-list")
+        case .archive:
+            return fixture(named: "search-list-archive")
+        case .all:
+            return fixture(named: "search-list-all")
+        }
     }
 
     static func fixture(named fixtureName: String) -> Response {


### PR DESCRIPTION
## Summary
Switching scopes during an active search performs a search and results are cached if already performed a search for the term. _Note: Loading state will replace current empty state in future ticket._

## References 
IN-973

## Implementation Details
Add new parameter for `updateScope` to take in search term if use switch scopes. This triggers a new search. Created new property `cachedSearchResults` to store cached results in a session and clear when user exits search experience.

## Test Steps
- [ ] WHEN I have an active search
AND I switch scopes
AND we have not yet performed a search for this search term and scope during this search session
THEN we perform the search (if possible)

- [ ] WHEN I have an active search
AND I switch scopes
AND we have performed a search for this search term and scope during this search session
THEN we display the previously displayed search results
 
Note: show offline view if no connection

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
|iPad|
|------|
|![iPad](https://user-images.githubusercontent.com/6743397/210599873-080a7104-7725-4f11-aaa1-e1f2f12bf1e0.MP4)|

[IN-973]: https://getpocket.atlassian.net/browse/IN-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ