### PR TITLE
fix(search): refactor search pagination

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -306,27 +306,20 @@ public extension Events.Search {
     /**
      Fired when a user scrolls down the search list and triggers another results page call
      */
-    static func nextSearchResultsPage(
-        url: URL,
-        positionInList: Int,
+    static func searchResultsPage(
+        numberOfItems: Int,
         scope: SearchScope
     ) -> Event {
         return Engagement(
             .general,
             uiEntity: UiEntity(
-                .button,
-                identifier: "global-nav.search.nextResultsPage",
+                .page,
+                identifier: "global-nav.search.searchPage",
                 componentDetail: getScopeIdentifier(scope: scope),
-                index: positionInList
-            ),
-            extraEntities: [
-                ContentEntity(
-                    url: url
-                )
-            ]
+                index: numberOfItems
+            )
         )
     }
-
 
     /// Premium upsell in Search visible
     static func premiumUpsellViewed() -> Event {

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -303,6 +303,31 @@ public extension Events.Search {
         )
     }
 
+    /**
+     Fired when a user scrolls down the search list and triggers another results page call
+     */
+    static func nextSearchResultsPage(
+        url: URL,
+        positionInList: Int,
+        scope: SearchScope
+    ) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.search.nextResultsPage",
+                componentDetail: getScopeIdentifier(scope: scope),
+                index: positionInList
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: url
+                )
+            ]
+        )
+    }
+
+
     /// Premium upsell in Search visible
     static func premiumUpsellViewed() -> Event {
         return Impression(

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -304,10 +304,10 @@ public extension Events.Search {
     }
 
     /**
-     Fired when a user scrolls down the search list and triggers another results page call
+     Fired when a user triggers a results page call in `Search`
      */
     static func searchResultsPage(
-        numberOfItems: Int,
+        pageNumber: Int,
         scope: SearchScope
     ) -> Event {
         return Engagement(
@@ -316,7 +316,7 @@ public extension Events.Search {
                 .page,
                 identifier: "global-nav.search.searchPage",
                 componentDetail: getScopeIdentifier(scope: scope),
-                index: numberOfItems
+                index: pageNumber
             )
         )
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -53,4 +53,8 @@ struct PocketItem {
     var url: URL? {
         item.bestURL
     }
+
+    var cursor: String? {
+        item.cursor
+    }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/ItemsListItem.swift
@@ -15,6 +15,7 @@ protocol ItemsListItem {
     var host: String? { get }
     var tagNames: [String]? { get }
     var remoteItemParts: SavedItemParts? { get }
+    var cursor: String? { get }
 }
 
 extension ItemsListItem {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -33,6 +33,10 @@ extension SavedItem: ItemsListItem {
     var tagNames: [String]? {
         tags?.compactMap { $0 as? Tag }.compactMap { $0.name }
     }
+
+    var cursor: String? {
+        item?.savedItem?.cursor
+    }
 }
 
 extension DomainMetadata: ItemsListItemDomainMetadata {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/OnlineSearch.swift
@@ -13,7 +13,7 @@ class OnlineSearch {
     private var cache: [String: [PocketItem]] = [:]
     private let scope: SearchScope
 
-    var numberOfItemsPerPage: Int = 0
+    var pageNumberLoaded: Int = 0
 
     @Published
     var results: Result<[PocketItem], Error>?
@@ -38,7 +38,7 @@ class OnlineSearch {
         searchService.results.dropFirst().sink { [weak self] items in
             guard let self, let items else { return }
             let searchItems = items.compactMap { PocketItem(item: $0) }
-            self.numberOfItemsPerPage = searchItems.count
+            self.pageNumberLoaded += 1
             guard let currentItems = self.cache[term] else {
                 self.cache[term] = searchItems
                 self.results = .success(searchItems)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -33,6 +33,10 @@ struct SearchView: View {
 
 // MARK: - Search Results Component
 struct ResultsView: View {
+    enum Constants {
+        static let indexToTriggerNextPage = 15
+    }
+
     @ObservedObject
     var viewModel: SearchViewModel
 
@@ -55,7 +59,8 @@ struct ResultsView: View {
                         viewModel.select(item, index: index)
                     }
                 }.onAppear {
-                    if index == results.count - 10 {
+                    let triggerNextPage = index == results.count - Constants.indexToTriggerNextPage
+                    if triggerNextPage {
                         viewModel.loadMoreSearchResults(with: item, at: index)
                     }
                     viewModel.trackViewResults(url: item.url, index: index)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -55,6 +55,9 @@ struct ResultsView: View {
                         viewModel.select(item, index: index)
                     }
                 }.onAppear {
+                    if index == results.count - 10 {
+                        viewModel.loadMoreSearchResults(with: item, at: index)
+                    }
                     viewModel.trackViewResults(url: item.url, index: index)
                 }
             }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -270,7 +270,7 @@ class SearchViewModel: ObservableObject {
                 guard let self, let result, self.selectedScope == .saves else { return }
                 if case .success(let items) = result {
                     self.searchState = items.isEmpty ? .emptyState(self.searchResultState()) : .searchResults(items)
-                    self.trackSearchResultsPage(numberOfItems: self.savesOnlineSearch.numberOfItemsPerPage, scope: .saves)
+                    self.trackSearchResultsPage(pageNumber: self.savesOnlineSearch.pageNumberLoaded, scope: .saves)
                 } else {
                     let results = self.savesLocalSearch.search(with: term)
                     self.searchState = .searchResults(results)
@@ -295,7 +295,7 @@ class SearchViewModel: ObservableObject {
                 guard let self, let result, self.selectedScope == scope else { return }
                 if case .success(let items) = result {
                     self.searchState = items.isEmpty ? .emptyState(self.searchResultState()) : .searchResults(items)
-                    self.trackSearchResultsPage(numberOfItems: onlineSearch.numberOfItemsPerPage, scope: scope)
+                    self.trackSearchResultsPage(pageNumber: onlineSearch.pageNumberLoaded, scope: scope)
                 } else if case .failure(let error) = result {
                     guard case SearchServiceError.noInternet = error else {
                         self.searchState = .emptyState(ErrorEmptyState())
@@ -469,12 +469,12 @@ extension SearchViewModel {
         tracker.track(event: Events.Search.searchCardContentOpen(url: url, positionInList: index, scope: selectedScope))
     }
 
-    /// Track when user scrolls down the search list and triggers another search call for the next page
+    /// Track when user triggers a search page call
     /// - Parameters:
-    ///   - url: url associated with the item
-    ///   - index: position index of item in the list
-    func trackSearchResultsPage(numberOfItems: Int, scope: SearchScope) {
-        tracker.track(event: Events.Search.searchResultsPage(numberOfItems: numberOfItems, scope: scope))
+    ///   - pageNumber: page number of search results that was loaded
+    ///   - scope: scope that the page was loaded in
+    func trackSearchResultsPage(pageNumber: Int, scope: SearchScope) {
+        tracker.track(event: Events.Search.searchResultsPage(pageNumber: pageNumber, scope: scope))
     }
 
     /// track premium upgrade view dismissed

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -165,8 +165,6 @@ class SearchViewModelTests: XCTestCase {
 
     func test_updateScope_forFreeUser_withArchiveAndTerm_showsResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
-
         let viewModel = await subject(user: MockUser(status: .free))
 
         let searchExpectation = expectation(description: "search Expectation")
@@ -182,6 +180,8 @@ class SearchViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.updateScope(with: .archive, searchTerm: term)
+
+        await setupOnlineSearch(with: term)
 
         wait(for: [searchExpectation], timeout: 1)
     }
@@ -202,7 +202,6 @@ class SearchViewModelTests: XCTestCase {
 
     func test_updateScope_forPremiumUser_withSavesAndTerm_showsResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
 
         let viewModel = await subject(user: MockUser(status: .premium))
 
@@ -220,12 +219,13 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .saves, searchTerm: term)
 
+        await setupOnlineSearch(with: term)
+
         wait(for: [searchExpectation], timeout: 1)
     }
 
     func test_updateScope_forPremiumUser_withArchiveAndTerm_showsResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
 
         let viewModel = await subject(user: MockUser(status: .premium))
         let searchExpectation = expectation(description: "search Expectation")
@@ -242,12 +242,13 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .archive, searchTerm: term)
 
+        await setupOnlineSearch(with: term)
+
         wait(for: [searchExpectation], timeout: 1)
     }
 
     func test_updateScope_forPremiumUser_withAllAndTerm_showsResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
 
         let viewModel = await subject(user: MockUser(status: .premium))
         let searchExpectation = expectation(description: "search Expectation")
@@ -263,6 +264,8 @@ class SearchViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.updateScope(with: .all, searchTerm: term)
+
+        await setupOnlineSearch(with: term)
 
         wait(for: [searchExpectation], timeout: 1)
     }
@@ -313,14 +316,10 @@ class SearchViewModelTests: XCTestCase {
     }
 
     func test_updateSearchResults_forPremiumUser_withNoItems_showsNoResultsEmptyState() async {
-        searchService.stubSearch { _, _ in }
-        searchService._results = []
-
         let viewModel = await subject(user: MockUser(status: .premium))
-        viewModel.updateSearchResults(with: "search-term")
         let searchExpectation = expectation(description: "search Expectation")
-        viewModel.$searchState.receive(on: DispatchQueue.main).sink { state in
-            guard case .emptyState(let emptyStateViewModel) = viewModel.searchState else {
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
+            guard case .emptyState(let emptyStateViewModel) = state else {
                 XCTFail("Should not have failed")
                 return
             }
@@ -330,12 +329,16 @@ class SearchViewModelTests: XCTestCase {
             searchExpectation.fulfill()
         }.store(in: &subscriptions)
 
+        viewModel.updateSearchResults(with: "search-term")
+
+        searchService.stubSearch { _, _ in }
+        searchService._results = []
+
         wait(for: [searchExpectation], timeout: 1)
     }
 
     func test_updateSearchResults_forPremiumUser_withItems_showsResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
 
         let viewModel = await subject(user: MockUser(status: .premium))
 
@@ -352,6 +355,8 @@ class SearchViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.updateSearchResults(with: term)
+
+        await setupOnlineSearch(with: term)
 
         wait(for: [searchExpectation], timeout: 1)
     }
@@ -533,7 +538,6 @@ class SearchViewModelTests: XCTestCase {
     // MARK: - Clear
     func test_clear_resetsSearchResults() async {
         let term = "search-term"
-        await setupOnlineSearch(with: term)
 
         let viewModel = await subject(user: MockUser(status: .premium))
 
@@ -564,6 +568,8 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateSearchResults(with: term)
 
+        await setupOnlineSearch(with: term)
+
         wait(for: [searchResultsExpectation], timeout: 1)
 
         viewModel.clear()
@@ -572,8 +578,6 @@ class SearchViewModelTests: XCTestCase {
     }
 
     func test_search_whenDeviceRegainsInternetConnection_submitsSearch() async {
-        await setupOnlineSearch(with: "search-term")
-
         let user = MockUser()
         let viewModel = await subject(user: user)
         networkPathMonitor.update(status: .unsatisfied)
@@ -603,7 +607,11 @@ class SearchViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.updateScope(with: .archive, searchTerm: "search-term")
+
         networkPathMonitor.update(status: .satisfied)
+
+        await setupOnlineSearch(with: "search-term")
+
         wait(for: [offlineExpectation, onlineExpectation], timeout: 1, enforceOrder: true)
     }
 
@@ -615,7 +623,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = await subject(user: MockUser(status: .premium))
         let localSavesExpectation = expectation(description: "handle local saves scenario")
 
-        viewModel.$searchState.dropFirst(3).receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -640,7 +648,7 @@ class SearchViewModelTests: XCTestCase {
         let viewModel = await subject(user: MockUser(status: .premium))
         let errorExpectation = expectation(description: "handle apollo internet connection error")
 
-        viewModel.$searchState.dropFirst(3).receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
             guard case .emptyState(let emptyStateViewModel) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -666,12 +674,11 @@ class SearchViewModelTests: XCTestCase {
         let item = space.buildSavedItem()
         let pocketItem = PocketItem(item: item)
         let term = "search-term"
-        await setupOnlineSearch(with: term)
+
         let viewModel = await subject(user: MockUser(status: .free))
-        viewModel.updateScope(with: .archive, searchTerm: "search-term")
 
         let searchExpectation = expectation(description: "search Expectation")
-        viewModel.$searchState.dropFirst(2).receive(on: DispatchQueue.main).sink { state in
+        viewModel.$searchState.dropFirst(3).receive(on: DispatchQueue.main).sink { state in
             guard case .searchResults(let results) = state else {
                 XCTFail("Should not have failed")
                 return
@@ -681,7 +688,11 @@ class SearchViewModelTests: XCTestCase {
             searchExpectation.fulfill()
         }.store(in: &subscriptions)
 
+        viewModel.updateScope(with: .archive, searchTerm: "search-term")
+        await setupOnlineSearch(with: term)
+
         viewModel.loadMoreSearchResults(with: pocketItem, at: 0)
+        await setupOnlineSearch(with: term)
 
         wait(for: [searchExpectation], timeout: 1)
     }

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -14,6 +14,7 @@ struct MockItemsListItem: ItemsListItem {
     let isPending: Bool
     let host: String?
     let tagNames: [String]?
+    let cursor: String?
 
     static func build(
         id: String? = nil,
@@ -27,7 +28,8 @@ struct MockItemsListItem: ItemsListItem {
         timeToRead: Int? = nil,
         isPending: Bool = false,
         host: String? = nil,
-        tagNames: [String]? = nil
+        tagNames: [String]? = nil,
+        cursor: String? = nil
     ) -> MockItemsListItem {
         MockItemsListItem(
             id: id,
@@ -41,7 +43,8 @@ struct MockItemsListItem: ItemsListItem {
             timeToRead: timeToRead,
             isPending: isPending,
             host: host,
-            tagNames: tagNames
+            tagNames: tagNames,
+            cursor: cursor
         )
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -8,6 +8,9 @@ class MockSearchService: SearchService {
     var _results: [SearchSavedItem]? = []
     var results: Published<[SearchSavedItem]?>.Publisher { $_results }
 
+    public var hasFinishedResults: Bool = false
+    public var lastEndCursor: String = ""
+
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -28,7 +28,7 @@ extension MockSearchService {
         implementations[Self.search] = impl
     }
 
-    func search(for term: String, scope: SharedPocketKit.SearchScope) throws {
+    func search(for term: String, scope: SharedPocketKit.SearchScope) async throws {
         guard let impl = implementations[Self.search] as? SearchImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }

--- a/Tests iOS/Fixtures/search-list-page-1.json
+++ b/Tests iOS/Fixtures/search-list-page-1.json
@@ -424,16 +424,1696 @@
                                 }
                             }
                         }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-7",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-7",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-7",
+                                    "title": "Item 7",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-7/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-7/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-7/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-8",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-8",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-8",
+                                    "title": "Item 8",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-8/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-8/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-8/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-9",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-9",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-9",
+                                    "title": "Item 9",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-9/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-9/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-9/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-10",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-10",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-10",
+                                    "title": "Item 10",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-10/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-10/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-10/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-11",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-11",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-11",
+                                    "title": "Item 11",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-11/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-11/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-11/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-12",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-12",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-12",
+                                    "title": "Item 12",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-12/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-12/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-12/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-13",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-13",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-13",
+                                    "title": "Item 13",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-13/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-13/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-13/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-14",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-14",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-14",
+                                    "title": "Item 14",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-4/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-14/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-14/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-15",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-15",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-15",
+                                    "title": "Item 15",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-5/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-15/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-15/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-16",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-16",
+                                    "title": "Item 16",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-16/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-16/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-16/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-17",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-17",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-17",
+                                    "title": "Item 17",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-17/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-17/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-17/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-18",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-18",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-18",
+                                    "title": "Item 18",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-18/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-18/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-18/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-19",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-19",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-19",
+                                    "title": "Item 19",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-19/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-19/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-19/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-20",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-20",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-20",
+                                    "title": "Item 20",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-20/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-20/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-20/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-21",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-21",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-21",
+                                    "title": "Item 21",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-21/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-21/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-21/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-22",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-22",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-22",
+                                    "title": "Item 22",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-22/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-22/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-22/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-23",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-23",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-23",
+                                    "title": "Item 23",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-23/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-23/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-23/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-24",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-24",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-24",
+                                    "title": "Item 24",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-24/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-24/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-24/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-25",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-25",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-25",
+                                    "title": "Item 25",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-25/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-25/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-25/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-26",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-26",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-26",
+                                    "title": "Item 26",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-26/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-26/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-26/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-27",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-27",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-27",
+                                    "title": "Item 27",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-27/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-27/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-27/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-28",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-28",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-28",
+                                    "title": "Item 28",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-28/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-28/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-28/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-29",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-29",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-29",
+                                    "title": "Item 29",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-29/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-29/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-29/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-30",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-30",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-30",
+                                    "title": "Item 30",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-30/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-30/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-30/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
                     }
                 ],
                 "pageInfo": {
                     "__typename": "[type-name-here]",
-                    "endCursor": "cursor-6",
+                    "endCursor": "cursor-30",
                     "hasNextPage": true,
                     "hasPreviousPage": false,
                     "startCursor": null
                 },
-                "totalCount": 2
+                "totalCount": 39
             }
         }
     }

--- a/Tests iOS/Fixtures/search-list-page-1.json
+++ b/Tests iOS/Fixtures/search-list-page-1.json
@@ -1,0 +1,442 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-1",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-1",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-1",
+                                    "title": "Item 1",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-1/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-1/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-1/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-2",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-2",
+                                    "title": "Item 2",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-2/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-2/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-2/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-3",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-3",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-3",
+                                    "title": "Item 3",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-3/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-3/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-3/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-4",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-4",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-4",
+                                    "title": "Item 4",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-4/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-4/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-4/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-5",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-5",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-5",
+                                    "title": "Item 5",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-5/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-5/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-5/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-6",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-6",
+                                    "title": "Item 6",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-2/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-6/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-6/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": "cursor-6",
+                    "hasNextPage": true,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}
+
+

--- a/Tests iOS/Fixtures/search-list-page-2.json
+++ b/Tests iOS/Fixtures/search-list-page-2.json
@@ -1,0 +1,160 @@
+{
+    "data": {
+        "user": {
+            "__typename": "[type-name-here]",
+            "searchSavedItems": {
+                "__typename": "[type-name-here]",
+                "edges": [
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-7",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-1",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-7",
+                                    "title": "Item 7",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-7/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": #MARTICLE#,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-7/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-7/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-8",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-2",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-8",
+                                    "title": "Item 8",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-8/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": #MARTICLE#,
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-8/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-8/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "__typename": "[type-name-here]",
+                    "endCursor": null,
+                    "hasNextPage": false,
+                    "hasPreviousPage": false,
+                    "startCursor": null
+                },
+                "totalCount": 2
+            }
+        }
+    }
+}

--- a/Tests iOS/Fixtures/search-list-page-2.json
+++ b/Tests iOS/Fixtures/search-list-page-2.json
@@ -7,12 +7,12 @@
                 "edges": [
                     {
                         "__typename": "[type-name-here]",
-                        "cursor": "cursor-7",
+                        "cursor": "cursor-31",
                         "node": {
                             "__typename": "[type-name-here]",
                             "savedItem": {
                                 "__typename": "[type-name-here]",
-                                "remoteID": "saved-item-1",
+                                "remoteID": "saved-item-31",
                                 "url": "http://localhost:8080/hello",
                                 "_createdAt": 1,
                                 "_deletedAt": null,
@@ -28,15 +28,15 @@
                                 ],
                                 "item": {
                                     "__typename": "Item",
-                                    "remoteID": "item-7",
-                                    "title": "Item 7",
+                                    "remoteID": "item-31",
+                                    "title": "Item 31",
                                     "givenUrl": "http://localhost:8080/hello",
                                     "resolvedUrl": "http://localhost:8080/hello",
-                                    "topImageUrl": "https://example.com/item-7/top-image.jpg",
+                                    "topImageUrl": "https://example.com/item-31/top-image.jpg",
                                     "domain": null,
                                     "language": "en",
                                     "timeToRead": 6,
-                                    "marticle": #MARTICLE#,
+                                    "marticle": [],
                                     "datePublished": "2021-01-01 12:01:01",
                                     "excerpt": "Cursus Aenean Elit",
                                     "authors": [
@@ -56,14 +56,14 @@
                                     "domainMetadata": {
                                         "__typename": "[type-name-here]",
                                         "name": "WIRED",
-                                        "logo": "http://example.com/item-7/domain-logo.jpg"
+                                        "logo": "http://example.com/item-31/domain-logo.jpg"
                                     },
                                     "images": [
                                         {
                                             "__typename": "[type-name-here]",
                                             "height": 1,
                                             "width": 2,
-                                            "src": "http://example.com/item-7/image-1.jpg",
+                                            "src": "http://example.com/item-31/image-1.jpg",
                                             "imageId": 1
                                         }
                                     ],
@@ -77,12 +77,12 @@
                     },
                     {
                         "__typename": "[type-name-here]",
-                        "cursor": "cursor-8",
+                        "cursor": "cursor-32",
                         "node": {
                             "__typename": "[type-name-here]",
                             "savedItem": {
                                 "__typename": "[type-name-here]",
-                                "remoteID": "saved-item-2",
+                                "remoteID": "saved-item-32",
                                 "url": "http://localhost:8080/hello",
                                 "_createdAt": 1,
                                 "_deletedAt": null,
@@ -98,15 +98,15 @@
                                 ],
                                 "item": {
                                     "__typename": "Item",
-                                    "remoteID": "item-8",
-                                    "title": "Item 8",
+                                    "remoteID": "item-32",
+                                    "title": "Item 32",
                                     "givenUrl": "http://localhost:8080/hello",
                                     "resolvedUrl": "http://localhost:8080/hello",
-                                    "topImageUrl": "https://example.com/item-8/top-image.jpg",
+                                    "topImageUrl": "https://example.com/item-32/top-image.jpg",
                                     "domain": null,
                                     "language": "en",
                                     "timeToRead": 6,
-                                    "marticle": #MARTICLE#,
+                                    "marticle": [],
                                     "datePublished": "2021-01-01 12:01:01",
                                     "excerpt": "Cursus Aenean Elit",
                                     "authors": [
@@ -126,14 +126,504 @@
                                     "domainMetadata": {
                                         "__typename": "[type-name-here]",
                                         "name": "WIRED",
-                                        "logo": "http://example.com/item-8/domain-logo.jpg"
+                                        "logo": "http://example.com/item-32/domain-logo.jpg"
                                     },
                                     "images": [
                                         {
                                             "__typename": "[type-name-here]",
                                             "height": 1,
                                             "width": 2,
-                                            "src": "http://example.com/item-8/image-1.jpg",
+                                            "src": "http://example.com/item-32/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-33",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-33",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-33",
+                                    "title": "Item 33",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-33/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-33/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-33/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-34",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-34",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-34",
+                                    "title": "Item 34",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-34/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-34/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-34/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-35",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-35",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-35",
+                                    "title": "Item 35",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-35/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-35/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-35/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-36",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-36",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-36",
+                                    "title": "Item 36",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-36/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-36/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-36/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-37",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-37",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-37",
+                                    "title": "Item 37",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-37/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-37/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-37/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-38",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-38",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-38",
+                                    "title": "Item 38",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-38/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-38/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-38/image-1.jpg",
+                                            "imageId": 1
+                                        }
+                                    ],
+                                    "isArticle": true,
+                                    "hasImage": "HAS_IMAGES",
+                                    "hasVideo": "HAS_VIDEOS",
+                                    "syndicatedArticle": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "__typename": "[type-name-here]",
+                        "cursor": "cursor-39",
+                        "node": {
+                            "__typename": "[type-name-here]",
+                            "savedItem": {
+                                "__typename": "[type-name-here]",
+                                "remoteID": "saved-item-39",
+                                "url": "http://localhost:8080/hello",
+                                "_createdAt": 1,
+                                "_deletedAt": null,
+                                "archivedAt": null,
+                                "isArchived": false,
+                                "isFavorite": false,
+                                "tags": [
+                                    {
+                                        "__typename": "Tag",
+                                        "id": "id-0",
+                                        "name": "tag 0"
+                                    }
+                                ],
+                                "item": {
+                                    "__typename": "Item",
+                                    "remoteID": "item-39",
+                                    "title": "Item 39",
+                                    "givenUrl": "http://localhost:8080/hello",
+                                    "resolvedUrl": "http://localhost:8080/hello",
+                                    "topImageUrl": "https://example.com/item-39/top-image.jpg",
+                                    "domain": null,
+                                    "language": "en",
+                                    "timeToRead": 6,
+                                    "marticle": [],
+                                    "datePublished": "2021-01-01 12:01:01",
+                                    "excerpt": "Cursus Aenean Elit",
+                                    "authors": [
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-1",
+                                            "name": "Jacob",
+                                            "url": "https://example.com/authors/jacob"
+                                        },
+                                        {
+                                            "__typename": "Author",
+                                            "id": "author-2",
+                                            "name": "David",
+                                            "url": "https://example.com/authors/david"
+                                        }
+                                    ],
+                                    "domainMetadata": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "WIRED",
+                                        "logo": "http://example.com/item-39/domain-logo.jpg"
+                                    },
+                                    "images": [
+                                        {
+                                            "__typename": "[type-name-here]",
+                                            "height": 1,
+                                            "width": 2,
+                                            "src": "http://example.com/item-39/image-1.jpg",
                                             "imageId": 1
                                         }
                                     ],
@@ -153,7 +643,7 @@
                     "hasPreviousPage": false,
                     "startCursor": null
                 },
-                "totalCount": 2
+                "totalCount": 39
             }
         }
     }

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -594,6 +594,48 @@ class SearchTests: XCTestCase {
         searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
+    // MARK: Pagination
+    @MainActor
+    func test_search_showsPagination() async {
+        app.launch()
+        tapSearch()
+
+        let searchField = app.navigationBar.searchFields["Search"].wait()
+        searchField.tap()
+        searchField.typeText("item\n")
+        app.saves.searchView.searchResultsView.wait()
+        app.saves.searchView.searchItemCell(at: 1).wait()
+        app.saves.searchView.searchItemCell(at: 1).element.swipeDown()
+//
+//        let firstExpectRequest = expectation(description: "First request to the server")
+//        server.routes.post("/graphql") { request, loop in
+//            defer { firstExpectRequest.fulfill() }
+//            let apiRequest = ClientAPIRequest(request)
+//            XCTAssertTrue(apiRequest.isToFavoriteAnItem)
+//            XCTAssertTrue(apiRequest.contains("item-2"))
+//
+//            return Response.searchPagination()
+//        }
+//
+//        itemCell.favoriteButton.tap()
+//        wait(for: [firstExpectRequest])
+//        XCTAssertTrue(itemCell.favoriteButton.isFilled)
+//
+//        let secondExpectRequest = expectation(description: "Second request to the server")
+//        server.routes.post("/graphql") { request, loop in
+//            defer { expectUnfavoriteRequest.fulfill() }
+//            let apiRequest = ClientAPIRequest(request)
+//            XCTAssertTrue(apiRequest.isToUnfavoriteAnItem)
+//            XCTAssertTrue(apiRequest.contains("item-2"))
+//
+//            return Response.unfavorite()
+//        }
+//
+//        itemCell.favoriteButton.tap()
+//        wait(for: [expectUnfavoriteRequest])
+//        XCTAssertFalse(itemCell.favoriteButton.isFilled)
+    }
+
     private func tapSearch(fromArchive: Bool = false) {
         app.tabBar.savesButton.wait().tap()
         if fromArchive {

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -629,9 +629,17 @@ class SearchTests: XCTestCase {
         wait(for: [firstExpectRequest, secondExpectRequest])
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.searchPage")
-        searchEvent!.getUIContext()!.assertHas(type: "page")
-        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
+
+        async let event0 = snowplowMicro.getFirstEvent(with: "global-nav.search.searchPage", index: 1)
+        async let event1 = snowplowMicro.getFirstEvent(with: "global-nav.search.searchPage", index: 2)
+
+        let events = await [event0, event1]
+
+        events[0]!.getUIContext()!.assertHas(type: "page")
+        events[0]!.getUIContext()!.assertHas(componentDetail: "saves")
+
+        events[1]!.getUIContext()!.assertHas(type: "page")
+        events[1]!.getUIContext()!.assertHas(componentDetail: "saves")
     }
 
     private func tapSearch(fromArchive: Bool = false) {

--- a/Tests iOS/Support/Elements/SearchViewElement.swift
+++ b/Tests iOS/Support/Elements/SearchViewElement.swift
@@ -51,7 +51,7 @@ struct SearchViewElement: PocketUIElement {
         element.staticTexts["banner"].wait().exists && element.staticTexts[message].wait().exists
     }
 
-    func searchItemCell(at index: Int) -> ItemRowElement {
-        ItemRowElement(searchResultsView.cells.element(boundBy: index))
+    func searchItemCell(matching identifier: String) -> ItemRowElement {
+        ItemRowElement(searchResultsView.cells.containing(.staticText, identifier: identifier).element(boundBy: 0))
     }
 }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -114,6 +114,10 @@ extension Response {
         }
     }
 
+    static func searchPagination(_ fixtureName: String = "search-list-page-1") -> Response {
+        fixture(named: fixtureName)
+    }
+
     static func fixture(named fixtureName: String) -> Response {
         Response {
             Status.ok


### PR DESCRIPTION
## Summary
PR to fix issues where share sheet was dismissing due to triggering pagination for search results when not needed.

## References 
IN-1187

## Implementation Details
* Modified `SearchService` to only call once unless the user scrolls down the list. After the initial search call and the user scrolls down the list, I will check if the `pageInfo` from GraphQL response has `hasNextPage == true` and also create a variable `lastEndCursor` that gets hold by the service until the user submits another search or cancels search. 
* Created function `loadMoreResults` to trigger the next page call after a certain index has been reached in the list. This is an arbitrary constant that fits for both iPad and iPhone.

## Test Steps
Verify that all search functionality exists and works properly

**Confirm Bug Fix**
1. Navigate to Search and submit a search for a specific term
2. Tap on share icon for an item in the results view
3. Confirm that Share sheet does not auto dismiss and no network called for search query4. 

**Confirm Pagination Works Fix**
1. Navigate to Search and submit a search for a specific term
2. Scroll down the list and see how the list populates the results in the scroll bar3. 
3. Confirm analytics for `searchPage` is called.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://user-images.githubusercontent.com/6743397/224354359-685aa1cd-d53c-41e2-947b-a317d2caca36.mov

