### PR TITLE
ci(tests):a few more home tests

### DIFF
--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -332,6 +332,46 @@ class HomeTests: XCTestCase {
         rec2Cell.savedButton.wait()
         rec1Cell.savedButton.wait()
     }
+    
+    func test_returningFromSaves_maintainsHomePosition() {
+        let home = app.launch().homeView
+        home.overscroll()
+        validateBottomMessage()
+        app.tabBar.savesButton.tap()
+        app.tabBar.homeButton.tap()
+        validateBottomMessage()
+    }
+    
+    func test_returningFromSettings_maintainsHomePosition() {
+        let home = app.launch().homeView
+        home.overscroll()
+        validateBottomMessage()
+        app.tabBar.settingsButton.tap()
+        app.tabBar.homeButton.tap()
+        validateBottomMessage()
+    }
+    
+    func test_returningFromReader_maintainsHomePosition() {
+        let home = app.launch().homeView
+        home.overscroll()
+        validateBottomMessage()
+        home.recommendationCell("Syndicated Article Rec, 1").tap()
+        app.readerView.readerHomeButton.wait().tap()
+        validateBottomMessage()
+    }
+    
+    func test_returningFromSeeAll_maintainsHomePosition() {
+        let home = app.launch().homeView
+        home.overscroll()
+        validateBottomMessage()
+        home.seeAllCollectionButton.tap()
+        app.readerView.readerHomeButton.wait().tap()
+        validateBottomMessage()
+    }
+    
+    func validateBottomMessage() {
+        XCTAssertTrue(app.homeView.overscrollText.exists)
+    }
 }
 
 extension HomeTests {

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -161,10 +161,8 @@ class ReportARecommendationTests: XCTestCase {
         // Swipe down to a syndicated item
         app.homeView.element.swipeUp()
         app.homeView.recommendationCell("Syndicated Article Rec, 1").wait().tap()
-
         app.readerView.readerToolbar.moreButton.tap()
         app.reportButton.wait().tap()
-
         app.reportView.wait()
     }
 }

--- a/Tests iOS/Support/Elements/HomeViewElement.swift
+++ b/Tests iOS/Support/Elements/HomeViewElement.swift
@@ -77,4 +77,16 @@ struct HomeViewElement: PocketUIElement {
             .coordinate(withNormalizedOffset: origin)
             .press(forDuration: 0.1, thenDragTo: element.coordinate(withNormalizedOffset: destination), withVelocity: .fast, thenHoldForDuration: 1)
     }
+    
+    var overscrollText: XCUIElement {
+        element.otherElements["slate-detail-overscroll"]
+    }
+    
+    var seeAllCollectionButton: XCUIElement {
+        element.staticTexts["See All"]
+    }
+    
+    var returnToHomeButton: XCUIElement {
+        element.buttons["Home"]
+    }
 }

--- a/Tests iOS/Support/Elements/ReaderElement.swift
+++ b/Tests iOS/Support/Elements/ReaderElement.swift
@@ -78,6 +78,10 @@ struct ReaderElement: PocketUIElement {
     var safariDoneButton: XCUIElement {
         element.buttons["Done"]
     }
+    
+    var readerHomeButton: XCUIElement {
+        element.buttons["Home"]
+    }
 
     var unsupportedElementOpenButton: XCUIElement {
         element.buttons["Open in Web View"]


### PR DESCRIPTION
## Summary
I'm going to add a few more Home tests to the existing set.

## Implementation Details
Review of the Android Home regression tests, and bringing in missing tests on the iOS side.

Adding:
test_returningFromSaves_maintainsHomePosition
test_returningFromSettings_maintainsHomePosition
test_returningFromReader_maintainsHomePosition
test_returningFromSeeAll_maintainsHomePosition

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
