### PR TITLE
feat(search): online search that fails on network presents offline view

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -40,7 +40,6 @@ class OnlineSearch {
                 try await searchService.search(for: term, scope: scope)
             } catch {
                 // TODO: How to handle errors
-                Crashlogger.capture(error: error)
                 self.results = .failure(error)
             }
         }

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -30,6 +30,8 @@ public class PocketSearchService: SearchService {
         static var pageSize: Int {
             UIDevice.current.userInterfaceIdiom == .phone ? 30 : 50
         }
+        // This error code is returned from Apollo when there is a no internet connection
+        static let noConnectionErrorCode = -1009
     }
 
     typealias SearchItemEdge = SearchSavedItemsQuery.Data.User.SearchSavedItems.Edge
@@ -53,7 +55,7 @@ public class PocketSearchService: SearchService {
             Crashlogger.capture(error: error)
             if case URLSessionClient.URLSessionClientError.networkError(_, _, let underlying) = error {
                 switch (underlying as NSError).code {
-                case -1009:
+                case Constants.noConnectionErrorCode:
                     throw SearchServiceError.noInternet
                 default:
                     throw error

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -332,7 +332,7 @@ class HomeTests: XCTestCase {
         rec2Cell.savedButton.wait()
         rec1Cell.savedButton.wait()
     }
-    
+
     func test_returningFromSaves_maintainsHomePosition() {
         let home = app.launch().homeView
         home.overscroll()
@@ -341,7 +341,7 @@ class HomeTests: XCTestCase {
         app.tabBar.homeButton.tap()
         validateBottomMessage()
     }
-    
+
     func test_returningFromSettings_maintainsHomePosition() {
         let home = app.launch().homeView
         home.overscroll()
@@ -350,7 +350,7 @@ class HomeTests: XCTestCase {
         app.tabBar.homeButton.tap()
         validateBottomMessage()
     }
-    
+
     func test_returningFromReader_maintainsHomePosition() {
         let home = app.launch().homeView
         home.overscroll()
@@ -359,7 +359,7 @@ class HomeTests: XCTestCase {
         app.readerView.readerHomeButton.wait().tap()
         validateBottomMessage()
     }
-    
+
     func test_returningFromSeeAll_maintainsHomePosition() {
         let home = app.launch().homeView
         home.overscroll()
@@ -368,7 +368,7 @@ class HomeTests: XCTestCase {
         app.readerView.readerHomeButton.wait().tap()
         validateBottomMessage()
     }
-    
+
     func validateBottomMessage() {
         XCTAssertTrue(app.homeView.overscrollText.exists)
     }

--- a/Tests iOS/Support/Elements/AddTagsViewElement.swift
+++ b/Tests iOS/Support/Elements/AddTagsViewElement.swift
@@ -44,11 +44,11 @@ struct AddTagsViewElement: PocketUIElement {
         newTagTextField.typeText(XCUIKeyboardKey.delete.rawValue)
     }
 
-     func enterRandomTagName() -> Int {
-         let randomInt = Int.random(in: 1..<155)
-         let tagInt = String(randomInt)
-         newTagTextField.typeText(tagInt)
-         newTagTextField.typeText("\n")
-         return randomInt
-     }
+    func enterRandomTagName() -> Int {
+        let randomInt = Int.random(in: 1..<155)
+        let tagInt = String(randomInt)
+        newTagTextField.typeText(tagInt)
+        newTagTextField.typeText("\n")
+        return randomInt
+    }
 }

--- a/Tests iOS/Support/Elements/HomeViewElement.swift
+++ b/Tests iOS/Support/Elements/HomeViewElement.swift
@@ -77,15 +77,15 @@ struct HomeViewElement: PocketUIElement {
             .coordinate(withNormalizedOffset: origin)
             .press(forDuration: 0.1, thenDragTo: element.coordinate(withNormalizedOffset: destination), withVelocity: .fast, thenHoldForDuration: 1)
     }
-    
+
     var overscrollText: XCUIElement {
         element.otherElements["slate-detail-overscroll"]
     }
-    
+
     var seeAllCollectionButton: XCUIElement {
         element.staticTexts["See All"]
     }
-    
+
     var returnToHomeButton: XCUIElement {
         element.buttons["Home"]
     }

--- a/Tests iOS/Support/Elements/ReaderElement.swift
+++ b/Tests iOS/Support/Elements/ReaderElement.swift
@@ -78,7 +78,7 @@ struct ReaderElement: PocketUIElement {
     var safariDoneButton: XCUIElement {
         element.buttons["Done"]
     }
-    
+
     var readerHomeButton: XCUIElement {
         element.buttons["Home"]
     }


### PR DESCRIPTION
## Summary
An online search of Archive or All Items that fails because of network connection problems presents a message

## References 
IN-974

## Implementation Details
Separated our logic for receiving results from the `OnlineSearch` into their own private functions for `saves`, `archive` and `all items`. Added error type `SearchServiceError` to specify when there was an internet connection issue. This error gets passed on from `SearchService` to `OnlineSearch` to `SearchViewModel` and we set the view to the offline empty state when this error is received. The error is determined to be `noInternet` if Apollo returns an error of `URLSessionClient.URLSessionClientError.networkError` with code `-1009`. Also, fixed a couple of bugs found when trigger a new search or switching scopes by making modifications to `clear` and `resetSearch`

## Test Steps
- [ ] WHEN “Archive” is the selected search scope
AND the device is online
THEN I submit a search
THEN the search fails because the internet connection is lost
THEN we display a message that offline Archive searches are not possible

- [ ] WHEN “All Items” is the selected search scope
AND the device is online
THEN I submit a search
THEN the search fails because the internet connection is lost
THEN we display a message that offline All items searches are not possible

# PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
