### PR TITLE
feat(search): search locally for saves if online fails

### DIFF
--- a/PocketKit/Sources/PocketKit/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/PocketKit/Banner/BottomNotification.swift
@@ -9,7 +9,7 @@ struct BannerModifier: ViewModifier {
         var detail: String
     }
 
-    @Binding var data: BannerData
+    let data: BannerData
     @Binding var show: Bool
 
     func body(content: Content) -> some View {
@@ -21,47 +21,51 @@ struct BannerModifier: ViewModifier {
                         Image(asset: data.image)
                             .resizable()
                             .frame(width: 83, height: 50, alignment: .leading)
-                            .padding(8)
-                        VStack(alignment: .leading, spacing: 2) {
+                        Spacer(minLength: 10)
+                        VStack(alignment: .leading, spacing: 8) {
                             Text(data.title)
                                 .style(.title)
                             Text(data.detail)
                                 .style(.subtitle)
                         }
-                        Spacer()
                     }
-                    .foregroundColor(Color.white)
-                    .padding(8)
-                    .background(Color(red: 1, green: 0.984, blue: 0.89))
-                    .cornerRadius(8)
+                    .padding(13)
+                    .background(Color(.branding.amber5))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color(.branding.amber3), lineWidth: 1)
+                    )
                 }
                 .padding()
+                .transition(.move(edge: .bottom).combined(with: .opacity))
                 .animation(.easeInOut, value: show)
-                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity))
                 .onTapGesture {
                     withAnimation {
                         self.show = false
                     }
-                }.onAppear(perform: {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                        withAnimation {
-                            self.show = false
+                }
+                .gesture(DragGesture(minimumDistance: 20, coordinateSpace: .global)
+                    .onEnded { value in
+                        let verticalAmount = value.translation.height
+                        if verticalAmount > 0 {
+                            withAnimation {
+                                self.show = false
+                            }
                         }
-                    }
-                })
+                    })
             }
         }
     }
 }
 
 extension View {
-    func banner(data: Binding<BannerModifier.BannerData>, show: Binding<Bool>) -> some View {
+    func banner(data: BannerModifier.BannerData, show: Binding<Bool>) -> some View {
         self.modifier(BannerModifier(data: data, show: show))
     }
 }
 
 private extension Style {
-    static let title: Self = .header.sansSerif.h4.with(weight: .semibold).with { paragraph in
+    static let title: Self = .header.sansSerif.p2.with(weight: .semibold).with { paragraph in
         paragraph.with(lineSpacing: 4)
     }
     static let subtitle: Self = .header.sansSerif.p4.with(weight: .regular).with { paragraph in

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -8,7 +8,6 @@ import Textile
 struct SearchView: View {
     @ObservedObject
     var viewModel: SearchViewModel
-    var showTempResultsView: Bool = false
 
     var body: some View {
         if let results = viewModel.searchResults, !results.isEmpty {
@@ -29,7 +28,7 @@ struct ResultsView: View {
 
     @State private var showingAlert = false
 
-    @State var bannerData: BannerModifier.BannerData = BannerModifier.BannerData(image: .looking, title: "Limited search results", detail: "You can only search titles and URLs while offline. Connect to the internet to use Premium's full-text search.")
+    let bannerData: BannerModifier.BannerData = BannerModifier.BannerData(image: .looking, title: "Limited search results", detail: "You can only search titles and URLs while offline. Connect to the internet to use Premium's full-text search.")
 
     var body: some View {
         List(results, id: \.id) { item in
@@ -46,9 +45,10 @@ struct ResultsView: View {
                 }
             }.accessibilityIdentifier("search-results-item")
         }
+        .zIndex(-1)
         .listStyle(.plain)
         .accessibilityIdentifier("search-results")
-        .banner(data: $bannerData, show: $viewModel.isPremiumAndOffline)
+        .banner(data: bannerData, show: $viewModel.showBanner)
         .alert(isPresented: $showingAlert) {
             Alert(title: Text("You must have an internet connection to view this item."), dismissButton: .default(Text("OK")))
         }

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -6,8 +6,8 @@ import SharedPocketKit
 import Combine
 
 public protocol SearchService: AnyObject {
-    var results: Published<[SearchSavedItem]>.Publisher { get }
-    func search(for term: String, scope: SearchScope) async
+    var results: Published<[SearchSavedItem]?>.Publisher { get }
+    func search(for term: String, scope: SearchScope) async throws
 }
 
 public struct SearchSavedItem {
@@ -31,8 +31,8 @@ public class PocketSearchService: SearchService {
     typealias SearchItemEdge = SearchSavedItemsQuery.Data.User.SearchSavedItems.Edge
 
     @Published
-    private var _results: [SearchSavedItem] = []
-    public var results: Published<[SearchSavedItem]>.Publisher { $_results }
+    private var _results: [SearchSavedItem]?
+    public var results: Published<[SearchSavedItem]?>.Publisher { $_results }
 
     private let apollo: ApolloClientProtocol
 
@@ -40,12 +40,13 @@ public class PocketSearchService: SearchService {
         self.apollo = apollo
     }
 
-    public func search(for term: String, scope: SearchScope) async {
+    public func search(for term: String, scope: SearchScope) async throws {
         do {
             try await fetch(for: term, scope: scope)
         } catch {
             // TODO: How to handle errors
             Crashlogger.capture(error: error)
+            throw error
         }
     }
 

--- a/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
@@ -27,14 +27,27 @@ class OnlineSearchTests: XCTestCase {
 
     func test_search_withSaves_showsResultsAndCaches() async {
         let sut = subject()
+
         sut.search(with: "search-term")
         await setupOnlineSearch(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .saves)
 
         sut.search(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertNil(searchService.searchCall(at: 1))
     }
 
@@ -42,12 +55,23 @@ class OnlineSearchTests: XCTestCase {
         let sut = subject(scope: .archive)
         sut.search(with: "search-term")
         await setupOnlineSearch(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .archive)
 
         sut.search(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertNil(searchService.searchCall(at: 1))
     }
 
@@ -55,12 +79,23 @@ class OnlineSearchTests: XCTestCase {
         let sut = subject(scope: .all)
         sut.search(with: "search-term")
         await setupOnlineSearch(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertEqual(searchService.searchCall(at: 0)?.term, "search-term")
         XCTAssertEqual(searchService.searchCall(at: 0)?.scope, .all)
 
         sut.search(with: "search-term")
-        XCTAssertEqual(sut.results?.count, 2)
+        guard case .success(let items) = sut.results else {
+            XCTFail("should not have failed")
+            return
+        }
+
+        XCTAssertEqual(items.count, 2)
         XCTAssertNil(searchService.searchCall(at: 1))
     }
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -5,8 +5,8 @@ import PocketGraph
 
 class MockSearchService: SearchService {
     @Published
-    var _results: [SearchSavedItem] = []
-    var results: Published<[SearchSavedItem]>.Publisher { $_results }
+    var _results: [SearchSavedItem]? = []
+    var results: Published<[SearchSavedItem]?>.Publisher { $_results }
 
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
@@ -14,7 +14,7 @@ class MockSearchService: SearchService {
 
 extension MockSearchService {
     private static let search = "search"
-    typealias SearchImpl = (String, SearchScope) -> Void
+    typealias SearchImpl = (String, SearchScope) throws -> Void
 
     struct SearchCall {
         let term: String
@@ -25,7 +25,7 @@ extension MockSearchService {
         implementations[Self.search] = impl
     }
 
-    func search(for term: String, scope: SharedPocketKit.SearchScope) {
+    func search(for term: String, scope: SharedPocketKit.SearchScope) throws {
         guard let impl = implementations[Self.search] as? SearchImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
@@ -34,7 +34,7 @@ extension MockSearchService {
             SearchCall(term: term, scope: scope)
         ]
 
-        impl(term, scope)
+        try impl(term, scope)
     }
 
     func searchCall(at index: Int) -> SearchCall? {

--- a/PocketKit/Tests/PocketKitTests/Support/TestError.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/TestError.swift
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+enum TestError: Error {
+    case anError
+}

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -26,7 +26,7 @@ class PocketSearchServiceTests: XCTestCase {
         )
     }
 
-    func test_search_forSaves_fetchesSearchSavedItemsQueryWithTerm() async {
+    func test_search_forSaves_fetchesSearchSavedItemsQueryWithTerm() async throws {
         apollo.setupSearchListResponse()
         let service = subject()
         let searchExpectation = expectation(description: "searchExpectation")
@@ -35,7 +35,7 @@ class PocketSearchServiceTests: XCTestCase {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        await service.search(for: "search-term", scope: .saves)
+        try await service.search(for: "search-term", scope: .saves)
 
         wait(for: [searchExpectation], timeout: 1)
 
@@ -44,7 +44,7 @@ class PocketSearchServiceTests: XCTestCase {
         XCTAssertEqual(call?.query.filter.status, .init(.unread))
     }
 
-    func test_search_forArchive_fetchesSearchSavedItemsQueryWithTerm() async {
+    func test_search_forArchive_fetchesSearchSavedItemsQueryWithTerm() async throws {
         apollo.setupSearchListResponse()
         let service = subject()
         let searchExpectation = expectation(description: "searchExpectation")
@@ -53,7 +53,7 @@ class PocketSearchServiceTests: XCTestCase {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        await service.search(for: "search-term", scope: .archive)
+        try await service.search(for: "search-term", scope: .archive)
 
         wait(for: [searchExpectation], timeout: 1)
 
@@ -62,7 +62,7 @@ class PocketSearchServiceTests: XCTestCase {
         XCTAssertEqual(call?.query.filter.status, .init(.archived))
     }
 
-    func test_search_forAll_fetchesSearchSavedItemsQueryWithTerm() async {
+    func test_search_forAll_fetchesSearchSavedItemsQueryWithTerm() async throws {
         apollo.setupSearchListResponse()
         let service = subject()
         let searchExpectation = expectation(description: "searchExpectation")
@@ -71,7 +71,7 @@ class PocketSearchServiceTests: XCTestCase {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        await service.search(for: "search-term", scope: .all)
+        try await service.search(for: "search-term", scope: .all)
 
         wait(for: [searchExpectation], timeout: 1)
 
@@ -85,7 +85,7 @@ class PocketSearchServiceTests: XCTestCase {
         apollo.setupSearchListResponseForPagination()
         let service = subject()
 
-        _ = await service.search(for: "search-term", scope: .all)
+        try await service.search(for: "search-term", scope: .all)
 
         XCTAssertEqual(self.apollo.fetchCalls(withQueryType: SearchSavedItemsQuery.self).count, 3)
     }


### PR DESCRIPTION
## Summary
An online search of saves that fails because for network reasons or other errors is resubmitted as an offline search

## References 
IN-971

## Implementation Details
Converted the `search` function to throw an error if it encounters one in `PocketSearchService` . We pass this error on in our OnlineSearch class and we use the `Result` type to return whether the search failed or succeeded. If there is a failure, then run local search for saves only in our `SearchViewModel`. Updated UI banner with some refinements to match Figma and figured out bug with animation in SwiftUI as we needed to specific zIndex(-1).

## Test Steps
- [ ] WHEN the user submits a search query
AND the network connection is active
AND the connection fails
THEN re-submit the search query as a search of local data
AND display the offline search message (banner)

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
