### PR TITLE
fix(reader): trigger pop to root after archiving or deleting from reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -160,9 +160,22 @@ extension RegularMainCoordinator {
             self?.share(activity)
         }.store(in: &readerSubscriptions)
 
+        readable.events.sink { [weak self] event in
+            switch event {
+            case .contentUpdated:
+                break
+            case .archive, .delete:
+                self?.popToHome()
+            }
+        }.store(in: &readerSubscriptions)
+
         let readableVC = ReadableHostViewController(readableViewModel: readable)
         readerRoot.viewControllers = [readableVC]
         splitController.setViewController(readerRoot, for: .secondary)
+    }
+
+    private func popToHome() {
+        splitController.setViewController(home.viewController, for: .secondary)
     }
 }
 


### PR DESCRIPTION
## Summary
Fix Archive button (and Delete) in Reader as it was not popping to home view controller

## References 
IN-949

## Implementation Details
Similar to how we handle clicking "Done" on Web View, we want to dismiss the article and bring the user back to Home. Archive and Delete both utilize this presentation logic, so applied it to both.

## Test Steps
1. Nav to Saves > Reader on iPad
2. Click Archive 
3. Verify that the item goes away and the user is brought to home view

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
https://user-images.githubusercontent.com/6743397/222240914-7f37e504-4991-4857-af3a-567a4ee93df3.mp4

