### PR TITLE
project(spm): use exact dependency versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,10 +10,16 @@ let package = Package(
         .library(name: "DangerDeps", type: .dynamic, targets: ["DangerDependencies"]), // dev
     ],
     dependencies: [
-        .package(name: "Danger", url: "https://github.com/danger/swift.git", from: "3.14.2"), // dev
-        .package(name: "DangerSwiftCoverage", url: "https://github.com/f-meloni/danger-swift-coverage", from: "1.2.1") // dev
+        .package(url: "https://github.com/danger/swift.git", exact: "3.15.0"), // dev
+        .package(url: "https://github.com/f-meloni/danger-swift-coverage", exact: "1.2.1") // dev
     ],
     targets: [
-        .target(name: "DangerDependencies", dependencies: ["Danger", "DangerSwiftCoverage"]), // dev
+        .target(
+            name: "DangerDependencies",
+            dependencies: [
+                .product(name: "Danger", package: "swift"),
+                .product(name: "DangerSwiftCoverage", package: "danger-swift-coverage")
+            ]
+        ) // dev
     ]
 )

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -1530,8 +1530,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.6.4;
+				kind = exactVersion;
+				version = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "7afd6e0ac0bf59fcf9918e243298114888581ee2",
-        "version" : "5.6.4"
+        "revision" : "3f322b0ca1ec2f53bc87192a39377be7e8f142db",
+        "version" : "5.8.1"
       }
     },
     {
@@ -70,6 +70,15 @@
       "state" : {
         "branch" : "master",
         "revision" : "730166aa43b900e71a128e74910b1d9a431b24cf"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "4178d12a44691182c2eb79c70281b14cb73f4cbf",
+        "version" : "5.14.3"
       }
     },
     {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -15,14 +15,14 @@ let package = Package(
         .library(name: "Analytics", targets: ["Analytics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apollographql/apollo-ios.git", .upToNextMajor(from: "1.0.5")),
-        .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "7.4.1")),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", .upToNextMajor(from: "7.31.5")),
-        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", .upToNextMajor(from: "4.0.1")),
-        .package(url: "https://github.com/airbnb/lottie-ios.git", from: "3.5.0"),
-        .package(url: "https://github.com/johnxnguyen/Down", .upToNextMinor(from: "0.11.0")),
-        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", .upToNextMinor(from: "1.1.5")),
-        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", .upToNextMajor(from: "5.6.4"))
+        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.0.5"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.4.1"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "7.31.5"),
+        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "4.1.0"),
+        .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "3.5.0"),
+        .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
+        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.1.12"),
+        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "5.8.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

Update usage of Swift Package Manager to utilize exact versions instead of up to next major. This is in hopes that this helps us resolve issues with conflicting `Package.resolved` files, or repeatedly seeing file change when switching branches.

## References 

IN-1126

## Implementation Details

- Update both `Package.swift` files
  - Additionally update all files to use latest APIs and Swift 5.7
- Update package(s) within Pocket project settings

## QA Steps

- [x] Passing bitrise build

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
