### PR TITLE
fix(tests): fix ui test suite 3

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -24,6 +24,8 @@ struct SearchView: View {
             default:
                 EmptyView()
             }
+        }.onAppear {
+            viewModel.trackOpenSearch()
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -159,6 +159,7 @@ class SearchViewModel: ObservableObject {
             searchState = .emptyState(searchResultState())
             return
         }
+        trackPerformSearch()
         searchState = .loading
         submitSearch(with: term, scope: selectedScope)
         recentSearches = updateRecentSearches(with: term)
@@ -391,7 +392,6 @@ extension SearchViewModel {
         tracker.track(event: Events.Search.searchCardContentOpen(url: url, positionInList: index, scope: selectedScope))
     }
 }
-
 
 // MARK: Premium upgrades
 extension SearchViewModel {

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -136,7 +136,7 @@ extension SettingsForm {
             ) {
                 model.isPresentingSignOutConfirm.toggle()
             }
-                .accessibilityIdentifier("sign-out-button")
+                .accessibilityIdentifier("log-out-button")
                 .alert(
                     L10n.Settings.Logout.areyousure,
                     isPresented: $model.isPresentingSignOutConfirm,


### PR DESCRIPTION
## Summary
This PR fixes some UI tests that broke in develop.

## References 
Related to: https://github.com/Pocket/pocket-ios/pull/446

## Implementation Details
* Update accessibility identifier for `SignOutTests`
* Add back analytics call for `SearchTests`

## Test Steps
* Checkout this branch
* Run all UI tests and make sure they pass in test suite 3

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots