### PR TITLE
feat(search): analytics

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -21,6 +21,9 @@ public extension Events.Search {
         }
     }
 
+    /**
+     Fired when a user clicks the Favorite icon in a card for `Search`
+     */
     static func favoriteItem(
         itemUrl: URL,
         positionInList: Int,
@@ -42,6 +45,9 @@ public extension Events.Search {
         )
     }
 
+    /**
+     Fired when a user clicks the Un-Favorite icon in a card for `Search`
+     */
     static func unfavoriteItem(
         itemUrl: URL,
         positionInList: Int,
@@ -63,6 +69,9 @@ public extension Events.Search {
         )
     }
 
+    /**
+     Fired when a user shares a card in `Search`
+     */
     static func shareItem(
         itemUrl: URL,
         positionInList: Int,
@@ -81,6 +90,96 @@ public extension Events.Search {
                     url: itemUrl
                 )
             ]
+        )
+    }
+
+    /**
+     Fired when a user opens `Search` experience
+     */
+    static func openSearch(
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search",
+                componentDetail: getScopeIdentifier(scope: scope)
+            )
+        )
+    }
+
+    /**
+     Fired when a user submits a search term
+     */
+    static func submitSearch(
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.submit",
+                componentDetail: getScopeIdentifier(scope: scope)
+            )
+        )
+    }
+    /**
+     Fired when a user changes `Search` scope
+     */
+    static func switchScope(
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.switchscope",
+                componentDetail: getScopeIdentifier(scope: scope)
+            )
+        )
+    }
+
+    /**
+     Fired when a card in the `Search` comes into view
+     */
+    static func searchCardImpression(
+        url: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Impression {
+        return Impression(
+            component: .card,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .card,
+                identifier: "global-nav.search.impression",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user clicks a card in the `Search`
+     */
+    static func searchCardContentOpen(
+        url: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> ContentOpen {
+        return ContentOpen(
+            contentEntity:
+                ContentEntity(url: url),
+            uiEntity: UiEntity(
+                .card,
+                identifier: "global-nav.search.card.open",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            )
         )
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -82,7 +82,7 @@ class PocketItemViewModel: ObservableObject {
         if let url = item.url {
             tracker.track(event: Events.Search.shareItem(itemUrl: url, positionInList: index, scope: scope))
         } else {
-            Log.breadcrumb(category: "analytics", level: .warning, message: "Skipping tracking of Item \(item) because url is missing")
+            Log.capture(message: "Selected search item without an associated url, not logging analytics for shareItem")
         }
         presentShareSheet = true
     }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -142,7 +142,9 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {
         guard let titles = searchBar.scopeButtonTitles else { return }
         searchBar.returnKeyType = .search
-        searchViewModel.updateScope(with: SearchScope(rawValue: titles[selectedScope]) ?? .saves, searchTerm: searchBar.text)
+        let searchScope = SearchScope(rawValue: titles[selectedScope]) ?? .saves
+        searchViewModel.trackSwitchScope(with: searchScope)
+        searchViewModel.updateScope(with: searchScope, searchTerm: searchBar.text)
     }
 
     func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -10,17 +10,21 @@ struct SearchView: View {
     var viewModel: SearchViewModel
 
     var body: some View {
-        switch viewModel.searchState {
-        case .emptyState(let emptyStateViewModel):
-            SearchEmptyView(viewModel: emptyStateViewModel)
-        case .recentSearches(let searches):
-            RecentSearchView(viewModel: viewModel, recentSearches: searches)
-        case .searchResults(let results):
-            ResultsView(viewModel: viewModel, results: results)
-        case .loading:
-            SkeletonView()
-        default:
-            EmptyView()
+        Group {
+            switch viewModel.searchState {
+            case .emptyState(let emptyStateViewModel):
+                SearchEmptyView(viewModel: emptyStateViewModel)
+            case .recentSearches(let searches):
+                RecentSearchView(viewModel: viewModel, recentSearches: searches)
+            case .searchResults(let results):
+                ResultsView(viewModel: viewModel, results: results)
+            case .loading:
+                SkeletonView()
+            default:
+                EmptyView()
+            }
+        }.onAppear {
+            viewModel.trackOpenSearch()
         }
     }
 }
@@ -45,8 +49,10 @@ struct ResultsView: View {
                     if viewModel.isOffline {
                         showingAlert = true
                     } else {
-                        viewModel.select(item)
+                        viewModel.select(item, index: index)
                     }
+                }.onAppear {
+                    viewModel.trackViewResults(url: item.url, index: index)
                 }
             }
         }

--- a/Tests iOS/Support/SnowplowMicro.swift
+++ b/Tests iOS/Support/SnowplowMicro.swift
@@ -127,6 +127,10 @@ struct SnowplowMicroContext: Codable {
         return (self.dataDict()["url"] as? String) == url
     }
 
+    func has(index: Int) -> Bool {
+        return (self.dataDict()["index"] as? Int) == index
+    }
+
     func assertHas(url: String) {
         return XCTAssertEqual((self.dataDict()["url"] as? String), url)
     }
@@ -141,6 +145,14 @@ struct SnowplowMicroContext: Codable {
 
     func assertHas(reason: String) {
         return XCTAssertEqual((self.dataDict()["reason"] as? String), reason)
+    }
+
+    func assertHas(type: String) {
+        return XCTAssertEqual((self.dataDict()["type"] as? String), type)
+    }
+
+    func assertHas(componentDetail: String) {
+        return XCTAssertEqual((self.dataDict()["component_detail"] as? String), componentDetail)
     }
 }
 
@@ -241,6 +253,20 @@ class SnowplowMicro {
             }
 
             return uiContext.has(identifier: uiIdentifier) && recommendationContext.has(recomendationId: recommendationId)
+        })
+    }
+
+    /**
+     Gets the first event we can find with the given UI identifier and position index in a list
+     */
+    func getFirstEvent(with uiIdentifier: String, index: Int) async -> SnowplowMicroEvent? {
+        let events = await getGoodSnowplowEvents()
+        return events.first(where: {
+            guard let uiContext = $0.getUIContext() else {
+                return false
+            }
+
+            return uiContext.has(identifier: uiIdentifier) && uiContext.has(index: index)
         })
     }
 }


### PR DESCRIPTION
## Summary
PR to add tracking for search: 
**Three engagement events:**
- Opening Search View
- Performing a Search 
- Changing the scope

**One impression event:**
- Viewing Search Results

**One content_open event:**
- Opening a Search Result

## References 
IN-1106

## Implementation Details
* Added comments to Search tracking events (pulled from Analytics spreadsheet)
* Added 5 events described above in `Search` and created tracking methods in `SearchViewModel` to trigger those events
* Used snowplow micro ui testing

## Test Steps
* Run through the UI tests as well as verified the calls are being triggered appropriately for each event

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
