### PR TITLE
ci(tests): fix for saving tags test

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "braze-swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/braze-inc/braze-swift-sdk",
+      "location" : "https://github.com/braze-inc/braze-swift-sdk.git",
       "state" : {
-        "revision" : "7afd6e0ac0bf59fcf9918e243298114888581ee2",
-        "version" : "5.6.4"
+        "revision" : "2a4c863027f716e088175bcf71b0b2d7bfb9d46f",
+        "version" : "5.8.0"
       }
     },
     {
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "4178d12a44691182c2eb79c70281b14cb73f4cbf",
+        "version" : "5.14.3"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -55,10 +55,13 @@ class AddTagsItemTests: XCTestCase {
         let addTagsView = app.addTagsView.wait()
         addTagsView.wait()
         addTagsView.newTagTextField.tap()
-        addTagsView.newTagTextField.typeText("Tag 1")
+        addTagsView.newTagTextField.typeText(XCUIKeyboardKey.delete.rawValue)
+        let randomInt = Int.random(in: 1..<155)
+        let tagInt = String(randomInt)
+        addTagsView.newTagTextField.typeText(tagInt)
         addTagsView.newTagTextField.typeText("\n")
 
-        addTagsView.tag(matching: "tag 1").wait()
+        addTagsView.tag(matching: tagInt).wait()
 
         server.routes.post("/graphql") { request, _ in
             Response.savedItemWithTag()
@@ -69,6 +72,7 @@ class AddTagsItemTests: XCTestCase {
         itemCell.itemActionButton.wait().tap()
         app.addTagsButton.wait().tap()
         app.addTagsView.wait()
+        addTagsView.tag(matching: tagInt).wait()
     }
 
     func test_addTagsToItemFromSaves_savesFromExistingTags() {


### PR DESCRIPTION
## Summary
I'd like to rewrite some of the test_addTagsToItemFromSaves_savesNewTags() test in AddTagsItemTests

Currently, it doesn't quite function correctly, because the tag name is typically not entered correctly by the simulator keyboard, so only the stored value is checked, which doesn't account for the new tag name being added successfully
I'm going to figure out a solution and check the new tag name on the Saves screen, after the add tags modal is dismissed to sharpen up this test a bit

## Implementation Details
Basically I'm deleting the extra character that the simulator keyboard adds after the field is tapped, then choosing a random Int to use as a temp test tag name, which is checked after it's entered as a solution.


## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
![Pocket — AddTagsItemTests swift 2023-01-09 09-55-11](https://user-images.githubusercontent.com/22959063/211424839-bde6e637-8728-45a2-b275-feb53e1fe617.png)
