### PR TITLE
Fix test build failing

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -849,7 +849,7 @@
 /* Begin XCBuildConfiguration section */
 		166A81D82637406C0015AA1D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */;
+			baseConfigurationReference = 16973355263CBB3F0003DE2A /* secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -65,9 +65,9 @@
 		8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */; };
 		8A8F5EFE28CB740000124B6D /* EditTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */; };
 		8ADAC6B028AD4E7500DE9A62 /* AddTagsViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */; };
-		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
 		8ADD6A9F292C189C007F419D /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6A9E292C189C007F419D /* SearchTests.swift */; };
 		8ADD6AA1292C1B2C007F419D /* SearchViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */; };
+		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
 		D26A5EF4297F1D8400FA5A88 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
 		F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */; };
@@ -216,12 +216,12 @@
 		8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesCellElement.swift; sourceTree = "<group>"; };
 		8A8F5EFD28CB740000124B6D /* EditTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTagsTests.swift; sourceTree = "<group>"; };
 		8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsViewElement.swift; sourceTree = "<group>"; };
-		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
-		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		8ADD6A9E292C189C007F419D /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewElement.swift; sourceTree = "<group>"; };
+		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
+		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		F204A76027E22EC50010E155 /* SaveToPocket.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaveToPocket.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F20BB0382744542F00AE5E70 /* AlertElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertElement.swift; sourceTree = "<group>"; };
@@ -849,7 +849,7 @@
 /* Begin XCBuildConfiguration section */
 		166A81D82637406C0015AA1D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 16973355263CBB3F0003DE2A /* secrets.xcconfig */;
+			baseConfigurationReference = AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -338,9 +338,6 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <StoreKitConfigurationFileReference
-         identifier = "../../Config/Test_Subscriptions.storekit">
-      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -338,6 +338,9 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Config/Test_Subscriptions.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -119,9 +119,11 @@ class SearchViewModel: ObservableObject {
 
         networkPathMonitor.start(queue: .global())
         observeNetworkChanges()
-
+        // Listen for user status changes and update the UI accordingly.
+        // Drop the first occurrence that happens when user is initialized.
         userStatusListener = user
             .statusPublisher
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
                 guard self?.searchState?.isEmptyState == true else {

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -14,7 +14,6 @@ enum PremiumSubscriptionType {
 /// A type that maps to a subscription product on the App Store
 struct PremiumSubscription {
     let product: Product
-    var isPurchased = false
 
     var name: String {
         switch type {

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
@@ -6,21 +6,6 @@ import SharedPocketKit
 import StoreKit
 import Sync
 
-/// Subscription store error(s)
-enum SubscriptionStoreError: Error {
-    case unverifiedPurchase
-}
-
-/// Generic type representing a subscription store
-protocol SubscriptionStore {
-    var subscriptions: [PremiumSubscription] { get }
-    var subscriptionsPublisher: Published<[PremiumSubscription]>.Publisher { get }
-    var purchasedSubscription: PremiumSubscription? { get }
-    var purchasedSubscriptionPublisher: Published<PremiumSubscription?>.Publisher { get }
-    func requestSubscriptions() async throws
-    func purchase(_ subscription: PremiumSubscription) async
-}
-
 /// A concrete implementation of SubscriptionStore that handles premium subscriptions purchases from the App Store
 final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     @Published private(set) var subscriptions: [PremiumSubscription] = []

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscriptionStore.swift
@@ -18,11 +18,14 @@ final class PremiumSubscriptionStore: ObservableObject {
     /// Will listen for transaction updates while the app is running
     private var transactionListener: Task<Void, Error>?
 
+    private let subscriptionMap: [String: PremiumSubscriptionType]
+
     // TODO: determine what we actually need to store here
     /// For premium users, this property contains details of the purchased subscription
     @Published private(set) var purchasedSubscription: PremiumSubscription?
 
-    init(user: User) {
+    init(user: User, subscriptionMap: [String: PremiumSubscriptionType]? = nil) {
+        self.subscriptionMap = subscriptionMap ?? [Keys.shared.pocketPremiumMonthly: .monthly, Keys.shared.pocketPremiumAnnual: .annual]
         self.user = user
         transactionListener = makeTransactionListener()
 
@@ -38,7 +41,7 @@ final class PremiumSubscriptionStore: ObservableObject {
 
     /// Fetch available subscriptions from the App Store
     func requestSubscriptions() async throws {
-        subscriptions = try await .init()
+        subscriptions = try await .init(subscriptionMap: subscriptionMap)
     }
 
     /// Return a detached Task to lListen for transaction updates from the App Store

--- a/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Subscription store error(s)
+enum SubscriptionStoreError: Error {
+    case unverifiedPurchase
+}
+
+/// Generic type representing a subscription store
+protocol SubscriptionStore {
+    var subscriptions: [PremiumSubscription] { get }
+    var subscriptionsPublisher: Published<[PremiumSubscription]>.Publisher { get }
+    var purchasedSubscription: PremiumSubscription? { get }
+    var purchasedSubscriptionPublisher: Published<PremiumSubscription?>.Publisher { get }
+    func requestSubscriptions() async throws
+    func purchase(_ subscription: PremiumSubscription) async
+}

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Textile
 
 struct PremiumUpgradeView: View {
-    static let shouldAllowUpgrade = false
+    static let shouldAllowUpgrade = true
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false
     @Environment(\.dismiss) private var dismiss

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Textile
 
 struct PremiumUpgradeView: View {
+    // TODO: remove this property and the two @State properties once we are ready to ship premium upgrades to beta users
     static let shouldAllowUpgrade = true
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -6,7 +6,7 @@ import Combine
 import Foundation
 import SharedPocketKit
 
-@MainActor
+//@MainActor
 class PremiumUpgradeViewModel: ObservableObject {
     let store: PremiumSubscriptionStore
 
@@ -37,7 +37,7 @@ class PremiumUpgradeViewModel: ObservableObject {
                         self?.annualName = $0.name
                         self?.annualPrice = $0.price
                         self?.annualPriceDescription = $0.priceDescription
-                    case .none:
+                    case .unknown:
                         break
                     }
                 }

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -8,7 +8,7 @@ import SharedPocketKit
 
 //@MainActor
 class PremiumUpgradeViewModel: ObservableObject {
-    let store: PremiumSubscriptionStore
+    let store: SubscriptionStore
 
     @Published private(set) var monthlyName = ""
     @Published private(set) var monthlyPrice = ""
@@ -21,10 +21,10 @@ class PremiumUpgradeViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(store: PremiumSubscriptionStore) {
+    init(store: SubscriptionStore) {
         self.store = store
 
-        store.$subscriptions
+        store.subscriptionsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] subscriptions in
                 subscriptions.forEach {
@@ -44,7 +44,7 @@ class PremiumUpgradeViewModel: ObservableObject {
             }
             .store(in: &cancellables)
         // Dismiss premium upgrade view if user is successfully upgraded to premium
-        store.$purchasedSubscription
+        store.purchasedSubscriptionPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self]  subscription in
                 if subscription != nil {

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -6,7 +6,6 @@ import Combine
 import Foundation
 import SharedPocketKit
 
-//@MainActor
 class PremiumUpgradeViewModel: ObservableObject {
     let store: SubscriptionStore
 

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -30,7 +30,7 @@ struct Services {
     let instantSync: InstantSyncProtocol
     let braze: BrazeProtocol
     let appBadgeSetup: AppBadgeSetup
-    let subscriptionStore: PremiumSubscriptionStore
+    let subscriptionStore: SubscriptionStore
 
     private let persistentContainer: PersistentContainer
 
@@ -112,7 +112,7 @@ struct Services {
             userDefaults: userDefaults,
             badgeProvider: UIApplication.shared
         )
-        subscriptionStore = .init(user: user)
+        subscriptionStore = PocketSubscriptionStore(user: user)
     }
 }
 

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -10,7 +10,6 @@ public enum Status: String {
 public protocol User {
     var status: Status { get }
     var statusPublisher: Published<Status>.Publisher { get }
-    var publishedStatus: Published<Status> { get }
     func setPremiumStatus(_ isPremium: Bool)
     func clear()
 }
@@ -18,7 +17,6 @@ public protocol User {
 public class PocketUser: User, ObservableObject {
     @Published public private(set) var status: Status = .unknown
     public var statusPublisher: Published<Status>.Publisher { $status }
-    public var publishedStatus: Published<Status> { _status }
     @AppStorage private var storedStatus: Status
 
     private static let userStatusKey = "User.statusKey"

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -12,6 +12,17 @@ import Apollo
 @testable import Sync
 @testable import PocketKit
 
+class MockSubscriptionStore: SubscriptionStore {
+    @Published var subscriptions: [PocketKit.PremiumSubscription] = []
+    var subscriptionsPublisher: Published<[PocketKit.PremiumSubscription]>.Publisher { $subscriptions }
+    @Published var purchasedSubscription: PocketKit.PremiumSubscription?
+    var purchasedSubscriptionPublisher: Published<PocketKit.PremiumSubscription?>.Publisher { $purchasedSubscription }
+    func requestSubscriptions() async throws {
+    }
+    func purchase(_ subscription: PocketKit.PremiumSubscription) async {
+    }
+}
+
 class SearchViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var user: MockUser!
@@ -21,6 +32,7 @@ class SearchViewModelTests: XCTestCase {
     private var searchService: MockSearchService!
     private var tracker: MockTracker!
     private var subscriptions: [AnyCancellable] = []
+    private var subscriptionStore: SubscriptionStore!
 
     override func setUpWithError() throws {
         networkPathMonitor = MockNetworkPathMonitor()
@@ -32,6 +44,7 @@ class SearchViewModelTests: XCTestCase {
         space = .testSpace()
         searchService = MockSearchService()
         source.stubMakeSearchService { self.searchService }
+        subscriptionStore = MockSubscriptionStore()
     }
 
     override func tearDownWithError() throws {
@@ -50,7 +63,7 @@ class SearchViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil
     ) -> SearchViewModel {
-        let premiumViewModel = PremiumUpgradeViewModel(store: PremiumSubscriptionStore(user: MockUser(), subscriptionMap: ["monthly": .monthly, "annual": .annual]))
+        let premiumViewModel = PremiumUpgradeViewModel(store: subscriptionStore)
         return SearchViewModel(
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user ?? self.user,

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -50,12 +50,16 @@ class SearchViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil
     ) -> SearchViewModel {
-        SearchViewModel(
+        let premiumViewModel = PremiumUpgradeViewModel(store: PremiumSubscriptionStore(user: MockUser(), subscriptionMap: ["monthly": .monthly, "annual": .annual]))
+        return SearchViewModel(
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user ?? self.user,
             userDefaults: userDefaults ?? self.userDefaults,
             source: source ?? self.source,
-            tracker: tracker ?? self.tracker
+            tracker: tracker ?? self.tracker,
+            premiumUpgradeViewModelFactory: {
+                premiumViewModel
+            }
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
@@ -2,12 +2,15 @@ import SharedPocketKit
 import Combine
 
 class MockUser: User {
-    @Published public private(set) var status: Status = .unknown
+    @Published public private(set) var status: Status
     public var statusPublisher: Published<Status>.Publisher { $status }
-    public var publishedStatus: Published<Status> { _status }
 
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
+
+    init(status: Status = .unknown) {
+        self.status = status
+    }
 }
 
 // MARK: - Set Status
@@ -21,12 +24,6 @@ extension MockUser {
 
     func stubSetStatus(impl: @escaping SetStatusImpl) {
         implementations[Self.setStatus] = impl
-    }
-
-    func stubStandardSetStatus() {
-        implementations[Self.setStatus] = { isPremium in
-            self.status = isPremium ? .premium : .free
-        }
     }
 
     func setPremiumStatus(_ isPremium: Bool) {

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -4,7 +4,6 @@ import Combine
 class MockUser: User {
     @Published public private(set) var status: Status = .unknown
     public var statusPublisher: Published<Status>.Publisher { $status }
-    public var publishedStatus: Published<Status> { _status }
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
 }


### PR DESCRIPTION
## Summary
* This PR fixes some unit tests and improves general testability by adding a `SubscriptionStore` protocol

## Implementation Details
* Add `protocol SubscriptionStore`, a generic subscription store. `PocketSubscriptionStore` is the concrete implementation that handles subscription purchase and retrieval from the App Store.
* Refactor `SearchViewModelTests`

## Test Steps
* Checkout this branch
* Run all unit tests and make sure they pass
* Build and run the app and make sure the purchase flow described in #437 and #421 works as expected
> **Warning**
The same limitations to the purchase flow, as in #421 apply here: testing between launches won't provide reliable results as of now, because we are not syncing the purchase with the backend. If you want to re-test after relaunching, you should delete existing transactions from the `StoreKit` configuration file.

## PR Checklist:
- [x] ~~Added Unit / UI tests~~ - (refactored existing)
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
