### PR TITLE
feat(search): saved search offline notification

### DIFF
--- a/PocketKit/Sources/PocketKit/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/PocketKit/Banner/BottomNotification.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import Textile
+import UIKit
+
+struct BannerModifier: ViewModifier {
+    struct BannerData {
+        var image: ImageAsset
+        var title: String
+        var detail: String
+    }
+
+    @Binding var data: BannerData
+    @Binding var show: Bool
+
+    func body(content: Content) -> some View {
+        ZStack(alignment: .bottom) {
+            content
+            if show {
+                VStack {
+                    HStack {
+                        Image(asset: data.image)
+                            .resizable()
+                            .frame(width: 83, height: 50, alignment: .leading)
+                            .padding(8)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(data.title)
+                                .style(.title)
+                            Text(data.detail)
+                                .style(.subtitle)
+                        }
+                        Spacer()
+                    }
+                    .foregroundColor(Color.white)
+                    .padding(8)
+                    .background(Color(red: 1, green: 0.984, blue: 0.89))
+                    .cornerRadius(8)
+                }
+                .padding()
+                .animation(.easeInOut, value: show)
+                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity))
+                .onTapGesture {
+                    withAnimation {
+                        self.show = false
+                    }
+                }.onAppear(perform: {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                        withAnimation {
+                            self.show = false
+                        }
+                    }
+                })
+            }
+        }
+    }
+}
+
+extension View {
+    func banner(data: Binding<BannerModifier.BannerData>, show: Binding<Bool>) -> some View {
+        self.modifier(BannerModifier(data: data, show: show))
+    }
+}
+
+private extension Style {
+    static let title: Self = .header.sansSerif.h4.with(weight: .semibold).with { paragraph in
+        paragraph.with(lineSpacing: 4)
+    }
+    static let subtitle: Self = .header.sansSerif.p4.with(weight: .regular).with { paragraph in
+        paragraph.with(lineSpacing: 4)
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -29,6 +29,8 @@ struct ResultsView: View {
 
     @State private var showingAlert = false
 
+    @State var bannerData: BannerModifier.BannerData = BannerModifier.BannerData(image: .looking, title: "Limited search results", detail: "You can only search titles and URLs while offline. Connect to the internet to use Premium's full-text search.")
+
     var body: some View {
         List(results, id: \.id) { item in
             HStack {
@@ -46,6 +48,7 @@ struct ResultsView: View {
         }
         .listStyle(.plain)
         .accessibilityIdentifier("search-results")
+        .banner(data: $bannerData, show: $viewModel.isPremiumAndOffline)
         .alert(isPresented: $showingAlert) {
             Alert(title: Text("You must have an internet connection to view this item."), dismissButton: .default(Text("OK")))
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -34,6 +34,8 @@ class SearchViewModel: ObservableObject {
         return user.status == .premium
     }
 
+    var isPremiumAndOffline: Bool = false
+
     private var selectedScope: SearchScope = .saves
 
     @Published
@@ -86,6 +88,8 @@ class SearchViewModel: ObservableObject {
         savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
         archiveOnlineSearch = OnlineSearch(source: source, scope: .archive)
         allOnlineSearch = OnlineSearch(source: source, scope: .all)
+
+        isPremiumAndOffline = isPremium && isOffline
     }
 
     func updateScope(with scope: SearchScope, searchTerm: String? = nil) {


### PR DESCRIPTION
show banner for offline notification on saves

## Summary
* when the user is offline during a saves search, a banner will show if the user is premium and offline

## References 
*  [IN-1067](https://getpocket.atlassian.net/jira/software/projects/IN/boards/80?selectedIssue=IN-1067)

## Implementation Details
* added new notification banner in swift UI

## Test Steps
* if the user is offline and premium, a banner show show

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots


[IN-1067]: https://getpocket.atlassian.net/browse/IN-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ