### PR TITLE
feat(search): offline users cannot search archive

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4ad2c3733845abd9ee8892a323b0fa0d80f37e34",
-        "version" : "2.47.0"
+        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
+        "version" : "2.48.0"
       }
     },
     {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -10,12 +10,15 @@ struct SearchView: View {
     var viewModel: SearchViewModel
 
     var body: some View {
-        if let results = viewModel.searchResults, !results.isEmpty {
+        switch viewModel.searchState {
+        case .emptyState(let viewModel):
+            SearchEmptyView(viewModel: viewModel)
+        case .recentSearches(let searches):
+            RecentSearchView(viewModel: viewModel, recentSearches: searches)
+        case .searchResults(let results):
             ResultsView(viewModel: viewModel, results: results)
-        } else if viewModel.showRecentSearches == true, !viewModel.recentSearches.isEmpty {
-            RecentSearchView(viewModel: viewModel, recentSearches: viewModel.recentSearches)
-        } else if let emptyState = viewModel.emptyState {
-            SearchEmptyView(viewModel: emptyState)
+        default:
+            EmptyView()
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "Tag your saves by topic to find them later." = "Tag your saves by topic to find them later.";
 "How to tag" = "How to tag";
 
+"Search" = "Search";
 "All" = "All";
 "Tagged" = "Tagged";
 "Favorites" = "Favorites";

--- a/Tests iOS/MyList/SavesTests.swift
+++ b/Tests iOS/MyList/SavesTests.swift
@@ -158,7 +158,7 @@ class SavesTests: XCTestCase {
         safari.typeText("http://localhost:8080/new-item\n")
         safari.staticTexts["Hello, world"].wait()
         safari.toolbars.buttons["ShareButton"].tap()
-        
+
         let activityView = safari.descendants(matching: .other)["ActivityListView"].wait()
 
         var promise: EventLoopPromise<Response>?

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -70,7 +70,7 @@ class SaveToPocketTests: XCTestCase {
         addTagsView.saveButton.tap()
         safari.staticTexts["Hello, world"].wait()
     }
-    
+
     func tapPocketShareMenuIcon() {
         let safariShareMenu = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
         let activityView = safariShareMenu.descendants(matching: .other)["ActivityListView"].wait()

--- a/Tests iOS/Support/Elements/AddTagsViewElement.swift
+++ b/Tests iOS/Support/Elements/AddTagsViewElement.swift
@@ -38,12 +38,12 @@ struct AddTagsViewElement: PocketUIElement {
     func tag(matching string: String) -> XCUIElement {
         return element.staticTexts[string]
     }
-    
+
     func clearTagsTextfield() {
         newTagTextField.wait().tap()
         newTagTextField.typeText(XCUIKeyboardKey.delete.rawValue)
     }
- 
+
      func enterRandomTagName() -> Int {
          let randomInt = Int.random(in: 1..<155)
          let tagInt = String(randomInt)


### PR DESCRIPTION
## Summary
* Handles offline user scenario when the user navigates to the search experience before submitting search
* Also refactors how we were managing state for our `SearchView`

## References 
IN-962

## Implementation Details
Refactor how we were presenting the different states of the `SearchView`. Instead of managing three separate objects, I decided to create a single enum object called `SearchViewState` that can set which view should be shown and the associated values that will be used in presenting the details of the view. Added some logic of checking if the user is offline + show the offline view when they enter the search experience in `freeEmptyState` and `premiumEmptyState ` 

## Test Steps
**For premium user:**
- [ ] WHEN a user selects the “Saves” search scope
AND the device is offline
THEN show the recent searches view

**For premium and free user:**
 - [ ] WHEN a user selects the “Archive” search scope
AND the device is offline
THEN show a message in the search results area

”Your device is currently offline.” 
”You must have a network connection to search your archived items”

- [ ] WHEN a user submits a search
AND “Archive” is the selected scope
AND the device is offline
THEN show a message in the search results area

”Your device is currently offline.” 
”You must have a network connection to search your archived items”

**For premium user, free user should see Premium upsell instead**
- [ ] WHEN a user selects the “All items” search scope
AND the device is offline
THEN show a message in the search results area
”Your device is currently offline.” 
”You must have a network connection to search all items”

- [ ] WHEN a user submits a search
AND “All items” is the selected scope
AND the device is offline
THEN show a message in the search results area
”Your device is currently offline.” 
”You must have a network connection to search all items”

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
