### PR TITLE
ci(tests): small fix for a recent saves test

### DIFF
--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -82,13 +82,11 @@ class HomeTests: XCTestCase {
 
     func test_navigatingToHomeTab_showsRecentlySavedItems() {
         let home = app.launch().homeView.wait()
-
         home.savedItemCell("Item 1").wait()
         home.savedItemCell("Item 2").wait()
-
         home.savedItemCell("Item 1").swipeLeft(velocity: .fast)
         home.savedItemCell("Item 3").swipeLeft(velocity: .fast)
-        waitForDisappearance(of: home.savedItemCell("Item 6"))
+        waitForDisappearance(of: home.savedItemCell("Item 3"))
     }
 
     func test_tappingRecentSavesItem_showsReader() {


### PR DESCRIPTION
A recent saves test was not validating the test expectation correctly, this PR will fix it.

I'm scrolling past an actual item in the recent saves list with this change, if it causes flaky fails I'll revert the changes or make the test more robust.