### PR TITLE
Premium - Analytics

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Premium.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Premium.swift
@@ -12,13 +12,13 @@ public extension Events {
 public extension Events.Premium {
     /// Premium Upgrade View appears
     /// - Parameter source: "settings" or "search"
-    static func premiumUpgradeViewShown(source: String) -> Event {
+    static func premiumUpgradeViewShown(source: PremiumUpgradeSource) -> Event {
         return Engagement(
             .general,
             uiEntity: UiEntity(
                 .screen,
                 identifier: "global-nav.premium",
-                componentDetail: source
+                componentDetail: source.rawValue
             )
         )
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Premium.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Premium.swift
@@ -47,13 +47,14 @@ public extension Events.Premium {
 
     /// Visual confirmation of successful subscription purchase
     /// - Parameter type: "monthly" or "annual
-    static func purchaseSuccess(type: String) -> Event {
+    static func purchaseSuccess(type: PremiumSubscriptionType) -> Event {
         return Impression(
             component: .dialog,
             requirement: .viewable,
             uiEntity: UiEntity(
                 .dialog,
-                identifier: "global-nav.premium.purchase.success"
+                identifier: "global-nav.premium.purchase.success",
+                componentDetail: type.rawValue
             )
         )
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Premium.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Premium.swift
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SharedPocketKit
+
+public extension Events {
+    struct Premium {}
+}
+
+public extension Events.Premium {
+    /// Premium Upgrade View appears
+    /// - Parameter source: "settings" or "search"
+    static func premiumUpgradeViewShown(source: String) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "global-nav.premium",
+                componentDetail: source
+            )
+        )
+    }
+
+    /// Monthly Subscription button tapped
+    static func purchaseMonthlyButtonTapped() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.premium.monthly"
+            )
+        )
+    }
+
+    /// Annual Subscription button tapped
+    static func purchaseAnnualButtonTapped() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.premium.annual"
+            )
+        )
+    }
+
+    /// Visual confirmation of successful subscription purchase
+    /// - Parameter type: "monthly" or "annual
+    static func purchaseSuccess(type: String) -> Event {
+        return Impression(
+            component: .dialog,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .dialog,
+                identifier: "global-nav.premium.purchase.success"
+            )
+        )
+    }
+
+    /// Visual confirmation of subscription purchase failed
+    static func purchaseFailed() -> Event {
+        return Impression(
+            component: .dialog,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .dialog,
+                identifier: "global-nav.premium.purchase.failed"
+            )
+        )
+    }
+
+    /// Subscription purchase cancelled by the user
+    static func purchaseCancelled() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.premium.purchase.cancelled"
+            )
+        )
+    }
+
+    /// Premium Upgrade View dismissed by the user
+    /// - Parameter action: "button" or "swipe"
+    static func premiumUpgradeViewDismissed(reason: DismissReason) -> Event {
+        print("Dismiss called with \(reason.rawValue)")
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "global-nav.premium.dismiss",
+                componentDetail: reason.rawValue
+            )
+        )
+    }
+}

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -182,4 +182,16 @@ public extension Events.Search {
             )
         )
     }
+
+    /// Premium upsell in Search visible
+    static func premiumUpsellViewed() -> Event {
+        return Impression(
+            component: .button,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.premium.upsell"
+            )
+        )
+    }
 }

--- a/PocketKit/Sources/Analytics/AppEvents/Settings.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Settings.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SharedPocketKit
+
+public extension Events {
+    struct Settings {}
+}
+
+public extension Events.Settings {
+    /// "Go Premium" button viewed
+    static func premiumUpsellViewed() -> Event {
+        return Impression(
+            component: .button,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "account.premium.upsell"
+            )
+        )
+    }
+}

--- a/PocketKit/Sources/Analytics/Events/Impression.swift
+++ b/PocketKit/Sources/Analytics/Events/Impression.swift
@@ -64,6 +64,7 @@ extension Impression {
         case screen
         case pushNotification
         case button
+        case dialog
 
         func toComponent() -> Component {
             switch self {
@@ -79,6 +80,8 @@ extension Impression {
                 return Component(value: "push_notification", requiredEntities: [])
             case .button:
                 return Component(value: "button", requiredEntities: [])
+            case .dialog:
+                return Component(value: "dialog", requiredEntities: [])
             }
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import SharedPocketKit
 import SwiftUI
 import Textile
 
@@ -89,6 +90,7 @@ struct SearchEmptyView: View {
 }
 
 struct GetPocketPremiumButton: View {
+    @State var dismissReason: DismissReason = .swipe
     @EnvironmentObject private var searchViewModel: SearchViewModel
     private let text: String
 
@@ -105,8 +107,16 @@ struct GetPocketPremiumButton: View {
                 .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                 .frame(maxWidth: 320)
         }).buttonStyle(GetPocketPremiumButtonStyle())
-            .sheet(isPresented: $searchViewModel.isPresentingPremiumUpgrade) {
-                PremiumUpgradeView(viewModel: searchViewModel.makePremiumUpgradeViewModel())
+            .sheet(
+                isPresented: $searchViewModel.isPresentingPremiumUpgrade,
+                onDismiss: {
+                    searchViewModel.trackPremiumDismissed(dismissReason: dismissReason)
+            }
+            ) {
+                PremiumUpgradeView(dismissReason: self.$dismissReason, viewModel: searchViewModel.makePremiumUpgradeViewModel())
+            }
+            .task {
+                searchViewModel.trackPremiumUpsellViewed()
             }
     }
 }

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -21,8 +21,8 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                             userDefaults: Services.shared.userDefaults,
                             source: Services.shared.source,
                             tracker: Services.shared.tracker.childTracker(hosting: .saves.search)
-                        ) {
-                            PremiumUpgradeViewModel(store: Services.shared.subscriptionStore)
+                        ) { tracker, source in
+                            PremiumUpgradeViewModel(store: Services.shared.subscriptionStore, tracker: tracker, source: source)
                         },
                         savedItemsList: SavedItemsListViewModel(
                             source: Services.shared.source,
@@ -45,10 +45,11 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                     account: AccountViewModel(
                         appSession: Services.shared.appSession,
                         user: Services.shared.user,
+                        tracker: Services.shared.tracker,
                         userDefaults: Services.shared.userDefaults,
                         notificationCenter: .default
-                    ) {
-                        PremiumUpgradeViewModel(store: Services.shared.subscriptionStore)
+                    ) { tracker, source in
+                        PremiumUpgradeViewModel(store: Services.shared.subscriptionStore, tracker: tracker, source: source)
                     }
                 ),
                 source: Services.shared.source,

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -5,7 +5,7 @@
 import StoreKit
 
 /// An enum that maps all available subscription IDs on the App Store
-enum PremiumSubscriptionType {
+enum PremiumSubscriptionType: String {
     case monthly
     case annual
     case unknown

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -1,15 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+import SharedPocketKit
 import StoreKit
-
-/// An enum that maps all available subscription IDs on the App Store
-enum PremiumSubscriptionType: String {
-    case monthly
-    case annual
-    case unknown
-}
 
 /// A type that maps to a subscription product on the App Store
 struct PremiumSubscription {

--- a/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import SharedPocketKit
 
 /// Subscription store error(s)
 enum SubscriptionStoreError: Error {

--- a/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
@@ -7,14 +7,24 @@ import Foundation
 /// Subscription store error(s)
 enum SubscriptionStoreError: Error {
     case unverifiedPurchase
+    case purchaseFailed
+    case invalidProduct
+}
+
+/// Describes the state of a purchase made from a `SubscriptionStore`
+enum PurchaseState {
+    case unsubscribed
+    case subscribed(PremiumSubscriptionType)
+    case cancelled
+    case failed
 }
 
 /// Generic type representing a subscription store
 protocol SubscriptionStore {
     var subscriptions: [PremiumSubscription] { get }
     var subscriptionsPublisher: Published<[PremiumSubscription]>.Publisher { get }
-    var purchasedSubscription: PremiumSubscription? { get }
-    var purchasedSubscriptionPublisher: Published<PremiumSubscription?>.Publisher { get }
+    var state: PurchaseState { get }
+    var statePublisher: Published<PurchaseState>.Publisher { get }
     func requestSubscriptions() async throws
     func purchase(_ subscription: PremiumSubscription) async
 }

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -1,17 +1,15 @@
+import SharedPocketKit
 import SwiftUI
 import Textile
 
 struct PremiumUpgradeView: View {
     // TODO: remove this property and the two @State properties once we are ready to ship premium upgrades to beta users
-    static let shouldAllowUpgrade = false
+    static let shouldAllowUpgrade = true
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false
+    @Binding var dismissReason: DismissReason
     @Environment(\.dismiss) private var dismiss
     @StateObject var viewModel: PremiumUpgradeViewModel
-
-    init(viewModel: PremiumUpgradeViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -22,6 +20,7 @@ struct PremiumUpgradeView: View {
         .background(PremiumBackgroundView())
         .task {
             do {
+                dismissReason = .swipe
                 try await viewModel.requestSubscriptions()
             } catch {
                 // TODO: Here we will handle any error providing user feedback if/when needed
@@ -30,6 +29,7 @@ struct PremiumUpgradeView: View {
         }
         .onChange(of: viewModel.shouldDismiss) { shouldDismiss in
             if shouldDismiss {
+                dismissReason = .system
                 dismiss()
             }
         }
@@ -39,6 +39,7 @@ struct PremiumUpgradeView: View {
         HStack(spacing: 0) {
             Spacer()
             Button {
+                self.dismissReason = .button
                 dismiss()
             } label: {
                 Image(asset: .close).renderingMode(.template).foregroundColor(Color(.ui.grey5))

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -4,7 +4,7 @@ import Textile
 
 struct PremiumUpgradeView: View {
     // TODO: remove this property and the two @State properties once we are ready to ship premium upgrades to beta users
-    static let shouldAllowUpgrade = true
+    static let shouldAllowUpgrade = false
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false
     @Binding var dismissReason: DismissReason

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -19,8 +19,9 @@ struct PremiumUpgradeView: View {
         .padding([.top, .bottom], 20)
         .background(PremiumBackgroundView())
         .task {
+            viewModel.trackPremiumUpgradeViewShown()
+            dismissReason = .swipe
             do {
-                dismissReason = .swipe
                 try await viewModel.requestSubscriptions()
             } catch {
                 // TODO: Here we will handle any error providing user feedback if/when needed
@@ -72,6 +73,7 @@ struct PremiumUpgradeView: View {
                         ) {
                             Task {
                                 if Self.shouldAllowUpgrade {
+                                    viewModel.trackMonthlyButtonTapped()
                                     await viewModel.purchaseMonthlySubscription()
                                 } else {
                                     showingMonthlyAlert = true
@@ -95,6 +97,7 @@ struct PremiumUpgradeView: View {
                             ) {
                                 Task {
                                     if Self.shouldAllowUpgrade {
+                                        viewModel.trackAnnualButtonTapped()
                                         await viewModel.purchaseAnnualSubscription()
                                     } else {
                                         showingAnnualAlert = true

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -109,7 +109,7 @@ extension PremiumUpgradeViewModel {
     /// track purchase success
     /// - Parameter type: "monthly" or "annual"
     func trackPurchaseSubscriptionSuccess(type: PremiumSubscriptionType) {
-        tracker.track(event: Events.Premium.purchaseSuccess(type: type.rawValue))
+        tracker.track(event: Events.Premium.purchaseSuccess(type: type))
     }
     /// track purchase subscription cancelled by the user
     func trackPurchaseSubscriptionCancelled() {

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -2,13 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import Analytics
 import Combine
 import Foundation
 import SharedPocketKit
 
 @MainActor
 class PremiumUpgradeViewModel: ObservableObject {
-    let store: SubscriptionStore
+    private let store: SubscriptionStore
+    private let tracker: Tracker
+    private let source: PremiumUpgradeSource
 
     @Published private(set) var monthlyName = ""
     @Published private(set) var monthlyPrice = ""
@@ -21,8 +24,10 @@ class PremiumUpgradeViewModel: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(store: SubscriptionStore) {
+    init(store: SubscriptionStore, tracker: Tracker, source: PremiumUpgradeSource) {
         self.store = store
+        self.tracker = tracker
+        self.source = source
 
         store.subscriptionsPublisher
             .receive(on: DispatchQueue.main)
@@ -44,11 +49,24 @@ class PremiumUpgradeViewModel: ObservableObject {
             }
             .store(in: &cancellables)
         // Dismiss premium upgrade view if user is successfully upgraded to premium
-        store.purchasedSubscriptionPublisher
+        store.statePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self]  subscription in
-                if subscription != nil {
+            .sink { [weak self]  state in
+                switch state {
+                case .subscribed(let type):
+                    Task {
+                        self?.trackPurchaseSubscriptionSuccess(type: type)
+                    }
                     self?.shouldDismiss = true
+                case .unsubscribed:
+                    // TODO: also do nothing here, this should only be received once when viewing the screen
+                    break
+                case .cancelled:
+                    // TODO: probably we should just do nothing other than track the event here
+                    self?.trackPurchaseSubscriptionCancelled()
+                case .failed:
+                    // TODO: display an alert here
+                    self?.trackPurchaseSubscriptionFailed()
                 }
             }
             .store(in: &cancellables)
@@ -71,5 +89,40 @@ class PremiumUpgradeViewModel: ObservableObject {
             return
         }
         await store.purchase(annualSubscription)
+    }
+}
+
+// MARK: Analytics
+/// Used to track the upsell source
+enum PremiumUpgradeSource: String {
+    case search
+    case settings
+}
+
+extension PremiumUpgradeViewModel {
+    /// track Premium Upgrade View shown
+    func trackPremiumUpgradeViewShown() {
+        tracker.track(event: Events.Premium.premiumUpgradeViewShown(source: source.rawValue))
+    }
+    /// track monthly button tapped
+    func trackMonthlyButtonTapped() {
+        tracker.track(event: Events.Premium.purchaseMonthlyButtonTapped())
+    }
+    /// track annual button tapped
+    func trackAnnualButtonTapped() {
+        tracker.track(event: Events.Premium.purchaseAnnualButtonTapped())
+    }
+    /// track purchase success
+    /// - Parameter type: "monthly" or "annual"
+    func trackPurchaseSubscriptionSuccess(type: PremiumSubscriptionType) {
+        tracker.track(event: Events.Premium.purchaseSuccess(type: type.rawValue))
+    }
+    /// track purchase subscription cancelled by the user
+    func trackPurchaseSubscriptionCancelled() {
+        tracker.track(event: Events.Premium.purchaseCancelled())
+    }
+    /// track purchase subscription failed because of an error
+    func trackPurchaseSubscriptionFailed() {
+        tracker.track(event: Events.Premium.purchaseFailed())
     }
 }

--- a/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Premium/ViewModel/PremiumUpgradeViewModel.swift
@@ -93,16 +93,10 @@ class PremiumUpgradeViewModel: ObservableObject {
 }
 
 // MARK: Analytics
-/// Used to track the upsell source
-enum PremiumUpgradeSource: String {
-    case search
-    case settings
-}
-
 extension PremiumUpgradeViewModel {
     /// track Premium Upgrade View shown
     func trackPremiumUpgradeViewShown() {
-        tracker.track(event: Events.Premium.premiumUpgradeViewShown(source: source.rawValue))
+        tracker.track(event: Events.Premium.premiumUpgradeViewShown(source: source))
     }
     /// track monthly button tapped
     func trackMonthlyButtonTapped() {

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import SharedPocketKit
 import SwiftUI
 import Textile
 
@@ -39,6 +40,7 @@ struct SettingsView: View {
 }
 
 struct SettingsForm: View {
+    @State var dismissReason: DismissReason = .swipe
     @ObservedObject
     var model: AccountViewModel
 
@@ -168,8 +170,16 @@ extension SettingsForm {
 
     private func makeGoPremiumRow() -> some View {
         makePremiumRowContent(false)
-            .sheet(isPresented: $model.isPresentingPremiumUpgrade) {
-                PremiumUpgradeView(viewModel: model.makePremiumUpgradeViewModel())
+            .sheet(
+                isPresented: $model.isPresentingPremiumUpgrade,
+                onDismiss: {
+                model.trackPremiumDismissed(dismissReason: dismissReason)
+            }
+            ) {
+                PremiumUpgradeView(dismissReason: self.$dismissReason, viewModel: model.makePremiumUpgradeViewModel())
+            }
+            .task {
+                model.trackPremiumUpsellViewed()
             }
     }
 

--- a/PocketKit/Sources/SharedPocketKit/DismissReason.swift
+++ b/PocketKit/Sources/SharedPocketKit/DismissReason.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Tracks the action that dismisses a sheet
+public enum DismissReason: String {
+    case swipe
+    case button
+    case system
+}

--- a/PocketKit/Sources/SharedPocketKit/PremiumSubscriptionType.swift
+++ b/PocketKit/Sources/SharedPocketKit/PremiumSubscriptionType.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// An enum that maps all available subscription IDs on the App Store
+public enum PremiumSubscriptionType: String {
+    case monthly
+    case annual
+    case unknown
+}

--- a/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
+++ b/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Used to track the upsell source
+public enum PremiumUpgradeSource: String {
+    case search
+    case settings
+}

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -15,8 +15,8 @@ import Apollo
 class MockSubscriptionStore: SubscriptionStore {
     @Published var subscriptions: [PocketKit.PremiumSubscription] = []
     var subscriptionsPublisher: Published<[PocketKit.PremiumSubscription]>.Publisher { $subscriptions }
-    @Published var purchasedSubscription: PocketKit.PremiumSubscription?
-    var purchasedSubscriptionPublisher: Published<PocketKit.PremiumSubscription?>.Publisher { $purchasedSubscription }
+    @Published var state: PurchaseState = .unsubscribed
+    var statePublisher: Published<PurchaseState>.Publisher { $state }
     func requestSubscriptions() async throws {
     }
     func purchase(_ subscription: PocketKit.PremiumSubscription) async {
@@ -60,14 +60,14 @@ class SearchViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil
     ) async -> SearchViewModel {
-        let premiumViewModel = await PremiumUpgradeViewModel(store: subscriptionStore)
+        let premiumViewModel = await PremiumUpgradeViewModel(store: subscriptionStore, tracker: MockTracker(), source: .search)
         return SearchViewModel(
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user,
             userDefaults: userDefaults ?? self.userDefaults,
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
-            premiumUpgradeViewModelFactory: {
+            premiumUpgradeViewModelFactory: { _, _ in
                 premiumViewModel
             }
         )


### PR DESCRIPTION
## Summary
* This PR adds the analytics events associated with premium upsell and premium purchases.

## Implementation Details
* Add `Events.Premium` type, with a variety of premium purchases events
* Add `premiumUpsellViewed` event in `Events.Search`
* Add `Events.Settings` type with a `premiumUpsellViewed` event
* Refactor `SubscriptionStore`, `PocketSubscriptionStore`, add a `state` property to publish `PurchaseState`
* Update views and view models to track the added events

## Test Steps
* Checkout this branch
* To test subscription purchase events, setup the environment as indicated in #421 
* Build/run
* Login with a free account
* Execute the following actions, and make sure the related events show up in the console
    * Go to Saves > Search
    * Go to All Items - Event `global-nav.search.premium.upsell`
    * Go to Settings - Event `account.premium.upsell`
    * Either from Settings or Search, tap the premium upsell button to open the Premium Upgrade View - Event `global-nav.premium` this event has a `source` parameter that is either "settings" or "search" depending on where it's shown from
    * Dismiss the view tapping on the `X` in the top-right - Event `global-nav.premium.dismiss` parameter: `dismissReason = "button"
    * Reopen Premium Upgrade
    * Dismiss the view by swiping down  - Event `global-nav.premium.dismiss` parameter: `dismissReason = "swipe"
    * Reopen the view
    * Tap on "Monthly" - Event `global-nav.premium.monthly`
    * Cancel the purchase - Event `global-nav.premium.purchase.cancelled`
    * Tap on Annual - Event `global-nav.premium.annual`
    * Complete the purchase then tap "OK" - Event `global-nav.premium.purchase.success`
> **Note**
There isn't a trivial way to test the purchase failure (other than cancelled by the user)
To easily view events in the console, filter by "Tracking"

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
