### PR TITLE
feat(search): add overflow menu

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -94,6 +94,126 @@ public extension Events.Search {
     }
 
     /**
+     Fired when a user clicks the Delete option in the overflow menu in a card for `Search`
+     */
+    static func deleteItem(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.delete",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /**
+     Fired when a user clicks the Archive option in the overflow menu in a card for `Search`
+     */
+    static func archiveItem(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.archive",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /**
+     Fired when a user clicks the Unarchive option in the overflow menu in a card for `Search`
+     */
+    static func unarchiveItem(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.unarchive",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /**
+     Fired when a user clicks the Unarchive option in the overflow menu in a card for `Search`
+     */
+    static func overFlowMenu(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.overflow",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /**
+     Fired when a user clicks the Add Tags option in the overflow menu in a card for `Search`
+     */
+    static func showAddTags(
+        itemUrl: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.addTags",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /**
      Fired when a user opens `Search` experience
      */
     static func openSearch(

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -22,6 +22,10 @@ struct PocketItem {
         item.isFavorite
     }
 
+    var isArchived: Bool {
+        item.isArchived
+    }
+
     var title: NSAttributedString {
         itemPresenter.attributedTitle
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -56,12 +56,18 @@ class PocketItemViewModel: ObservableObject {
     func favoriteAction() -> ItemAction {
         if isFavorite {
             return .unfavorite { [weak self] _ in
-                guard let self else { return }
+                guard let self else {
+                    Log.capture(message: "Unfavorite action not taken; self is nil")
+                    return
+                }
                 self._unfavorite()
             }
         } else {
             return .favorite { [weak self] _ in
-                guard let self else { return }
+                guard let self else {
+                    Log.capture(message: "Favorite action not taken; self is nil")
+                    return
+                }
                 self._favorite()
             }
         }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -7,11 +7,14 @@ import Analytics
 import Sync
 import SharedPocketKit
 
+/// View model used for List Item to handle actions for a specific item
 class PocketItemViewModel: ObservableObject {
     private let tracker: Tracker
     private let source: Source
+    private let index: Int
+    private let scope: SearchScope
+
     let item: PocketItem
-    let index: Int
 
     @Published
     var isFavorite: Bool
@@ -19,37 +22,53 @@ class PocketItemViewModel: ObservableObject {
     @Published
     var presentShareSheet: Bool = false
 
-    init(item: PocketItem, index: Int, source: Source, tracker: Tracker) {
+    /// Determines whether an item should show Archive or Move To Saves
+    var isArchived: Bool {
+        item.isArchived
+    }
+
+    /// Retrieves view model to present Add Tags view
+    var tagsViewModel: PocketAddTagsViewModel? {
+        guard let savedItem = fetchSavedItem() else {
+            Log.capture(message: "PocketAddTagsViewModel not returned")
+            return nil
+        }
+
+        let addTagsViewModel = PocketAddTagsViewModel(
+            item: savedItem,
+            source: source,
+            saveAction: {}
+        )
+        tracker.track(event: Events.Search.showAddTags(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        return addTagsViewModel
+    }
+
+    init(item: PocketItem, index: Int, source: Source, tracker: Tracker, scope: SearchScope) {
         self.item = item
         self.index = index
         self.source = source
         self.tracker = tracker
+        self.scope = scope
         self.isFavorite = item.isFavorite
     }
 
-    func favoriteAction(index: Int, scope: SearchScope) -> ItemAction {
+    /// Triggers action to favorite or unfavorite an item in a list
+    func favoriteAction() -> ItemAction {
         if isFavorite {
             return .unfavorite { [weak self] _ in
-                self?._unfavorite(index: index, scope: scope)
+                guard let self else { return }
+                self._unfavorite()
             }
         } else {
             return .favorite { [weak self] _ in
-                self?._favorite(index: index, scope: scope)
+                guard let self else { return }
+                self._favorite()
             }
         }
     }
 
-    private func _favorite(index: Int, scope: SearchScope) {
-        guard
-            let id = item.id,
-            let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
-                and: item.remoteItemParts
-            )
-        else {
-            Log.capture(message: "Saved Item not created")
-            return
-        }
+    private func _favorite() {
+        guard let savedItem = fetchSavedItem() else { return }
 
         // This view model should be reusable, aside from this tracking call. We can refactor this call when we reuse this for other lists.
         tracker.track(event: Events.Search.favoriteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
@@ -57,28 +76,20 @@ class PocketItemViewModel: ObservableObject {
         isFavorite = savedItem.isFavorite
     }
 
-    private func _unfavorite(index: Int, scope: SearchScope) {
-        guard
-            let id = item.id,
-            let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
-                and: item.remoteItemParts
-            )
-        else {
-            Log.capture(message: "Saved Item not created")
-            return
-        }
+    private func _unfavorite() {
+        guard let savedItem = fetchSavedItem() else { return }
 
         tracker.track(event: Events.Search.unfavoriteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
         source.unfavorite(item: savedItem)
         isFavorite = savedItem.isFavorite
     }
 
-    func shareAction(index: Int, scope: SearchScope) -> ItemAction {
-        return .share { [weak self] sender in self?._share(scope: scope) }
+    /// Triggers action to show share sheet for an item in a list
+    func shareAction() -> ItemAction {
+        return .share { [weak self] sender in self?._share() }
     }
 
-    func _share(scope: SearchScope) {
+    private func _share() {
         if let url = item.url {
             tracker.track(event: Events.Search.shareItem(itemUrl: url, positionInList: index, scope: scope))
         } else {
@@ -87,13 +98,45 @@ class PocketItemViewModel: ObservableObject {
         presentShareSheet = true
     }
 
-    var overflowActions: [ItemAction] {
-        [ItemAction.addTags { _ in Log.info("Add tags button tapped!") }, ItemAction.archive { _ in Log.info("Archive button tapped!") }, ItemAction.delete { _ in Log.info("Delete button tapped!") }]
+    /// Triggers action to delete an item in a list
+    func delete() {
+        guard let savedItem = fetchSavedItem() else { return }
+        tracker.track(event: Events.Search.deleteItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        source.delete(item: savedItem)
     }
 
-    var trackOverflow: ItemAction {
-        ItemAction(title: "", identifier: UIAction.Identifier(rawValue: ""), accessibilityIdentifier: "", image: nil, handler: {_ in
-            Log.info("Overflow button tapped!")
-        })
+    /// Triggers action to archive an item in a list
+    func archive() {
+        guard let savedItem = fetchSavedItem() else { return }
+        tracker.track(event: Events.Search.archiveItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        source.archive(item: savedItem)
+    }
+
+    /// Triggers action to move an item from archive to saves in a list
+    func moveToSaves() {
+        guard let savedItem = fetchSavedItem() else { return }
+        tracker.track(event: Events.Search.unarchiveItem(itemUrl: savedItem.url, positionInList: index, scope: scope))
+        source.unarchive(item: savedItem)
+    }
+
+    /// Track tapping on overflow menu
+    func trackOverflowMenu() {
+        guard let savedItem = fetchSavedItem() else { return }
+        tracker.track(event: Events.Search.overFlowMenu(itemUrl: savedItem.url, positionInList: index, scope: scope))
+    }
+
+    /// Fetch a SavedItem or create one in order to use actions related to source
+    private func fetchSavedItem() -> SavedItem? {
+        guard
+            let id = item.id,
+            let savedItem = source.fetchOrCreateSavedItem(
+                with: id,
+                and: item.remoteItemParts
+            )
+        else {
+            Log.capture(message: "Saved Item not created")
+            return nil
+        }
+        return savedItem
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
@@ -2,37 +2,97 @@ import SwiftUI
 import Textile
 
 struct OverflowMenu: View {
-    var overflowActions: [ItemAction]
-    var trackOverflow: ItemAction?
-    var image: ImageAsset = .overflow
-    var trailingPadding: Bool = false
+    @EnvironmentObject
+    var viewModel: PocketItemViewModel
+    @State private var showingAlert = false
+    @State private var showingSheet = false
 
     var body: some View {
-        if !overflowActions.isEmpty {
-            Menu {
-                ForEach(overflowActions, id: \.self) { action in
-                    Button {
-                        action.handler? {}
-                    } label: {
-                        HStack(alignment: .center) {
-                            Text(action.title)
-                            Spacer()
-                            if let image = action.image {
-                                Image(uiImage: image)
-                                    .accessibilityIdentifier(action.accessibilityIdentifier)
-                            }
-                        }
-                    }
+        Menu {
+            Button(action: {
+                showingSheet = true
+            }) {
+                Label {
+                    Text(L10n.addTags)
+                } icon: {
+                    Image(asset: .tag)
                 }
-            } label: {
-                Image(asset: image)
-                    .actionButtonStyle(selected: false, trailingPadding: trailingPadding)
-                    .accessibilityIdentifier("More Actions")
-            }.onTapGesture {
-                if let trackOverflow = trackOverflow {
-                    trackOverflow.handler? {}
+            }.accessibilityIdentifier("item-action-add-tags")
+
+            if viewModel.isArchived {
+                MoveToSavesButton()
+                    .environmentObject(viewModel)
+            } else {
+                ArchiveButton()
+                    .environmentObject(viewModel)
+            }
+
+            Button(action: {
+                showingAlert = true
+            }) {
+                Label {
+                    Text(L10n.delete)
+                } icon: {
+                    Image(asset: .delete)
+                }
+            }.accessibilityIdentifier("item-action-delete")
+        } label: {
+            Image(asset: .overflow)
+                .actionButtonStyle(selected: false)
+        }
+        .alert(L10n.areYouSureYouWantToDeleteThisItem, isPresented: $showingAlert) {
+            Button(L10n.no, role: .cancel) { }
+            Button(L10n.yes, role: .destructive) {
+                withAnimation {
+                    viewModel.delete()
                 }
             }
         }
+        .sheet(isPresented: $showingSheet) {
+            if let viewModel = viewModel.tagsViewModel {
+                AddTagsView(viewModel: viewModel)
+                    .onDisappear {}
+            }
+        }
+        .onTapGesture {
+            viewModel.trackOverflowMenu()
+        }
+        .accessibilityIdentifier("overflow-menu")
+    }
+}
+
+struct ArchiveButton: View {
+    @EnvironmentObject
+    var viewModel: PocketItemViewModel
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                viewModel.archive()
+            }
+        }) {
+            Label {
+                Text(L10n.archive)
+            } icon: {
+                Image(asset: .archive)
+            }
+        }.accessibilityIdentifier("item-action-archive")
+    }
+}
+
+struct MoveToSavesButton: View {
+    @EnvironmentObject
+    var viewModel: PocketItemViewModel
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                viewModel.moveToSaves()
+            }
+        }) {
+            Label {
+                Text(L10n.moveToSaves)
+            } icon: {
+                Image(asset: .save)
+            }
+        }.accessibilityIdentifier("item-action-move-to-saves")
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
@@ -7,8 +7,6 @@ struct ListItem: View {
     @ObservedObject
     var viewModel: PocketItemViewModel
 
-    let scope: SearchScope
-
     let constants = Constants.self
 
     var body: some View {
@@ -26,9 +24,8 @@ struct ListItem: View {
             HStack(alignment: .center, spacing: constants.tags.horizontalSpacing) {
                 ItemTags(tags: viewModel.item.tags, tagCount: viewModel.item.tagCount)
                 Spacer()
-                ActionButton(viewModel.favoriteAction(index: viewModel.index, scope: scope), selected: viewModel.isFavorite)
-
-                ActionButton(viewModel.shareAction(index: viewModel.index, scope: scope))
+                ActionButton(viewModel.favoriteAction(), selected: viewModel.isFavorite)
+                ActionButton(viewModel.shareAction())
                     .sheet(isPresented: $viewModel.presentShareSheet) {
                         if #available(iOS 16.0, *) {
                             ShareSheetView(activity: PocketItemActivity(url: viewModel.item.url))
@@ -38,8 +35,9 @@ struct ListItem: View {
                             ShareSheetView(activity: PocketItemActivity(url: viewModel.item.url))
                         }
                     }
-
-                OverflowMenu(overflowActions: viewModel.overflowActions, trackOverflow: viewModel.trackOverflow, trailingPadding: false)
+                // Instead of using existing code of overflow, we created a new SwiftUI view
+                OverflowMenu()
+                    .environmentObject(viewModel)
             }
         }
         .padding(.vertical, constants.verticalPadding)

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/ItemsListItem.swift
@@ -5,6 +5,7 @@ protocol ItemsListItem {
     var id: String? { get }
     var title: String? { get }
     var isFavorite: Bool { get }
+    var isArchived: Bool { get }
     var bestURL: URL? { get }
     var topImageURL: URL? { get }
     var domain: String? { get }

--- a/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension SavedItem: ItemsListItem {
     var id: String? {
-        item?.remoteID
+        remoteID
     }
 
     var domain: String? {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
@@ -15,6 +15,10 @@ extension SearchSavedItem: ItemsListItem {
         remoteItem.isFavorite
     }
 
+    var isArchived: Bool {
+        remoteItem.isArchived
+    }
+
     var title: String? {
         item.asItem?.title
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -35,7 +35,8 @@ struct SearchView: View {
 struct ResultsView: View {
     @ObservedObject
     var viewModel: SearchViewModel
-    var results: [PocketItem]
+
+    let results: [PocketItem]
 
     @State private var showingAlert = false
 
@@ -43,7 +44,7 @@ struct ResultsView: View {
         List {
             ForEach(Array(results.enumerated()), id: \.offset) { index, item in
                 HStack {
-                    ListItem(viewModel: viewModel.itemViewModel(item, index: index), scope: viewModel.selectedScope)
+                    ListItem(viewModel: viewModel.itemViewModel(item, index: index))
                     Spacer()
                 }
                 .contentShape(Rectangle())

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -215,4 +215,9 @@ public enum Predicates {
         let predicates = filters + [NSPredicate(format: "isArchived = true && deletedAt = nil")]
         return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
     }
+
+    public static func allItems(filters: [NSPredicate] = []) -> NSPredicate {
+        let predicates = filters + [NSPredicate(format: "deletedAt = nil")]
+        return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+    }
 }

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -32,6 +32,7 @@ class SearchViewModelTests: XCTestCase {
     private var tracker: MockTracker!
     private var subscriptions: [AnyCancellable] = []
     private var subscriptionStore: SubscriptionStore!
+    private var itemsController: MockSavedItemsController!
 
     override func setUpWithError() throws {
         networkPathMonitor = MockNetworkPathMonitor()
@@ -41,7 +42,17 @@ class SearchViewModelTests: XCTestCase {
         space = .testSpace()
         searchService = MockSearchService()
         source.stubMakeSearchService { self.searchService }
+
         subscriptionStore = MockSubscriptionStore()
+
+        itemsController = MockSavedItemsController()
+        itemsController.stubIndexPathForObject { _ in IndexPath(item: 0, section: 0) }
+        source.stubMakeItemsController {
+            self.itemsController
+        }
+        itemsController.stubPerformFetch {
+            self.itemsController.fetchedObjects = []
+        }
     }
 
     override func tearDownWithError() throws {

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -5,6 +5,7 @@ struct MockItemsListItem: ItemsListItem {
     let id: String?
     let title: String?
     let isFavorite: Bool
+    let isArchived: Bool
     let bestURL: URL?
     let topImageURL: URL?
     let domain: String?
@@ -18,6 +19,7 @@ struct MockItemsListItem: ItemsListItem {
         id: String? = nil,
         title: String? = nil,
         isFavorite: Bool = false,
+        isArchived: Bool = false,
         bestURL: URL? = nil,
         topImageURL: URL? = nil,
         domain: String? = nil,
@@ -31,6 +33,7 @@ struct MockItemsListItem: ItemsListItem {
             id: id,
             title: title,
             isFavorite: isFavorite,
+            isArchived: isArchived,
             bestURL: bestURL,
             topImageURL: topImageURL,
             domain: domain,

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -27,8 +27,12 @@ class SearchTests: XCTestCase {
                 return Response.slateLineup()
             } else if apiRequest.isForSavesContent {
                 return Response.saves()
+            } else if apiRequest.isToSaveAnItem {
+                return Response.saveItem()
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
+            } else if apiRequest.isToArchiveAnItem {
+                return Response.archive()
             } else if apiRequest.isForTags {
                 return Response.emptyTags()
             } else if apiRequest.isForSearch(.saves) {
@@ -37,6 +41,10 @@ class SearchTests: XCTestCase {
                 return Response.searchList(.archive)
             } else if apiRequest.isForSearch(.all) {
                 return Response.searchList(.all)
+            } else if apiRequest.isToDeleteAnItem {
+                return Response.delete()
+            } else if apiRequest.isForItemDetail {
+                return Response.itemDetail()
             } else {
                 fatalError("Unexpected request")
             }
@@ -62,9 +70,9 @@ class SearchTests: XCTestCase {
         XCTAssertTrue(app.navigationBar.buttons["Saves"].isSelected)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
     }
 
     @MainActor
@@ -76,9 +84,9 @@ class SearchTests: XCTestCase {
         XCTAssertTrue(app.navigationBar.buttons["Saves"].isSelected)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
     }
 
     func test_searchSaves_forFreeUser_showsEmptyStateView() {
@@ -164,9 +172,9 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 1)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "archive")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "archive")
     }
 
     @MainActor
@@ -180,9 +188,9 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 2)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
 
         async let impression0 = snowplowMicro.getFirstEvent(with: "global-nav.search.impression", index: 0)
         async let impression1 = snowplowMicro.getFirstEvent(with: "global-nav.search.impression", index: 1)
@@ -206,9 +214,9 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 1)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "archive")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "archive")
     }
 
     @MainActor
@@ -223,9 +231,9 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 3)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "all_items")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "all_items")
     }
 
     @MainActor
@@ -242,30 +250,30 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(searchView.cells.count, 3)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "all_items")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "all_items")
 
         app.navigationBar.buttons["Archive"].wait().tap()
         XCTAssertEqual(searchView.cells.count, 1)
 
-        let openSearch2 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
-        openSearch2!.getUIContext()!.assertHas(type: "button")
-        openSearch2!.getUIContext()!.assertHas(componentDetail: "archive")
+        let searchEvent2 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
+        searchEvent2!.getUIContext()!.assertHas(type: "button")
+        searchEvent2!.getUIContext()!.assertHas(componentDetail: "archive")
 
         app.navigationBar.buttons["All items"].wait().tap()
         XCTAssertEqual(searchView.cells.count, 3)
 
-        let openSearch3 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
-        openSearch3!.getUIContext()!.assertHas(type: "button")
-        openSearch3!.getUIContext()!.assertHas(componentDetail: "all_items")
+        let searchEvent3 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
+        searchEvent3!.getUIContext()!.assertHas(type: "button")
+        searchEvent3!.getUIContext()!.assertHas(componentDetail: "all_items")
 
         app.navigationBar.buttons["Archive"].wait().tap()
         XCTAssertEqual(searchView.cells.count, 1)
 
-        let openSearch4 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
-        openSearch4!.getUIContext()!.assertHas(type: "button")
-        openSearch4!.getUIContext()!.assertHas(componentDetail: "archive")
+        let searchEvent4 = await snowplowMicro.getFirstEvent(with: "global-nav.search.switchscope")
+        searchEvent4!.getUIContext()!.assertHas(type: "button")
+        searchEvent4!.getUIContext()!.assertHas(componentDetail: "archive")
     }
 
     // MARK: - Recent Search
@@ -294,9 +302,9 @@ class SearchTests: XCTestCase {
         XCTAssertFalse(app.saves.itemView(at: 0).element.isHittable)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.submit")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
     }
 
     // MARK: - Select a Search Item
@@ -315,10 +323,10 @@ class SearchTests: XCTestCase {
         app.readerView.cell(containing: "Commodo Consectetur Dapibus").wait()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.card.open")
-        openSearch!.getUIContext()!.assertHas(type: "card")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
-        openSearch!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.card.open")
+        searchEvent!.getUIContext()!.assertHas(type: "card")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     // MARK: - Search Loading State
@@ -399,6 +407,7 @@ class SearchTests: XCTestCase {
         XCTAssertTrue(app.saves.searchView.hasBanner(with: "Limited search results"))
     }
 
+    // MARK: Search Actions
     @MainActor
     func test_favoritingAndUnfavoritingAnItemFromSearch_showsFavoritedIcon() async {
         app.launch()
@@ -429,10 +438,10 @@ class SearchTests: XCTestCase {
         XCTAssertTrue(itemCell.favoriteButton.isFilled)
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.favorite")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
-        openSearch!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.favorite")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
 
         let expectUnfavoriteRequest = expectation(description: "A request to the server")
         server.routes.post("/graphql") { request, loop in
@@ -448,10 +457,10 @@ class SearchTests: XCTestCase {
         wait(for: [expectUnfavoriteRequest])
         XCTAssertFalse(itemCell.favoriteButton.isFilled)
 
-        let openSearch2 = await snowplowMicro.getFirstEvent(with: "global-nav.search.unfavorite")
-        openSearch2!.getUIContext()!.assertHas(type: "button")
-        openSearch2!.getUIContext()!.assertHas(componentDetail: "saves")
-        openSearch2!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+        let searchEvent2 = await snowplowMicro.getFirstEvent(with: "global-nav.search.unfavorite")
+        searchEvent2!.getUIContext()!.assertHas(type: "button")
+        searchEvent2!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent2!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     @MainActor
@@ -474,10 +483,113 @@ class SearchTests: XCTestCase {
         app.shareSheet.wait()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let openSearch = await snowplowMicro.getFirstEvent(with: "global-nav.search.share")
-        openSearch!.getUIContext()!.assertHas(type: "button")
-        openSearch!.getUIContext()!.assertHas(componentDetail: "saves")
-        openSearch!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.share")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+    }
+
+    @MainActor
+    func test_addTagsFromSearch_showsAddTagsView() async {
+        app.launch()
+        tapSearch()
+
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        app.saves.searchView.searchResultsView.wait()
+
+        let itemCell = app
+            .saves.searchView
+            .searchItemCell(at: 0)
+            .wait()
+
+        itemCell.overFlowMenu.tap()
+        app.addTagsButton.wait().tap()
+        app.addTagsView.wait()
+        app.addTagsView.allTagsView.wait()
+
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.addTags")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+    }
+
+    @MainActor
+    func test_archivingAnItemFromSearch_removesItem() async {
+        app.launch()
+        tapSearch()
+
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        app.saves.searchView.searchResultsView.wait()
+
+        let itemCell = app
+            .saves.searchView
+            .searchItemCell(at: 0)
+            .wait()
+
+        itemCell.overFlowMenu.tap()
+        app.archiveButton.wait().tap()
+
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.archive")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+    }
+
+    @MainActor
+    func test_unArchivingAnItemFromSearch_removesItem() async {
+        app.launch()
+        tapSearch(fromArchive: true)
+
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        app.saves.searchView.searchResultsView.wait()
+
+        let itemCell = app
+            .saves.searchView
+            .searchItemCell(at: 0)
+            .wait()
+
+        itemCell.overFlowMenu.tap()
+        app.reAddButton.wait().tap()
+
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.unarchive")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "archive")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+    }
+
+    @MainActor
+    func test_deletingAnItemFromSearch_presentsOverflowMenu() async {
+        app.launch()
+        tapSearch()
+
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        app.saves.searchView.searchResultsView.wait()
+
+        let itemCell = app
+            .saves.searchView
+            .searchItemCell(at: 1)
+            .wait()
+
+        itemCell.overFlowMenu.tap()
+        app.deleteButton.wait().tap()
+        app.alert.yes.wait().tap()
+
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.delete")
+        searchEvent!.getUIContext()!.assertHas(type: "button")
+        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     private func tapSearch(fromArchive: Bool = false) {

--- a/Tests iOS/Support/Elements/ItemRowElement.swift
+++ b/Tests iOS/Support/Elements/ItemRowElement.swift
@@ -41,6 +41,10 @@ struct ItemRowElement: PocketUIElement {
     var shareButton: XCUIElement {
         element.buttons["item-action-share"]
     }
+
+    var overFlowMenu: XCUIElement {
+        element.buttons["overflow-menu"]
+    }
 }
 
 extension ItemRowElement {


### PR DESCRIPTION
## Summary
User can activate result overflow button

## References 
IN-1123

## Implementation Details
* Create new `OverflowMenu` view for overflow actions (add tags, archive/unarchive and delete). 
* Added `SavedItemsController` so that `SearchViewModel` can observe changes from core data
* Added 5 new search analytic actions

Note: Some issues may still exist and will be done in future tickets
* All Items have both Saves and Archive (archive and deleting is weird for this case) - I would like to discuss with the team on how to handle this and vote a new ticket to be created.
* Resubmitting search after performing an action will cause some inconsistencies in the search result view - ticket for edge case

## Test Steps
- [ ] GIVEN search is active
AND a search has been performed
AND there are 1+ results
AND search results are visible
THEN every search result includes an overflow button

- [ ] GIVEN that a user taps on the search result overflow button 
THEN the search results overflow menu is shown exactly as it would be if the same overflow button were tapped from Saved/Archived

**For All Items scope:**
1. If a user taps on add tags option, the user should be able to see the add tags view.
2. If a user deletes an item, the user should see that the item is deleted and removed the list.
3. If a user archives or moves an item to saves, the user should still see the item in the list, but update the cell to reflect “Archive” or “Move to Saves” depending on the type of item.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
https://user-images.githubusercontent.com/6743397/221930660-3146e072-932c-45c6-92fa-f41ddb7c86ff.mp4