### PR TITLE
fix(sentry): add breadcrumbs for FetchList errors

### DIFF
--- a/PocketKit/Sources/Sync/Operations/FetchList.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchList.swift
@@ -44,10 +44,20 @@ class FetchList: SyncOperation {
         } catch {
             switch error {
             case is URLSessionClient.URLSessionClientError:
+                Crashlogger.breadcrumb(
+                    category: "sync",
+                    level: .error,
+                    message: "URLSessionClient.URLSessionClientError with Error: \(error.localizedDescription)"
+                )
                 return .retry(error)
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
+                    Crashlogger.breadcrumb(
+                        category: "sync",
+                        level: .error,
+                        message: "ResponseCodeInterceptor.ResponseCodeError with Error: \(error.localizedDescription) and status code \(String(describing: response?.statusCode))"
+                    )
                     return .retry(error)
                 default:
                     return .failure(error)


### PR DESCRIPTION
## Summary
Add more breadcrumbs to gain better insight on the following issue: 
Sentry Issue: [IOS-NEXT-9C](https://sentry.io/organizations/pocket/issues/3702278188/?referrer=jira_integration)
`Retriable operation "Sync.FetchList" exceeded maximum number of retries`

## References 
IN-988

## Implementation Details
Added breadcrumbs with details after checking where `retry` is being called and what error cases can trigger it

## Test Steps
N / A. I don't know how to test these errors, but seems we'll rely on verifying that we receive more Information in Sentry.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots