### PR TITLE
Premium - Restore Subscription Manually

### DIFF
--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -52,9 +52,12 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                         userDefaults: Services.shared.userDefaults,
                         userManagementService: Services.shared.userManagementService,
                         notificationCenter: .default
-                    ) { tracker, source in
-                        PremiumUpgradeViewModel(store: Services.shared.subscriptionStore, tracker: tracker, source: source)
+                    ) {
+                        try await Services.shared.subscriptionStore.restoreSubscription()
                     }
+                    premiumUpgradeViewModelFactory: { tracker, source in
+                            PremiumUpgradeViewModel(store: Services.shared.subscriptionStore, tracker: tracker, source: source)
+                        }
                 ),
                 source: Services.shared.source,
                 tracker: Services.shared.tracker

--- a/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketSceneDelegate.swift
@@ -51,13 +51,14 @@ public class PocketSceneDelegate: UIResponder, UIWindowSceneDelegate {
                         tracker: Services.shared.tracker,
                         userDefaults: Services.shared.userDefaults,
                         userManagementService: Services.shared.userManagementService,
-                        notificationCenter: .default
-                    ) {
-                        try await Services.shared.subscriptionStore.restoreSubscription()
-                    }
-                    premiumUpgradeViewModelFactory: { tracker, source in
+                        notificationCenter: .default,
+                        restoreSubscription: {
+                            try await Services.shared.subscriptionStore.restoreSubscription()
+                        },
+                        premiumUpgradeViewModelFactory: { tracker, source in
                             PremiumUpgradeViewModel(store: Services.shared.subscriptionStore, tracker: tracker, source: source)
                         }
+                    )
                 ),
                 source: Services.shared.source,
                 tracker: Services.shared.tracker

--- a/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift
@@ -58,6 +58,8 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     /// Manually restore a purchase in those (rare?) cases when the automatic sync fails
     func restoreSubscription() async throws {
         try await AppStore.sync()
+        // TODO: double check if we still need the following call when dealing with the real App Store
+        await updateSubscription()
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/PocketKit/Resources/en.lproj/Localizable.strings
@@ -162,6 +162,11 @@
 //Loading screen showing that the account deletion is in progress
 "settings.accountManagement.deleteAccount.deleting" = "Deleting your account";
 "settings.accountManagement.deleteAccount.error.body" = "We’re experiencing an error and can't delete your account. Please try again later.";
+"settings.accountManagement.restoreSubscription" = "Restore Existing Subscription";
+"settings.accountManagement.restoreSubscription.restoreSuccessful.title" = "Restore successful";
+"settings.accountManagement.restoreSubscription.restoreSuccessful.message" = "Your Pocket Premium subscription has been restored.";
+"settings.accountManagement.restoreSubscription.restoreNotSuccessful.title" = "Restore not successful";
+"settings.accountManagement.restoreSubscription.restoreNotSuccessful.message" = "We were unable to find a subscription. If you believe you have one, please send an email to support@getpocket.com and let us know.";
 
 //Shown to the user after they deleted their account
 "login.deletedAccount.banner.title" = "You’ve deleted your Pocket account";

--- a/PocketKit/Sources/PocketKit/Strings.swift
+++ b/PocketKit/Sources/PocketKit/Strings.swift
@@ -306,6 +306,8 @@ internal enum L10n {
       internal static let deleteAccount = L10n.tr("Localizable", "settings.accountManagement.deleteAccount", fallback: "Delete Account")
       /// Delete your account
       internal static let deleteYourAccount = L10n.tr("Localizable", "settings.accountManagement.deleteYourAccount", fallback: "Delete your account")
+      /// Restore Existing Subscription
+      internal static let restoreSubscription = L10n.tr("Localizable", "settings.accountManagement.restoreSubscription", fallback: "Restore Existing Subscription")
       internal enum DeleteAccount {
         /// Deleting your account
         internal static let deleting = L10n.tr("Localizable", "settings.accountManagement.deleteAccount.deleting", fallback: "Deleting your account")
@@ -320,6 +322,20 @@ internal enum L10n {
         internal enum Error {
           /// We’re experiencing an error and can't delete your account. Please try again later.
           internal static let body = L10n.tr("Localizable", "settings.accountManagement.deleteAccount.error.body", fallback: "We’re experiencing an error and can't delete your account. Please try again later.")
+        }
+      }
+      internal enum RestoreSubscription {
+        internal enum RestoreNotSuccessful {
+          /// We were unable to find a subscription. If you believe you have one, please send an email to support@getpocket.com and let us know.
+          internal static let message = L10n.tr("Localizable", "settings.accountManagement.restoreSubscription.restoreNotSuccessful.message", fallback: "We were unable to find a subscription. If you believe you have one, please send an email to support@getpocket.com and let us know.")
+          /// Restore not successful
+          internal static let title = L10n.tr("Localizable", "settings.accountManagement.restoreSubscription.restoreNotSuccessful.title", fallback: "Restore not successful")
+        }
+        internal enum RestoreSuccessful {
+          /// Your Pocket Premium subscription has been restored.
+          internal static let message = L10n.tr("Localizable", "settings.accountManagement.restoreSubscription.restoreSuccessful.message", fallback: "Your Pocket Premium subscription has been restored.")
+          /// Restore successful
+          internal static let title = L10n.tr("Localizable", "settings.accountManagement.restoreSubscription.restoreSuccessful.title", fallback: "Restore successful")
         }
       }
     }


### PR DESCRIPTION
## Summary
* This PR adds the option to manually restore a subscription in those "rare" (according to Apple) cases where the automatic restore won't work

## Implementation Details
* Update `PocketSubscriptionStore`, add explicit entitlements resync after `Appstore.sync()`
* Update `AccountViewModel`, add logic to request a restore and handle its result
* Update `AccountManagementView`, add "Restore Existing Subscription" button and alerts for success and failure

## Test
### Pre-requisite 
- checkout this branch and configure your environment to use the `StoreKit` configuration file, as described in #421 

### Testing steps
#### Successful purchase
* Build/run and login with a free account
* Tap Settings > Go Premium, then purchase a subscription
* Stop the execution
* Comment out [this line](https://github.com/Pocket/pocket-ios/blob/b20497956cf16a4d7ede122a5adc0229c4581bd6/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift#L38) of code, and below add `user.setPremiumStatus(false)`. This will simulate a subscription not retrieved (see example below)
```
           // Restore a purchased subscription, if any
            //await self.updateSubscription()
            user.setPremiumStatus(false)
```
* Run again, then tap Settings
* Note how the first row is now "Go Premium" again
* Tap Account Management > Restore Existing Subscription
* This will show an alert that simulates entering credentials to login to the App Store (see animations)
> **Warning** this only happens in a simulated environment. In a real scenario, you would be prompted to log in to the App Store. to see this, disable the `StoreKit` configuration file and attempt to restore

- Tap "OK", and make sure that the "Restore Successful" alert appears
- Go back to Settings and make sure that the first row is now "Premium Subscription" instead of "Go Premium"

#### Unsuccessful purchase
- stop the execution, comment out the code inside [this](https://github.com/Pocket/pocket-ios/blob/b20497956cf16a4d7ede122a5adc0229c4581bd6/PocketKit/Sources/PocketKit/Premium/Model/PocketSubscriptionStore.swift#L60) method and throw an error inside the same method (see example below) this will simulate an unsuccessful restore

```
    /// Manually restore a purchase in those (rare?) cases when the automatic sync fails
    func restoreSubscription() async throws {
        throw SubscriptionStoreError.purchaseFailed
        //try await AppStore.sync()
        // TODO: double check if we still need the following call when dealing with the real App Store
        //await updateSubscription()
    }
```
- Run again, then tap Settings > Account Management > Restore Existing subscription
- Make sure the unsuccessful alert appears
- Go back to Settings and make sure the "Go Premium" row is still showing

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Animations

iPad Light Successful | iPhone Dark Unsuccessful
-- | --
<img width=400 src=https://user-images.githubusercontent.com/34376330/223883832-237c618d-5ab3-4d5b-b109-2ec22c0b2bc4.gif> | <img width=250 src=https://user-images.githubusercontent.com/34376330/223883877-dfe92324-3a44-4ea7-9e88-fc20839d5580.gif>

