### PR TITLE
Premium Subscriptions - minor tweaks to Premium Upgrade Screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,7 @@ iOSInjectionProject/
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,swift
 
-Config/secrets.xcconfig
+Config/secrets*.xcconfig
 **/*.otf
 **/.swiftpm
 **/.tmp

--- a/Info.plist
+++ b/Info.plist
@@ -56,10 +56,10 @@
 	<string>$(POCKET_API_BASE_URL)</string>
 	<key>PocketAPIConsumerKey</key>
 	<string>$(POCKET_API_CONSUMER_KEY)</string>
-	<key>PocketPremiumMonthlyAlpha</key>
-	<string>$(POCKET_PREMIUM_MONTHLY_ALPHA)</string>
-	<key>PocketPremiumAnnualAlpha</key>
-	<string>$(POCKET_PREMIUM_ANNUAL_ALPHA)</string>
+	<key>PocketPremiumMonthly</key>
+	<string>$(POCKET_PREMIUM_MONTHLY)</string>
+	<key>PocketPremiumAnnual</key>
+	<string>$(POCKET_PREMIUM_ANNUAL)</string>
 	<key>SentryDSN</key>
 	<string>$(SENTRY_DSN)</string>
 	<key>SnowplowEndpoint</key>

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -62,10 +62,10 @@
 		8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */; };
 		8A8F5EFE28CB740000124B6D /* EditTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */; };
 		8ADAC6B028AD4E7500DE9A62 /* AddTagsViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */; };
-		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
-		D26A5EF4297F1D8400FA5A88 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */; };
 		8ADD6A9F292C189C007F419D /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6A9E292C189C007F419D /* SearchTests.swift */; };
 		8ADD6AA1292C1B2C007F419D /* SearchViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */; };
+		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
+		D26A5EF4297F1D8400FA5A88 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
 		F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */; };
 		F2675EAB27D9424B0016769E /* HomeWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2675EAA27D9424B0016769E /* HomeWebViewTests.swift */; };
@@ -210,10 +210,11 @@
 		8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesCellElement.swift; sourceTree = "<group>"; };
 		8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTagsTests.swift; sourceTree = "<group>"; };
 		8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsViewElement.swift; sourceTree = "<group>"; };
-		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
-		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		8ADD6A9E292C189C007F419D /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewElement.swift; sourceTree = "<group>"; };
+		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
+		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
+		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		F204A76027E22EC50010E155 /* SaveToPocket.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaveToPocket.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
@@ -404,6 +405,7 @@
 		16973354263CBB290003DE2A /* Config */ = {
 			isa = PBXGroup;
 			children = (
+				AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */,
 				16973355263CBB3F0003DE2A /* secrets.xcconfig */,
 			);
 			path = Config;
@@ -1061,7 +1063,7 @@
 		};
 		1676E5A727FBC89A00F9283A /* Debug_Test */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 16973355263CBB3F0003DE2A /* secrets.xcconfig */;
+			baseConfigurationReference = AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/PocketKit/Sources/PocketKit/Keys.swift
+++ b/PocketKit/Sources/PocketKit/Keys.swift
@@ -11,8 +11,8 @@ struct Keys {
     let sentryDSN: String
     let brazeAPIEndpoint: String
     let brazeAPIKey: String
-    let pocketPremiumMonthlyAlpha: String
-    let pocketPremiumAnnualAlpha: String
+    let pocketPremiumMonthly: String
+    let pocketPremiumAnnual: String
 
     private init() {
         guard let info = Bundle.main.infoDictionary else {
@@ -35,11 +35,11 @@ struct Keys {
             fatalError("Unable to extract BrazeAPIKey from main bundle")
         }
 
-        guard let pocketPremiumMonthlyAlpha = info["PocketPremiumMonthlyAlpha"] as? String else {
+        guard let pocketPremiumMonthly = info["PocketPremiumMonthly"] as? String else {
             fatalError("Unable to extract PocketPremiumMonthlyAlpha from main bundle")
         }
 
-        guard let pocketPremiumAnnualAlpha = info["PocketPremiumAnnualAlpha"] as? String else {
+        guard let pocketPremiumAnnual = info["PocketPremiumAnnual"] as? String else {
             fatalError("Unable to extract PocketPremiumAnnualAlpha from main bundle")
         }
 
@@ -47,7 +47,7 @@ struct Keys {
         self.sentryDSN = sentryDSN
         self.brazeAPIEndpoint = brazeAPIEndpoint
         self.brazeAPIKey = brazeAPIKey
-        self.pocketPremiumMonthlyAlpha = pocketPremiumMonthlyAlpha
-        self.pocketPremiumAnnualAlpha = pocketPremiumAnnualAlpha
+        self.pocketPremiumMonthly = pocketPremiumMonthly
+        self.pocketPremiumAnnual = pocketPremiumAnnual
     }
 }

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -46,24 +46,36 @@ struct PremiumSubscription {
         }
     }
 
-    var priceDescription: String {
-        product.displayPrice + priceDescriptionSuffix
-    }
-
     var type: PremiumSubscriptionType? {
         PremiumSubscriptionType.type(from: product.id)
     }
 
-    private var priceDescriptionSuffix: String {
+    /// Localized subscription price
+    var price: String {
+        product.displayPrice
+    }
+
+    /// Descriptive representation of the subscription type; format: `price_frequency`, where:
+    ///  - `price` is the localized subscription price (e. g. $ 4.99)
+    ///  - `frequency` is the renewal time, (e. g. /month)
+    /// In the above example, the returned value would be $4.99/month.
+    var priceDescription: String {
+        price + frequency
+    }
+
+    /// Suffix of the price description
+    private var frequency: String {
         switch type {
         case .monthly:
-            return "/" + L10n.month
+            return Self.separator + L10n.month
         case .annual:
-            return "/" + L10n.year
+            return Self.separator + L10n.year
         case .none:
             return ""
         }
     }
+
+    private static let separator = "/"
 }
 
 extension Array where Element == PremiumSubscription {

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -55,7 +55,7 @@ struct PremiumSubscription {
         product.displayPrice
     }
 
-    /// Descriptive representation of the subscription type; format: `price_frequency`, where:
+    /// Descriptive representation of the subscription price; format: `price_frequency`, where:
     ///  - `price` is the localized subscription price (e. g. $ 4.99)
     ///  - `frequency` is the renewal time, (e. g. /month)
     /// In the above example, the returned value would be $4.99/month.

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -12,17 +12,17 @@ enum PremiumSubscriptionType: CaseIterable {
     var id: String {
         switch self {
         case .monthly:
-            return Keys.shared.pocketPremiumMonthlyAlpha
+            return Keys.shared.pocketPremiumMonthly
         case .annual:
-            return Keys.shared.pocketPremiumAnnualAlpha
+            return Keys.shared.pocketPremiumAnnual
         }
     }
 
     static func type(from productId: String) -> Self? {
         switch productId {
-        case Keys.shared.pocketPremiumMonthlyAlpha:
+        case Keys.shared.pocketPremiumMonthly:
             return .monthly
-        case Keys.shared.pocketPremiumAnnualAlpha:
+        case Keys.shared.pocketPremiumAnnual:
             return .annual
         default:
             return .none

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -36,15 +36,33 @@ struct PremiumSubscription {
     var isPurchased = false
 
     var name: String {
-        product.displayName
+        switch type {
+        case .monthly:
+            return L10n.monthly
+        case .annual:
+            return L10n.annual
+        case .none:
+            return ""
+        }
     }
 
     var priceDescription: String {
-        product.displayPrice + product.description
+        product.displayPrice + priceDescriptionSuffix
     }
 
     var type: PremiumSubscriptionType? {
         PremiumSubscriptionType.type(from: product.id)
+    }
+
+    private var priceDescriptionSuffix: String {
+        switch type {
+        case .monthly:
+            return "/" + L10n.month
+        case .annual:
+            return "/" + L10n.year
+        case .none:
+            return ""
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -53,25 +53,25 @@ struct PremiumUpgradeView: View {
                 Divider().background(Color(.ui.grey1))
                 PremiumUpgradeFeaturesView()
                 HStack {
-                    if viewModel.monthlySubscriptionName.isEmpty {
+                    if viewModel.monthlyName.isEmpty {
                         PremiumUpgradeButton(isYearly: false)
                             .redacted(reason: .placeholder)
                     } else {
                         PremiumUpgradeButton(
-                            text: viewModel.monthlySubscriptionName,
-                            pricing: viewModel.monthlySubscriptionPriceDescription,
+                            text: viewModel.monthlyName,
+                            pricing: viewModel.monthlyPriceDescription,
                             isYearly: false
                         )
                     }
                     Spacer().frame(width: 28)
                     ZStack(alignment: .topTrailing) {
-                        if viewModel.annualSubscriptionName.isEmpty {
+                        if viewModel.annualName.isEmpty {
                             PremiumUpgradeButton(isYearly: true)
                                 .redacted(reason: .placeholder)
                         } else {
                             PremiumUpgradeButton(
-                                text: viewModel.annualSubscriptionName,
-                                pricing: viewModel.annualSubscriptionPriceDescription,
+                                text: viewModel.annualName,
+                                pricing: viewModel.annualPriceDescription,
                                 isYearly: true
                             )
                             PremiumYearlyPercent()
@@ -79,7 +79,12 @@ struct PremiumUpgradeView: View {
                         }
                     }
                 }
-                PremiumInfoView()
+                if viewModel.monthlyPrice.isEmpty, viewModel.annualPrice.isEmpty {
+                    PremiumInfoView(monthlyPrice: viewModel.monthlyPrice, annualPrice: viewModel.annualPrice)
+                        .redacted(reason: .placeholder)
+                } else {
+                    PremiumInfoView(monthlyPrice: viewModel.monthlyPrice, annualPrice: viewModel.annualPrice)
+                }
                 PremiumTermsView()
             }
             .padding([.leading, .trailing], 32)
@@ -196,14 +201,15 @@ private struct PremiumYearlyPercent: View {
 }
 
 private struct PremiumInfoView: View {
-    private let text = """
-Subscriptions will be charged to your credit card through your iTunes account. \
-Your account will be charged $TBD (monthly) or $TBD (yearly) for renewal within 24 hours prior to the end of the current period. \
-Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. \
-It will not be possible to immediately cancel a subscription. \
-You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. \
-Refunds are not available for unused portions of a subscription.
-"""
+    let monthlyPrice: String
+    let annualPrice: String
+    private let text: String
+
+    init(monthlyPrice: String, annualPrice: String) {
+        self.monthlyPrice = monthlyPrice
+        self.annualPrice = annualPrice
+        self.text = L10n.Premium.Upgradeview.description(monthlyPrice, annualPrice)
+    }
 
     var body: some View {
         Text(text).style(.info)

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -12,11 +12,13 @@ class PremiumUpgradeViewModel: ObservableObject {
 
     private var store: PremiumSubscriptionStore?
 
-    @Published var monthlySubscriptionName = ""
-    @Published var monthlySubscriptionPriceDescription = ""
+    @Published private(set) var monthlyName = ""
+    @Published private(set) var monthlyPrice = ""
+    @Published private(set) var monthlyPriceDescription = ""
 
-    @Published var annualSubscriptionName = ""
-    @Published var annualSubscriptionPriceDescription = ""
+    @Published private(set) var annualName = ""
+    @Published private(set) var annualPrice = ""
+    @Published private(set) var annualPriceDescription = ""
 
     private var cancellable: AnyCancellable?
 
@@ -34,11 +36,13 @@ class PremiumUpgradeViewModel: ObservableObject {
             subscriptions.forEach {
                 switch $0.type {
                 case .monthly:
-                    self?.monthlySubscriptionName = $0.name
-                    self?.monthlySubscriptionPriceDescription = $0.priceDescription
+                    self?.monthlyName = $0.name
+                    self?.monthlyPrice = $0.price
+                    self?.monthlyPriceDescription = $0.priceDescription
                 case .annual:
-                    self?.annualSubscriptionName = $0.name
-                    self?.annualSubscriptionPriceDescription = $0.priceDescription
+                    self?.annualName = $0.name
+                    self?.annualPrice = $0.price
+                    self?.annualPriceDescription = $0.priceDescription
                 case .none:
                     break
                 }

--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -137,3 +137,5 @@
 "year" = "year";
 // Short name of the annual premium subscription
 "Annual" = "Annual";
+// Description of the premium uprgade view
+"premium.upgradeview.description" = "Subscriptions will be charged to your credit card through your iTunes account. Your account will be charged %1$@ (monthly) or %2$@ (yearly) for renewal within 24 hours prior to the end of the current period. Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. It will not be possible to immediately cancel a subscription. You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. Refunds are not available for unused portions of a subscription.";

--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -128,3 +128,12 @@
 "It's rude, vulgar, or offensive" = "It's rude, vulgar, or offensive";
 "It contains misinformation" = "It contains misinformation";
 "Other" = "Other";
+
+// Short name of the monthly premium subscription
+"Monthly" = "Monthly";
+// Suffix of the monthly premium subscription price description
+"month" = "month";
+// Suffix of the annual premium subscription price description
+"year" = "year";
+// Short name of the annual premium subscription
+"Annual" = "Annual";

--- a/PocketKit/Sources/PocketKit/Strings.swift
+++ b/PocketKit/Sources/PocketKit/Strings.swift
@@ -24,6 +24,8 @@ internal enum L10n {
   internal static let all = L10n.tr("Localizable", "All", fallback: "All")
   /// An error occurred
   internal static let anErrorOccurred = L10n.tr("Localizable", "An error occurred", fallback: "An error occurred")
+  /// Annual
+  internal static let annual = L10n.tr("Localizable", "Annual", fallback: "Annual")
   /// App Customization
   internal static let appCustomization = L10n.tr("Localizable", "App Customization", fallback: "App Customization")
   /// Archive
@@ -97,6 +99,10 @@ internal enum L10n {
   internal static let longestToRead = L10n.tr("Localizable", "Longest to read", fallback: "Longest to read")
   /// Make the most of any moment
   internal static let makeTheMostOfAnyMoment = L10n.tr("Localizable", "Make the most of any moment", fallback: "Make the most of any moment")
+  /// month
+  internal static let month = L10n.tr("Localizable", "month", fallback: "month")
+  /// Monthly
+  internal static let monthly = L10n.tr("Localizable", "Monthly", fallback: "Monthly")
   /// Move to Saves
   internal static let moveToSaves = L10n.tr("Localizable", "Move to Saves", fallback: "Move to Saves")
   /// Newest saved
@@ -189,6 +195,8 @@ internal enum L10n {
   internal static let thisVideoCouldNotBeLoaded = L10n.tr("Localizable", "This video could not be loaded.", fallback: "This video could not be loaded.")
   /// Unfavorite
   internal static let unfavorite = L10n.tr("Localizable", "Unfavorite", fallback: "Unfavorite")
+  /// year
+  internal static let year = L10n.tr("Localizable", "year", fallback: "year")
   /// Yes
   internal static let yes = L10n.tr("Localizable", "Yes", fallback: "Yes")
   /// You will be signed out of your account and any files that have been saved for offline viewing will be deleted.

--- a/PocketKit/Sources/PocketKit/Strings.swift
+++ b/PocketKit/Sources/PocketKit/Strings.swift
@@ -216,6 +216,14 @@ internal enum L10n {
     /// Save from Safari, Twitter, YouTube or your favorite news app (for starters). Your articles and videos will be ready for you in Pocket
     internal static let yourArticlesAndVideosWillBeReadyForYouInPocket = L10n.tr("Localizable", "Save from Safari, Twitter, YouTube or your favorite news app (for starters). Your articles and videos will be ready for you in Pocket", fallback: "Save from Safari, Twitter, YouTube or your favorite news app (for starters). Your articles and videos will be ready for you in Pocket")
   }
+  internal enum Premium {
+    internal enum Upgradeview {
+      /// Subscriptions will be charged to your credit card through your iTunes account. Your account will be charged %1$@ (monthly) or %2$@ (yearly) for renewal within 24 hours prior to the end of the current period. Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. It will not be possible to immediately cancel a subscription. You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. Refunds are not available for unused portions of a subscription.
+      internal static func description(_ p1: Any, _ p2: Any) -> String {
+        return L10n.tr("Localizable", "premium.upgradeview.description", String(describing: p1), String(describing: p2), fallback: "Subscriptions will be charged to your credit card through your iTunes account. Your account will be charged %1$@ (monthly) or %2$@ (yearly) for renewal within 24 hours prior to the end of the current period. Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. It will not be possible to immediately cancel a subscription. You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. Refunds are not available for unused portions of a subscription.")
+      }
+    }
+  }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces


### PR DESCRIPTION
## Summary
* This pull request replaces the placeholder TBD prices in the description at the bottom of the Premium Upgrade view with the actual subscription prices.

## References 
* Links to docs, tickets, designs if available

## Implementation Details

* Adds the description at the bottom of `PremiumUpgradeView` to `Localizable.strings` and, by means of `SwiftGen`, to `Strings.swift`
* Uses localized names and descriptions for the upgrade buttons in `PremiumUpgradeView`
* Updates `.gitignore` to allow usage of separate `.xcconfig` files for separate configuration (will be useful for StoreKit tests)
* Shorten key names for subscriptions in `Keys` and `Info.plist`

## Test Steps
* Checkout, build and run this branch
* Log in with a free account
* Tap Settings, then Go Premium
* Make sure that the description at the bottom reflect the same subscription prices shown in the buttons above the description.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
before | after
-- | --
<img width="300" src="https://user-images.githubusercontent.com/34376330/219546853-e78e2c27-5425-4aea-9424-347a2d046205.png"> | <img width="300" src="https://user-images.githubusercontent.com/34376330/219546893-72d1d951-1762-4c04-8e4c-2570e5a0b872.png">
