### PR TITLE
Premium Purchases - Send App Store receipt to the backend

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -26,7 +26,7 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
         self.user = user
         self.receiptService = receiptService
         self.subscriptionMap = subscriptionMap ?? [Keys.shared.pocketPremiumMonthly: .monthly, Keys.shared.pocketPremiumAnnual: .annual]
-        receiptService.send()
+
         transactionListener = makeTransactionListener()
 
         Task {
@@ -39,8 +39,14 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
             }
             // Restore a purchased subscription, if any
             await self.updateSubscription()
+
+            do {
+                // send App Store receipt at launch
+                try await receiptService.send(nil)
+            } catch {
+                Log.capture(error: error)
+            }
         }
-        // TODO: Send the App Receipt to the backend
     }
 
     /// Fetch available subscriptions from the App Store
@@ -61,7 +67,6 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     /// Manually restore a purchase in those (rare?) cases when the automatic sync fails
     func restoreSubscription() async throws {
         try await AppStore.sync()
-        // TODO: double check if we still need the following call when dealing with the real App Store
         await updateSubscription()
     }
 }
@@ -123,7 +128,6 @@ extension PocketSubscriptionStore {
 
     /// Updates app status when a new subscription is found
     private func updateSubscription() async {
-        // TODO: we need to handle the downgrade as well
         for await transaction in Transaction.currentEntitlements {
             do {
                 let verifiedTransaction = try verify(transaction)
@@ -132,7 +136,11 @@ extension PocketSubscriptionStore {
                     if let subscription = subscriptions.first(where: { $0.product.id == verifiedTransaction.productID }) {
                         state = .subscribed(subscription.type)
                         user.setPremiumStatus(true)
-                        receiptService.send()
+                        do {
+                            try await receiptService.send(subscription.product)
+                        } catch {
+                            Log.capture(error: error)
+                        }
                     }
                 default:
                     // We do not have other product types as of now.

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -31,7 +31,7 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
 
         Task {
             do {
-                // Pull available subscriptions from the App Store
+                // Obtain purchaseable subscriptions from the App Store
                 try await requestSubscriptions()
             } catch {
                 state = .failed

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -1,29 +1,42 @@
 import Foundation
+import StoreKit
 import Sync
 
-/// Generic type to validate a subscription purchase or redeem
+/// Generic type to send subscription receipt to a server
 public protocol ReceiptService {
-    func send()
+    func send(_ product: Product?) async throws
 }
 
 public enum ReceiptError: Error {
     case noData
 }
 
-/// Concrete implementation that sends the App Store Receipt to the backend
+/// Concrete implementation that sends the App Store Receipt to the Pocket backend
 struct AppStoreReceiptService: ReceiptService {
-    func send() {
-        do {
-            let data = try getReceipt()
-            let receiptString = data.base64EncodedString(options: [])
-        } catch {
-            Log.capture(error: error)
-        }
+    func send(_ product: Product?) async throws {
+        let data = try getReceipt()
+        let receiptString = data.base64EncodedString(options: [])
+        let transactionInfo = receiptString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let source = "itunes"
+        let productId = product?.id ?? ""
+        let amount = product?.price != nil ? "\(product!.price)" : ""
+        let transactionType = product != nil ? "purchase" : "restore"
+        let currency = product?.priceFormatStyle.currencyCode ?? ""
+
+        try await Services.shared.v3Client.sendAppstoreReceipt(
+            source: source,
+            transactionInfo: transactionInfo!,
+            amount: amount,
+            productId: productId,
+            currency: currency,
+            transactionType: transactionType
+        )
     }
 }
 
 // MARK: private methods
 extension AppStoreReceiptService {
+    /// Return the App Store receipt if it exists
     func getReceipt() throws -> Data {
         guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) else {

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -9,14 +9,13 @@ public protocol ReceiptService {
 
 public enum ReceiptError: Error {
     case noData
+    case invalidReceipt
 }
 
 /// Concrete implementation that sends the App Store Receipt to the Pocket backend
 struct AppStoreReceiptService: ReceiptService {
     func send(_ product: Product?) async throws {
-        let data = try getReceipt()
-        let receiptString = data.base64EncodedString(options: [])
-        let transactionInfo = receiptString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let transactionInfo = try getReceipt()
         let source = "itunes"
         let productId = product?.id ?? ""
         let amount = product?.price != nil ? "\(product!.price)" : ""
@@ -25,7 +24,7 @@ struct AppStoreReceiptService: ReceiptService {
 
         try await Services.shared.v3Client.sendAppstoreReceipt(
             source: source,
-            transactionInfo: transactionInfo!,
+            transactionInfo: transactionInfo,
             amount: amount,
             productId: productId,
             currency: currency,
@@ -35,13 +34,20 @@ struct AppStoreReceiptService: ReceiptService {
 }
 
 // MARK: private methods
-extension AppStoreReceiptService {
+private extension AppStoreReceiptService {
     /// Return the App Store receipt if it exists
-    func getReceipt() throws -> Data {
+    func getReceipt() throws -> String {
         guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
               FileManager.default.fileExists(atPath: appStoreReceiptURL.path) else {
             throw ReceiptError.noData
         }
-        return try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+        let receiptString = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+            .base64EncodedString(options: [])
+
+        guard let receipt = receiptString
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            throw ReceiptError.invalidReceipt
+        }
+        return receipt
     }
 }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Sync
+
+/// Generic type to validate a subscription purchase or redeem
+public protocol ReceiptService {
+    func send()
+}
+
+public enum ReceiptError: Error {
+    case noData
+}
+
+/// Concrete implementation that sends the App Store Receipt to the backend
+struct AppStoreReceiptService: ReceiptService {
+    func send() {
+        do {
+            let data = try getReceipt()
+            let receiptString = data.base64EncodedString(options: [])
+        } catch {
+            Log.capture(error: error)
+        }
+    }
+}
+
+// MARK: private methods
+extension AppStoreReceiptService {
+    func getReceipt() throws -> Data {
+        guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL,
+              FileManager.default.fileExists(atPath: appStoreReceiptURL.path) else {
+            throw ReceiptError.noData
+        }
+        return try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
+    }
+}

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -15,6 +15,9 @@ public enum ReceiptError: Error {
 /// Concrete implementation that sends the App Store Receipt to the Pocket backend
 struct AppStoreReceiptService: ReceiptService {
     func send(_ product: Product?) async throws {
+    #if DEBUG
+        // TODO: at the moment we are not sending the receipt in debug
+    #else
         let transactionInfo = try getReceipt()
         let source = "itunes"
         let productId = product?.id ?? ""
@@ -30,6 +33,7 @@ struct AppStoreReceiptService: ReceiptService {
             currency: currency,
             transactionType: transactionType
         )
+        #endif
     }
 }
 

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
@@ -4,7 +4,7 @@ import Textile
 
 struct PremiumUpgradeView: View {
     // TODO: remove this property and the two @State properties once we are ready to ship premium upgrades to beta users
-    static let shouldAllowUpgrade = false
+    static let shouldAllowUpgrade = true
     @State private var showingMonthlyAlert = false
     @State private var showingAnnualAlert = false
     @Binding var dismissReason: DismissReason

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -115,7 +115,7 @@ struct Services {
             userDefaults: userDefaults,
             badgeProvider: UIApplication.shared
         )
-        subscriptionStore = PocketSubscriptionStore(user: user)
+        subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService())
 
         userManagementService = UserManagementService(appSession: appSession, user: user, notificationCenter: .default, source: source)
     }

--- a/PocketKit/Sources/Sync/V3/V3Client.swift
+++ b/PocketKit/Sources/Sync/V3/V3Client.swift
@@ -242,7 +242,9 @@ extension V3Client {
     }
 }
 
+// MARK: Premium subscription info
 extension V3Client {
+    /// Fetch premium subscription details for the premium user
     public func premiumStatus() async throws -> PremiumStatusResponse {
         let currentSession = try fallbackSession(session: sessionProvider.session)
 
@@ -259,7 +261,9 @@ extension V3Client {
     }
 }
 
+// MARK: App Store receipt
 extension V3Client {
+    /// Send the App Store receipt to the backend
     public func sendAppstoreReceipt(source: String,
                                     transactionInfo: String,
                                     amount: String,

--- a/PocketKit/Sources/Sync/V3/V3ClientProtocol.swift
+++ b/PocketKit/Sources/Sync/V3/V3ClientProtocol.swift
@@ -52,4 +52,5 @@ public protocol V3ClientProtocol {
      - Returns: PremiumStatusResponse
      */
     func premiumStatus() async throws -> PremiumStatusResponse
+    func sendAppstoreReceipt(source: String, transactionInfo: String, amount: String, productId: String, currency: String, transactionType: String) async throws
 }

--- a/PocketKit/Sources/Sync/V3/V3RequestTypes.swift
+++ b/PocketKit/Sources/Sync/V3/V3RequestTypes.swift
@@ -36,3 +36,15 @@ public struct PremiumStatusRequest: Codable, Equatable, V3Request {
 
     let guid: String
 }
+
+public struct AppstoreReceiptRequest: Codable, Equatable, V3Request {
+    let accessToken: String
+    let consumerKey: String
+    let guid: String
+    let source: String
+    let transactionInfo: String
+    let amount: String
+    let productId: String
+    let currency: String
+    let transactionType: String
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockV3Client.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockV3Client.swift
@@ -2,6 +2,8 @@ import Foundation
 import Sync
 
 class MockV3Client: V3ClientProtocol {
+    func sendAppstoreReceipt(source: String, transactionInfo: String, amount: String, productId: String, currency: String, transactionType: String) async throws {}
+
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
 }


### PR DESCRIPTION
## Summary
* This PR adds code to send the App Store receipt to the backend. The receipt is sent in two occasions:
    - at app launch, as a fail-safe in case the local listener does not receive existing entitlements
    - at every successful transaction
> **Note**
at this moment, the receipt is not sent when building for debug.
- This PR also does some small refactor to the existing V3 client and enables the premium purchases flag

## Implementation Details
* Add `ReceiptService` and concrete implementation `AppStoreReceiptService`
* Update `PocketSubscriptionStore`, send the receipt when needed (see above)
* Update `V3Client`, add calls to send the App Store receipt, some minor refactor

## Test Steps
* This code is not really testable at the moment from Xcode. You can still run the tests to make sure nothing broke.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
