### PR TITLE
Premium Upgrade View - UI Tests

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		8ADAC6B028AD4E7500DE9A62 /* AddTagsViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */; };
 		8ADD6A9F292C189C007F419D /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6A9E292C189C007F419D /* SearchTests.swift */; };
 		8ADD6AA1292C1B2C007F419D /* SearchViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */; };
+		AA69A28429B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69A28329B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift */; };
 		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
 		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
 		AAEE908229B69BA70028587D /* PremiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908129B69BA70028587D /* PremiumTests.swift */; };
@@ -227,6 +228,7 @@
 		8ADAC6AF28AD4E7500DE9A62 /* AddTagsViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagsViewElement.swift; sourceTree = "<group>"; };
 		8ADD6A9E292C189C007F419D /* SearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewElement.swift; sourceTree = "<group>"; };
+		AA69A28329B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchGetPremiumEmptyViewElement.swift; sourceTree = "<group>"; };
 		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				16A6808026EBC78800A64545 /* HomeViewElement.swift */,
 				1648D5A627024C6400F67C4B /* SlateDetailElement.swift */,
 				AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */,
+				AA69A28329B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift */,
 				16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */,
 				8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */,
 				8A4ECEF8287775F90007DB67 /* SectionHeaderElement.swift */,
@@ -796,6 +799,7 @@
 				8A47CA8E28BD4A9C003DB4BD /* TagsFilterViewElement.swift in Sources */,
 				16D76883279F3C73004A3694 /* ArchiveTests.swift in Sources */,
 				1613B2B3275571940014F301 /* SettingsViewElement.swift in Sources */,
+				AA69A28429B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift in Sources */,
 				16BB40A8279F436100FE8650 /* SelectionSwitcherElement.swift in Sources */,
 				F2A5B6B4271E03B300FB8BF2 /* LaunchArguments.swift in Sources */,
 				F2FC070327A9B749009F8D98 /* ArchiveFiltersTests.swift in Sources */,

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		8ADD6A9F292C189C007F419D /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6A9E292C189C007F419D /* SearchTests.swift */; };
 		8ADD6AA1292C1B2C007F419D /* SearchViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADD6AA0292C1B2C007F419D /* SearchViewElement.swift */; };
 		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
+		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
+		AAEE908229B69BA70028587D /* PremiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908129B69BA70028587D /* PremiumTests.swift */; };
+		AAEE908429B69E9F0028587D /* PremiumUpgradeViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */; };
 		D26A5EF4297F1D8400FA5A88 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */; };
 		F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20BB0382744542F00AE5E70 /* AlertElement.swift */; };
 		F24B1E1C27ECB55600C75487 /* SaveToPocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24B1E1B27ECB55600C75487 /* SaveToPocket.swift */; };
@@ -227,6 +230,8 @@
 		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
+		AAEE908129B69BA70028587D /* PremiumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumTests.swift; sourceTree = "<group>"; };
+		AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumUpgradeViewElement.swift; sourceTree = "<group>"; };
 		D26A5EF3297F1D8400FA5A88 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		F204A76027E22EC50010E155 /* SaveToPocket.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SaveToPocket.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F204A76727E22EC50010E155 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -365,6 +370,7 @@
 				1613B2B02755696B0014F301 /* SignOutTests.swift */,
 				F2A009E927F61C81004B5E71 /* SaveToPocketTests.swift */,
 				656041ED29B18105007E7CD0 /* SettingsTests.swift */,
+				AAEE908129B69BA70028587D /* PremiumTests.swift */,
 			);
 			path = "Tests iOS";
 			sourceTree = "<group>";
@@ -405,6 +411,7 @@
 				16A6807E26EBC71300A64545 /* TabBarElement.swift */,
 				16A6808026EBC78800A64545 /* HomeViewElement.swift */,
 				1648D5A627024C6400F67C4B /* SlateDetailElement.swift */,
+				AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */,
 				16C2B03E270CF82700D194AA /* RecommendationCellElement.swift */,
 				8A7765A1288EE80900127BB4 /* RecentSavesCellElement.swift */,
 				8A4ECEF8287775F90007DB67 /* SectionHeaderElement.swift */,
@@ -668,6 +675,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				166BACF62656E34B00E401F0 /* Fixtures in Resources */,
+				AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +766,7 @@
 				65BE918E29A5B9AF00B13BF1 /* AnyCodable.swift in Sources */,
 				16E4B16D27A31BEC00E01746 /* RequestMatchers.swift in Sources */,
 				166BAD0C2656E76B00E401F0 /* SavesElement.swift in Sources */,
+				AAEE908229B69BA70028587D /* PremiumTests.swift in Sources */,
 				F20BB0392744542F00AE5E70 /* AlertElement.swift in Sources */,
 				166BAD0D2656E76B00E401F0 /* PocketAppElement.swift in Sources */,
 				8A7765A2288EE80900127BB4 /* RecentSavesCellElement.swift in Sources */,
@@ -797,6 +806,7 @@
 				166BAD0A2656E76B00E401F0 /* SignInFormElement.swift in Sources */,
 				8A4ECEF9287775F90007DB67 /* SectionHeaderElement.swift in Sources */,
 				16C2B03F270CF82700D194AA /* RecommendationCellElement.swift in Sources */,
+				AAEE908429B69E9F0028587D /* PremiumUpgradeViewElement.swift in Sources */,
 				16A6808126EBC78800A64545 /* HomeViewElement.swift in Sources */,
 				16A6807F26EBC71300A64545 /* TabBarElement.swift in Sources */,
 				168292C826CC64C300830140 /* ShareAnItemTests.swift in Sources */,

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/PocketKit/Sources/Analytics/AppEvents/Premium.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Premium.swift
@@ -49,7 +49,7 @@ public extension Events.Premium {
     /// - Parameter type: "monthly" or "annual
     static func purchaseSuccess(type: PremiumSubscriptionType) -> Event {
         return Impression(
-            component: .dialog,
+            component: .ui,
             requirement: .viewable,
             uiEntity: UiEntity(
                 .dialog,
@@ -62,7 +62,7 @@ public extension Events.Premium {
     /// Visual confirmation of subscription purchase failed
     static func purchaseFailed() -> Event {
         return Impression(
-            component: .dialog,
+            component: .ui,
             requirement: .viewable,
             uiEntity: UiEntity(
                 .dialog,

--- a/PocketKit/Sources/Analytics/Events/Impression.swift
+++ b/PocketKit/Sources/Analytics/Events/Impression.swift
@@ -64,7 +64,6 @@ extension Impression {
         case screen
         case pushNotification
         case button
-        case dialog
 
         func toComponent() -> Component {
             switch self {
@@ -80,8 +79,6 @@ extension Impression {
                 return Component(value: "push_notification", requiredEntities: [])
             case .button:
                 return Component(value: "button", requiredEntities: [])
-            case .dialog:
-                return Component(value: "dialog", requiredEntities: [])
             }
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -52,6 +52,7 @@ struct EmptyStateView<Content: View>: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: viewModel.maxWidth)
+                .accessibilityIdentifier(viewModel.accessibilityIdentifier)
 
             VStack(alignment: .center, spacing: 20) {
                 if let headline = viewModel.headline {

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -81,7 +81,9 @@ struct EmptyStateView<Content: View>: View {
                     }
                 }
             }
-        }.accessibilityIdentifier(viewModel.accessibilityIdentifier)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(viewModel.accessibilityIdentifier)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -119,6 +119,7 @@ struct GetPocketPremiumButton: View {
             .task {
                 searchViewModel.trackPremiumUpsellViewed()
             }
+            .accessibilityIdentifier("get-pocket-premium-button")
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/Premium/View/PremiumUpgradeView.swift
@@ -4,7 +4,7 @@ import Textile
 
 struct PremiumUpgradeView: View {
     // TODO: remove this property and the two @State properties once we are ready to ship premium upgrades to beta users
-    static let shouldAllowUpgrade = false
+    static let shouldAllowUpgrade = true
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false
     @Binding var dismissReason: DismissReason
@@ -16,6 +16,8 @@ struct PremiumUpgradeView: View {
             dismissButton
             upgradeView
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("premium-upgrade-view")
         .padding([.top, .bottom], 20)
         .background(PremiumBackgroundView())
         .task {
@@ -45,6 +47,7 @@ struct PremiumUpgradeView: View {
             } label: {
                 Image(asset: .close).renderingMode(.template).foregroundColor(Color(.ui.grey5))
             }
+            .accessibilityIdentifier("premium-upgrade-view-dismiss-button")
             .padding(.top, 10)
             .padding([.leading, .trailing], 32)
         }
@@ -80,6 +83,7 @@ struct PremiumUpgradeView: View {
                                 }
                             }
                         }
+                        .accessibilityIdentifier("premium-upgrade-view-monthly-button")
                         .alert("Comiing Soon!", isPresented: $showingMonthlyAlert) {
                             Button("OK", role: .cancel) { }
                         }
@@ -104,6 +108,7 @@ struct PremiumUpgradeView: View {
                                     }
                                 }
                             }
+                            .accessibilityIdentifier("premium-upgrade-view-annual-button")
                             .alert("Comiing Soon!", isPresented: $showingAnnualAlert) {
                                 Button("OK", role: .cancel) { }
                             }

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -129,8 +129,10 @@ extension SettingsForm {
         Section(header: Text(L10n.yourAccount).style(.settings.header)) {
             if model.isPremium {
                 makePremiumSubscriptionRow()
+                    .accessibilityIdentifier("premium-subscription-button")
             } else {
                 makeGoPremiumRow()
+                    .accessibilityIdentifier("go-premium-button")
             }
 
             // Custom implementation to hide the > arrow and let us use our own.

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -116,7 +116,8 @@ class PremiumTests: XCTestCase {
         purchaseSuccessEvent!.getUIContext()!.assertHas(type: "dialog")
     }
 
-    @MainActor func configureFreeUser() {
+    /// Set user to free
+    @MainActor private func configureFreeUser() {
         server.routes.post("/graphql") { request, _ in
             let apiRequest = ClientAPIRequest(request)
             if apiRequest.isForSavesContent {
@@ -126,6 +127,7 @@ class PremiumTests: XCTestCase {
         }
     }
 
+    /// Load premium upgrade view from Settings
     @MainActor private func loadPremiumUpgradeViewFromSettings() async {
         app.tabBar.settingsButton.wait().tap()
         XCTAssertTrue(app.settingsView.exists)
@@ -138,17 +140,14 @@ class PremiumTests: XCTestCase {
 
         goPremiumButtonImpression!.getUIContext()!.assertHas(type: "button")
 
-        tapSettingsPremiumUpsell()
+        app.settingsView.goPremiumButton.tap()
         XCTAssertTrue(app.premiumUpgradeView.exists)
 
         let premiumViewShownEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium")
         XCTAssertNotNil(premiumViewShownEvent)
     }
 
-    private func tapSettingsPremiumUpsell() {
-        app.settingsView.goPremiumButton.tap()
-    }
-
+    /// Load premium upgrade view from Saves > Search > All Items
     @MainActor private func loadPremiumUpgradeViewFromSearch() async {
         app.tabBar.savesButton.wait().tap()
         app.saves.filterButton(for: "Search").wait().tap()
@@ -160,14 +159,10 @@ class PremiumTests: XCTestCase {
 
         goPremiumButtonImpression!.getUIContext()!.assertHas(type: "button")
 
-        tapSearchPremiumUpsell()
+        app.searchGetPremiumEmptyView.getPocketPremiumButton.tap()
         XCTAssertTrue(app.premiumUpgradeView.exists)
 
         let searchUpsellEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.premium.upsell")
         XCTAssertNotNil(searchUpsellEvent)
-    }
-
-    private func tapSearchPremiumUpsell() {
-        app.searchGetPremiumEmptyView.getPocketPremiumButton.tap()
     }
 }

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -14,9 +14,10 @@ class PremiumTests: XCTestCase {
 
     override func setUp() async throws {
         continueAfterFailure = false
-        storeSession = try! SKTestSession(configurationFileNamed: "Test_Subscriptions")
-        storeSession.disableDialogs = true
+        storeSession = try SKTestSession(configurationFileNamed: "Test_Subscriptions")
+        storeSession.resetToDefaultState()
         storeSession.clearTransactions()
+        storeSession.disableDialogs = true
         app = PocketAppElement(app: XCUIApplication())
         server = Application()
 
@@ -27,19 +28,22 @@ class PremiumTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         storeSession.clearTransactions()
+        storeSession.resetToDefaultState()
         storeSession = nil
         app.terminate()
     }
 
-    @MainActor
-    func test_tapGoPremiumShowsUpgradeView() async {
+
+    /// Test that tapping "Go Premium" in Settings presents the Premium Upgrade view
+    @MainActor func test_tapGoPremiumShowsUpgradeView() async {
         configureFreeUser()
         app.launch()
         await loadPremiumUpgradeView()
     }
 
-    @MainActor
-    func test_tapDismiss_dismissPremiumView() async {
+
+    /// Test that Premium Upgrade view dismisses when tapping the dismiss button
+    @MainActor func test_tapDismissDismissPremiumView() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -52,8 +56,9 @@ class PremiumTests: XCTestCase {
         XCTAssertFalse(app.premiumUpgradeView.exists)
     }
 
-    @MainActor
-    func test_monthlyButtonTapped() async {
+
+    /// Test that monthly button tapped triggers the right event
+    @MainActor func test_monthlyButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -65,8 +70,9 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(monthlyButtonTappedEvent)
     }
 
-    @MainActor
-    func test_annualButtonTapped() async {
+
+    /// Test that annual button tapped triggers the right event
+    @MainActor func test_annualButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -78,8 +84,9 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(monthlyButtonTappedEvent)
     }
 
-    @MainActor
-    func test_purchaseMonthlySubscriptionSuccess() async {
+
+    /// Test that purchase monthly subscription succeeds
+    @MainActor func test_purchaseMonthlySubscriptionSuccess() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -91,8 +98,8 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(purchaseSuccessEvent)
     }
 
-    @MainActor
-    func test_purchaseAnnualSubscriptionSuccess() async {
+    /// Test that purchase annual subscription succeeds
+    @MainActor func test_purchaseAnnualSubscriptionSuccess() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -104,8 +111,7 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(purchaseSuccessEvent)
     }
 
-    @MainActor
-    func configureFreeUser() {
+    @MainActor func configureFreeUser() {
         server.routes.post("/graphql") { request, _ in
             let apiRequest = ClientAPIRequest(request)
             if apiRequest.isForSavesContent {
@@ -115,8 +121,7 @@ class PremiumTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func loadPremiumUpgradeView() async {
+    @MainActor func loadPremiumUpgradeView() async {
         app.tabBar.settingsButton.wait().tap()
         XCTAssertTrue(app.settingsView.exists)
 

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -38,6 +38,7 @@ class PremiumTests: XCTestCase {
         configureFreeUser()
         app.launch()
         await loadPremiumUpgradeViewFromSettings()
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     @MainActor func test_tapSearchPremiumUpsellShowsUpgradeView() async {
@@ -58,6 +59,7 @@ class PremiumTests: XCTestCase {
         let dismissPremiumEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.dismiss")
         XCTAssertNotNil(dismissPremiumEvent)
         XCTAssertFalse(app.premiumUpgradeView.exists)
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     /// Test that monthly button tapped triggers the right event
@@ -71,6 +73,7 @@ class PremiumTests: XCTestCase {
         // Then
         let monthlyButtonTappedEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.monthly")
         XCTAssertNotNil(monthlyButtonTappedEvent)
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     /// Test that annual button tapped triggers the right event
@@ -84,6 +87,7 @@ class PremiumTests: XCTestCase {
         // Then
         let monthlyButtonTappedEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.annual")
         XCTAssertNotNil(monthlyButtonTappedEvent)
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     /// Test that purchase monthly subscription succeeds
@@ -99,6 +103,7 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(purchaseSuccessEvent)
 
         purchaseSuccessEvent!.getUIContext()!.assertHas(type: "dialog")
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     /// Test that purchase annual subscription succeeds
@@ -114,6 +119,7 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(purchaseSuccessEvent)
 
         purchaseSuccessEvent!.getUIContext()!.assertHas(type: "dialog")
+        await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
     /// Set user to free

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sails
+
+class PremiumTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+    //var snowplowMicro = SnowplowMicro()
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+
+        app = PocketAppElement(app: XCUIApplication())
+        server = Application()
+
+        //await snowplowMicro.resetSnowplowEvents()
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    @MainActor
+    func test_tappingGoPremiumShowsUpgradeView_freeUser() async {
+        server.routes.post("/graphql") { request, _ in
+            let apiRequest = ClientAPIRequest(request)
+            if apiRequest.isForSavesContent {
+                return Response.freeUserSaves()
+            }
+            return Response.fallbackResponses(apiRequest: apiRequest)
+        }
+
+        app.launch()
+        await loadPremiumUpgradeView()
+    }
+
+    @MainActor
+    func loadPremiumUpgradeView() async {
+        app.tabBar.settingsButton.wait().tap()
+        XCTAssertTrue(app.settingsView.exists)
+
+        //let settingsViewEvent = await snowplowMicro.getFirstEvent(with: "global-nav.settings")
+        //XCTAssertNotNil(settingsViewEvent)
+
+        tap_GoPremium()
+
+        XCTAssertTrue(app.premiumUpgradeView.exists)
+    }
+
+    func tap_GoPremium() {
+        app.settingsView.goPremiumButton.tap()
+    }
+}

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -33,21 +33,25 @@ class PremiumTests: XCTestCase {
         app.terminate()
     }
 
-
     /// Test that tapping "Go Premium" in Settings presents the Premium Upgrade view
-    @MainActor func test_tapGoPremiumShowsUpgradeView() async {
+    @MainActor func test_tapSettingsUpsellShowsUpgradeView() async {
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
     }
 
+    @MainActor func test_tapSearchPremiumUpsellShowsUpgradeView() async {
+        configureFreeUser()
+        app.launch()
+        await loadPremiumUpgradeViewFromSearch()
+    }
 
     /// Test that Premium Upgrade view dismisses when tapping the dismiss button
     @MainActor func test_tapDismissDismissPremiumView() async {
         // Given
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
         // When
         app.premiumUpgradeView.dismissPremiumButton.wait().tap()
         // Then
@@ -56,13 +60,12 @@ class PremiumTests: XCTestCase {
         XCTAssertFalse(app.premiumUpgradeView.exists)
     }
 
-
     /// Test that monthly button tapped triggers the right event
     @MainActor func test_monthlyButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
         // When
         app.premiumUpgradeView.premiumUpgradeMonthlyButton.wait().tap()
         // Then
@@ -70,13 +73,12 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(monthlyButtonTappedEvent)
     }
 
-
     /// Test that annual button tapped triggers the right event
     @MainActor func test_annualButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
         // When
         app.premiumUpgradeView.premiumUpgradeAnnualButton.wait().tap()
         // Then
@@ -84,18 +86,19 @@ class PremiumTests: XCTestCase {
         XCTAssertNotNil(monthlyButtonTappedEvent)
     }
 
-
     /// Test that purchase monthly subscription succeeds
     @MainActor func test_purchaseMonthlySubscriptionSuccess() async {
         // Given
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
         // When
         try! storeSession.buyProduct(productIdentifier: "monthly.subscription.pocket")
         // Then
         let purchaseSuccessEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.purchase.success")
         XCTAssertNotNil(purchaseSuccessEvent)
+
+        purchaseSuccessEvent!.getUIContext()!.assertHas(type: "dialog")
     }
 
     /// Test that purchase annual subscription succeeds
@@ -103,12 +106,14 @@ class PremiumTests: XCTestCase {
         // Given
         configureFreeUser()
         app.launch()
-        await loadPremiumUpgradeView()
+        await loadPremiumUpgradeViewFromSettings()
         // When
         try! storeSession.buyProduct(productIdentifier: "annual.subscription.pocket")
         // Then
         let purchaseSuccessEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.purchase.success")
         XCTAssertNotNil(purchaseSuccessEvent)
+
+        purchaseSuccessEvent!.getUIContext()!.assertHas(type: "dialog")
     }
 
     @MainActor func configureFreeUser() {
@@ -121,21 +126,48 @@ class PremiumTests: XCTestCase {
         }
     }
 
-    @MainActor func loadPremiumUpgradeView() async {
+    @MainActor private func loadPremiumUpgradeViewFromSettings() async {
         app.tabBar.settingsButton.wait().tap()
         XCTAssertTrue(app.settingsView.exists)
 
         let settingsViewEvent = await snowplowMicro.getFirstEvent(with: "global-nav.settings")
         XCTAssertNotNil(settingsViewEvent)
 
-        tapGoPremium()
+        let goPremiumButtonImpression = await snowplowMicro.getFirstEvent(with: "account.premium.upsell")
+        XCTAssertNotNil(goPremiumButtonImpression)
+
+        goPremiumButtonImpression!.getUIContext()!.assertHas(type: "button")
+
+        tapSettingsPremiumUpsell()
         XCTAssertTrue(app.premiumUpgradeView.exists)
 
         let premiumViewShownEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium")
         XCTAssertNotNil(premiumViewShownEvent)
     }
 
-    func tapGoPremium() {
+    private func tapSettingsPremiumUpsell() {
         app.settingsView.goPremiumButton.tap()
+    }
+
+    @MainActor private func loadPremiumUpgradeViewFromSearch() async {
+        app.tabBar.savesButton.wait().tap()
+        app.saves.filterButton(for: "Search").wait().tap()
+        app.navigationBar.buttons["All items"].wait().tap()
+        XCTAssertTrue(app.searchGetPremiumEmptyView.exists)
+
+        let goPremiumButtonImpression = await snowplowMicro.getFirstEvent(with: "global-nav.search.premium.upsell")
+        XCTAssertNotNil(goPremiumButtonImpression)
+
+        goPremiumButtonImpression!.getUIContext()!.assertHas(type: "button")
+
+        tapSearchPremiumUpsell()
+        XCTAssertTrue(app.premiumUpgradeView.exists)
+
+        let searchUpsellEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.premium.upsell")
+        XCTAssertNotNil(searchUpsellEvent)
+    }
+
+    private func tapSearchPremiumUpsell() {
+        app.searchGetPremiumEmptyView.getPocketPremiumButton.tap()
     }
 }

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -9,13 +9,14 @@ import StoreKitTest
 class PremiumTests: XCTestCase {
     var server: Application!
     var app: PocketAppElement!
+    var storeSession: SKTestSession!
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
         continueAfterFailure = false
-        let session = try SKTestSession(configurationFileNamed: "Test_Subscriptions")
-        session.disableDialogs = true
-        session.clearTransactions()
+        storeSession = try! SKTestSession(configurationFileNamed: "Test_Subscriptions")
+        storeSession.disableDialogs = true
+        storeSession.clearTransactions()
         app = PocketAppElement(app: XCUIApplication())
         server = Application()
 
@@ -25,6 +26,8 @@ class PremiumTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try server.stop()
+        storeSession.clearTransactions()
+        storeSession = nil
         app.terminate()
     }
 
@@ -94,14 +97,14 @@ class PremiumTests: XCTestCase {
         let settingsViewEvent = await snowplowMicro.getFirstEvent(with: "global-nav.settings")
         XCTAssertNotNil(settingsViewEvent)
 
-        tap_GoPremium()
+        tapGoPremium()
         XCTAssertTrue(app.premiumUpgradeView.exists)
 
         let premiumViewShownEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium")
         XCTAssertNotNil(premiumViewShownEvent)
     }
 
-    func tap_GoPremium() {
+    func tapGoPremium() {
         app.settingsView.goPremiumButton.tap()
     }
 }

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -79,6 +79,32 @@ class PremiumTests: XCTestCase {
     }
 
     @MainActor
+    func test_purchaseMonthlySubscriptionSuccess() async {
+        // Given
+        configureFreeUser()
+        app.launch()
+        await loadPremiumUpgradeView()
+        // When
+        try! storeSession.buyProduct(productIdentifier: "monthly.subscription.pocket")
+        // Then
+        let purchaseSuccessEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.purchase.success")
+        XCTAssertNotNil(purchaseSuccessEvent)
+    }
+
+    @MainActor
+    func test_purchaseAnnualSubscriptionSuccess() async {
+        // Given
+        configureFreeUser()
+        app.launch()
+        await loadPremiumUpgradeView()
+        // When
+        try! storeSession.buyProduct(productIdentifier: "annual.subscription.pocket")
+        // Then
+        let purchaseSuccessEvent = await snowplowMicro.getFirstEvent(with: "global-nav.premium.purchase.success")
+        XCTAssertNotNil(purchaseSuccessEvent)
+    }
+
+    @MainActor
     func configureFreeUser() {
         server.routes.post("/graphql") { request, _ in
             let apiRequest = ClientAPIRequest(request)

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -40,6 +40,10 @@ struct PocketAppElement {
         return SettingsViewElement(app.collectionViews["settings"])
     }
 
+    var premiumUpgradeView: PremiumUpgradeViewElement {
+        PremiumUpgradeViewElement(app.otherElements["premium-upgrade-view"])
+    }
+
     var accountManagementView: AccountManagementViewElement {
         return AccountManagementViewElement(app.collectionViews["account-management"])
     }

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -44,6 +44,10 @@ struct PocketAppElement {
         PremiumUpgradeViewElement(app.otherElements["premium-upgrade-view"])
     }
 
+    var searchGetPremiumEmptyView: SearchGetPremiumEmptyViewElement {
+        SearchGetPremiumEmptyViewElement(app.otherElements["get-premium-empty-state"])
+    }
+
     var accountManagementView: AccountManagementViewElement {
         return AccountManagementViewElement(app.collectionViews["account-management"])
     }

--- a/Tests iOS/Support/Elements/PremiumUpgradeViewElement.swift
+++ b/Tests iOS/Support/Elements/PremiumUpgradeViewElement.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+struct PremiumUpgradeViewElement: PocketUIElement {
+    var element: XCUIElement
+
+    init(_ element: XCUIElement) {
+        self.element = element
+    }
+
+    var premiumUpgradeMonthlyButton: XCUIElement {
+        element.buttons["premium-upgrade-view-monthly-button"]
+    }
+
+    var premiumUpgradeAnnualButton: XCUIElement {
+        element.buttons["premium-upgrade-view-annual-button"]
+    }
+
+    var dismissPremiumButton: XCUIElement {
+        element.buttons["premium-upgrade-view-dismiss-button"]
+    }
+}

--- a/Tests iOS/Support/Elements/SearchGetPremiumEmptyViewElement.swift
+++ b/Tests iOS/Support/Elements/SearchGetPremiumEmptyViewElement.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+struct SearchGetPremiumEmptyViewElement: PocketUIElement {
+    var element: XCUIElement
+
+    init(_ element: XCUIElement) {
+        self.element = element
+    }
+
+    var getPocketPremiumButton: XCUIElement {
+        element.buttons["get-pocket-premium-button"]
+    }
+}

--- a/Tests iOS/Support/Elements/SettingsViewElement.swift
+++ b/Tests iOS/Support/Elements/SettingsViewElement.swift
@@ -18,4 +18,12 @@ struct SettingsViewElement: PocketUIElement {
     var accountManagementButton: XCUIElement {
         element.buttons["account-management-button"]
     }
+
+    var goPremiumButton: XCUIElement {
+        element.buttons["go-premium-button"]
+    }
+
+    var premiumSubscriptionButton: XCUIElement {
+        element.buttons["premium-subscription-button"]
+    }
 }

--- a/UITests-3.xctestplan
+++ b/UITests-3.xctestplan
@@ -78,7 +78,8 @@
         "EmptyStateTests",
         "FavoriteAnItemTests",
         "HomeTests",
-        "HomeWebViewTests"
+        "HomeWebViewTests",
+        "PremiumTests"
       ],
       "target" : {
         "containerPath" : "container:Pocket.xcodeproj",

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -70,6 +70,7 @@
       "skippedTests" : [
         "HomeTests",
         "HomeWebViewTests",
+        "PremiumTests",
         "PullToRefreshTests",
         "ReaderTests",
         "ReportARecommendationTests",


### PR DESCRIPTION
## Summary
* This PR adds UI tests for Premium Upgrade
> **Note**
There are no failing tests at this moment because setting `failTransactionsEnabled` in `SKTestSession` did not seem to produce the effect of a failed transaction in the store, more investigation to come.

## Implementation Details
* Add accessibility identifiers to `PremiumUpgradeView` and subviews
* Add `PremiumTests` to UI test suite

## Test Steps
* Checkout this branch
* Run snowplow micro locally
* Run the UI tests and make sure they succeed

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
NA