### PR TITLE
Premium Subscriptions: Update UI after user purchases a subscription

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -25,7 +25,7 @@ open class SwiftUICollectionViewCell<Content>: UICollectionViewCell where Conten
     }
 }
 
-class EmptyStateCollectionViewCell: SwiftUICollectionViewCell<EmptyStateView> {
+class EmptyStateCollectionViewCell: SwiftUICollectionViewCell<EmptyStateView<EmptyView>> {
     func configure(parent: UIViewController, _ viewModel: EmptyStateViewModel) {
         embed(in: parent, withView: EmptyStateView(viewModel: viewModel))
         host?.view.frame = self.contentView.bounds
@@ -34,14 +34,16 @@ class EmptyStateCollectionViewCell: SwiftUICollectionViewCell<EmptyStateView> {
     }
 }
 
-struct EmptyStateView: View {
-    private var viewModel: EmptyStateViewModel
+struct EmptyStateView<Content: View>: View {
+    private let viewModel: EmptyStateViewModel
+    private var content: Content?
 
     @State
     private var showSafariView = false
 
-    init(viewModel: EmptyStateViewModel) {
+    init(viewModel: EmptyStateViewModel, content: (() -> Content)? = nil) {
         self.viewModel = viewModel
+        self.content = content?()
     }
 
     var body: some View {
@@ -64,8 +66,9 @@ struct EmptyStateView: View {
                         }
                     } else { Text(subtitle).style(.detail) }
                 }
-
-                if let buttonText = viewModel.buttonText, let webURL = viewModel.webURL {
+                if let content {
+                    content
+                } else if let buttonText = viewModel.buttonText, let webURL = viewModel.webURL {
                     Button(action: {
                         self.showSafariView = true
                     }, label: {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -61,11 +61,44 @@ struct ResultsView: View {
 
 // MARK: - Search Empty States Component
 struct SearchEmptyView: View {
-    var viewModel: EmptyStateViewModel
+    private var viewModel: EmptyStateViewModel
+
+    init(viewModel: EmptyStateViewModel) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
-        EmptyStateView(viewModel: viewModel)
+        if let text = viewModel.buttonText {
+            EmptyStateView(viewModel: viewModel) {
+                GetPocketPremiumButton(text: text)
+            }
             .padding(Margins.normal.rawValue)
+        } else {
+            EmptyStateView<EmptyView>(viewModel: viewModel)
+                .padding(Margins.normal.rawValue)
+        }
+    }
+}
+
+struct GetPocketPremiumButton: View {
+    @EnvironmentObject private var searchViewModel: SearchViewModel
+    private let text: String
+
+    init(text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Button(action: {
+            searchViewModel.showPremiumUpgrade()
+        }, label: {
+            Text(text).style(.header.sansSerif.h7.with(color: .ui.white))
+                .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
+                .frame(maxWidth: 320)
+        }).buttonStyle(ActionsPrimaryButtonStyle())
+            .sheet(isPresented: $searchViewModel.isPresentingPremiumUpgrade) {
+            PremiumUpgradeView(viewModel: searchViewModel.makePremiumUpgradeViewModel())
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -13,6 +13,7 @@ struct SearchView: View {
         switch viewModel.searchState {
         case .emptyState(let emptyStateViewModel):
             SearchEmptyView(viewModel: emptyStateViewModel)
+                .environmentObject(viewModel)
         case .recentSearches(let searches):
             RecentSearchView(viewModel: viewModel, recentSearches: searches)
         case .searchResults(let results):

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -92,13 +92,14 @@ struct GetPocketPremiumButton: View {
         Button(action: {
             searchViewModel.showPremiumUpgrade()
         }, label: {
-            Text(text).style(.header.sansSerif.h7.with(color: .ui.white))
+            Text(text)
+                .style(.header.sansSerif.h7.with(color: .ui.white))
                 .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                 .frame(maxWidth: 320)
-        }).buttonStyle(ActionsPrimaryButtonStyle())
+        }).buttonStyle(GetPocketPremiumButtonStyle())
             .sheet(isPresented: $searchViewModel.isPresentingPremiumUpgrade) {
-            PremiumUpgradeView(viewModel: searchViewModel.makePremiumUpgradeViewModel())
-        }
+                PremiumUpgradeView(viewModel: searchViewModel.makePremiumUpgradeViewModel())
+            }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -17,7 +17,7 @@ enum SearchViewState {
 
     var isEmptyState: Bool {
         switch self {
-        case .emptyState( _):
+        case .emptyState:
             return true
         default:
             return false

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -21,7 +21,9 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                             userDefaults: Services.shared.userDefaults,
                             source: Services.shared.source,
                             tracker: Services.shared.tracker.childTracker(hosting: .saves.search)
-                        ),
+                        ) {
+                            PremiumUpgradeViewModel(store: Services.shared.subscriptionStore)
+                        },
                         savedItemsList: SavedItemsListViewModel(
                             source: Services.shared.source,
                             tracker: Services.shared.tracker.childTracker(hosting: .saves.saves),

--- a/PocketKit/Sources/PocketKit/Style/GetPocketPremiumButtonStyle.swift
+++ b/PocketKit/Sources/PocketKit/Style/GetPocketPremiumButtonStyle.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct GetPocketPremiumButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(configuration.isPressed ? Color(.ui.coral1) : Color(.ui.coral2))
+            .cornerRadius(13)
+    }
+}


### PR DESCRIPTION
## Summary
* This PR adds logic to update the app UI when the user successfully purchases a premium subscription

## Implementation Details
* Inject `PremiumViewModel` factory into `SarchViewModel`, so we can instantiate `PremiumUpgradeView` when needed
* `SearchViewModel` now listens to user status changes, to update the UI accordingly
* `EmptyStateView` now accepts an alternate external view that can be used in place of the standard button, so that we are not limited to a button that calls a web view anymore
* `GetPocketPremiumButton` is a button that presents `PocketPremiumView`, used in `EmptyStateView`, online search, free users

## Test Steps
Pre-requisite:
- configure the `StoreKit` testing environment using the steps described in #421 on this branch
Testing steps (see animation below):
- Once the prerequisites are implemented, build and run this branch
- Login with a free account
- Go to "Saves" then select "Search", and navigate to "All Items"
- Make sure you see the premium upsell, with the "Get Pocket Premium" button
- Make sure the button color is `Coral2`
- Tap the "Get Pocket Premium" button and make sure the premium upgrade screen appears
- Purchase a subscriptions and, after you see the "You're all set" alert, tap "OK"
- Make sure the premium upgrade screen gets dismissed, and you don't see the premium upsell in the empty view
- Go to the "Settings" tab, and make sure that the "Go Premium" row above the "Sign Out" does not appear

> **Note**
At this moment, the premium status is not synced with the backend. If you relaunch, the user status will be reverted to free.

## PR Checklist:
- [ ] ~~Added Unit / UI tests~~
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Animation
<p align=center>
<img width=300 src=https://user-images.githubusercontent.com/34376330/221334669-b8666301-fef6-4daf-bc08-9b0c45c1133c.gif>
</p>
