### PR TITLE
feat(search): support pagination, copy updates, cancel search

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/ArchiveEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/ArchiveEmptyStateViewModel.swift
@@ -5,7 +5,7 @@ struct ArchiveEmptyStateViewModel: EmptyStateViewModel {
     let imageAsset: ImageAsset = .chest
     let maxWidth: CGFloat = Width.wide.rawValue
     let icon: ImageAsset? = .archive
-    let headline = "Keep your list fresh and clean"
+    let headline: String? = "Keep your list fresh and clean"
     let detailText: String? = "Archive the saves you're finished with\n using the archive icon."
     let buttonText: String? = "How to archive"
     let webURL: URL? = URL(string: "https://getpocket.com/what-is-the-archive-ios")!

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -52,7 +52,9 @@ struct EmptyStateView: View {
                 .frame(maxWidth: viewModel.maxWidth)
 
             VStack(alignment: .center, spacing: 20) {
-                Text(viewModel.headline).style(.main)
+                if let headline = viewModel.headline {
+                    Text(headline).style(.main)
+                }
 
                 if let subtitle = viewModel.detailText {
                     if let icon = viewModel.icon {

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
@@ -6,7 +6,7 @@ protocol EmptyStateViewModel {
     var imageAsset: ImageAsset { get }
     var maxWidth: CGFloat { get }
     var icon: ImageAsset? { get }
-    var headline: String { get }
+    var headline: String? { get }
     var detailText: String? { get }
     var buttonText: String? { get }
     var webURL: URL? { get }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/FavoritesEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/FavoritesEmptyStateViewModel.swift
@@ -5,7 +5,7 @@ struct FavoritesEmptyStateViewModel: EmptyStateViewModel {
     let imageAsset: ImageAsset = .chest
     let maxWidth: CGFloat = Width.wide.rawValue
     let icon: ImageAsset? = .favorite
-    let headline = "Find your favorites here"
+    let headline: String? = "Find your favorites here"
     let detailText: String? = "Hit the star icon to favorite an article and find it faster."
     let buttonText: String? = nil
     let webURL: URL? = nil

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/SavesEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/SavesEmptyStateViewModel.swift
@@ -5,7 +5,7 @@ struct SavesEmptyStateViewModel: EmptyStateViewModel {
     let imageAsset: ImageAsset = .welcomeShelf
     let maxWidth: CGFloat = Width.wide.rawValue
     let icon: ImageAsset? = nil
-    let headline = "Start building your Pocket list"
+    let headline: String? = "Start building your Pocket list"
     let detailText: String? = nil
     let buttonText: String? = "How to save"
     let webURL: URL? = URL(string: "https://getpocket.com/saving-in-ios")!

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/GetPremiumEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/GetPremiumEmptyState.swift
@@ -6,8 +6,8 @@ struct GetPremiumEmptyState: EmptyStateViewModel {
     let imageAsset: ImageAsset = .diamond
     let maxWidth: CGFloat = Width.normal.rawValue
     let icon: ImageAsset? = nil
-    let headline = "Searching in All Your Items?"
-    let detailText: String? = "See results from both saves and archive when you join Pocket Premium."
+    let headline: String? = "Unlock more search options"
+    let detailText: String? = "Search your entire Pocket, including archived items, with Pocket Premium."
     let buttonText: String? = "Get Pocket Premium"
     let webURL: URL? = URL(string: "https://getpocket.com/premium")
     let accessibilityIdentifier = "get-premium-empty-state"

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/NoResultsEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/NoResultsEmptyState.swift
@@ -6,8 +6,8 @@ struct NoResultsEmptyState: EmptyStateViewModel {
     let imageAsset: ImageAsset = .searchNoResults
     let maxWidth: CGFloat = Width.normal.rawValue
     let icon: ImageAsset? = nil
-    let headline = "No Results Found"
-    let detailText: String? = "Try using different keywords, checking for typos, or changing your filters."
+    let headline: String? = "No results found"
+    let detailText: String? = "Try using different keywords, checking for typos or changing your filters."
     let buttonText: String? = nil
     let webURL: URL? = nil
     let accessibilityIdentifier = "no-results-empty-state"

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/OfflineEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/OfflineEmptyState.swift
@@ -1,13 +1,23 @@
 import Foundation
 import Textile
+import SharedPocketKit
 
 // TODO: Localization
 struct OfflineEmptyState: EmptyStateViewModel {
+    private let type: SearchScope
+
+    init(type: SearchScope) {
+        self.type = type
+    }
+
     let imageAsset: ImageAsset = .looking
     let maxWidth: CGFloat = Width.wide.rawValue
     let icon: ImageAsset? = nil
-    let headline = "No Internet Connection"
-    let detailText: String? = "You must be online to search."
+    let headline: String? = "No Internet Connection"
+    var detailText: String? {
+        let searchScopeText = type == .archive ? "archived" : "all"
+        return "You must be online to search \(searchScopeText) items."
+    }
     let buttonText: String? = nil
     let webURL: URL? = nil
     let accessibilityIdentifier = "offline-empty-state"

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/RecentSearchEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/RecentSearchEmptyState.swift
@@ -6,8 +6,8 @@ struct RecentSearchEmptyState: EmptyStateViewModel {
     let imageAsset: ImageAsset = .searchRecent
     let maxWidth: CGFloat = Width.normal.rawValue
     let icon: ImageAsset? = nil
-    let headline = "Recent Searches"
-    let detailText: String? = "Your latest searches will appear here so you can get right back to them"
+    let headline: String? = nil
+    let detailText: String? = "Recent searches will appear here, so you can easily jump back in."
     let buttonText: String? = nil
     let webURL: URL? = nil
     let accessibilityIdentifier = "recent-search-empty-state"

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/SearchEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/SearchEmptyState.swift
@@ -6,7 +6,7 @@ struct SearchEmptyState: EmptyStateViewModel {
     let imageAsset: ImageAsset = .search
     let maxWidth: CGFloat = Width.normal.rawValue
     let icon: ImageAsset? = nil
-    let headline = "Search by Title or URL"
+    let headline: String? = "Search by title or URL"
     let detailText: String? = nil
     let buttonText: String? = nil
     let webURL: URL? = nil

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/TagsEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/TagsEmptyStateViewModel.swift
@@ -5,7 +5,7 @@ struct TagsEmptyStateViewModel: EmptyStateViewModel {
     let imageAsset: ImageAsset = .chest
     let maxWidth: CGFloat = Width.wide.rawValue
     let icon: ImageAsset? = nil
-    let headline = "No saves with this tag."
+    let headline: String? = "No saves with this tag."
     let detailText: String? = "Tag your saves by topic to find them later."
     let buttonText: String? = "How to tag"
     let webURL: URL? = URL(string: "https://help.getpocket.com/article/940-tagging-in-pocket-for-iphone")!

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -128,7 +128,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
         }
         navigationItem.searchController?.showsSearchResultsController = true
 
-        searchViewModel.$searchText.sink { searchText in
+        searchViewModel.$searchText.dropFirst().sink { searchText in
             self.updateSearchBar(searchText: searchText)
         }.store(in: &subscriptions)
     }
@@ -158,6 +158,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchViewModel.clear()
         searchViewModel.clearCache()
+        searchBar.text = nil
     }
 
     func updateSearchScope() {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -165,7 +165,7 @@ class SearchViewModel: ObservableObject {
         case .saves:
             return NoResultsEmptyState()
         case .archive, .all:
-            return isOffline ? OfflineEmptyState() : NoResultsEmptyState()
+            return isOffline ? OfflineEmptyState(type: selectedScope) : NoResultsEmptyState()
         }
     }
 

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -1,5 +1,5 @@
 public enum SearchScope: String, CaseIterable, Codable {
     case saves = "Saves"
     case archive = "Archive"
-    case all = "All Items"
+    case all = "All items"
 }

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -1,4 +1,5 @@
 import Apollo
+import UIKit
 import Foundation
 import PocketGraph
 import SharedPocketKit
@@ -11,7 +12,9 @@ public protocol SearchService: AnyObject {
 
 public class PocketSearchService: SearchService {
     enum Constants {
-        static let pageSize = 30
+        static var pageSize: Int {
+            UIDevice.current.userInterfaceIdiom == .phone ? 30 : 50
+        }
     }
 
     @Published

--- a/PocketKit/Tests/SyncTests/Fixtures/search-list-page-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/search-list-page-1.json
@@ -1,0 +1,161 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-1",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-1",
+                                    "title": "Item 1",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-1/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-1/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-2",
+                                    "title": "Item 2",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-1/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-2/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-2/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "cursor-2",
+                    "hasNextPage": true,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}
+

--- a/PocketKit/Tests/SyncTests/Fixtures/search-list-page-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/search-list-page-2.json
@@ -1,0 +1,161 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-3",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-3",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-3",
+                                    "title": "Item 3",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-3/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-3/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-3/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-4",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-4",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-4",
+                                    "title": "Item 4",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-1/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-4/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-4/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "cursor-4",
+                    "hasNextPage": true,
+                    "hasPreviousPage": true,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}
+

--- a/PocketKit/Tests/SyncTests/Fixtures/search-list-page-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/search-list-page-3.json
@@ -1,0 +1,91 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-5",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-5",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-5",
+                                    "title": "Item 5",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImage": {
+                                        "__typename": "Image",
+                                        "url": "https://example.com/item-5/top-image.jpg",
+                                    },
+                                    "domain": null,
+                                    "timeToRead": 6,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-5/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-5/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "cursor-5",
+                    "hasNextPage": false,
+                    "hasPreviousPage": true,
+                    "startCursor": null
+                },
+                "totalCount": 1
+            }
+        }
+    }
+}
+

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -216,9 +216,11 @@ class SearchTests: XCTestCase {
         searchView = app.saves.searchView.searchResultsView.wait()
 
         app.navigationBar.buttons["Cancel"].tap()
+        XCTAssertTrue(app.saves.itemView(at: 0).element.isHittable)
 
         searchField.tap()
         app.saves.searchView.recentSearchesView.staticTexts["item"].tap()
         XCTAssertEqual(searchView.cells.count, 2)
+        XCTAssertFalse(app.saves.itemView(at: 0).element.isHittable)
     }
 }

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -167,7 +167,7 @@ class SearchTests: XCTestCase {
     func test_submitSearch_forPremiumUser_withAllItems_showsResults() {
         app.launch()
         tapSearch()
-        app.navigationBar.buttons["All Items"].wait().tap()
+        app.navigationBar.buttons["All items"].wait().tap()
         let searchField = app.navigationBar.searchFields["Search"].wait()
         searchField.tap()
         searchField.typeText("item\n")
@@ -184,7 +184,7 @@ class SearchTests: XCTestCase {
         let searchView = app.saves.searchView.searchResultsView.wait()
         XCTAssertEqual(searchView.cells.count, 2)
 
-        app.navigationBar.buttons["All Items"].wait().tap()
+        app.navigationBar.buttons["All items"].wait().tap()
         XCTAssertEqual(searchView.cells.count, 3)
 
         app.navigationBar.buttons["Archive"].wait().tap()


### PR DESCRIPTION
## Summary
This PR consist of work related to 3 tickets:
* Support pagination for online search results
* Copy updates for Search Flow
* User can cancel searching

## References 
IN-993, IN-1089, IN-968

## Implementation Details
Small changes in terms of updating string values for the various empty states, modify pagesize constant to use `30` or `50` depending on device size and clear search field when user cancels search.

## Test Steps
- [ ] We should request the same number of search results per page, as we do list items. 
[ ] For small devices, like phone, this should be 30 items per page. 
[ ] For large devices, like iPads, this should be 50 items per page. 
- [ ] Verify copy updates for search flow
- [ ] WHEN search is active
AND the user taps the cancel button
THEN the search experience is closed
AND the user is returned to where they were before activating search (e.g., saved or archived)
AND any active searches are cancelled

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
