### PR TITLE
Fix unit tests that failed after refactoring User

### DIFF
--- a/PocketKit/Sources/Textile/Style/Style.swift
+++ b/PocketKit/Sources/Textile/Style/Style.swift
@@ -176,7 +176,7 @@ public struct Style {
             backgroundColor: backgroundColorAsset
         )
     }
-    
+
     public func with(alignment: TextAlignment) -> Style {
         Style(
             fontDescriptor: fontDescriptor,

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -25,6 +25,7 @@ class SearchViewModelTests: XCTestCase {
     override func setUpWithError() throws {
         networkPathMonitor = MockNetworkPathMonitor()
         user = MockUser()
+        user.stubStandardSetStatus()
         source = MockSource()
         tracker = MockTracker()
         userDefaults = UserDefaults(suiteName: "SearchViewModelTests")

--- a/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
@@ -23,6 +23,12 @@ extension MockUser {
         implementations[Self.setStatus] = impl
     }
 
+    func stubStandardSetStatus() {
+        implementations[Self.setStatus] = { isPremium in
+            self.status = isPremium ? .premium : .free
+        }
+    }
+
     func setPremiumStatus(_ isPremium: Bool) {
         guard let impl = implementations[Self.setStatus] as? SetStatusImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -27,6 +27,7 @@ class PocketSourceTests: XCTestCase {
     override func setUpWithError() throws {
         space = .testSpace()
         user = MockUser()
+        user.stubStandardSetStatus()
         apollo = MockApolloClient()
         operations = MockOperationFactory()
         lastRefresh = MockLastRefresh()

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -22,6 +22,12 @@ extension MockUser {
         implementations[Self.setStatus] = impl
     }
 
+    func stubStandardSetStatus() {
+        implementations[Self.setStatus] = { isPremium in
+            self.status = isPremium ? .premium : .free
+        }
+    }
+
     func setPremiumStatus(_ isPremium: Bool) {
         guard let impl = implementations[Self.setStatus] as? SetStatusImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")


### PR DESCRIPTION
## Summary
* This PR fixes a few unit test that were failing after refactoring `User`

## Implementation Details
* Update `MockUser`, both locations, add a method that stubs the "standard" setStatus, and use that method to allow setting the premium status calling `setPremiumStatus( _:), since it's not possible to change `status` directly.

## Test Steps
* Run all unit tests and make sure they pass

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
