### PR TITLE
Add DeleteAccountViewModel

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/AccountManagementView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountManagementView.swift
@@ -63,9 +63,7 @@ struct AccountManagementForm: View {
                         )
                     }
                     .sheet(isPresented: $model.isPresentingDeleteYourAccount) {
-                        DeleteAccountView(isPremium: model.isPremium, isPresentingCancelationHelp: $model.isPresentingCancelationHelp, hasError: $model.hasError, isDeletingAccount: $model.isDeletingAccount, deleteAccount: model.deleteAccount, helpCancelPremium: model.helpCancelPremium, dismissDelete: { dismiss in model.trackDeleteDismissed(dismissReason: dismiss) }, helpAppeared: model.trackHelpCancelingPremiumImpression ).onAppear {
-                            model.trackDeleteConfirmationImpression()
-                        }
+                        DeleteAccountView(viewModel: model.makeDeleteAccountViewModel())
                     }
                     .accessibilityIdentifier("delete-your-account-button")
                 }

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -34,12 +34,6 @@ class AccountViewModel: ObservableObject {
 
     @Published var isPremium: Bool
 
-    /// Signals to the DeleteAccountView that there was an error deleting the account
-    @Published var hasError: Bool = false
-
-    /// Signals to the DeleteAccount View that the account is being deleted.
-    @Published var isDeletingAccount: Bool = false
-
     init(appSession: AppSession,
          user: User,
          tracker: Tracker,
@@ -65,25 +59,6 @@ class AccountViewModel: ObservableObject {
             }
     }
 
-    /// Calls the user management service to delete the account and log the user out.
-    func deleteAccount() {
-        self.trackConfirmDeleteTapped()
-        self.isDeletingAccount = true
-        Task {
-            do {
-                try await userManagementService.deleteAccount()
-            } catch {
-                Log.capture(error: error)
-                DispatchQueue.main.async {
-                    self.hasError = true
-                }
-            }
-            DispatchQueue.main.async {
-               self.isDeletingAccount = false
-            }
-        }
-    }
-
     /// Calls the user management service to sign the user out.
     func signOut() {
         userManagementService.logout()
@@ -107,7 +82,7 @@ class AccountViewModel: ObservableObject {
     }
 }
 
-// MARK: Premium upgrades
+// MARK: Premium upgrades factory
 extension AccountViewModel {
     @MainActor
     func makePremiumUpgradeViewModel() -> PremiumUpgradeViewModel {
@@ -132,6 +107,14 @@ extension AccountViewModel {
                 isPresentingRestoreNotSuccessful = true
             }
         }
+    }
+}
+
+// MARK: delete account factory
+extension AccountViewModel {
+    @MainActor
+    func makeDeleteAccountViewModel() -> DeleteAccountViewModel {
+        DeleteAccountViewModel(isPremium: self.isPremium, userManagementService: userManagementService, tracker: tracker)
     }
 }
 
@@ -175,48 +158,8 @@ extension AccountViewModel {
     func trackAccountManagementTapped() {
         tracker.track(event: Events.Settings.accountManagementRowTapped())
     }
-}
-
-// MARK: Delete Account Flow
-extension AccountViewModel {
     /// track delete settings row tapped
     func trackDeleteTapped() {
         tracker.track(event: Events.Settings.deleteRowTapped())
-    }
-
-    /// track delete confirmation viewed
-    func trackDeleteConfirmationImpression() {
-        tracker.track(event: Events.Settings.deleteConfirmationImpression())
-    }
-
-    /// track premium help tapped
-    func trackHelpCancelingPremiumTapped() {
-        tracker.track(event: Events.Settings.helpCancelingPremiumTapped())
-    }
-
-    /// track premium help viewed
-    func trackHelpCancelingPremiumImpression() {
-        tracker.track(event: Events.Settings.helpCancelingPremiumImpression())
-    }
-
-    /// track delete tapped
-    func trackConfirmDeleteTapped() {
-        tracker.track(event: Events.Settings.deleteConfirmationTapped())
-    }
-
-    /// track cancel delete tapped
-    func trackDeleteDismissed(dismissReason: DismissReason) {
-        switch dismissReason {
-        case .swipe, .button, .closeButton:
-            tracker.track(event: Events.Settings.deleteDismissed(reason: dismissReason))
-        case .system:
-            break
-        }
-    }
-
-    /// Help canceling premium tapped
-    func helpCancelPremium() {
-        trackHelpCancelingPremiumTapped()
-        self.isPresentingCancelationHelp = true
     }
 }

--- a/PocketKit/Sources/PocketKit/Settings/DeleteAccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/DeleteAccountViewModel.swift
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Analytics
+import Foundation
+import SharedPocketKit
+import Sync
+
+@MainActor
+class DeleteAccountViewModel: ObservableObject {
+    @Published var isPresentingCancelationHelp: Bool
+    @Published var isDeletingAccount: Bool
+    @Published var showErrorAlert: Bool
+
+    let isPremium: Bool
+
+    private let userManagementService: UserManagementServiceProtocol
+    private let tracker: Tracker
+
+    init(isPresentingCancellationHelp: Bool = false,
+         isDeletingAccount: Bool = false,
+         showErrorAlert: Bool = false,
+         isPremium: Bool,
+         userManagementService: UserManagementServiceProtocol,
+         tracker: Tracker) {
+        self.isPresentingCancelationHelp = isPresentingCancellationHelp
+        self.isDeletingAccount = isDeletingAccount
+        self.showErrorAlert = showErrorAlert
+        self.isPremium = isPremium
+        self.userManagementService = userManagementService
+        self.tracker = tracker
+    }
+
+    /// Calls the user management service to delete the account and log the user out.
+    func deleteAccount() {
+        trackConfirmDeleteTapped()
+        isDeletingAccount = true
+        Task {
+            do {
+                try await userManagementService.deleteAccount()
+            } catch {
+                Log.capture(error: error)
+                self.showErrorAlert = true
+            }
+            isDeletingAccount = false
+        }
+    }
+}
+
+// MARK: Delete Account Flow
+extension DeleteAccountViewModel {
+    /// track delete settings row tapped
+    func trackDeleteTapped() {
+        tracker.track(event: Events.Settings.deleteRowTapped())
+    }
+
+    /// track premium help tapped
+    func trackHelpCancelingPremiumTapped() {
+        tracker.track(event: Events.Settings.helpCancelingPremiumTapped())
+    }
+
+    /// track delete confirmation viewed
+    func trackDeleteConfirmationImpression() {
+        tracker.track(event: Events.Settings.deleteConfirmationImpression())
+    }
+
+    /// track premium help viewed
+    func trackHelpCancelingPremiumImpression() {
+        tracker.track(event: Events.Settings.helpCancelingPremiumImpression())
+    }
+
+    /// track delete tapped
+    func trackConfirmDeleteTapped() {
+        tracker.track(event: Events.Settings.deleteConfirmationTapped())
+    }
+
+    /// track cancel delete tapped
+    func trackDeleteDismissed(dismissReason: DismissReason) {
+        switch dismissReason {
+        case .swipe, .button, .closeButton:
+            tracker.track(event: Events.Settings.deleteDismissed(reason: dismissReason))
+        case .system:
+            break
+        }
+    }
+    /// Help canceling premium tapped
+    func helpCancelPremium() {
+        trackHelpCancelingPremiumTapped()
+        isPresentingCancelationHelp = true
+    }
+}

--- a/PocketKit/Sources/PocketKit/SwiftUIPreviewSupport/PreviewTypes.swift
+++ b/PocketKit/Sources/PocketKit/SwiftUIPreviewSupport/PreviewTypes.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Textile
+import SharedPocketKit
+import Analytics
+
+/// A collection of concrete types to be used in SwiftUI previews
+class PreviewUserManagementService: ObservableObject, UserManagementServiceProtocol {
+    func deleteAccount() async throws { }
+    func logout() { }
+    @Published public private(set) var accountDeleted: Bool = false
+    var accountDeletedPublisher: Published<Bool>.Publisher { $accountDeleted }
+}
+
+class PreviewTracker: Tracker {
+    func childTracker(with contexts: [Analytics.Context]) -> Analytics.Tracker { return self }
+    func track<T>(event: T, _ contexts: [Analytics.Context]?) where T: Analytics.OldEvent {}
+    func addPersistentEntity(_ entity: Analytics.Entity) {}
+    func resetPersistentEntities(_ entities: [Analytics.Entity]) {}
+    func track(event: Event, filename: String, line: Int, column: Int, funcName: String) {}
+}


### PR DESCRIPTION
## Summary
* This PR does a small refactor to extract view model logic related to account deletion from `AccountViewModel` to `DeleteAccountViewModel`


## Implementation Details
* Add `DeleteAccountViewModel`
* Add `PreviewTypes`, a collection of types to be used in static SwiftUI previews instead of the production types

## Test Steps
* Build/run, go through the account deletion flow and make sure it works as expected

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
