### PR TITLE
fix(search): fix caching issues with switching scopes

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -157,7 +157,6 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchViewModel.clear()
-        searchViewModel.clearCache()
         searchBar.text = nil
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sync
+
+class LocalSavesSearch {
+    private let source: Source
+    private var cache: [String: [SearchItem]] = [:]
+
+    init(source: Source) {
+        self.source = source
+    }
+
+    func search(with term: String) -> [SearchItem] {
+        guard cache[term] == nil else {
+            return cache[term] ?? []
+        }
+        let items = source.searchSaves(search: term)?.compactMap { SearchItem(item: $0) } ?? []
+        cache[term] = items
+        return cache[term] ?? []
+    }
+
+    func clear() {
+        cache = [:]
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
@@ -20,8 +20,4 @@ class LocalSavesSearch {
         cache[term] = items
         return cache[term] ?? []
     }
-
-    func clear() {
-        cache = [:]
-    }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -14,11 +14,7 @@ class OnlineSearch {
     private let scope: SearchScope
 
     @Published
-    var results: [SearchItem]? {
-        didSet {
-            subscriptions = []
-        }
-    }
+    var results: [SearchItem]?
 
     init(source: Source, scope: SearchScope) {
         self.source = source
@@ -42,10 +38,5 @@ class OnlineSearch {
         Task {
             await searchService.search(for: term, scope: scope)
         }
-    }
-
-    func clear() {
-        cache = [:]
-        subscriptions = []
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sync
+import Combine
+import SharedPocketKit
+
+class OnlineSearch {
+    private let source: Source
+    private let searchService: SearchService
+    private var subscriptions: [AnyCancellable] = []
+    private var cache: [String: [SearchItem]] = [:]
+    private let scope: SearchScope
+
+    @Published
+    var results: [SearchItem]? {
+        didSet {
+            subscriptions = []
+        }
+    }
+
+    init(source: Source, scope: SearchScope) {
+        self.source = source
+        self.searchService = source.makeSearchService()
+        self.scope = scope
+    }
+
+    func search(with term: String) {
+        guard cache[term] == nil else {
+            results = cache[term] ?? []
+            return
+        }
+
+        searchService.results.sink { [weak self] items in
+            guard let self else { return }
+            let searchItems = items.compactMap { SearchItem(item: $0) }
+            self.cache[term] = searchItems
+            self.results = self.cache[term] ?? []
+        }.store(in: &subscriptions)
+
+        Task {
+            await searchService.search(for: term, scope: scope)
+        }
+    }
+
+    func clear() {
+        cache = [:]
+        subscriptions = []
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -16,10 +16,10 @@ class SearchViewModel: ObservableObject {
     private let userDefaults: UserDefaults
     private let source: Source
 
-    private let savesLocalSearch: LocalSavesSearch
-    private let savesOnlineSearch: OnlineSearch
-    private let archiveOnlineSearch: OnlineSearch
-    private let allOnlineSearch: OnlineSearch
+    private var savesLocalSearch: LocalSavesSearch
+    private var savesOnlineSearch: OnlineSearch
+    private var archiveOnlineSearch: OnlineSearch
+    private var allOnlineSearch: OnlineSearch
 
     private var isOffline: Bool {
         networkPathMonitor.currentNetworkPath.status == .unsatisfied
@@ -103,7 +103,7 @@ class SearchViewModel: ObservableObject {
             emptyState = searchResultState()
             return
         }
-        submitSearch(with: term)
+        submitSearch(with: term, scope: selectedScope)
 
         showRecentSearches = false
         recentSearches = updateRecentSearches(with: term)
@@ -112,14 +112,14 @@ class SearchViewModel: ObservableObject {
     func clear() {
         searchResults = []
         subscriptions = []
-        savesLocalSearch.clear()
-        savesOnlineSearch.clear()
-        archiveOnlineSearch.clear()
-        allOnlineSearch.clear()
+        savesLocalSearch = LocalSavesSearch(source: source)
+        savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
+        archiveOnlineSearch = OnlineSearch(source: source, scope: .archive)
+        allOnlineSearch = OnlineSearch(source: source, scope: .all)
     }
 
-    private func submitSearch(with term: String) {
-        switch selectedScope {
+    private func submitSearch(with term: String, scope: SearchScope) {
+        switch scope {
         case .saves:
             // TODO: Handle Offline for Premium https://getpocket.atlassian.net/browse/IN-971
             guard isPremium else {

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -37,7 +37,6 @@ public class PocketSearchService: SearchService {
     }
 
     private func fetch(for term: String, scope: SearchScope) async throws {
-        _results = []
         var shouldFetchNextPage = true
         var items: [SearchSavedItemParts] = []
         var pagination = PaginationInput(first: GraphQLNullable<Int>(integerLiteral: Constants.pageSize))

--- a/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sync
+import PocketGraph
+import Combine
+import SharedPocketKit
+
+@testable import PocketKit
+
+class OnlineSearchTests: XCTestCase {
+    private var source: MockSource!
+    private var searchService: MockSearchService!
+    private var user: MockUser!
+    private var subscriptions: [AnyCancellable] = []
+
+    override func setUpWithError() throws {
+        source = MockSource()
+        searchService = MockSearchService()
+        source.stubMakeSearchService { self.searchService }
+    }
+
+    func subject(source: Source? = nil, scope: SearchScope? = nil) -> OnlineSearch {
+        return OnlineSearch(source: source ?? self.source, scope: scope ?? .saves)
+    }
+
+    func test_search_withSaves_showsResultsAndCaches() async {
+        let sut = subject()
+        sut.search(with: "search-term")
+        await setupOnlineSearch(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
+        XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .saves)
+
+        searchService._results = []
+
+        sut.search(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertNil(searchService.searchCall(at: 1))
+    }
+
+    func test_search_withArchive_showsResultsAndCaches() async {
+        let sut = subject(scope: .archive)
+        sut.search(with: "search-term")
+        await setupOnlineSearch(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
+        XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .archive)
+
+        searchService._results = []
+
+        sut.search(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertNil(searchService.searchCall(at: 1))
+    }
+
+    func test_search_withAll_showsResultsAndCaches() async {
+        let sut = subject(scope: .all)
+        sut.search(with: "search-term")
+        await setupOnlineSearch(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
+        XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .all)
+
+        searchService._results = []
+
+        sut.search(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertNil(searchService.searchCall(at: 1))
+    }
+
+    func test_clear_emptiesCaches() async {
+        let sut = subject()
+        sut.search(with: "search-term")
+        await setupOnlineSearch(with: "search-term")
+        XCTAssertEqual(sut.results?.count, 2)
+        XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
+        XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .saves)
+
+        sut.clear()
+        sut.search(with: "search-term")
+
+        await withCheckedContinuation { continuation in
+            searchService.stubSearch { _, _ in
+                self.searchService._results = []
+                continuation.resume()
+            }
+        }
+
+        XCTAssertEqual(sut.results?.count, 0)
+        XCTAssertEqual(searchService.searchCall(at: 1)?.term, "search-term")
+        XCTAssertEqual(searchService.searchCall(at: 1)?.scope, .saves)
+    }
+
+    private func setupOnlineSearch(with term: String) async {
+        let item = SearchSavedItemParts(data: DataDict([
+            "__typename": "SavedItem",
+            "item": [
+                "__typename": "Item",
+                "title": term,
+                "givenUrl": "http://localhost:8080/hello",
+                "resolvedUrl": "http://localhost:8080/hello"
+            ]
+        ], variables: nil))
+
+        await withCheckedContinuation { continuation in
+            searchService.stubSearch { _, _ in
+                self.searchService._results = [item, item]
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
@@ -14,7 +14,6 @@ class OnlineSearchTests: XCTestCase {
     private var source: MockSource!
     private var searchService: MockSearchService!
     private var user: MockUser!
-    private var subscriptions: [AnyCancellable] = []
 
     override func setUpWithError() throws {
         source = MockSource()
@@ -34,8 +33,6 @@ class OnlineSearchTests: XCTestCase {
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .saves)
 
-        searchService._results = []
-
         sut.search(with: "search-term")
         XCTAssertEqual(sut.results?.count, 2)
         XCTAssertNil(searchService.searchCall(at: 1))
@@ -48,8 +45,6 @@ class OnlineSearchTests: XCTestCase {
         XCTAssertEqual(sut.results?.count, 2)
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .archive)
-
-        searchService._results = []
 
         sut.search(with: "search-term")
         XCTAssertEqual(sut.results?.count, 2)
@@ -64,34 +59,9 @@ class OnlineSearchTests: XCTestCase {
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .all)
 
-        searchService._results = []
-
         sut.search(with: "search-term")
         XCTAssertEqual(sut.results?.count, 2)
         XCTAssertNil(searchService.searchCall(at: 1))
-    }
-
-    func test_clear_emptiesCaches() async {
-        let sut = subject()
-        sut.search(with: "search-term")
-        await setupOnlineSearch(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
-        XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
-        XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .saves)
-
-        sut.clear()
-        sut.search(with: "search-term")
-
-        await withCheckedContinuation { continuation in
-            searchService.stubSearch { _, _ in
-                self.searchService._results = []
-                continuation.resume()
-            }
-        }
-
-        XCTAssertEqual(sut.results?.count, 0)
-        XCTAssertEqual(searchService.searchCall(at: 1)?.term, "search-term")
-        XCTAssertEqual(searchService.searchCall(at: 1)?.scope, .saves)
     }
 
     private func setupOnlineSearch(with term: String) async {

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -39,19 +39,6 @@ class LocalSavesSearchTests: XCTestCase {
         XCTAssertEqual(results.count, 2)
     }
 
-    func test_clear_emptiesCaches() throws {
-        try setupLocalSavesSearch()
-        let sut = subject()
-        var results = sut.search(with: "saved")
-        XCTAssertEqual(results.count, 2)
-
-        source.stubSearchItems { _ in return [] }
-
-        sut.clear()
-        results = sut.search(with: "saved")
-        XCTAssertEqual(results.count, 0)
-    }
-
     private func setupLocalSavesSearch() throws {
         let savedItems = (1...2).map {
             space.buildSavedItem(

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import SharedPocketKit
+
+@testable import Sync
+@testable import PocketKit
+
+class LocalSavesSearchTests: XCTestCase {
+    private var source: MockSource!
+    private var user: MockUser!
+    private var space: Space!
+
+    override func setUpWithError() throws {
+        source = MockSource()
+        user = MockUser()
+        space = .testSpace()
+    }
+
+    override func tearDownWithError() throws {
+        try space.clear()
+    }
+
+    func subject(source: Source? = nil) -> LocalSavesSearch {
+        LocalSavesSearch(source: source ?? self.source)
+    }
+
+    func test_search_showsResultsAndCaches() throws {
+        try setupLocalSavesSearch()
+        let sut = subject()
+        var results = sut.search(with: "saved")
+        XCTAssertEqual(results.count, 2)
+
+        source.stubSearchItems { _ in return [] }
+
+        results = sut.search(with: "saved")
+        XCTAssertEqual(results.count, 2)
+    }
+
+    func test_clear_emptiesCaches() throws {
+        try setupLocalSavesSearch()
+        let sut = subject()
+        var results = sut.search(with: "saved")
+        XCTAssertEqual(results.count, 2)
+
+        source.stubSearchItems { _ in return [] }
+
+        sut.clear()
+        results = sut.search(with: "saved")
+        XCTAssertEqual(results.count, 0)
+    }
+
+    private func setupLocalSavesSearch() throws {
+        let savedItems = (1...2).map {
+            space.buildSavedItem(
+                remoteID: "saved-item-\($0)",
+                createdAt: Date(timeIntervalSince1970: TimeInterval($0)),
+                item: space.buildItem(title: "saved-item-\($0)")
+            )
+        }
+        try space.save()
+
+        source.stubSearchItems { _ in return savedItems }
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -324,6 +324,22 @@ class SearchViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentSearches, ["search-term-3", "search-term-4", "search-term-5", "search-term-6", "search-term-2"])
     }
 
+    // MARK: - Clear
+    func test_clear_resetsSearchResults() async {
+        let term = "search-term"
+        user.status = .premium
+        await setupOnlineSearch(with: term)
+
+        let viewModel = subject()
+        viewModel.updateSearchResults(with: term)
+
+        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title.string }, ["search-term"])
+
+        viewModel.clear()
+
+        XCTAssertEqual(viewModel.searchResults?.compactMap { $0.title.string }, [])
+    }
+
     private func setupLocalSavesSearch(with url: URL? = nil) throws {
         let savedItems = (1...2).map {
             space.buildSavedItem(

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -36,4 +36,12 @@ extension MockSearchService {
 
         impl(term, scope)
     }
+
+    func searchCall(at index: Int) -> SearchCall? {
+        guard let calls = calls[Self.search], calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? SearchCall
+    }
 }

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -175,7 +175,7 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 3)
     }
 
-    func test_switchingScopes_showsResults() {
+    func test_switchingScopes_showsResultsWithCache() {
         app.launch()
         tapSearch()
         let searchField = app.navigationBar.searchFields["Search"].wait()
@@ -183,6 +183,12 @@ class SearchTests: XCTestCase {
         searchField.typeText("item\n")
         let searchView = app.saves.searchView.searchResultsView.wait()
         XCTAssertEqual(searchView.cells.count, 2)
+
+        app.navigationBar.buttons["All items"].wait().tap()
+        XCTAssertEqual(searchView.cells.count, 3)
+
+        app.navigationBar.buttons["Archive"].wait().tap()
+        XCTAssertEqual(searchView.cells.count, 1)
 
         app.navigationBar.buttons["All items"].wait().tap()
         XCTAssertEqual(searchView.cells.count, 3)


### PR DESCRIPTION
## Summary
Fix issue where switching search scopes too quickly causes wrong results due to caching the results for the wrong scope

## References 
IN-1127

## Implementation Details
Previously, we were using two types of search (online, local) with one cache. We learned that this was a data issue in terms of how we were setting cached results and updating search results. From the meeting, we decided it was best to follow the [SOLID principles](https://www.freecodecamp.org/news/solid-principles-explained-in-plain-english/) and create four different instances that act as containers for the 4 search types (local saves, online saves, online archive, online all items). Each container will have its own cache and this will avoid the issue of having results from one scope appear in another. Overall, this decouples each scope from one another.

## Test Steps
1. Go to Search
2. Switch Between Scopes Quickly
3. Search results for all items are correct and cache properly

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
