### PR TITLE
feat(search): matching web default sort order

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/ItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/ItemSummary.graphql.swift
@@ -13,7 +13,6 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
       title
       language
       topImageUrl
-      topImageUrl
       timeToRead
       domain
       datePublished

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
@@ -8,10 +8,15 @@ public class SearchSavedItemsQuery: GraphQLQuery {
   public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
-      query SearchSavedItems($term: String!, $pagination: PaginationInput, $filter: SearchFilterInput) {
+      query SearchSavedItems($term: String!, $pagination: PaginationInput, $filter: SearchFilterInput, $sort: SearchSortInput) {
         user {
           __typename
-          searchSavedItems(term: $term, pagination: $pagination, filter: $filter) {
+          searchSavedItems(
+            term: $term
+            pagination: $pagination
+            filter: $filter
+            sort: $sort
+          ) {
             __typename
             edges {
               __typename
@@ -42,21 +47,25 @@ public class SearchSavedItemsQuery: GraphQLQuery {
   public var term: String
   public var pagination: GraphQLNullable<PaginationInput>
   public var filter: GraphQLNullable<SearchFilterInput>
+  public var sort: GraphQLNullable<SearchSortInput>
 
   public init(
     term: String,
     pagination: GraphQLNullable<PaginationInput>,
-    filter: GraphQLNullable<SearchFilterInput>
+    filter: GraphQLNullable<SearchFilterInput>,
+    sort: GraphQLNullable<SearchSortInput>
   ) {
     self.term = term
     self.pagination = pagination
     self.filter = filter
+    self.sort = sort
   }
 
   public var __variables: Variables? { [
     "term": term,
     "pagination": pagination,
-    "filter": filter
+    "filter": filter,
+    "sort": sort
   ] }
 
   public struct Data: PocketGraph.SelectionSet {
@@ -83,7 +92,8 @@ public class SearchSavedItemsQuery: GraphQLQuery {
         .field("searchSavedItems", SearchSavedItems?.self, arguments: [
           "term": .variable("term"),
           "pagination": .variable("pagination"),
-          "filter": .variable("filter")
+          "filter": .variable("filter"),
+          "sort": .variable("sort")
         ]),
       ] }
 

--- a/PocketKit/Sources/PocketGraph/Schema/Enums/SearchItemsSortBy.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Enums/SearchItemsSortBy.graphql.swift
@@ -1,0 +1,15 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+/// Enum to specify the sort by field (these are the current options, we could add more in the future)
+public enum SearchItemsSortBy: String, EnumType {
+  /// Indicates when a SavedItem was created
+  case createdAt = "CREATED_AT"
+  /// Estimated time to read a SavedItem
+  case timeToRead = "TIME_TO_READ"
+  /// Sort SavedItems based on a relevance score
+  /// This is a feature of elasticsearch and current only available for premium search
+  case relevance = "RELEVANCE"
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Enums/SearchItemsSortOrder.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Enums/SearchItemsSortOrder.graphql.swift
@@ -1,0 +1,10 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+/// Enum to specify the sort order of user items fetched
+public enum SearchItemsSortOrder: String, EnumType {
+  case asc = "ASC"
+  case desc = "DESC"
+}

--- a/PocketKit/Sources/PocketGraph/Schema/InputObjects/SearchSortInput.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/InputObjects/SearchSortInput.graphql.swift
@@ -1,0 +1,34 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public struct SearchSortInput: InputObject {
+  public private(set) var __data: InputDict
+
+  public init(_ data: InputDict) {
+    __data = data
+  }
+
+  public init(
+    sortBy: GraphQLEnum<SearchItemsSortBy>,
+    sortOrder: GraphQLNullable<GraphQLEnum<SearchItemsSortOrder>> = nil
+  ) {
+    __data = InputDict([
+      "sortBy": sortBy,
+      "sortOrder": sortOrder
+    ])
+  }
+
+  /// The field by which to sort user items
+  public var sortBy: GraphQLEnum<SearchItemsSortBy> {
+    get { __data["sortBy"] }
+    set { __data["sortBy"] = newValue }
+  }
+
+  /// The order in which to sort user items
+  public var sortOrder: GraphQLNullable<GraphQLEnum<SearchItemsSortOrder>> {
+    get { __data["sortOrder"] }
+    set { __data["sortOrder"] = newValue }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/Tag.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/Tag.graphql.swift
@@ -7,6 +7,6 @@ public extension Objects {
   /// Represents a Tag that a User has created for their list
   static let Tag = Object(
     typename: "Tag",
-    implementedInterfaces: [Interfaces.RemoteEntity.self]
+    implementedInterfaces: []
   )
 }

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/list.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/list.graphql
@@ -124,9 +124,9 @@ query Tags($pagination: PaginationInput) {
   }
 }
 
-query SearchSavedItems($term: String!, $pagination: PaginationInput, $filter: SearchFilterInput) {
+query SearchSavedItems($term: String!, $pagination: PaginationInput, $filter: SearchFilterInput, $sort: SearchSortInput) {
   user {
-    searchSavedItems(term: $term, pagination: $pagination, filter: $filter) {
+    searchSavedItems(term: $term, pagination: $pagination, filter: $filter, sort: $sort) {
       edges {
         node {
             savedItem {

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -71,7 +71,8 @@ public class PocketSearchService: SearchService {
 
         while shouldFetchNextPage {
             let filter = getSearchFilter(with: scope)
-            let query = SearchSavedItemsQuery(term: term, pagination: .init(pagination), filter: .some(filter))
+            let sortOrder = getSortOrder()
+            let query = SearchSavedItemsQuery(term: term, pagination: .init(pagination), filter: .some(filter), sort: .some(sortOrder))
             let result = try await apollo.fetch(query: query)
             result.data?.user?.searchSavedItems?.edges.forEach { edge in
                 var searchSavedItem = SearchSavedItem(remoteItem: edge.node.savedItem.fragments.savedItemParts)
@@ -98,5 +99,9 @@ public class PocketSearchService: SearchService {
         case .all:
             return SearchFilterInput()
         }
+    }
+
+    private func getSortOrder() -> SearchSortInput {
+        return SearchSortInput(sortBy: .init(.createdAt), sortOrder: .init(.desc))
     }
 }


### PR DESCRIPTION
## Summary

When validating the Search work I noticed that my results were not matching Web no matter what I did. It turns out that after talking to @collectedmind, Web utilizes a sort order which changes your default result set. 

This brings us in line with them.

Long term we should align with @collectedmind and a search product partner to align all clients.
