### PR TITLE
feat(search): favorite search results

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -3,7 +3,70 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import SharedPocketKit
 
 public extension Events {
     struct Search {}
+}
+
+public extension Events.Search {
+    static func favoriteItem(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        var identifier = ""
+        switch scope {
+        case .saves:
+            identifier = "global-nav.search.saves.favorite"
+        case .archive:
+            identifier = "global-nav.search.archive.favorite"
+        case .all:
+            identifier = "global-nav.search.all.favorite"
+        }
+
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: identifier,
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    static func unfavoriteItem(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        var identifier = ""
+        switch scope {
+        case .saves:
+            identifier = "global-nav.search.saves.unfavorite"
+        case .archive:
+            identifier = "global-nav.search.archive.unfavorite"
+        case .all:
+            identifier = "global-nav.search.all.unfavorite"
+        }
+
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: identifier,
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
 }

--- a/PocketKit/Sources/Analytics/Entities/UserEntity.swift
+++ b/PocketKit/Sources/Analytics/Entities/UserEntity.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Foundation
+import class SnowplowTracker.SelfDescribingJson
+
+public struct UserEntity: Entity {
+    public static var schema = "iglu:com.pocket/user/jsonschema/1-0-0"
+
+    let guid: String
+    let userID: String
+
+    public init(guid: String, userID: String) {
+        self.guid = guid
+        self.userID = userID
+    }
+
+    public func toSelfDescribingJson() -> SelfDescribingJson {
+        return SelfDescribingJson(schema: UserEntity.schema, andDictionary: [
+            "hashed_guid": guid,
+            "hashed_user_id": userID
+        ])
+    }
+}

--- a/PocketKit/Sources/Analytics/Tracker/LinkedTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/LinkedTracker.swift
@@ -15,6 +15,10 @@ class LinkedTracker: Tracker {
         parent.addPersistentContext(context)
     }
 
+    func addPersistentEntity(_ entity: Entity) {
+        parent.addPersistentEntity(entity)
+    }
+
     func track<T>(event: T, _ contexts: [Context]?) where T: OldEvent {
         let additional = contexts ?? []
         parent.track(event: event, self.contexts + additional)
@@ -31,5 +35,9 @@ class LinkedTracker: Tracker {
 
     func resetPersistentContexts(_ contexts: [Context]) {
         parent.resetPersistentContexts(contexts)
+    }
+
+    func resetPersistentEntities(_ entities: [Entity]) {
+        parent.resetPersistentEntities(entities)
     }
 }

--- a/PocketKit/Sources/Analytics/Tracker/NoopTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/NoopTracker.swift
@@ -9,6 +9,10 @@ public struct NoopTracker: Tracker {
         fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
     }
 
+    public func addPersistentEntity(_ entity: Entity) {
+        fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
+    }
+
     public func track<T: OldEvent>(event: T, _ contexts: [Context]?) {
         fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
     }
@@ -22,6 +26,10 @@ public struct NoopTracker: Tracker {
     }
 
     public func resetPersistentContexts(_ contexts: [Context]) {
+        fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
+    }
+
+    public func resetPersistentEntities(_ entities: [Entity]) {
         fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
     }
 }

--- a/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
@@ -8,6 +8,7 @@ public class PocketTracker: Tracker {
     private let snowplow: SnowplowTracker
 
     private var persistentContexts: [Context] = []
+    private var persistentEntities: [Entity] = []
 
     public init(snowplow: SnowplowTracker) {
         self.snowplow = snowplow
@@ -15,6 +16,10 @@ public class PocketTracker: Tracker {
 
     public func addPersistentContext(_ context: Context) {
         persistentContexts.append(context)
+    }
+
+    public func addPersistentEntity(_ entity: Entity) {
+        persistentEntities.append(entity)
     }
 
     public func track<T: OldEvent>(event: T, _ contexts: [Context]?) {
@@ -32,7 +37,7 @@ public class PocketTracker: Tracker {
 
     public func track(event: Event) {
         let selfDescribing = event.toSelfDescribing()
-        persistentContexts.forEach { selfDescribing.contexts.add($0) }
+        persistentEntities.forEach { selfDescribing.contexts.add($0.toSelfDescribingJson()) }
         snowplow.track(event: selfDescribing)
     }
 
@@ -42,6 +47,10 @@ public class PocketTracker: Tracker {
 
     public func resetPersistentContexts(_ contexts: [Context]) {
         persistentContexts = contexts
+    }
+
+    public func resetPersistentEntities(_ entities: [Entity]) {
+        persistentEntities = entities
     }
 }
 

--- a/PocketKit/Sources/Analytics/Tracker/Tracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/Tracker.swift
@@ -6,17 +6,23 @@ import SnowplowTracker
 
 public protocol Tracker {
     func addPersistentContext(_ context: Context)
+    func addPersistentEntity(_ entity: Entity)
     @available(*, deprecated, message: "Use track with an explict Event defintion")
     func track<T: OldEvent>(event: T, _ contexts: [Context]?)
     func track(event: Event)
     @available(*, deprecated, message: "No need to longer use a child tracker")
     func childTracker(with contexts: [Context]) -> Tracker
     func resetPersistentContexts(_ contexts: [Context])
+    func resetPersistentEntities(_ entities: [Entity])
 }
 
 public extension Tracker {
     func addPersistentContexts(_ contexts: [Context]) {
         contexts.forEach { addPersistentContext($0) }
+    }
+
+    func addPersistentContexts(_ entities: [Entity]) {
+        entities.forEach { addPersistentEntity($0) }
     }
 
     func childTracker(hosting context: UIContext) -> Tracker {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -1,9 +1,11 @@
-import Foundation
-import UIKit
-import PocketGraph
-import Sync
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-struct SearchItem {
+import Foundation
+import PocketGraph
+
+struct PocketItem {
     private let item: ItemsListItem
     private let itemPresenter: ItemsListItemPresenter
 
@@ -14,6 +16,10 @@ struct SearchItem {
 
     var id: String? {
         item.id
+    }
+
+    var isFavorite: Bool {
+        item.isFavorite
     }
 
     var title: NSAttributedString {
@@ -34,24 +40,6 @@ struct SearchItem {
 
     var thumbnailURL: URL? {
         itemPresenter.thumbnailURL
-    }
-
-    var shareAction: ItemAction {
-        ItemAction.share { _ in Log.info("Share button tapped!") }
-    }
-
-    var favoriteAction: ItemAction {
-        ItemAction.favorite { _ in Log.info("Favorite button tapped!") }
-    }
-
-    var overflowActions: [ItemAction] {
-        [ItemAction.addTags { _ in Log.info("Add tags button tapped!") }, ItemAction.archive { _ in Log.info("Archive button tapped!") }, ItemAction.delete { _ in Log.info("Delete button tapped!") }]
-    }
-
-    var trackOverflow: ItemAction {
-        ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
-            Log.info("Overflow button tapped!")
-        })
     }
 
     var remoteItemParts: SavedItemParts? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Analytics
+import Sync
+import SharedPocketKit
+
+class PocketItemViewModel: ObservableObject {
+    private let tracker: Tracker
+    private let source: Source
+    let item: PocketItem
+    let index: Int
+
+    @Published
+    var isFavorite: Bool
+
+    init(item: PocketItem, index: Int, source: Source, tracker: Tracker) {
+        self.item = item
+        self.index = index
+        self.source = source
+        self.tracker = tracker
+        self.isFavorite = item.isFavorite
+    }
+
+    func favoriteAction(index: Int, scope: SearchScope) -> ItemAction {
+        if isFavorite {
+            return .unfavorite { [weak self] _ in
+                self?._unfavorite(index: index, scope: scope)
+            }
+        } else {
+            return .favorite { [weak self] _ in
+                self?._favorite(index: index, scope: scope)
+            }
+        }
+    }
+
+    private func _favorite(index: Int, scope: SearchScope) {
+        guard
+            let id = item.id,
+            let savedItem = source.fetchOrCreateSavedItem(
+                with: id,
+                and: item.remoteItemParts
+            )
+        else {
+            Log.capture(message: "Saved Item not created")
+            return
+        }
+
+        tracker.track(event: Events.Search.unfavoriteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        source.favorite(item: savedItem)
+        isFavorite = savedItem.isFavorite
+    }
+
+    private func _unfavorite(index: Int, scope: SearchScope) {
+        guard
+            let id = item.id,
+            let savedItem = source.fetchOrCreateSavedItem(
+                with: id,
+                and: item.remoteItemParts
+            )
+        else {
+            Log.capture(message: "Saved Item not created")
+            return
+        }
+
+        tracker.track(event: Events.Search.favoriteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        source.unfavorite(item: savedItem)
+        isFavorite = savedItem.isFavorite
+    }
+
+    var shareAction: ItemAction {
+        ItemAction.share { _ in Log.info("Share button tapped!") }
+    }
+
+    var overflowActions: [ItemAction] {
+        [ItemAction.addTags { _ in Log.info("Add tags button tapped!") }, ItemAction.archive { _ in Log.info("Archive button tapped!") }, ItemAction.delete { _ in Log.info("Delete button tapped!") }]
+    }
+
+    var trackOverflow: ItemAction {
+        ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
+            Log.info("Overflow button tapped!")
+        })
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -48,6 +48,7 @@ class PocketItemViewModel: ObservableObject {
             return
         }
 
+        // This view model should be reusable, aside from this tracking call. We can refactor this call when we reuse this for other lists.
         tracker.track(event: Events.Search.unfavoriteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
         source.favorite(item: savedItem)
         isFavorite = savedItem.isFavorite

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ActionButton.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ActionButton.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import Textile
 
 struct ActionButton: View {
-    var itemAction: ItemAction?
-    var selected: Bool = false
-    var trailingPadding: Bool = true
+    private var itemAction: ItemAction?
+    private var selected: Bool = false
+    private var trailingPadding: Bool = true
 
     init(_ itemAction: ItemAction?, selected: Bool = false, trailingPadding: Bool = true) {
         self.itemAction = itemAction
@@ -20,6 +20,7 @@ struct ActionButton: View {
                 Image(uiImage: image)
                     .actionButtonStyle(selected: selected, trailingPadding: trailingPadding)
                     .accessibilityIdentifier(action.accessibilityIdentifier)
+                    .accessibilityLabel(action.title)
             }.buttonStyle(.borderless)
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
@@ -1,18 +1,22 @@
 import SwiftUI
 import Textile
 import Kingfisher
+import SharedPocketKit
 
 struct ListItem: View {
-    var model: SearchItem
+    @ObservedObject
+    var viewModel: PocketItemViewModel
+
+    let scope: SearchScope
 
     let constants = Constants.self
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: 0) {
-                ItemDetails(attributedTitle: model.title, attributedDetail: model.detail)
+                ItemDetails(attributedTitle: viewModel.item.title, attributedDetail: viewModel.item.detail)
 
-                KFImage(model.thumbnailURL)
+                KFImage(viewModel.item.thumbnailURL)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: constants.image.width, height: constants.image.height, alignment: .center)
@@ -20,11 +24,11 @@ struct ListItem: View {
             }
 
             HStack(alignment: .center, spacing: constants.tags.horizontalSpacing) {
-                ItemTags(tags: model.tags, tagCount: model.tagCount)
+                ItemTags(tags: viewModel.item.tags, tagCount: viewModel.item.tagCount)
                 Spacer()
-                ActionButton(model.favoriteAction)
-                ActionButton(model.shareAction)
-                OverflowMenu(overflowActions: model.overflowActions, trackOverflow: model.trackOverflow, trailingPadding: false)
+                ActionButton(viewModel.favoriteAction(index: viewModel.index, scope: scope), selected: viewModel.isFavorite)
+                ActionButton(viewModel.shareAction)
+                OverflowMenu(overflowActions: viewModel.overflowActions, trackOverflow: viewModel.trackOverflow, trailingPadding: false)
             }
         }
         .padding(.vertical, constants.verticalPadding)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/ActionButtonStyles.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/ActionButtonStyles.swift
@@ -7,7 +7,7 @@ extension Image {
         self
             .renderingMode(.template)
             .resizable()
-            .foregroundColor(selected ? Color(.branding.amber5) : Color(.ui.grey5))
+            .foregroundColor(selected ? Color(.branding.amber4) : Color(.ui.grey5))
             .scaledToFit()
             .frame(width: constants.imageSize, height: constants.imageSize, alignment: .center)
             .padding(trailingPadding ? [.all] : [.vertical, .leading], constants.padding)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
@@ -3,20 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Sync
+import Analytics
 
 class LocalSavesSearch {
     private let source: Source
-    private var cache: [String: [SearchItem]] = [:]
+    private var cache: [String: [PocketItem]] = [:]
 
     init(source: Source) {
         self.source = source
     }
 
-    func search(with term: String) -> [SearchItem] {
+    func search(with term: String) -> [PocketItem] {
         guard cache[term] == nil else {
             return cache[term] ?? []
         }
-        let items = source.searchSaves(search: term)?.compactMap { SearchItem(item: $0) } ?? []
+        let items = source.searchSaves(search: term)?.compactMap { PocketItem(item: $0) } ?? []
         cache[term] = items
         return cache[term] ?? []
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -10,11 +10,11 @@ class OnlineSearch {
     private let source: Source
     private let searchService: SearchService
     private var subscriptions: [AnyCancellable] = []
-    private var cache: [String: [SearchItem]] = [:]
+    private var cache: [String: [PocketItem]] = [:]
     private let scope: SearchScope
 
     @Published
-    var results: Result<[SearchItem], Error>?
+    var results: Result<[PocketItem], Error>?
 
     init(source: Source, scope: SearchScope) {
         self.source = source
@@ -34,7 +34,7 @@ class OnlineSearch {
 
         searchService.results.sink { [weak self] items in
             guard let self, let items else { return }
-            let searchItems = items.compactMap { SearchItem(item: $0) }
+            let searchItems = items.compactMap { PocketItem(item: $0) }
             self.cache[term] = searchItems
             self.results = .success(self.cache[term] ?? [])
         }.store(in: &subscriptions)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -29,24 +29,26 @@ struct SearchView: View {
 struct ResultsView: View {
     @ObservedObject
     var viewModel: SearchViewModel
-    var results: [SearchItem]
+    var results: [PocketItem]
 
     @State private var showingAlert = false
 
     var body: some View {
-        List(results, id: \.id) { item in
-            HStack {
-                ListItem(model: item)
-                Spacer()
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                if viewModel.isOffline {
-                    showingAlert = true
-                } else {
-                    viewModel.select(item)
+        List {
+            ForEach(Array(results.enumerated()), id: \.offset) { index, item in
+                HStack {
+                    ListItem(viewModel: viewModel.itemViewModel(item, index: index), scope: viewModel.selectedScope)
+                    Spacer()
                 }
-            }.accessibilityIdentifier("search-results-item")
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if viewModel.isOffline {
+                        showingAlert = true
+                    } else {
+                        viewModel.select(item)
+                    }
+                }
+            }
         }
         .zIndex(-1)
         .listStyle(.plain)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -13,7 +13,7 @@ enum SearchViewState {
     case loading
     case emptyState(EmptyStateViewModel)
     case recentSearches([String])
-    case searchResults([SearchItem])
+    case searchResults([PocketItem])
 }
 
 class SearchViewModel: ObservableObject {
@@ -42,7 +42,7 @@ class SearchViewModel: ObservableObject {
         return user.status == .premium
     }
 
-    private var selectedScope: SearchScope = .saves
+    var selectedScope: SearchScope = .saves
 
     @Published
     var showBanner: Bool = false
@@ -285,7 +285,11 @@ class SearchViewModel: ObservableObject {
 }
 
 extension SearchViewModel {
-    func select(_ searchItem: SearchItem) {
+    func itemViewModel(_ searchItem: PocketItem, index: Int) -> PocketItemViewModel {
+        return PocketItemViewModel(item: searchItem, index: index, source: source, tracker: tracker)
+    }
+
+    func select(_ searchItem: PocketItem) {
         guard
             let id = searchItem.id,
             let savedItem = source.fetchOrCreateSavedItem(
@@ -293,6 +297,7 @@ extension SearchViewModel {
                 and: searchItem.remoteItemParts
             )
         else {
+            Log.capture(message: "Saved Item not created")
             return
         }
 

--- a/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootViewModel.swift
@@ -101,6 +101,10 @@ class RootViewModel {
             APIUserContext(consumerKey: Keys.shared.pocketApiConsumerKey)
         ])
         tracker.addPersistentContext(UserContext(guid: session.guid, userID: session.userIdentifier))
+        tracker.resetPersistentEntities([
+            APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey)
+        ])
+        tracker.addPersistentEntity(UserEntity(guid: session.guid, userID: session.userIdentifier))
         Log.setUserID(session.userIdentifier)
         source.refresh()
     }
@@ -111,6 +115,9 @@ class RootViewModel {
         userDefaults.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
         tracker.resetPersistentContexts([
             APIUserContext(consumerKey: Keys.shared.pocketApiConsumerKey)
+        ])
+        tracker.resetPersistentEntities([
+            APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey)
         ])
 
         Log.clearUser()

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -35,7 +35,12 @@ class SavedItemViewModel {
         tracker.resetPersistentContexts([
             APIUserContext(consumerKey: consumerKey)
         ])
+        tracker.resetPersistentEntities([
+            APIUserEntity(consumerKey: consumerKey)
+        ])
         tracker.addPersistentContext(UserContext(guid: session.guid, userID: session.userIdentifier))
+
+        tracker.addPersistentEntity(UserEntity(guid: session.guid, userID: session.userIdentifier))
     }
 
     func save(from context: ExtensionContext?) async {

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -5,20 +5,18 @@
 import CoreData
 
 public class PersistentContainer: NSPersistentContainer {
-    
     public lazy var rootSpace = { Space(context: viewContext) }()
 
     public enum Storage {
         case inMemory
         case shared
     }
-    
+
     let userDefaults: UserDefaults
 
     public init(storage: Storage = .shared, userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
 
-        
         ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
         ValueTransformer.setValueTransformer(SyncTaskTransformer(), forName: .syncTaskTransformer)
 
@@ -62,7 +60,7 @@ public extension PersistentContainer {
             userDefaults.set(newValue, forKey: Self.hasResetData2212023Key)
         }
     }
-    
+
     /**
      During our Testflight, we merged a change that made values non-null in CoreData. Turns out that we were unknowningly saving null values in fields that should have been required.
      Instead of coding a whole core data migration, this wipes the core data store and sets a flag to not wipe it again.
@@ -73,7 +71,7 @@ public extension PersistentContainer {
             do {
                 try FileManager.default.removeItem(at: sharedContainerURL)
             } catch {
-                //Capture error and move on.
+                // Capture error and move on.
                 Log.capture(error: error)
             }
             hasResetData2212023 = true

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -649,7 +649,7 @@ extension PocketSource {
     }
 
     public func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
-        var savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
+        let savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
 
         if let remoteParts {
             savedItem?.update(from: remoteParts, with: space)
@@ -660,8 +660,8 @@ extension PocketSource {
             return savedItem
         }
 
-        savedItem = SavedItem(context: space.context, url: url, remoteID: remoteID)
-        savedItem?.update(from: remoteParts, with: space)
+        let remoteSavedItem = SavedItem(context: space.context, url: url, remoteID: remoteID)
+        remoteSavedItem.update(from: remoteParts, with: space)
         try? space.save()
 
         return savedItem

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -664,6 +664,6 @@ extension PocketSource {
         remoteSavedItem.update(from: remoteParts, with: space)
         try? space.save()
 
-        return savedItem
+        return remoteSavedItem
     }
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -649,15 +649,17 @@ extension PocketSource {
     }
 
     public func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
+        let savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
+
         guard let remoteParts, let url = URL(string: remoteParts.url) else {
-            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of SavedItem because we do not have a valid url or we have no remoteParts")
-            return nil
+            Log.breadcrumb(category: "sync", level: .debug, message: "SavedItem found and don't need to create one")
+            return savedItem
         }
 
-        let savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID)) ?? SavedItem(context: space.context, url: url, remoteID: remoteID)
-        savedItem.update(from: remoteParts, with: space)
+        let remoteSavedItem = SavedItem(context: space.context, url: url, remoteID: remoteID)
+        remoteSavedItem.update(from: remoteParts, with: space)
         try? space.save()
 
-        return savedItem
+        return remoteSavedItem
     }
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -649,17 +649,21 @@ extension PocketSource {
     }
 
     public func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
-        let savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
+        var savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
 
-        guard let remoteParts, let url = URL(string: remoteParts.url) else {
+        if let remoteParts {
+            savedItem?.update(from: remoteParts, with: space)
+        }
+
+        guard savedItem == nil, let remoteParts, let url = URL(string: remoteParts.url) else {
             Log.breadcrumb(category: "sync", level: .debug, message: "SavedItem found and don't need to create one")
             return savedItem
         }
 
-        let remoteSavedItem = SavedItem(context: space.context, url: url, remoteID: remoteID)
-        remoteSavedItem.update(from: remoteParts, with: space)
+        savedItem = SavedItem(context: space.context, url: url, remoteID: remoteID)
+        savedItem?.update(from: remoteParts, with: space)
         try? space.save()
 
-        return remoteSavedItem
+        return savedItem
     }
 }

--- a/PocketKit/Tests/AnalyticsTests/LinkedTrackerTests.swift
+++ b/PocketKit/Tests/AnalyticsTests/LinkedTrackerTests.swift
@@ -13,7 +13,7 @@ class LinkedTrackerTests: XCTestCase {
         let tracker = LinkedTracker(parent: mockTracker, contexts: [context])
         tracker.addPersistentContext(context)
 
-        XCTAssertEqual(mockTracker.addPersistentCalls.last?.context as? MockContext, context)
+        XCTAssertEqual(mockTracker.oldAddPersistentCalls.last?.context as? MockContext, context)
     }
 
     func test_track_forwardsEventToParent() {

--- a/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
+++ b/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
@@ -14,17 +14,27 @@ class MockTracker: Analytics.Tracker {
         let event: Analytics.Event
     }
 
-    struct AddPersistentCall {
+    struct OldAddPersistentCall {
         let context: Context
+    }
+
+    struct AddPersistentCall {
+        let entity: Entity
     }
 
     private(set) var oldTrackCalls = Calls<OldTrackCall>()
     private(set) var trackCalls = Calls<TrackCall>()
+    private(set) var oldAddPersistentCalls = Calls<OldAddPersistentCall>()
     private(set) var addPersistentCalls = Calls<AddPersistentCall>()
-    private(set) var clearPersistentContextsCalls = Calls<[Context]>()
+    private(set) var oldClearPersistentContextsCalls = Calls<[Context]>()
+    private(set) var clearPersistentContextsCalls = Calls<[Entity]>()
 
     func addPersistentContext(_ context: Context) {
-        addPersistentCalls.add(AddPersistentCall(context: context))
+        oldAddPersistentCalls.add(OldAddPersistentCall(context: context))
+    }
+
+    func addPersistentEntity(_ entity: Analytics.Entity) {
+        addPersistentCalls.add(AddPersistentCall(entity: entity))
     }
 
     func track<T: Analytics.OldEvent>(event: T, _ contexts: [Context]?) {
@@ -36,7 +46,11 @@ class MockTracker: Analytics.Tracker {
     }
 
     func resetPersistentContexts(_ contexts: [Context]) {
-        clearPersistentContextsCalls.add(contexts)
+        oldClearPersistentContextsCalls.add(contexts)
+    }
+
+    func resetPersistentEntities(_ entities: [Analytics.Entity]) {
+        clearPersistentContextsCalls.add(entities)
     }
 
     func childTracker(with contexts: [Context]) -> Analytics.Tracker {

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModel.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModel.swift
@@ -1,0 +1,85 @@
+import XCTest
+import Analytics
+
+@testable import PocketKit
+@testable import Sync
+
+class PocketItemViewModelTests: XCTestCase {
+    private var source: MockSource!
+    private var tracker: MockTracker!
+    var space: Space!
+
+    override func setUpWithError() throws {
+        source = MockSource()
+        tracker = MockTracker()
+        self.space = .testSpace()
+    }
+
+    override func tearDownWithError() throws {
+        source = nil
+        tracker = nil
+        try space.clear()
+    }
+
+    func subject(
+        item: PocketItem,
+        index: Int = 0,
+        source: Source? = nil,
+        tracker: Tracker? = nil
+    ) -> PocketItemViewModel {
+        PocketItemViewModel(
+            item: item,
+            index: index,
+            source: source ?? self.source,
+            tracker: tracker ?? self.tracker
+        )
+    }
+
+    func test_favoriteAction_delegatesToSource_updatesPublishedProperty() {
+        let item = space.buildSavedItem()
+
+        let expectFavoriteCall = expectation(description: "expect source.favorite(_:)")
+        let expectFetchSavedItemCall = expectation(description: "expect source.fetchOrCreateSavedItem(_:)")
+        source.stubFavoriteSavedItem { item in
+            defer { expectFavoriteCall.fulfill() }
+            item.isFavorite = true
+        }
+
+        source.stubFetchSavedItem { _ in
+            defer { expectFetchSavedItemCall.fulfill() }
+            return item
+        }
+
+        let viewModel = subject(item: PocketItem(item: item))
+
+        _ = viewModel.favoriteAction(index: 0, scope: .saves).handler?(nil)
+
+        wait(for: [expectFavoriteCall, expectFetchSavedItemCall], timeout: 1)
+        XCTAssertEqual(source.favoriteSavedItemCall(at: 0)?.item, item)
+        XCTAssertTrue(viewModel.isFavorite)
+    }
+
+    func test_unfavoriteAction_delegatesToSource_updatesPublishedProperty() {
+        let item = space.buildSavedItem(isFavorite: true)
+
+        let expectUnfavoriteCall = expectation(description: "expect source.unfavorite(_:)")
+        let expectFetchSavedItemCall = expectation(description: "expect source.fetchOrCreateSavedItem(_:)")
+        source.stubUnfavoriteSavedItem { item in
+            defer { expectUnfavoriteCall.fulfill() }
+            item.isFavorite = false
+        }
+
+        source.stubFetchSavedItem { _ in
+            defer { expectFetchSavedItemCall.fulfill() }
+            return item
+        }
+
+        let viewModel = subject(item: PocketItem(item: item))
+
+        _ = viewModel.favoriteAction(index: 0, scope: .saves).handler?(nil)
+
+        wait(for: [expectUnfavoriteCall, expectFetchSavedItemCall], timeout: 1)
+        XCTAssertEqual(source.unfavoriteSavedItemCall(at: 0)?.item, item)
+        XCTAssertFalse(viewModel.isFavorite)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -10,6 +10,7 @@ import SharedPocketKit
 
 class LocalSavesSearchTests: XCTestCase {
     private var source: MockSource!
+    private var tracker: MockTracker!
     private var user: MockUser!
     private var space: Space!
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
@@ -13,7 +13,8 @@ class MockTracker: Tracker {
         let event: Event
     }
 
-    private var persistentContexts: [Context] = []
+    private var oldPersistentContexts: [Context] = []
+    private var persistentContexts: [Entity] = []
 
     private(set) var oldTrackCalls = Calls<OldTrackCall>()
     private(set) var trackCalls = Calls<TrackCall>()
@@ -21,7 +22,14 @@ class MockTracker: Tracker {
     func addPersistentContext(_ context: Context) {
     }
 
+    func addPersistentEntity(_ entity: Entity) {
+    }
+
     func resetPersistentContexts(_ contexts: [Context]) {
+        oldPersistentContexts = []
+    }
+
+    func resetPersistentEntities(_ entities: [Entity]) {
         persistentContexts = []
     }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
@@ -13,7 +13,8 @@ class MockTracker: Tracker {
         let event: Event
     }
 
-    private var persistentContexts: [Context] = []
+    private var oldPersistentContexts: [Context] = []
+    private var persistentContexts: [Entity] = []
 
     private(set) var oldTrackCalls = Calls<OldTrackCall>()
     private(set) var trackCalls = Calls<TrackCall>()
@@ -21,7 +22,14 @@ class MockTracker: Tracker {
     func addPersistentContext(_ context: Context) {
     }
 
+    func addPersistentEntity(_ entity: Entity) {
+    }
+
     func resetPersistentContexts(_ contexts: [Context]) {
+        oldPersistentContexts = []
+    }
+
+    func resetPersistentEntities(_ entities: [Entity]) {
         persistentContexts = []
     }
 

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -110,8 +110,6 @@ extension Space {
     }
 }
 
-
-
 // MARK: - Item
 extension Space {
     @discardableResult

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -225,7 +225,7 @@ class HomeTests: XCTestCase {
 
         app.readerView.cell(containing: "Jacob and David").wait()
     }
-    
+
     func test_tappingRecommendationCell_whenItemIsNotSaved_andItemIsSyndicated_andUserGoesBack_SyndicationInfoStays() {
         app.launch()
             .homeView.recommendationCell("Slate 1, Recommendation 1")
@@ -235,12 +235,11 @@ class HomeTests: XCTestCase {
             .wait().tap()
 
         app.readerView.cell(containing: "Syndicated Article Slate 2, Rec 2").wait()
-        
+
         app.navigationBar.buttons["Home"].tap()
-        
+
         XCTAssertTrue(app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").element.staticTexts["Mozilla"].exists)
     }
-
 
     func test_tappingSaveButtonInRecommendationCell_savesItemToList() {
         let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")

--- a/Tests iOS/Support/Elements/SearchViewElement.swift
+++ b/Tests iOS/Support/Elements/SearchViewElement.swift
@@ -51,7 +51,7 @@ struct SearchViewElement: PocketUIElement {
         element.staticTexts["banner"].exists && element.staticTexts[message].exists
     }
 
-    func searchItemCell(at index: Int) -> XCUIElement {
-        return searchResultsView.cells.element(boundBy: index)
+    func searchItemCell(at index: Int) -> ItemRowElement {
+        ItemRowElement(searchResultsView.cells.element(boundBy: index))
     }
 }


### PR DESCRIPTION
## Summary
PR adds functionality to favorite search result items

## References 
IN-1121

## Implementation Details
* Create `PocketItemViewModel` to hold the logic of favoriting items. Similar to existing logic except we have to create a savedItem from remote data. 
* Rename `SearchItem` to `PocketItem` to be more reusuable
* Fixed bug related to new use of entities for analytics. We were using old context from APIUser and User, so created new `persistentEntities` object.

## Test Steps
- [ ] GIVEN search is active
AND a search has been performed
AND there are 1+ results
AND search results are visible
THEN every search result includes a favorite button

- [ ] GIVEN a search result is a favorite
THEN the search result favorite button is filled

- [ ] GIVEN a search result is not a favorite
THEN the search result favorite button is not filled

- [ ] GIVEN that a user taps on the search result favorite button 
AND the search result has already been favorited
THEN the search result will be unfavorited
AND the search result button will not be filled

- [ ] GIVEN that a user taps on the search result favorite button 
AND the search result has not already been favorited
THEN the search result will be favorited
AND the search result button will be filled

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
