### PR TITLE
ci(tests): Safari open flaky fix

### DIFF
--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -189,7 +189,7 @@ class ReaderTests: XCTestCase {
     }
 
     func validateSafariOpens() {
-        XCTAssertTrue(app.readerView.safariDoneButton.exists)
+        XCTAssertTrue(app.readerView.safariDoneButton.wait().exists)
     }
 
     func openReaderOverflowMenu() {


### PR DESCRIPTION
This PR adds a .wait() to a safari opening method, which is an attempt to fix a flaky fail rate of about 1% for test_tappingWebViewButton_showsSafari