### PR TITLE
feat(tags): force lowercase on tag text input field

### DIFF
--- a/PocketKit/Sources/Textile/Views/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/Textile/Views/Tags/AddTagsView.swift
@@ -28,9 +28,10 @@ public struct AddTagsView<ViewModel>: View where ViewModel: AddTagsViewModel {
                     InputTagsView(viewModel: viewModel, geometry: geometry)
                     OtherTagsView(viewModel: viewModel)
                     Spacer()
-                    TextField(viewModel.placeholderText, text: $viewModel.newTagInput)
+                    TextField(viewModel.placeholderText, text: Binding(get: { viewModel.newTagInput }, set: { string in viewModel.newTagInput = string.lowercased() }))
                         .limitText($viewModel.newTagInput, to: 25)
                         .textFieldStyle(.roundedBorder)
+                        .autocapitalization(.none)
                         .padding(10)
                         .onSubmit {
                             guard viewModel.addTag(with: viewModel.newTagInput) else { return }


### PR DESCRIPTION
## Summary
Force lowercase on tag text input field for tags creation / add tags screen.

## References 
IN-1135

## Implementation Details
Added `autocapitalization` and set it to `none` to avoid capitalizing the first letter. Modified binding to force lowercase no matter what the user inputs. This accounts for cases if the user uses CapLocks or Shift.

## Test Steps
- [ ] WHEN I am in the tags creation screen
AND I select the text field to input text
AND I type
THEN all text should be forced lowercase

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
Although you may not see it, I am attempting to enter capitalized characters.

https://user-images.githubusercontent.com/6743397/224404186-a49b7318-10b5-46e6-90f5-498c53b744ae.mp4
