### PR TITLE
fix(user-defaults): setting user defaults to not wipe db

### DIFF
--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -35,11 +35,11 @@ struct Services {
 
     private init() {
         userDefaults = .standard
-        persistentContainer = .init(storage: .shared, userDefaults: userDefaults)
-
         firstLaunchDefaults = UserDefaults(
             suiteName: "\(Bundle.main.bundleIdentifier!).first-launch"
         )!
+        persistentContainer = .init(storage: .shared, userDefaults: firstLaunchDefaults)
+
         urlSession = URLSession.shared
 
         appSession = AppSession()

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -10,12 +10,16 @@ struct Services {
     let appSession: AppSession
     let saveService: PocketSaveService
     let tracker: Tracker
+    let firstLaunchDefaults: UserDefaults
 
     private let persistentContainer: PersistentContainer
 
     private init() {
         Log.start(dsn: Keys.shared.sentryDSN)
-        persistentContainer = .init(storage: .shared, userDefaults: .standard)
+        firstLaunchDefaults = UserDefaults(
+            suiteName: "\(Bundle.main.bundleIdentifier!).first-launch"
+        )!
+        persistentContainer = .init(storage: .shared, userDefaults: firstLaunchDefaults)
 
         appSession = AppSession()
 

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -5,20 +5,18 @@
 import CoreData
 
 public class PersistentContainer: NSPersistentContainer {
-    
     public lazy var rootSpace = { Space(context: viewContext) }()
 
     public enum Storage {
         case inMemory
         case shared
     }
-    
+
     let userDefaults: UserDefaults
 
     public init(storage: Storage = .shared, userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
 
-        
         ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
         ValueTransformer.setValueTransformer(SyncTaskTransformer(), forName: .syncTaskTransformer)
 
@@ -36,7 +34,8 @@ public class PersistentContainer: NSPersistentContainer {
                 .containerURL(forSecurityApplicationGroupIdentifier: "group.com.ideashower.ReadItLaterProAlphaNeue")!
                 .appendingPathComponent("PocketModel.sqlite")
 
-            removeDatabaseIfNeeded(sharedContainerURL: sharedContainerURL)
+            removeDatabaseIfNeeded(sharedContainerURL: FileManager.default
+                .containerURL(forSecurityApplicationGroupIdentifier: "group.com.ideashower.ReadItLaterProAlphaNeue")!)
 
             persistentStoreDescriptions = [
                 NSPersistentStoreDescription(url: sharedContainerURL)
@@ -62,7 +61,7 @@ public extension PersistentContainer {
             userDefaults.set(newValue, forKey: Self.hasResetData2212023Key)
         }
     }
-    
+
     /**
      During our Testflight, we merged a change that made values non-null in CoreData. Turns out that we were unknowningly saving null values in fields that should have been required.
      Instead of coding a whole core data migration, this wipes the core data store and sets a flag to not wipe it again.
@@ -71,9 +70,11 @@ public extension PersistentContainer {
     func removeDatabaseIfNeeded(sharedContainerURL: URL!) {
         if !hasResetData2212023 {
             do {
-                try FileManager.default.removeItem(at: sharedContainerURL)
+                try FileManager.default.removeItem(at: sharedContainerURL.appendingPathComponent("PocketModel.sqlite"))
+                try FileManager.default.removeItem(at: sharedContainerURL.appendingPathComponent("PocketModel.sqlite-shm"))
+                try FileManager.default.removeItem(at: sharedContainerURL.appendingPathComponent("PocketModel.sqlite-wal"))
             } catch {
-                //Capture error and move on.
+                // Capture error and move on.
                 Log.capture(error: error)
             }
             hasResetData2212023 = true

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -110,8 +110,6 @@ extension Space {
     }
 }
 
-
-
 // MARK: - Item
 extension Space {
     @discardableResult

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -225,7 +225,7 @@ class HomeTests: XCTestCase {
 
         app.readerView.cell(containing: "Jacob and David").wait()
     }
-    
+
     func test_tappingRecommendationCell_whenItemIsNotSaved_andItemIsSyndicated_andUserGoesBack_SyndicationInfoStays() {
         app.launch()
             .homeView.recommendationCell("Slate 1, Recommendation 1")
@@ -235,12 +235,11 @@ class HomeTests: XCTestCase {
             .wait().tap()
 
         app.readerView.cell(containing: "Syndicated Article Slate 2, Rec 2").wait()
-        
+
         app.navigationBar.buttons["Home"].tap()
-        
+
         XCTAssertTrue(app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").element.staticTexts["Mozilla"].exists)
     }
-
 
     func test_tappingSaveButtonInRecommendationCell_savesItemToList() {
         let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -30,6 +30,8 @@ class ReportARecommendationTests: XCTestCase {
                 return Response.archive()
             } else if apiRequest.isForRecommendationDetail(1) {
                 return Response.recommendationDetail(1)
+            } else if apiRequest.isForRecommendationDetail(4) {
+                return Response.recommendationDetail(4)
             } else if apiRequest.isForTags {
                 return Response.emptyTags()
             } else {
@@ -160,7 +162,7 @@ class ReportARecommendationTests: XCTestCase {
 
         // Swipe down to a syndicated item
         app.homeView.element.swipeUp()
-        app.homeView.recommendationCell("Syndicated Article Rec, 1").wait().tap()
+        app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").wait().tap()
         app.readerView.readerToolbar.moreButton.tap()
         app.reportButton.wait().tap()
         app.reportView.wait()

--- a/Tests iOS/Support/LaunchArguments.swift
+++ b/Tests iOS/Support/LaunchArguments.swift
@@ -54,6 +54,10 @@ struct LaunchArguments {
         if disableSnowplow {
             args.append("disableSnowplow")
         }
+
+        // Skip deleting the core data store in PersistentContainer by setting user defaults key to true.
+        args.append("-PersistentContainer.reset.data.02.21.2023 true")
+
         return args
     }
 


### PR DESCRIPTION
## Summary
Ensure that the tests do not try and wipe the core data db after it has been seeded already. Introduced in https://github.com/Pocket/pocket-ios/pull/414

* Also fixed some swiftlint issues..