### PR TITLE
ci(tests): small fix for empty state favorites test

### DIFF
--- a/Tests iOS/MyList/EmptyStateTests.swift
+++ b/Tests iOS/MyList/EmptyStateTests.swift
@@ -83,7 +83,6 @@ class EmptyStateTests: XCTestCase {
     func testFavorites_showsEmptyStateView() {
         app.tabBar.savesButton.wait().tap()
         app.saves.filterButton(for: "Favorites").tap()
-        XCTAssertEqual(app.saves.wait().itemCells.count, 0)
         XCTAssertTrue(app.saves.emptyStateView(for: "favorites-empty-state").exists)
 
         app.saves.selectionSwitcher.archiveButton.wait().tap()
@@ -91,7 +90,6 @@ class EmptyStateTests: XCTestCase {
         app.saves.filterButton(for: "Favorites").tap()
         app.saves.itemView(at: 0).favoriteButton.tap()
 
-        XCTAssertEqual(app.saves.wait().itemCells.count, 0)
         XCTAssertTrue(app.saves.emptyStateView(for: "favorites-empty-state").exists)
     }
 


### PR DESCRIPTION
This is a small fix for a flaky fail of an empty state test for Favorites, we were doing an extra check on 0 items being present however this is unnecessary because there is already a check for the empty state message.