### PR TITLE
fix(m1): moving ci to M1 Max

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -288,9 +288,6 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UNIT_XCRESULT_PATH'
 
   run-tests-ui-1:
-    meta:
-      bitrise.io:
-        machine_type_id: g2-m1.8core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
@@ -306,9 +303,6 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_1_XCRESULT_PATH'
 
   run-tests-ui-2:
-    meta:
-      bitrise.io:
-        machine_type_id: g2-m1.8core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
@@ -324,9 +318,6 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
 
   run-tests-ui-3:
-    meta:
-      bitrise.io:
-        machine_type_id: g2-m1.8core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
@@ -383,5 +374,5 @@ app:
 
 meta:
   bitrise.io:
-    machine_type_id: g2.4core
+    machine_type_id: g2-m1-max.5core
     stack: osx-xcode-14.2.x-ventura


### PR DESCRIPTION
## Summary
We are facing inconsistencies with our tests failing in CI intermittently and between our local machines. This level sets us by making our CI use M1 Max instead of intel to ensure that we are running on the same machine instruction sets.
