### PR TITLE
Premium Subscriptions: Premium Subscription Row

### DIFF
--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -149,7 +149,8 @@
 "Annual" = "Annual";
 // Description of the premium uprgade view
 "premium.upgradeview.description" = "Subscriptions will be charged to your credit card through your iTunes account. Your account will be charged %1$@ (monthly) or %2$@ (yearly) for renewal within 24 hours prior to the end of the current period. Subscriptions will automatically renew unless canceled at least 24 hours before the end of the current period. It will not be possible to immediately cancel a subscription. You can manage subscriptions and turn off auto-renewal by going to your account settings after purchase. Refunds are not available for unused portions of a subscription.";
-"settings.premiumRow" = "Go Premium";
+"settings.goPremiumRow" = "Go Premium";
+"settings.premiumSubscriptionRow" = "Premium Subscription";
 "Hooray!" = "Hooray!";
 "premium.success.message" = "You’re officially a Pocket Premium member. Welcome to the new ad-free, customizable, permanent version of your Pocket. We think you’ll like it here.";
 "back.to.pocket" = "Back to Pocket";

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
@@ -7,7 +7,8 @@ struct SettingsRowButton: View {
     var icon: SFIconModel?
     var leadingImageAsset: ImageAsset?
     var trailingImageAsset: ImageAsset?
-    var tintColor: Color?
+    var leadingTintColor: Color = Color(.ui.black1)
+    var trailingTintColor: Color = Color(.ui.black1)
 
     let action: () -> Void
 
@@ -16,8 +17,8 @@ struct SettingsRowButton: View {
             self.action()
         } label: {
             HStack(spacing: 0) {
-                if let leadingImageAsset, let tintColor {
-                    SettingsButtonImage(color: tintColor, asset: leadingImageAsset)
+                if let leadingImageAsset {
+                    SettingsButtonImage(color: leadingTintColor, asset: leadingImageAsset)
                         .padding(.trailing)
                 }
                 Text(title)
@@ -27,8 +28,8 @@ struct SettingsRowButton: View {
                 if let icon = icon {
                     SFIcon(icon)
                 }
-                if let trailingImageAsset, let tintColor {
-                    SettingsButtonImage(color: tintColor, asset: trailingImageAsset)
+                if let trailingImageAsset {
+                    SettingsButtonImage(color: trailingTintColor, asset: trailingImageAsset)
                 }
             }
             .padding(.vertical, 5)

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -115,18 +115,10 @@ extension SettingsForm {
     /// Provides the standard top section view
     private func topSection() -> some View {
         Section(header: Text(L10n.yourAccount).style(.settings.header)) {
-            if !model.isPremium {
-                SettingsRowButton(
-                    title: L10n.Settings.premiumRow,
-                    leadingImageAsset: .premiumIcon,
-                    trailingImageAsset: .chevronRight,
-                    tintColor: Color(.ui.black1)
-                ) {
-                    model.showPremiumUpgrade()
-                }
-                .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
-                    PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
-                }
+            if model.isPremium {
+                makePremiumSubscriptionRow()
+            } else {
+                makeGoPremiumRow()
             }
             SettingsRowButton(
                 title: L10n.signOut,
@@ -152,6 +144,33 @@ extension SettingsForm {
                     }
                 )
         }
+    }
+
+    private func makePremiumRowContent(_ isPremium: Bool) -> some View {
+        let title = isPremium ? L10n.Settings.premiumSubscriptionRow : L10n.Settings.goPremiumRow
+        let titleStyle: Style = isPremium ? .settings.row.active : .settings.row.default
+        let leadingTintColor = isPremium ? Color(.ui.teal2) : Color(.ui.black1)
+        let action = isPremium ? { } : { model.showPremiumUpgrade() }
+        return SettingsRowButton(
+            title: title,
+            titleStyle: titleStyle,
+            leadingImageAsset: .premiumIcon,
+            trailingImageAsset: .chevronRight,
+            leadingTintColor: leadingTintColor,
+            action: action
+        )
+    }
+
+    private func makeGoPremiumRow() -> some View {
+        makePremiumRowContent(false)
+            .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
+                PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
+            }
+    }
+
+    private func makePremiumSubscriptionRow() -> some View {
+        makePremiumRowContent(true)
+        // TODO: add logic to present the premium subscription sheet here
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Strings.swift
+++ b/PocketKit/Sources/PocketKit/Strings.swift
@@ -251,12 +251,14 @@ internal enum L10n {
     }
   }
   internal enum Settings {
+    /// Go Premium
+    internal static let goPremiumRow = L10n.tr("Localizable", "settings.goPremiumRow", fallback: "Go Premium")
     /// Pocket for iOS %@ (%@)
     internal static func pocketForiOS(_ p1: Any, _ p2: Any) -> String {
       return L10n.tr("Localizable", "settings.PocketForiOS %@ (%@)", String(describing: p1), String(describing: p2), fallback: "Pocket for iOS %@ (%@)")
     }
-    /// Go Premium
-    internal static let premiumRow = L10n.tr("Localizable", "settings.premiumRow", fallback: "Go Premium")
+    /// Premium Subscription
+    internal static let premiumSubscriptionRow = L10n.tr("Localizable", "settings.premiumSubscriptionRow", fallback: "Premium Subscription")
     internal enum Thankyou {
       /// Thank you for using Pocket
       internal static let credits = L10n.tr("Localizable", "settings.thankyou.credits", fallback: "Thank you for using Pocket")


### PR DESCRIPTION
## Summary
*This PR changes the premium row in "Settings" after a user has successfully purchased a premium subscription. The description will change from Go Premium to Premium Subscription, and the tint color from `black1` to `teal2`

## Implementation Details
* Update `SettingsRowButton` to allow color configuration of title and icons
* Update `AccountViewModel` to listen to `User.status` changes as they happen
* Update `Localizable.strings`, add `settings.premiumSubscriptionRow` string

## Test Steps
Pre-requisite:
- checkout this branch and setup `StoreKit` testing as described in #421 
Testing steps (see animation below):
- build/run
- login with a free account
- go to the "Settings" tab
-  tap "Go Premium"
- Make sure the premium upgrade screen appears
- Purchase a subscription
- Tap "OK" in the "You're all set" alert
- Make sure the premium upgrade screen dismisses
- Make sure the premium row (above "Sign Out") now shows "Premium Subscription" and its color is teal

> **Note**
Same limitations as #421 and #437 apply: if you relaunch, the status will be reverted to free.
Also, at this moment, tapping the "Premium Subscription" does nothing. The related screen will be added in a future PR.

## PR Checklist:
- [ ] ~~Added Unit / UI tests~~
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Animation
<p align=center>
<img width=300 src=https://user-images.githubusercontent.com/34376330/221333470-c6a64a42-c2ae-40b0-8c11-4afa4457bb63.gif>
</p>
