### PR TITLE
Settings Premium Row - Fix divider alignment and Image colors in dark mode

### DIFF
--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -139,3 +139,4 @@
 "Annual" = "Annual";
 // Description of the premium uprgade view
 "premium.upgradeview.description" = "Subscriptions will be charged to your credit card through your iTunes account. Your account will be charged %1$@ (monthly) or %2$@ (yearly) for renewal within 24 hours prior to the end of the current period. Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. It will not be possible to immediately cancel a subscription. You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. Refunds are not available for unused portions of a subscription.";
+"settings.premiumRow" = "Go Premium";

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
@@ -5,8 +5,9 @@ struct SettingsRowButton: View {
     var title: String
     var titleStyle: Style = .settings.row.default
     var icon: SFIconModel?
-    var leadingImage: UIImage?
-    var trailingImage: UIImage?
+    var leadingImageAsset: ImageAsset?
+    var trailingImageAsset: ImageAsset?
+    var tintColor: Color?
 
     let action: () -> Void
 
@@ -15,8 +16,8 @@ struct SettingsRowButton: View {
             self.action()
         } label: {
             HStack(spacing: 0) {
-                if let leadingImage = leadingImage {
-                    Image(uiImage: leadingImage)
+                if let leadingImageAsset, let tintColor {
+                    SettingsButtonImage(color: tintColor, asset: leadingImageAsset)
                         .padding(.trailing)
                 }
                 Text(title)
@@ -26,11 +27,22 @@ struct SettingsRowButton: View {
                 if let icon = icon {
                     SFIcon(icon)
                 }
-                if let trailingImage = trailingImage {
-                    Image(uiImage: trailingImage)
+                if let trailingImageAsset, let tintColor {
+                    SettingsButtonImage(color: tintColor, asset: trailingImageAsset)
                 }
             }
             .padding(.vertical, 5)
         }
+    }
+}
+
+struct SettingsButtonImage: View {
+    let color: Color
+    let asset: ImageAsset
+
+    var body: some View {
+        Image(uiImage: UIImage(asset: asset))
+            .renderingMode(.template)
+            .foregroundColor(color)
     }
 }

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -98,7 +98,7 @@ extension SettingsForm {
             Section(header: Text(L10n.yourAccount).style(.settings.header)) {
                 if !model.isPremium {
                     SettingsRowButton(
-                        title: L10n.Settings.goPremium,
+                        title: L10n.Settings.premiumRow,
                         leadingImageAsset: .premiumIcon,
                         trailingImageAsset: .chevronRight,
                         tintColor: Color(.ui.black1)

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -80,8 +80,8 @@ struct SettingsForm: View {
 // MARK: Top Section
 // These methods should be removed once we support iOS 16+
 extension SettingsForm {
-    @ViewBuilder
     /// Handles top section separator on different versions of iOS
+    @ViewBuilder
     private func topSectionWithLeadingDivider() -> some View {
         if #available(iOS 16.0, *) {
             topSection()

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -41,34 +41,50 @@ struct SettingsView: View {
 struct SettingsForm: View {
     @ObservedObject
     var model: AccountViewModel
+
+    @ViewBuilder
+    func topSection() -> some View {
+            Section(header: Text(L10n.yourAccount).style(.settings.header)) {
+                if !model.isPremium {
+                    SettingsRowButton(title: "Go Premium", leadingImage: UIImage(asset: .premiumIcon), trailingImage: UIImage(asset: .chevronRight)) {
+                        model.showPremiumUpgrade()
+                    }
+                    .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
+                        PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
+                    }
+                }
+                SettingsRowButton(title: L10n.signOut, titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
+                    .accessibilityIdentifier("sign-out-button")
+                    .alert(
+                        L10n.areYouSure,
+                        isPresented: $model.isPresentingSignOutConfirm,
+                        actions: {
+                            Button(L10n.signOut, role: .destructive) {
+                                model.signOut()
+                            }
+                        }, message: {
+                            Text(L10n.youWillBeSignedOutOfYourAccountAndAnyFilesThatHaveBeenSavedForOfflineViewingWillBeDeleted)
+                        }
+                    )
+            }
+    }
+
+    @ViewBuilder
+    func topSectionWithLeadingDivider() -> some View {
+        if #available(iOS 16.0, *) {
+            topSection()
+                .alignmentGuide(.listRowSeparatorLeading) { _ in
+                    return 0
+                }
+        } else {
+            topSection()
+        }
+    }
+
     var body: some View {
         Form {
             Group {
-                Section(header: Text(L10n.yourAccount).style(.settings.header)) {
-                    if !model.isPremium {
-                        SettingsRowButton(title: "Go Premium", leadingImage: UIImage(asset: .premiumIcon), trailingImage: UIImage(asset: .chevronRight)) {
-                            model.showPremiumUpgrade()
-                        }
-                        .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
-                            PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
-                        }
-                    }
-                    Divider()
-                    SettingsRowButton(title: L10n.signOut, titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
-                        .accessibilityIdentifier("sign-out-button")
-                        .alert(
-                            L10n.areYouSure,
-                            isPresented: $model.isPresentingSignOutConfirm,
-                            actions: {
-                                Button(L10n.signOut, role: .destructive) {
-                                    model.signOut()
-                                }
-                            }, message: {
-                                Text(L10n.youWillBeSignedOutOfYourAccountAndAnyFilesThatHaveBeenSavedForOfflineViewingWillBeDeleted)
-                            }
-                        )
-                }
-                .listRowSeparator(.hidden)
+                topSectionWithLeadingDivider()
                 .textCase(nil)
 
                 Section(header: Text(L10n.appCustomization).style(.settings.header)) {

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -42,45 +42,6 @@ struct SettingsForm: View {
     @ObservedObject
     var model: AccountViewModel
 
-    @ViewBuilder
-    func topSection() -> some View {
-            Section(header: Text(L10n.yourAccount).style(.settings.header)) {
-                if !model.isPremium {
-                    SettingsRowButton(title: "Go Premium", leadingImage: UIImage(asset: .premiumIcon), trailingImage: UIImage(asset: .chevronRight)) {
-                        model.showPremiumUpgrade()
-                    }
-                    .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
-                        PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
-                    }
-                }
-                SettingsRowButton(title: L10n.signOut, titleStyle: .settings.button.signOut, icon: SFIconModel("rectangle.portrait.and.arrow.right", weight: .semibold, color: Color(.ui.apricot1))) { model.isPresentingSignOutConfirm.toggle() }
-                    .accessibilityIdentifier("sign-out-button")
-                    .alert(
-                        L10n.areYouSure,
-                        isPresented: $model.isPresentingSignOutConfirm,
-                        actions: {
-                            Button(L10n.signOut, role: .destructive) {
-                                model.signOut()
-                            }
-                        }, message: {
-                            Text(L10n.youWillBeSignedOutOfYourAccountAndAnyFilesThatHaveBeenSavedForOfflineViewingWillBeDeleted)
-                        }
-                    )
-            }
-    }
-
-    @ViewBuilder
-    func topSectionWithLeadingDivider() -> some View {
-        if #available(iOS 16.0, *) {
-            topSection()
-                .alignmentGuide(.listRowSeparatorLeading) { _ in
-                    return 0
-                }
-        } else {
-            topSection()
-        }
-    }
-
     var body: some View {
         Form {
             Group {
@@ -113,5 +74,62 @@ struct SettingsForm: View {
             }
             .listRowBackground(Color(.ui.grey7))
         }
+    }
+}
+
+// MARK: Top Section
+// These methods should be removed once we support iOS 16+
+extension SettingsForm {
+    @ViewBuilder
+    /// Handles top section separator on different versions of iOS
+    private func topSectionWithLeadingDivider() -> some View {
+        if #available(iOS 16.0, *) {
+            topSection()
+                .alignmentGuide(.listRowSeparatorLeading) { _ in
+                    return 0
+                }
+        } else {
+            topSection()
+        }
+    }
+
+    /// Provides the standard top section view
+    private func topSection() -> some View {
+            Section(header: Text(L10n.yourAccount).style(.settings.header)) {
+                if !model.isPremium {
+                    SettingsRowButton(
+                        title: L10n.Settings.goPremium,
+                        leadingImageAsset: .premiumIcon,
+                        trailingImageAsset: .chevronRight,
+                        tintColor: Color(.ui.black1)
+                    ) {
+                        model.showPremiumUpgrade()
+                    }
+                    .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
+                        PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
+                    }
+                }
+                SettingsRowButton(
+                    title: L10n.signOut,
+                    titleStyle: .settings.button.signOut,
+                    icon: SFIconModel(
+                        "rectangle.portrait.and.arrow.right",
+                        weight: .semibold,
+                        color: Color(.ui.apricot1)
+                    )
+                ) { model.isPresentingSignOutConfirm.toggle() }
+                    .accessibilityIdentifier("sign-out-button")
+                    .alert(
+                        L10n.areYouSure,
+                        isPresented: $model.isPresentingSignOutConfirm,
+                        actions: {
+                            Button(L10n.signOut, role: .destructive) {
+                                model.signOut()
+                            }
+                        }, message: {
+                            Text(L10n.youWillBeSignedOutOfYourAccountAndAnyFilesThatHaveBeenSavedForOfflineViewingWillBeDeleted)
+                        }
+                    )
+            }
     }
 }

--- a/PocketKit/Sources/PocketKit/Strings.swift
+++ b/PocketKit/Sources/PocketKit/Strings.swift
@@ -224,6 +224,10 @@ internal enum L10n {
       }
     }
   }
+  internal enum Settings {
+    /// Go Premium
+    internal static let premiumRow = L10n.tr("Localizable", "settings.premiumRow", fallback: "Go Premium")
+  }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces


### PR DESCRIPTION
## Summary
* This PR fixes the divider alignment and the image color in dark mode of the "Go Premium" row in the Settings screen

## Implementation Details
* Applies `.listRowSeparatorLeading` for the premium row for iOS 16
* Minor changes to `SettingsButton` so that it can use a `SettingsButtonImage`,  formatted with passed asset and color
* Uses `black1` for the premium row icons
* Localizes "Go Premium"

## Test Steps
* Checkout, build and run this branch
* Tap Settings
* Make sure the divider between Go Premium and Sign Out looks consistent with all the others in that same screen
* Switch to dark mode, and make sure the icons (diamond and chevron right) look right
See screenshots for more details

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

### Divider

before | after
-- | --
<img height=400 src=https://user-images.githubusercontent.com/34376330/219797024-1a8f0ab8-a1c0-4e07-9651-2bb778f95b7b.png> | <img height=400 src=https://user-images.githubusercontent.com/34376330/219797081-5334f8d3-33fe-4de3-bfe0-5e68339ced62.png>

### Image color in dark mode

before | after
-- | --
<img height=120 src=https://user-images.githubusercontent.com/34376330/219797247-e23fc125-2a3d-486a-b432-b21f63887cd3.png> | <img height=120 src=https://user-images.githubusercontent.com/34376330/219797296-eab60e61-a09c-42a0-bc66-1a4ff6b9edb0.png>




