### PR TITLE
feat(premium): tos and privacy links

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "braze-swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/braze-inc/braze-swift-sdk.git",
+      "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
         "revision" : "3f322b0ca1ec2f53bc87192a39377be7e8f142db",
         "version" : "5.8.1"

--- a/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Textile
+import SafariServices
 
 struct PremiumUpgradeView: View {
     @Environment(\.dismiss)
@@ -175,10 +176,28 @@ Refunds are not available for unused portions of a subscription.
 }
 
 private struct PremiumTermsView: View {
+    @State var showSafari = false
+    @State var urlString = "https://getpocket.com/en/privacy/"
+    // TODO: URLs need to be localized
+    let privacyPolicyUrlString = "https://getpocket.com/en/privacy/"
+    let toSUrlString = "https://getpocket.com/en/tos/"
+
     var body: some View {
         HStack(spacing: 16) {
-            Button { } label: { Text("Privacy Policy").style(.terms) }
-            Button { } label: { Text("Terms of Service").style(.terms) }
+            Button(action: {
+                self.urlString = privacyPolicyUrlString
+                self.showSafari = true
+            }, label: { Text("Privacy Policy").style(.terms) })
+                .sheet(isPresented: $showSafari) {
+                    SafariView(url: URL(string: self.urlString)!)
+                }
+            Button(action: {
+                self.urlString = toSUrlString
+                self.showSafari = true
+            }, label: { Text("Terms of Service").style(.terms) })
+                .sheet(isPresented: $showSafari) {
+                    SafariView(url: URL(string: self.urlString)!)
+                }
         }.padding(.bottom)
     }
 }
@@ -202,6 +221,17 @@ private struct PremiumBackgroundView: View {
 
     private var borderWidth: CGFloat {
         CGFloat(UIDevice.current.userInterfaceIdiom == .pad ? 18.0 : 13.0)
+    }
+}
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
@@ -177,28 +177,48 @@ Refunds are not available for unused portions of a subscription.
 
 private struct PremiumTermsView: View {
     @State var showSafari = false
-    @State var urlString = "https://getpocket.com/en/privacy/"
-    // TODO: URLs need to be localized
-    let privacyPolicyUrlString = "https://getpocket.com/en/privacy/"
-    let toSUrlString = "https://getpocket.com/en/tos/"
 
     var body: some View {
         HStack(spacing: 16) {
             Button(action: {
-                self.urlString = privacyPolicyUrlString
                 self.showSafari = true
             }, label: { Text("Privacy Policy").style(.terms) })
-                .sheet(isPresented: $showSafari) {
-                    SafariView(url: URL(string: self.urlString)!)
+            .sheet(isPresented: $showSafari) {
+                if let privacyUrl = getUrlFor(typeOf: .PrivacyPolicy) {
+                    SFSafariView(url: privacyUrl)
                 }
+            }
+            .accessibilityIdentifier("privacy-policy")
             Button(action: {
-                self.urlString = toSUrlString
                 self.showSafari = true
             }, label: { Text("Terms of Service").style(.terms) })
-                .sheet(isPresented: $showSafari) {
-                    SafariView(url: URL(string: self.urlString)!)
+            .sheet(isPresented: $showSafari) {
+                if let toSUrl = getUrlFor(typeOf: .TermsOfService) {
+                    SFSafariView(url: toSUrl)
                 }
+            }
+            .accessibilityIdentifier("terms-of-service")
         }.padding(.bottom)
+    }
+
+    enum Link {
+        case PrivacyPolicy
+        case TermsOfService
+    }
+
+    private func getUrlFor(typeOf: Link) -> URL? {
+        switch typeOf {
+        case .PrivacyPolicy:
+            guard let privacyUrl = URL(string: "https://getpocket.com/privacy/") else {
+                return nil
+            }
+            return privacyUrl
+        case .TermsOfService:
+            guard let toSUrl = URL(string: "https://getpocket.com/tos/") else {
+                return nil
+            }
+            return toSUrl
+        }
     }
 }
 
@@ -221,17 +241,6 @@ private struct PremiumBackgroundView: View {
 
     private var borderWidth: CGFloat {
         CGFloat(UIDevice.current.userInterfaceIdiom == .pad ? 18.0 : 13.0)
-    }
-}
-
-struct SafariView: UIViewControllerRepresentable {
-    let url: URL
-
-    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
-        return SFSafariViewController(url: url)
-    }
-
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Textile
-import SafariServices
 
 struct PremiumUpgradeView: View {
     @Environment(\.dismiss)
@@ -185,7 +184,7 @@ private struct PremiumTermsView: View {
                 self.showPrivacyPolicy = true
             }, label: { Text("Privacy Policy").style(.terms) })
             .sheet(isPresented: $showPrivacyPolicy) {
-                if let privacyUrl = getUrlFor(typeOf: .PrivacyPolicy) {
+                if let privacyUrl = getUrlFor(typeOf: .privacyPolicy) {
                     SFSafariView(url: privacyUrl)
                 }
             }
@@ -194,7 +193,7 @@ private struct PremiumTermsView: View {
                 self.showTermsOfService = true
             }, label: { Text("Terms of Service").style(.terms) })
             .sheet(isPresented: $showTermsOfService) {
-                if let toSUrl = getUrlFor(typeOf: .TermsOfService) {
+                if let toSUrl = getUrlFor(typeOf: .termsOfService) {
                     SFSafariView(url: toSUrl)
                 }
             }
@@ -203,18 +202,18 @@ private struct PremiumTermsView: View {
     }
 
     enum Link {
-        case PrivacyPolicy
-        case TermsOfService
+        case privacyPolicy
+        case termsOfService
     }
 
     private func getUrlFor(typeOf: Link) -> URL? {
         switch typeOf {
-        case .PrivacyPolicy:
+        case .privacyPolicy:
             guard let privacyUrl = URL(string: "https://getpocket.com/privacy/") else {
                 return nil
             }
             return privacyUrl
-        case .TermsOfService:
+        case .termsOfService:
             guard let toSUrl = URL(string: "https://getpocket.com/tos/") else {
                 return nil
             }

--- a/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/PremiumUpgradeView.swift
@@ -176,23 +176,24 @@ Refunds are not available for unused portions of a subscription.
 }
 
 private struct PremiumTermsView: View {
-    @State var showSafari = false
+    @State var showPrivacyPolicy = false
+    @State var showTermsOfService = false
 
     var body: some View {
         HStack(spacing: 16) {
             Button(action: {
-                self.showSafari = true
+                self.showPrivacyPolicy = true
             }, label: { Text("Privacy Policy").style(.terms) })
-            .sheet(isPresented: $showSafari) {
+            .sheet(isPresented: $showPrivacyPolicy) {
                 if let privacyUrl = getUrlFor(typeOf: .PrivacyPolicy) {
                     SFSafariView(url: privacyUrl)
                 }
             }
             .accessibilityIdentifier("privacy-policy")
             Button(action: {
-                self.showSafari = true
+                self.showTermsOfService = true
             }, label: { Text("Terms of Service").style(.terms) })
-            .sheet(isPresented: $showSafari) {
+            .sheet(isPresented: $showTermsOfService) {
                 if let toSUrl = getUrlFor(typeOf: .TermsOfService) {
                     SFSafariView(url: toSUrl)
                 }


### PR DESCRIPTION
## Summary
* Adding Privacy Policy and ToS links

## References 
* [IN-1051](https://getpocket.atlassian.net/browse/IN-1051)

## Implementation Details
* added Safari View to allow users to stay on current stack of screens

## Test Steps
* As a free user, go to settings
* select "Go Premium"
* Click on "Privacy Policy" and/or "Terms of Services"

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots


[IN-1051]: https://getpocket.atlassian.net/browse/IN-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ