### PR TITLE
ci(tests): hyperlink+tags tests flaky fix

### DIFF
--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -47,10 +47,8 @@ class AddTagsItemTests: XCTestCase {
 
     func test_addTagsToItemFromSaves_savesNewTags() {
         app.tabBar.savesButton.wait().tap()
-
         let itemCell = app.saves.itemView(matching: "Item 1")
         itemCell.itemActionButton.wait().tap()
-
         app.addTagsButton.wait().tap()
         let addTagsView = app.addTagsView.wait()
         addTagsView.clearTagsTextfield()

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -59,10 +59,9 @@ class AddTagsItemTests: XCTestCase {
             Response.savedItemWithTag()
         }
         addTagsView.saveButton.tap()
-        itemCell.itemActionButton.wait().tap()
-        app.addTagsButton.wait().tap()
-        app.addTagsView.wait()
-        addTagsView.tag(matching: randomTagName).wait()
+        selectTaggedFilterButton()
+        let tagsFilterView = app.saves.tagsFilterView.wait()
+        tagsFilterView.tag(matching: randomTagName).wait()
     }
 
     func test_addTagsToItemFromSaves_savesFromExistingTags() {
@@ -135,5 +134,9 @@ class AddTagsItemTests: XCTestCase {
         app.addTagsButton.wait().tap()
         app.addTagsView.wait()
         app.addTagsView.allTagsView.wait()
+    }
+    
+    func selectTaggedFilterButton() {
+        app.saves.filterButton(for: "Tagged").tap()
     }
 }

--- a/Tests iOS/Fixtures/hello2.html
+++ b/Tests iOS/Fixtures/hello2.html
@@ -1,0 +1,22 @@
+<html>
+    <style>
+        .container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100%
+        }
+        h1 {
+            font-size: 48;
+            font-family: Arial;
+        }
+    </style>
+    <body>
+        <div class="container">
+            <a href="http://localhost:8080/welcome">
+                <h1>Hello, world</h1>
+            </a>
+
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
Fixes for a number of small-fail flaky tests.

I've made two attempts at changing the tests so that they don't flaky fail (time will tell if these changes are effective at preventing the flaky fails):

  **Tags**: I changed this test so it opens the All Tags view instead of the item tag, to check that the save function worked

  **Hyperlink**: I changed this test to long press a different hyperlink in a different item

Tracking the fail rate via Bitise graph tracking.
