### PR TITLE
feat(search): search loading state

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemSkeletonCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemSkeletonCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Textile
 
-class ItemPlaceholderCell: UICollectionViewListCell {
+class ItemSkeletonCell: UICollectionViewListCell {
     private let actionsImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.tintColor = UIColor(.ui.skeletonCellImageBackground)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -161,7 +161,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         let offlineCellRegistration: UICollectionView.CellRegistration<ItemsListOfflineCell, String> = .init { cell, _, _ in
         }
 
-        let placeholderCellRegistration: UICollectionView.CellRegistration<ItemPlaceholderCell, Int> = .init { cell, indexPath, itemIndex in
+        let placeholderCellRegistration: UICollectionView.CellRegistration<ItemSkeletonCell, Int> = .init { cell, indexPath, itemIndex in
             // no op
         }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -22,6 +22,10 @@ class OnlineSearch {
         self.scope = scope
     }
 
+    func hasCache(with term: String) -> Bool {
+        return cache[term] != nil
+    }
+
     func search(with term: String) {
         guard cache[term] == nil else {
             results = .success(cache[term] ?? [])

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -23,11 +23,11 @@ class OnlineSearch {
     }
 
     func hasCache(with term: String) -> Bool {
-        return cache[term] != nil
+        cache[term] != nil
     }
 
     func search(with term: String) {
-        guard cache[term] == nil else {
+        guard !hasCache(with: term) else {
             results = .success(cache[term] ?? [])
             return
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -11,12 +11,14 @@ struct SearchView: View {
 
     var body: some View {
         switch viewModel.searchState {
-        case .emptyState(let viewModel):
-            SearchEmptyView(viewModel: viewModel)
+        case .emptyState(let emptyStateViewModel):
+            SearchEmptyView(viewModel: emptyStateViewModel)
         case .recentSearches(let searches):
             RecentSearchView(viewModel: viewModel, recentSearches: searches)
         case .searchResults(let results):
             ResultsView(viewModel: viewModel, results: results)
+        case .loading:
+            SkeletonView()
         default:
             EmptyView()
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -8,7 +8,6 @@ import Sync
 import Combine
 import SharedPocketKit
 import Analytics
-import CoreData
 
 enum SearchViewState {
     case loading
@@ -18,7 +17,6 @@ enum SearchViewState {
 }
 
 class SearchViewModel: ObservableObject {
-    typealias ItemIdentifier = NSManagedObjectID
     static let recentSearchesKey = "Search.recentSearches"
     private var subscriptions: [AnyCancellable] = []
     private let networkPathMonitor: NetworkPathMonitor

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
@@ -5,18 +5,23 @@
 import SwiftUI
 
 struct SkeletonView: View {
+    private enum Constants {
+        static let titleHeight: CGFloat = 60
+        static let spacing: CGFloat = 12
+    }
+
     var body: some View {
         List {
-            ForEach(0..<10) { _ in
+            ForEach(0..<15) { _ in
                 HStack {
                     VStack(alignment: .leading) {
                         Image(asset: .itemSkeletonTitle)
                             .resizable()
-                            .frame(height: 60)
+                            .frame(height: Constants.titleHeight)
                         Image(asset: .itemSkeletonTags)
                     }
                     Spacer()
-                    VStack(spacing: 12) {
+                    VStack(spacing: Constants.spacing) {
                         Image(asset: .itemSkeletonThumbnail)
                         Image(asset: .itemSkeletonActions)
                     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct SkeletonView: View {
+    var body: some View {
+        List {
+            ForEach(0..<10) { _ in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Image(asset: .itemSkeletonTitle)
+                            .resizable()
+                            .frame(height: 60)
+                        Image(asset: .itemSkeletonTags)
+                    }
+                    Spacer()
+                    VStack(spacing: 12) {
+                        Image(asset: .itemSkeletonThumbnail)
+                        Image(asset: .itemSkeletonActions)
+                    }
+                }.foregroundColor(Color(.ui.skeletonCellImageBackground))
+            }
+        }
+        .listStyle(.plain)
+        .accessibilityIdentifier("skeleton-view")
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
@@ -99,6 +99,20 @@ class OnlineSearchTests: XCTestCase {
         XCTAssertNil(searchService.searchCall(at: 1))
     }
 
+    func test_hasCache_withPreviousSearchTerm_returnsTrue() async {
+        let sut = subject()
+        let term = "search-term"
+        sut.search(with: term)
+        await setupOnlineSearch(with: "search-term")
+        XCTAssertTrue(sut.hasCache(with: term))
+    }
+
+    func test_hasCache_withNewSearch_returnsFalse() {
+        let sut = subject()
+        let term = "search-term"
+        XCTAssertFalse(sut.hasCache(with: term))
+    }
+
     private func setupOnlineSearch(with term: String) async {
         let itemParts = SavedItemParts(data: DataDict([
             "__typename": "SavedItem",

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -160,7 +160,7 @@ class SearchViewModelTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search Expectation")
 
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -197,7 +197,7 @@ class SearchViewModelTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search Expectation")
 
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -220,7 +220,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = subject()
         let searchExpectation = expectation(description: "search Expectation")
 
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -243,7 +243,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = subject()
         let searchExpectation = expectation(description: "search Expectation")
 
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -323,7 +323,7 @@ class SearchViewModelTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search Expectation")
 
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -532,7 +532,7 @@ class SearchViewModelTests: XCTestCase {
         let recentSearchesExpectation = expectation(description: "show recent searches state")
 
         var count = 0
-        viewModel.$searchState.dropFirst().receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             count += 1
             if count == 1 {
                 guard case .searchResults(let results) = state else {
@@ -581,7 +581,7 @@ class SearchViewModelTests: XCTestCase {
 
                 XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
                 offlineExpectation.fulfill()
-            } else if count == 2 {
+            } else if count == 3 {
                 guard case .searchResults(let results) = state else {
                     XCTFail("Should not have failed")
                     return
@@ -611,7 +611,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = subject()
         let localSavesExpectation = expectation(description: "handle local saves scenario")
 
-        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(3).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -634,7 +634,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = subject()
         let errorExpectation = expectation(description: "handle apollo internet connection error")
 
-        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(3).receive(on: DispatchQueue.main).sink { state in
             guard case .emptyState(let emptyStateViewModel) = state else {
                 XCTFail("Should not have failed")
                 return

--- a/Tests iOS/Support/Elements/SearchViewElement.swift
+++ b/Tests iOS/Support/Elements/SearchViewElement.swift
@@ -35,6 +35,18 @@ struct SearchViewElement: PocketUIElement {
         return query["search-results"]
     }
 
+    var skeletonView: XCUIElement {
+        let query: XCUIElementQuery
+
+        if #available(iOS 16, *) {
+            query = element.collectionViews
+        } else {
+            query = element.tables
+        }
+
+        return query["skeleton-view"]
+    }
+
     func searchItemCell(at index: Int) -> XCUIElement {
         return searchResultsView.cells.element(boundBy: index)
     }


### PR DESCRIPTION
## Summary
Present loading state while (online) search is in-progress

## References 
IN-992

## Implementation Details
Created a SwiftUI view called `SkeletonView`. This view uses our already existing image assets that we are using in our other skeleton cells (`ItemPlaceholderCell` and `ReaderSkeletonCell`). There is another view called `SkeletonListView`, which uses SwiftUI’s redacted modifier on dummy data, which can act as a loading screen. Although I prefer the `SkeletonListView` as it is a more accurate representation of the data, to maintain consistency, we are using `Skeleton View`. Also, created another `searchState` called `.loading` that shows us the SkeletonView . Had to also add `hasCache` to make sure that we are resetting the search and show loading screen for a new search.

## Test Steps
- [ ] GIVEN search is activated
AND the user submits a search query
AND it is possible to search (e.g., device is online for archived items, etc)
THEN the search results area will show a loading state

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-09 at 10 13 08](https://user-images.githubusercontent.com/6743397/217852454-5cf9bdd8-eac1-4ae8-ae18-4a8d252a29f7.png)