### PR TITLE
Premium Subscriptions: read subscriptions from the App Store

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -56,6 +56,10 @@
 	<string>$(POCKET_API_BASE_URL)</string>
 	<key>PocketAPIConsumerKey</key>
 	<string>$(POCKET_API_CONSUMER_KEY)</string>
+	<key>PocketPremiumMonthlyAlpha</key>
+	<string>$(POCKET_PREMIUM_MONTHLY_ALPHA)</string>
+	<key>PocketPremiumAnnualAlpha</key>
+	<string>$(POCKET_PREMIUM_ANNUAL_ALPHA)</string>
 	<key>SentryDSN</key>
 	<string>$(SENTRY_DSN)</string>
 	<key>SnowplowEndpoint</key>

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */; };
 		8A8F5EFE28CB740000124B6D /* EditTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */; };
 		8ADAC6B028AD4E7500DE9A62 /* AddTagsViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */; };
+		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
 		D26A5EF4297F1D8400FA5A88 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */; };
 		8ADD6A9F292C189C007F419D /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6A9E292C189C007F419D /* SearchTests.swift */; };
 		8ADD6AA1292C1B2C007F419D /* SearchViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */; };
@@ -209,6 +210,7 @@
 		8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesCellElement.swift; sourceTree = "<group>"; };
 		8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTagsTests.swift; sourceTree = "<group>"; };
 		8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsViewElement.swift; sourceTree = "<group>"; };
+		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		8ADD6A9E292C189C007F419D /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewElement.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				16BA7D6626851579009A17C1 /* PocketKit in Frameworks */,
+				AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,6 +443,7 @@
 		F220F2B8264DC2750064D272 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */,
 				F227F0C3265E96290031F985 /* CoreText.framework */,
 				65EC272628BA8AD50075E1DF /* UserNotifications.framework */,
 				65EC272828BA8AD50075E1DF /* UserNotificationsUI.framework */,

--- a/PocketKit/Sources/PocketKit/Keys.swift
+++ b/PocketKit/Sources/PocketKit/Keys.swift
@@ -11,6 +11,8 @@ struct Keys {
     let sentryDSN: String
     let brazeAPIEndpoint: String
     let brazeAPIKey: String
+    let pocketPremiumMonthlyAlpha: String
+    let pocketPremiumAnnualAlpha: String
 
     private init() {
         guard let info = Bundle.main.infoDictionary else {
@@ -33,9 +35,19 @@ struct Keys {
             fatalError("Unable to extract BrazeAPIKey from main bundle")
         }
 
+        guard let pocketPremiumMonthlyAlpha = info["PocketPremiumMonthlyAlpha"] as? String else {
+            fatalError("Unable to extract PocketPremiumMonthlyAlpha from main bundle")
+        }
+
+        guard let pocketPremiumAnnualAlpha = info["PocketPremiumAnnualAlpha"] as? String else {
+            fatalError("Unable to extract PocketPremiumAnnualAlpha from main bundle")
+        }
+
         self.pocketApiConsumerKey = pocketApiConsumerKey
         self.sentryDSN = sentryDSN
         self.brazeAPIEndpoint = brazeAPIEndpoint
         self.brazeAPIKey = brazeAPIKey
+        self.pocketPremiumMonthlyAlpha = pocketPremiumMonthlyAlpha
+        self.pocketPremiumAnnualAlpha = pocketPremiumAnnualAlpha
     }
 }

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import StoreKit
+
+/// An enum that maps all available subscription IDs on the App Store
+enum PremiumSubscriptionType: CaseIterable {
+    case monthly
+    case annual
+
+    var id: String {
+        switch self {
+        case .monthly:
+            return Keys.shared.pocketPremiumMonthlyAlpha
+        case .annual:
+            return Keys.shared.pocketPremiumAnnualAlpha
+        }
+    }
+
+    static func type(from productId: String) -> Self? {
+        switch productId {
+        case Keys.shared.pocketPremiumMonthlyAlpha:
+            return .monthly
+        case Keys.shared.pocketPremiumAnnualAlpha:
+            return .annual
+        default:
+            return .none
+        }
+    }
+}
+
+/// A type that maps to a subscription product on the App Store
+struct PremiumSubscription {
+    let product: Product
+    var isPurchased = false
+
+    var name: String {
+        product.displayName
+    }
+
+    var priceDescription: String {
+        product.displayPrice + product.description
+    }
+
+    var type: PremiumSubscriptionType? {
+        PremiumSubscriptionType.type(from: product.id)
+    }
+}
+
+extension Array where Element == PremiumSubscription {
+    init() async throws {
+        self = try await Product
+            .products(for: PremiumSubscriptionType.allCases.map { $0.id })
+            .map {
+                PremiumSubscription(product: $0)
+            }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SharedPocketKit
+import StoreKit
+
+/// A type that handles premium subscriptions purchases from the App Store
+final class PremiumSubscriptionStore: ObservableObject {
+    @Published private(set) var subscriptions: [PremiumSubscription] = []
+
+    init() async throws {
+        try await requestSubscriptions()
+    }
+    @MainActor
+    func requestSubscriptions() async throws {
+        subscriptions = try await .init()
+    }
+}

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import Foundation
+import SharedPocketKit
+
+@MainActor
+class PremiumUpgradeViewModel: ObservableObject {
+    private let storeFactory: () async throws -> PremiumSubscriptionStore
+
+    private var store: PremiumSubscriptionStore?
+
+    @Published var monthlySubscriptionName = ""
+    @Published var monthlySubscriptionPriceDescription = ""
+
+    @Published var annualSubscriptionName = ""
+    @Published var annualSubscriptionPriceDescription = ""
+
+    private var cancellable: AnyCancellable?
+
+    init(storeFactory: @escaping () async throws -> PremiumSubscriptionStore) {
+        self.storeFactory = storeFactory
+    }
+
+    /// Initialize the subscription store and retrieve subscriptions
+    func requestSubscriptions() async throws {
+        self.store = try await storeFactory()
+
+        cancellable = store?.$subscriptions
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] subscriptions in
+            subscriptions.forEach {
+                switch $0.type {
+                case .monthly:
+                    self?.monthlySubscriptionName = $0.name
+                    self?.monthlySubscriptionPriceDescription = $0.priceDescription
+                case .annual:
+                    self?.annualSubscriptionName = $0.name
+                    self?.annualSubscriptionPriceDescription = $0.priceDescription
+                case .none:
+                    break
+                }
+            }
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -1,7 +1,6 @@
 import Sync
 import Analytics
 import Textile
-import Foundation
 import SharedPocketKit
 import SwiftUI
 
@@ -12,6 +11,12 @@ class AccountViewModel: ObservableObject {
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
 
+    @Published var isPresentingHelp = false
+    @Published var isPresentingTerms = false
+    @Published var isPresentingPrivacy = false
+    @Published var isPresentingSignOutConfirm = false
+    @Published var isPresentingPremiumUpgrade = false
+
     @AppStorage("Settings.ToggleAppBadge")
     public var appBadgeToggle: Bool = false
 
@@ -19,7 +24,10 @@ class AccountViewModel: ObservableObject {
         user.status == .premium
     }
 
-    init(appSession: AppSession, user: User, userDefaults: UserDefaults, notificationCenter: NotificationCenter) {
+    init(appSession: AppSession,
+         user: User,
+         userDefaults: UserDefaults,
+         notificationCenter: NotificationCenter) {
         self.appSession = appSession
         self.user = user
         self.userDefaults = userDefaults
@@ -49,10 +57,19 @@ class AccountViewModel: ObservableObject {
             self.notificationCenter.post(name: .listUpdated, object: nil)
         }
     }
+}
 
-    @Published var isPresentingHelp = false
-    @Published var isPresentingTerms = false
-    @Published var isPresentingPrivacy = false
-    @Published var isPresentingSignOutConfirm = false
-    @Published var isUpgrading = false
+// MARK: Premium upgrades
+extension AccountViewModel {
+    @MainActor
+    func makePremiumUpgradeViewModel() -> PremiumUpgradeViewModel {
+        PremiumUpgradeViewModel {
+            try await PremiumSubscriptionStore()
+        }
+    }
+
+    /// Ttoggle the presentation of `PremiumUpgradeView`
+    func showPremiumUpgrade() {
+        self.isPresentingPremiumUpgrade = true
+    }
 }

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -44,19 +44,13 @@ struct SettingsForm: View {
     var body: some View {
         Form {
             Group {
-                //                Section(header: Text("Your Account").style(.settings.header)) {
-                //                    PremiumRow(status: .notSubscribed, destination: EmptyView())
-                //                    SettingsRowLink(title: "Reset Password", destination: EmptyView())
-                //                    SettingsRowLink(title: "Delete Account", destination: EmptyView())
-                //                }.textCase(nil)
-
                 Section(header: Text(L10n.yourAccount).style(.settings.header)) {
                     if !model.isPremium {
                         SettingsRowButton(title: "Go Premium", icon: nil) {
-                            model.isUpgrading.toggle()
+                            model.showPremiumUpgrade()
                         }
-                        .sheet(isPresented: $model.isUpgrading) {
-                            PremiumUpgradeView()
+                        .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
+                            PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
                         }
                     }
                     SettingsRowButton(title: L10n.signOut, titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -8,7 +8,7 @@ public enum Status: String {
 }
 
 public protocol User {
-    var status: Status { get }
+    var status: Status? { get }
     func setPremiumStatus(_ isPremium: Bool)
     func clear()
 }
@@ -17,10 +17,10 @@ public class PocketUser: User {
     static let userStatusKey = "User.statusKey"
 
     @AppStorage
-    public var status: Status
+    public var status: Status?
 
     public init(status: Status = .unknown, userDefaults: UserDefaults) {
-        _status = AppStorage(wrappedValue: status, Self.userStatusKey, store: userDefaults)
+        _status = AppStorage(Self.userStatusKey, store: userDefaults)
     }
 
     public func setPremiumStatus(_ isPremium: Bool) {

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -1,8 +1,7 @@
 import SharedPocketKit
 
 class MockUser: User {
-    var status: SharedPocketKit.Status = .free
-
+    var status: SharedPocketKit.Status?
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
 }


### PR DESCRIPTION
## Summary
* This PR adds the capability of reading subscription prices from the App Store

## Implementation Details
* Update `Info.plist` and `Keys.swift` with subscription Id keys
* Add `PremiumSubscription`, `PremiumSubscriptionStore` and `PremiumUpgradeViewModel` types
* Update `AccountViewModel` and `SettingsView` to inject the view model (and the store) into `PremiumUpgradeViewModel`
* Update `PremiumUpgradeView` to use the view model 

> **Note**
- `StoreKit` will cache the products for short periods of time. So, if you dismiss the Premium Membership screen and then re-open it, you might see names and prices right away instead of the skeletons. This is normal
- This PR only deals with fetching subscriptions from the App Store. Purchasing and cancellation flows will be handled in future PRs

## Test Steps
* checkout, build and run this branch
* log in to Pocket with a free user
* choose the Settings tab
* tap Go Premium
* make sure that, after a loading time (which will depend on network conditions) subscription names and prices are displayed in the buttons below the premium features list (see animations below for more details)
* make sure that, during the loading time, skeletons are displayed in place of subscription names and prices (see animations below for more details)

## PR Checklist:
- [ ] ~~Added Unit / UI tests~~ `StoreKit` unit tests configuration is still wip, will be added in another PR
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

iPhone light | iPad dark
-- | --
<img height=400 src=https://user-images.githubusercontent.com/34376330/218870993-be36e77e-6922-47c9-927b-9c3f85f3d8e7.gif> | <img height=450 src=https://user-images.githubusercontent.com/34376330/218871079-ea7bf50d-e291-4f7e-a61e-472c5f1952c8.gif>
