### PR TITLE
Add manual purchase sync to SubscriptionStore

### DIFF
--- a/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift
@@ -56,8 +56,8 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     }
 
     /// Manually restore a purchase in those (rare?) cases when the automatic sync fails
-    func restorePurchase() {
-        // TODO: Add implementation
+    func restoreSubscription() async throws {
+        try await AppStore.sync()
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PremiumSubscription.swift
@@ -5,7 +5,7 @@ import SharedPocketKit
 import StoreKit
 
 /// A type that maps to a subscription product on the App Store
-struct PremiumSubscription {
+public struct PremiumSubscription {
     let product: Product
 
     var name: String {

--- a/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
@@ -13,7 +13,7 @@ enum SubscriptionStoreError: Error {
 }
 
 /// Describes the state of a purchase made from a `SubscriptionStore`
-enum PurchaseState {
+public enum PurchaseState {
     case unsubscribed
     case subscribed(PremiumSubscriptionType)
     case cancelled
@@ -21,7 +21,7 @@ enum PurchaseState {
 }
 
 /// Generic type representing a subscription store
-protocol SubscriptionStore {
+public protocol SubscriptionStore {
     var subscriptions: [PremiumSubscription] { get }
     var subscriptionsPublisher: Published<[PremiumSubscription]>.Publisher { get }
     var state: PurchaseState { get }

--- a/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/SubscriptionStore.swift
@@ -28,4 +28,5 @@ protocol SubscriptionStore {
     var statePublisher: Published<PurchaseState>.Publisher { get }
     func requestSubscriptions() async throws
     func purchase(_ subscription: PremiumSubscription) async
+    func restoreSubscription() async throws
 }

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -12,17 +12,6 @@ import Apollo
 @testable import Sync
 @testable import PocketKit
 
-class MockSubscriptionStore: SubscriptionStore {
-    @Published var subscriptions: [PocketKit.PremiumSubscription] = []
-    var subscriptionsPublisher: Published<[PocketKit.PremiumSubscription]>.Publisher { $subscriptions }
-    @Published var state: PurchaseState = .unsubscribed
-    var statePublisher: Published<PurchaseState>.Publisher { $state }
-    func requestSubscriptions() async throws {
-    }
-    func purchase(_ subscription: PocketKit.PremiumSubscription) async {
-    }
-}
-
 class SearchViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var userDefaults: UserDefaults!

--- a/PocketKit/Tests/PocketKitTests/Support/MockSubscriptionStore.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSubscriptionStore.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import Foundation
+import PocketKit
+import SharedPocketKit
+
+class MockSubscriptionStore: SubscriptionStore {
+    func restoreSubscription() async throws {}
+    @Published var subscriptions: [PocketKit.PremiumSubscription] = []
+    var subscriptionsPublisher: Published<[PocketKit.PremiumSubscription]>.Publisher { $subscriptions }
+    @Published var state: PurchaseState = .unsubscribed
+    var statePublisher: Published<PurchaseState>.Publisher { $state }
+    func requestSubscriptions() async throws {}
+    func purchase(_ subscription: PocketKit.PremiumSubscription) async {}
+}


### PR DESCRIPTION
## Summary
* This PR adds a direct call to purchase sync to `SubscriptionStore`, for those rare cases where the automatic sync does not happen

## Implementation Details
* Add a `restoreSubscription` call to `SubscriptionStore`, which corresponds to an `Appstore.sync()` call in the concrete implementation `PocketSubscriptionStore`

## Test Steps
* There's not much to test at the moment; here is the [documentation](https://developer.apple.com/documentation/storekit/appstore/3791906-sync) related to that call which, according to Apple, will only be needed in rare cases. When the call happens, the listener in place should receive existing transactions and entitlements.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
