### PR TITLE
fix(threads): moving all coredata to the background

### DIFF
--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -44,16 +44,13 @@ class AppBadgeSetup {
     }
 
     func manualCheckForSavedCount() {
-        let numberOfSavesRequest = Requests.fetchSavedItems()
-        var numberOfSaves: Int
+        var numberOfSaves: Int = 0
         let currentValue = userDefaults.bool(forKey: AccountViewModel.ToggleAppBadgeKey)
-        if currentValue == false {
-            numberOfSaves = 0
-        } else {
+        if currentValue != false {
             do {
-                numberOfSaves = try source.mainContext.fetch(numberOfSavesRequest).count
+                numberOfSaves = try source.unreadSaves()
             } catch {
-                numberOfSaves = 0
+                Log.capture(error: error)
             }
         }
 

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -11,7 +11,6 @@ protocol CompactHomeCoordinatorDelegate: AnyObject {
     func compactHomeCoordinatorDidSelectRecentSaves(_ coordinator: CompactHomeCoordinator)
 }
 
-@MainActor
 class CompactHomeCoordinator: NSObject {
     var viewController: UIViewController {
         return navigationController

--- a/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Home/CompactHomeCoordinator.swift
@@ -11,6 +11,7 @@ protocol CompactHomeCoordinatorDelegate: AnyObject {
     func compactHomeCoordinatorDidSelectRecentSaves(_ coordinator: CompactHomeCoordinator)
 }
 
+@MainActor
 class CompactHomeCoordinator: NSObject {
     var viewController: UIViewController {
         return navigationController

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -2,7 +2,6 @@ import UIKit
 import Sync
 import CoreData
 
-@MainActor
 class HomeViewControllerSectionProvider {
     struct Constants {
         static let margin: CGFloat = Margins.thin.rawValue

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -2,6 +2,7 @@ import UIKit
 import Sync
 import CoreData
 
+@MainActor
 class HomeViewControllerSectionProvider {
     struct Constants {
         static let margin: CGFloat = Margins.thin.rawValue

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -94,9 +94,11 @@ class HomeViewController: UIViewController {
             self?.updateOverflowView(contentOffset: contentOffset)
         }.store(in: &subscriptions)
 
-        model.$snapshot.sink { [weak self] snapshot in
-            self?.dataSource.apply(snapshot)
-        }.store(in: &subscriptions)
+        model.$snapshot
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] snapshot in
+                self?.dataSource.apply(snapshot)
+            }.store(in: &subscriptions)
     }
 
     override func viewDidLoad() {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -272,13 +272,13 @@ extension HomeViewModel {
         case .loading, .offline:
             return
         case .recentSaves(let objectID):
-            guard let savedItem = source.object(id: objectID) as? SavedItem else {
+            guard let savedItem = source.viewObject(id: objectID) as? SavedItem else {
                 return
             }
 
             select(savedItem: savedItem, at: indexPath)
         case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
-            guard let recommendation = source.object(id: objectID) as? Recommendation else {
+            guard let recommendation = source.viewObject(id: objectID) as? Recommendation else {
                 return
             }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -124,7 +124,9 @@ class HomeViewModel {
         NotificationCenter.default.publisher(
             for: NSManagedObjectContext.didSaveObjectsNotification,
             object: nil
-        ).sink { [weak self] notification in
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] notification in
             do {
                 try self?.handle(notification: notification)
             } catch {
@@ -208,6 +210,7 @@ extension HomeViewModel {
             Set(itemsToReload)
                 .filter { snapshot.indexOfItem($0) != nil }
         )
+
         self.snapshot = snapshot
     }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -74,6 +74,7 @@ enum SeeAll {
     }
 }
 
+@MainActor
 class HomeViewModel {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
     typealias ItemIdentifier = NSManagedObjectID

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import Textile
 
+@MainActor
 class RecommendationCarouselCell: HomeCarouselItemCell {
     struct Model: HomeCarouselItemCellModel {
         private let viewModel: HomeRecommendationCellViewModel

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 import Textile
 
-@MainActor
 class RecommendationCarouselCell: HomeCarouselItemCell {
     struct Model: HomeCarouselItemCellModel {
         private let viewModel: HomeRecommendationCellViewModel

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -40,7 +40,7 @@ class SlateDetailViewModel {
 
         NotificationCenter.default.publisher(
             for: NSManagedObjectContext.didSaveObjectsNotification,
-            object: source.mainContext
+            object: nil
         ).sink { [weak self] notification in
             do {
                 try self?.handle(notification: notification)
@@ -68,7 +68,7 @@ class SlateDetailViewModel {
         case .loading:
             return
         case .recommendation(let objectID):
-            guard let recommendation = source.mainContext.object(with: objectID) as? Recommendation else {
+            guard let recommendation = source.viewObject(id: objectID) as? Recommendation else {
                 return
             }
 
@@ -92,7 +92,7 @@ extension SlateDetailViewModel {
     }
 
     private func selectRecommendation(with objectID: NSManagedObjectID, at indexPath: IndexPath) {
-        guard let recommendation = source.mainContext.object(with: objectID) as? Recommendation else {
+        guard let recommendation = source.viewObject(id: objectID) as? Recommendation else {
             return
         }
 
@@ -130,7 +130,7 @@ extension SlateDetailViewModel {
         for objectID: NSManagedObjectID,
         at indexPath: IndexPath? = nil
     ) -> HomeRecommendationCellViewModel? {
-        guard let recommendation = source.mainContext.object(with: objectID) as? Recommendation else {
+        guard let recommendation = source.viewObject(id: objectID) as? Recommendation else {
             return nil
         }
 
@@ -244,7 +244,7 @@ private extension SlateDetailViewModel {
     }
 
     private func handle(notification: Notification) throws {
-        source.mainContext.refresh(slate, mergeChanges: true)
+        source.viewRefresh(slate, mergeChanges: true)
         var snapshot = buildSnapshot()
 
         guard let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> else {

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -41,7 +41,9 @@ class SlateDetailViewModel {
         NotificationCenter.default.publisher(
             for: NSManagedObjectContext.didSaveObjectsNotification,
             object: nil
-        ).sink { [weak self] notification in
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] notification in
             do {
                 try self?.handle(notification: notification)
             } catch {

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -6,7 +6,6 @@ import Sync
 import Combine
 import Textile
 
-@MainActor
 class CompactMainCoordinator: NSObject {
     var viewController: UIViewController {
         tabBarController

--- a/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/CompactMainCoordinator.swift
@@ -6,6 +6,7 @@ import Sync
 import Combine
 import Textile
 
+@MainActor
 class CompactMainCoordinator: NSObject {
     var viewController: UIViewController {
         tabBarController

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -4,6 +4,7 @@ import Sync
 import Combine
 import BackgroundTasks
 
+@MainActor
 class MainCoordinator {
     var viewController: UIViewController {
         regular.viewController

--- a/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainCoordinator.swift
@@ -4,7 +4,6 @@ import Sync
 import Combine
 import BackgroundTasks
 
-@MainActor
 class MainCoordinator {
     var viewController: UIViewController {
         regular.viewController

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -55,24 +55,20 @@ class MainViewModel: ObservableObject {
         }
     }
 
-    @MainActor
     func clearRecommendationToReport() {
         home.clearRecommendationToReport()
     }
 
-    @MainActor
     func clearSharedActivity() {
         home.clearSharedActivity()
         saves.clearSharedActivity()
     }
 
-    @MainActor
     func clearIsPresentingReaderSettings() {
         home.clearIsPresentingReaderSettings()
         saves.clearIsPresentingReaderSettings()
     }
 
-    @MainActor
     func clearPresentedWebReaderURL() {
         home.clearPresentedWebReaderURL()
         saves.clearPresentedWebReaderURL()

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -55,20 +55,24 @@ class MainViewModel: ObservableObject {
         }
     }
 
+    @MainActor
     func clearRecommendationToReport() {
         home.clearRecommendationToReport()
     }
 
+    @MainActor
     func clearSharedActivity() {
         home.clearSharedActivity()
         saves.clearSharedActivity()
     }
 
+    @MainActor
     func clearIsPresentingReaderSettings() {
         home.clearIsPresentingReaderSettings()
         saves.clearIsPresentingReaderSettings()
     }
 
+    @MainActor
     func clearPresentedWebReaderURL() {
         home.clearPresentedWebReaderURL()
         saves.clearPresentedWebReaderURL()

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 import BackgroundTasks
 import UIKit
 
+@MainActor
 class MainViewModel: ObservableObject {
     @Published
     var selectedSection: AppSection = .home

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -9,7 +9,6 @@ protocol RegularHomeCoordinatorDelegate: ModalContentPresenting {
     func homeCoordinatorDidSelectSaves(_ coordinator: RegularHomeCoordinator)
 }
 
-@MainActor
 class RegularHomeCoordinator: NSObject {
     weak var delegate: RegularHomeCoordinatorDelegate?
 

--- a/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularHomeCoordinator.swift
@@ -9,6 +9,7 @@ protocol RegularHomeCoordinatorDelegate: ModalContentPresenting {
     func homeCoordinatorDidSelectSaves(_ coordinator: RegularHomeCoordinator)
 }
 
+@MainActor
 class RegularHomeCoordinator: NSObject {
     weak var delegate: RegularHomeCoordinatorDelegate?
 

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -16,6 +16,7 @@ protocol ModalContentPresenting: AnyObject {
     func share(_ activity: PocketActivity?)
 }
 
+@MainActor
 class RegularMainCoordinator: NSObject {
     var viewController: UIViewController {
         splitController

--- a/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularMainCoordinator.swift
@@ -16,7 +16,6 @@ protocol ModalContentPresenting: AnyObject {
     func share(_ activity: PocketActivity?)
 }
 
-@MainActor
 class RegularMainCoordinator: NSObject {
     var viewController: UIViewController {
         splitController

--- a/PocketKit/Sources/PocketKit/Main/RegularSavesCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Main/RegularSavesCoordinator.swift
@@ -9,6 +9,7 @@ protocol RegularSavesCoordinatorDelegate: ModalContentPresenting {
     func savesCoordinator(_ coordinator: RegularSavesCoordinator, didSelectSavedItem savedItem: SavedItemViewModel?)
 }
 
+@MainActor
 class RegularSavesCoordinator: NSObject {
     weak var delegate: RegularSavesCoordinatorDelegate?
 

--- a/PocketKit/Sources/PocketKit/MyList/CompactSavesContainerCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/MyList/CompactSavesContainerCoordinator.swift
@@ -4,6 +4,7 @@ import SafariServices
 import SwiftUI
 import Textile
 
+@MainActor
 class CompactSavesContainerCoordinator: NSObject {
     var viewController: UIViewController {
         return navigationController

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -386,7 +386,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     }
 
     private func bareItem(with id: NSManagedObjectID) -> SavedItem? {
-        source.object(id: id)
+        source.viewObject(id: id)
     }
 
     private func itemsLoaded() {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -386,7 +386,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     }
 
     private func bareItem(with id: NSManagedObjectID) -> SavedItem? {
-        source.viewObject(id: id)
+        source.backgroundObject(id: id)
     }
 
     private func itemsLoaded() {
@@ -673,7 +673,7 @@ extension SavedItemsListViewModel {
         case .savedItemsUpdated(let updatedSavedItems):
             try? itemsController.performFetch()
             updatedSavedItems.forEach {
-                source.refresh($0, mergeChanges: true)
+                source.viewRefresh($0, mergeChanges: true)
             }
             var snapshot = buildSnapshot()
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -640,7 +640,7 @@ extension SavedItemsListViewModel: SavedItemsControllerDelegate {
     ) {
         var snapshot = buildSnapshot()
         let id = ItemsListCell<ItemIdentifier>.item(savedItem.objectID)
-        if snapshot.itemIdentifiers.first(where: { $0 == id }) != nil {
+        if snapshot.itemIdentifiers.contains(id) {
             snapshot.reloadItems([id])
         }
         _snapshot = snapshot

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -3,6 +3,7 @@ import Sync
 import UIKit
 import SharedPocketKit
 
+@MainActor
 class SavesContainerViewModel {
     enum Selection {
         case saves

--- a/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
@@ -6,7 +6,6 @@ import SafariServices
 import Analytics
 import Textile
 
-@MainActor
 class RootCoordinator {
     private var window: UIWindow?
 

--- a/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Root/RootCoordinator.swift
@@ -6,6 +6,7 @@ import SafariServices
 import Analytics
 import Textile
 
+@MainActor
 class RootCoordinator {
     private var window: UIWindow?
 

--- a/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
@@ -71,6 +71,7 @@ private class AuthParamsInterceptor: ApolloInterceptor {
 
     private func appendAuthorizationQueryParameters(to url: URL) -> URL {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            Log.capture(message: "Error - could not break Apollo url into components")
             return url
         }
 
@@ -78,12 +79,14 @@ private class AuthParamsInterceptor: ApolloInterceptor {
         items.append(contentsOf: [
             URLQueryItem(name: "consumer_key", value: consumerKey),
         ])
-        if let guid = sessionProvider.session?.guid {
-            items.append(URLQueryItem(name: "guid", value: guid))
+
+        if let session = sessionProvider.session {
+            items.append(URLQueryItem(name: "guid", value: session.guid))
+            items.append(URLQueryItem(name: "access_token", value: session.accessToken))
+        } else {
+            Log.capture(message: "Error - making PocketGraph request without auth")
         }
-        if let accessToken = sessionProvider.session?.accessToken {
-            items.append(URLQueryItem(name: "access_token", value: accessToken))
-        }
+
         components.queryItems = items
 
         return components.url ?? url

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -4,22 +4,23 @@
 
 import Apollo
 import ApolloAPI
+import Foundation
 
 public extension ApolloClientProtocol {
-    func fetch<Query: GraphQLQuery>(query: Query, resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
+    func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = .global(qos: .utility), resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
         return fetch(
             query: query,
             cachePolicy: .fetchIgnoringCacheCompletely,
             contextIdentifier: nil,
-            queue: .main,
+            queue: queue,
             resultHandler: resultHandler
         )
     }
 
-    func fetch<Query: GraphQLQuery>(query: Query, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) async throws -> GraphQLResult<Query.Data> {
+    func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = .global(qos: .utility), filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) async throws -> GraphQLResult<Query.Data> {
         Log.debug("Requesting \(String(describing: query))", filename: filename, line: line, column: column, funcName: funcName)
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GraphQLResult<Query.Data>, Error>) in
-            _ = fetch(query: query) { result in
+            _ = fetch(query: query, queue: queue) { result in
                 switch result {
                 case .failure(let error):
                     Log.capture(error: error, filename: filename, line: line, column: column, funcName: funcName)

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -53,14 +53,15 @@ class SaveItemOperation: SyncOperation {
         }
     }
 
-    @MainActor
     private func handle(result: GraphQLResult<SaveItemMutation.Data>) {
-        guard let remote = result.data?.upsertSavedItem.fragments.savedItemParts,
-              let savedItem: SavedItem = space.context.object(with: managedItemID) as? SavedItem else {
-            return
-        }
+        space.performAndWait {
+            guard let remote = result.data?.upsertSavedItem.fragments.savedItemParts,
+                  let savedItem: SavedItem = space.backgroundContext.object(with: managedItemID) as? SavedItem else {
+                return
+            }
 
-        savedItem.update(from: remote, with: space)
+            savedItem.update(from: remote, with: space)
+        }
 
         do {
             try space.save()

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -5,7 +5,7 @@
 import CoreData
 
 public class PersistentContainer: NSPersistentContainer {
-    public lazy var rootSpace = { Space(context: viewContext) }()
+    public lazy var rootSpace = { Space(backgroundContext: newBackgroundContext(), viewContext: viewContext) }()
 
     public enum Storage {
         case inMemory
@@ -45,5 +45,7 @@ public class PersistentContainer: NSPersistentContainer {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         }
+
+        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
     }
 }

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -5,7 +5,13 @@
 import CoreData
 
 public class PersistentContainer: NSPersistentContainer {
-    public lazy var rootSpace = { Space(backgroundContext: newBackgroundContext(), viewContext: viewContext) }()
+    public lazy var rootSpace = { Space(backgroundContext: backgroundContext, viewContext: viewContext) }()
+
+    private lazy var backgroundContext = {
+        let context = newBackgroundContext()
+        context.automaticallyMergesChangesFromParent = true
+        return context
+    }()
 
     public enum Storage {
         case inMemory
@@ -40,12 +46,17 @@ public class PersistentContainer: NSPersistentContainer {
             ]
         }
 
-        loadPersistentStores { storeDescription, error in
+        loadPersistentStores {[weak self] storeDescription, error in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-        }
+            guard let self else {
+                Log.capture(message: "No strong self loading persistent store")
+                return
+            }
 
-        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
+            self.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
+            self.viewContext.automaticallyMergesChangesFromParent = true
+        }
     }
 }

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -43,13 +43,15 @@ public class PocketSaveService: SaveService {
     }
 
     public func save(url: URL) -> SaveServiceStatus {
-        let result = fetchOrCreateSavedItem(url: url)
+        space.performAndWait {
+            let result = fetchOrCreateSavedItem(url: url)
 
-        expiringActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.save") { [weak self] expiring in
-            self?._save(expiring: expiring, savedItem: result.savedItem)
+            expiringActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.save") { [weak self] expiring in
+                self?._save(expiring: expiring, savedItem: result.savedItem)
+            }
+
+            return result
         }
-
-        return result
     }
 
     public func retrieveTags(excluding tags: [String]) -> [Tag]? {
@@ -61,104 +63,124 @@ public class PocketSaveService: SaveService {
     }
 
     public func addTags(savedItem: SavedItem, tags: [String]) -> SaveServiceStatus {
-        savedItem.tags = NSOrderedSet(array: tags.compactMap { $0 }.map({ tag in
-            space.fetchOrCreateTag(byName: tag)
-        }))
-
-       try? space.save()
-
-        osNotifications.post(name: .savedItemUpdated)
-
-        expiringActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.addTags") { [weak self] expiring in
-            self?._addTags(expiring: expiring, savedItem: savedItem)
-        }
-
-        return .taggedItem(savedItem)
-    }
-
-    private func fetchOrCreateSavedItem(url: URL) -> SaveServiceStatus {
-        if let existingItem = try! space.fetchSavedItem(byURL: url) {
-            existingItem.createdAt = Date()
-
-            let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
-            notification.savedItem = existingItem
+        return space.performAndWait {
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
+                Log.capture(message: "Save Service could not get a savedItem from the background context, for add tags")
+                return .taggedItem(savedItem)
+            }
+            savedItem.tags = NSOrderedSet(array: tags.compactMap { $0 }.map({ tag in
+                space.fetchOrCreateTag(byName: tag)
+            }))
 
             try? space.save()
 
             osNotifications.post(name: .savedItemUpdated)
-            return .existingItem(existingItem)
-        } else {
-            let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: url)
-            savedItem.url = url
-            savedItem.createdAt = Date()
-            try? space.save()
 
-            osNotifications.post(name: .savedItemCreated)
-            return .newItem(savedItem)
+            expiringActivityPerformer.performExpiringActivity(withReason: "com.mozilla.pocket.next.addTags") { [weak self] expiring in
+                self?._addTags(expiring: expiring, savedItem: savedItem)
+            }
+
+            return .taggedItem(savedItem)
+        }
+    }
+
+    private func fetchOrCreateSavedItem(url: URL) -> SaveServiceStatus {
+        return space.performAndWait {
+            if let existingItem = try! space.fetchSavedItem(byURL: url) {
+                existingItem.createdAt = Date()
+
+                let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
+                notification.savedItem = existingItem
+
+                try? space.save()
+
+                osNotifications.post(name: .savedItemUpdated)
+                return .existingItem(existingItem)
+            } else {
+                let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: url)
+                savedItem.url = url
+                savedItem.createdAt = Date()
+                try? space.save()
+
+                osNotifications.post(name: .savedItemCreated)
+                return .newItem(savedItem)
+            }
         }
     }
 
     private func _addTags(expiring: Bool, savedItem: SavedItem) {
-        guard !expiring else {
-            queue.cancelAllOperations()
-            queue.waitUntilAllOperationsAreFinished()
-            return
-        }
-
-        guard let tags = savedItem.tags, let remoteID = savedItem.remoteID else { return }
-        let names = Array(tags).compactMap { ($0 as? Tag)?.name }
-
-        if names.isEmpty {
-            let mutation = UpdateSavedItemRemoveTagsMutation(savedItemId: remoteID)
-
-            let operation = SaveOperation<UpdateSavedItemRemoveTagsMutation>(
-                apollo: apollo,
-                osNotifications: osNotifications,
-                space: space,
-                savedItem: savedItem,
-                mutation: mutation
-            ) { graphQLResultData in
-                return (graphQLResultData as? UpdateSavedItemRemoveTagsMutation.Data)?.updateSavedItemRemoveTags.fragments.savedItemParts
+        space.performAndWait {
+            guard !expiring else {
+                queue.cancelAllOperations()
+                queue.waitUntilAllOperationsAreFinished()
+                return
             }
-            queue.addOperation(operation)
-            queue.waitUntilAllOperationsAreFinished()
-        } else {
-            let mutation = ReplaceSavedItemTagsMutation(input: [SavedItemTagsInput(savedItemId: remoteID, tags: names)])
-
-            let operation = SaveOperation<ReplaceSavedItemTagsMutation>(
-                apollo: apollo,
-                osNotifications: osNotifications,
-                space: space,
-                savedItem: savedItem,
-                mutation: mutation
-            ) { graphQLResultData in
-                return (graphQLResultData as? ReplaceSavedItemTagsMutation.Data)?.replaceSavedItemTags.first?.fragments.savedItemParts
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
+                Log.capture(message: "Save Service could not get a savedItem from the background context, for _addTags")
+                return
             }
-            queue.addOperation(operation)
-            queue.waitUntilAllOperationsAreFinished()
+
+            guard let tags = savedItem.tags, let remoteID = savedItem.remoteID else { return }
+            let names = Array(tags).compactMap { ($0 as? Tag)?.name }
+
+            if names.isEmpty {
+                let mutation = UpdateSavedItemRemoveTagsMutation(savedItemId: remoteID)
+
+                let operation = SaveOperation<UpdateSavedItemRemoveTagsMutation>(
+                    apollo: apollo,
+                    osNotifications: osNotifications,
+                    space: space,
+                    savedItem: savedItem,
+                    mutation: mutation
+                ) { graphQLResultData in
+                    return (graphQLResultData as? UpdateSavedItemRemoveTagsMutation.Data)?.updateSavedItemRemoveTags.fragments.savedItemParts
+                }
+                queue.addOperation(operation)
+            } else {
+                let mutation = ReplaceSavedItemTagsMutation(input: [SavedItemTagsInput(savedItemId: remoteID, tags: names)])
+
+                let operation = SaveOperation<ReplaceSavedItemTagsMutation>(
+                    apollo: apollo,
+                    osNotifications: osNotifications,
+                    space: space,
+                    savedItem: savedItem,
+                    mutation: mutation
+                ) { graphQLResultData in
+                    return (graphQLResultData as? ReplaceSavedItemTagsMutation.Data)?.replaceSavedItemTags.first?.fragments.savedItemParts
+                }
+                queue.addOperation(operation)
+            }
         }
+        queue.waitUntilAllOperationsAreFinished()
     }
 
     private func _save(expiring: Bool, savedItem: SavedItem) {
-        guard !expiring else {
-            queue.cancelAllOperations()
-            queue.waitUntilAllOperationsAreFinished()
-            return
+        space.performAndWait {
+            guard !expiring else {
+                queue.cancelAllOperations()
+                queue.waitUntilAllOperationsAreFinished()
+                return
+            }
+
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
+                Log.capture(message: "Save Service could not get a savedItem from the background context, for _save")
+                return
+            }
+
+            let mutation =  SaveItemMutation(input: SavedItemUpsertInput(url: savedItem.url.absoluteString))
+
+            let operation = SaveOperation<SaveItemMutation>(
+                apollo: apollo,
+                osNotifications: osNotifications,
+                space: space,
+                savedItem: savedItem,
+                mutation: mutation
+            ) { graphQLResultData in
+                return (graphQLResultData as? SaveItemMutation.Data)?.upsertSavedItem.fragments.savedItemParts
+            }
+
+            queue.addOperation(operation)
         }
-
-        let mutation =  SaveItemMutation(input: SavedItemUpsertInput(url: savedItem.url.absoluteString))
-
-        let operation = SaveOperation<SaveItemMutation>(
-            apollo: apollo,
-            osNotifications: osNotifications,
-            space: space,
-            savedItem: savedItem,
-            mutation: mutation
-        ) { graphQLResultData in
-            return (graphQLResultData as? SaveItemMutation.Data)?.upsertSavedItem.fragments.savedItemParts
-        }
-
-        queue.addOperation(operation)
         queue.waitUntilAllOperationsAreFinished()
     }
 }
@@ -207,6 +229,7 @@ class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation {
             guard case .success(let graphQLResult) = result,
                     let data = graphQLResult.data,
                     let savedItemParts = self?.savedItemParts(data) else {
+                print(result)
                 self?.storeUnresolvedSavedItem()
                 self?.finishOperation()
                 return
@@ -216,17 +239,26 @@ class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation {
     }
 
     private func updateSavedItem(savedItemParts: SavedItemParts) {
-        savedItem.update(from: savedItemParts, with: space)
-        let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
-        notification.savedItem = savedItem
-        try? space.save()
-
+        space.performAndWait {
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
+                Log.capture(message: "Save Service could not get a savedItem from the background context, for update")
+                return
+            }
+            savedItem.update(from: savedItemParts, with: space)
+            let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
+            notification.savedItem = savedItem
+            try? space.save()
+        }
         osNotifications.post(name: .savedItemUpdated)
         finishOperation()
     }
 
     private func storeUnresolvedSavedItem() {
         try? space.performAndWait {
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
+                Log.capture(message: "Save Service could not get a savedItem from the background context, for unresolved item")
+                return
+            }
             let unresolved: UnresolvedSavedItem = UnresolvedSavedItem(context: space.backgroundContext)
             unresolved.savedItem = savedItem
             try space.save()

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -154,16 +154,20 @@ public class PocketSource: Source {
         FetchedImagesController(resultsController: space.makeUndownloadedImagesController())
     }
 
-    public func object<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
-        space.object(with: id)
+    public func backgroundObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
+        space.backgroundObject(with: id)
     }
 
     public func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
         space.viewObject(with: id)
     }
 
-    public func refresh(_ object: NSManagedObject, mergeChanges: Bool) {
-        space.refresh(object, mergeChanges: mergeChanges)
+    public func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool) {
+        space.viewContext.refresh(object, mergeChanges: flag)
+    }
+
+    public func backgroundRefresh(_ object: NSManagedObject, mergeChanges: Bool) {
+        space.backgroundRefresh(object, mergeChanges: mergeChanges)
     }
 
     public func retryImmediately() {
@@ -244,94 +248,111 @@ extension PocketSource {
     }
 
     public func favorite(item: SavedItem) {
-        guard let remoteID = item.remoteID else {
-            return
+        space.performAndWait {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
+                  let remoteID = item.remoteID else {
+                return
+            }
+
+            item.isFavorite = true
+            try? space.save()
+
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: FavoriteItemMutation(itemID: remoteID)
+            )
+
+            enqueue(operation: operation, task: .favorite(remoteID: remoteID))
         }
-
-        item.isFavorite = true
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: FavoriteItemMutation(itemID: remoteID)
-        )
-
-        enqueue(operation: operation, task: .favorite(remoteID: remoteID))
     }
 
     public func unfavorite(item: SavedItem) {
-        guard let remoteID = item.remoteID else {
-            return
+        space.performAndWait {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
+                  let remoteID = item.remoteID else {
+                return
+            }
+
+            item.isFavorite = false
+            try? space.save()
+
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: UnfavoriteItemMutation(itemID: remoteID)
+            )
+            enqueue(operation: operation, task: .unfavorite(remoteID: remoteID))
         }
-
-        item.isFavorite = false
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: UnfavoriteItemMutation(itemID: remoteID)
-        )
-        enqueue(operation: operation, task: .unfavorite(remoteID: remoteID))
     }
 
     public func delete(item savedItem: SavedItem) {
-        guard let remoteID = savedItem.remoteID else {
-            return
+        space.performAndWait {
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem,
+                  let remoteID = savedItem.remoteID else {
+                return
+            }
+
+            let item = savedItem.item
+
+            space.delete(savedItem)
+
+            if let item = item, item.recommendation == nil {
+                space.delete(item)
+            }
+
+            try? space.save()
+
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: DeleteItemMutation(itemID: remoteID)
+            )
+
+            enqueue(operation: operation, task: .delete(remoteID: remoteID))
         }
-
-        let item = savedItem.item
-
-        space.delete(savedItem)
-
-        if let item = item, item.recommendation == nil {
-            space.delete(item)
-        }
-
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: DeleteItemMutation(itemID: remoteID)
-        )
-
-        enqueue(operation: operation, task: .delete(remoteID: remoteID))
     }
 
     public func archive(item: SavedItem) {
-        guard let remoteID = item.remoteID else {
-            return
+        space.performAndWait {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
+                  let remoteID = item.remoteID else {
+                return
+            }
+
+            item.isArchived = true
+            item.archivedAt = Date()
+            try? space.save()
+
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: ArchiveItemMutation(itemID: remoteID)
+            )
+
+            enqueue(operation: operation, task: .archive(remoteID: remoteID))
         }
-
-        item.isArchived = true
-        item.archivedAt = Date()
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: ArchiveItemMutation(itemID: remoteID)
-        )
-
-        enqueue(operation: operation, task: .archive(remoteID: remoteID))
     }
 
     public func unarchive(item: SavedItem) {
-        item.isArchived = false
-        item.createdAt = Date()
-        try? space.save()
+        space.performAndWait {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem else {
+                return
+            }
+            item.isArchived = false
+            item.createdAt = Date()
+            try? space.save()
 
-        let operation = operations.saveItemOperation(
-            managedItemID: item.objectID,
-            url: item.url,
-            events: _events,
-            apollo: apollo,
-            space: space
-        )
+            let operation = operations.saveItemOperation(
+                managedItemID: item.objectID,
+                url: item.url,
+                events: _events,
+                apollo: apollo,
+                space: space
+            )
 
-        enqueue(operation: operation, task: .save(localID: item.objectID.uriRepresentation(), url: item.url))
+            enqueue(operation: operation, task: .save(localID: item.objectID.uriRepresentation(), url: item.url))
+        }
     }
 
     public func save(item: SavedItem) {
@@ -346,54 +367,63 @@ extension PocketSource {
     }
 
     public func addTags(item: SavedItem, tags: [String]) {
-        guard let remoteID = item.remoteID else {
-            return
+        space.performAndWait {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
+                  let remoteID = item.remoteID else {
+                return
+            }
+
+            item.tags = NSOrderedSet(array: tags.compactMap { $0 }.map({ tag in
+                space.fetchOrCreateTag(byName: tag)
+            }))
+
+            try? space.save()
+
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: getMutation(for: tags, and: remoteID)
+            )
+
+            enqueue(operation: operation, task: .addTags(remoteID: remoteID, tags: tags))
         }
-
-        item.tags = NSOrderedSet(array: tags.compactMap { $0 }.map({ tag in
-           space.fetchOrCreateTag(byName: tag)
-        }))
-
-        try? space.save()
-
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: getMutation(for: tags, and: remoteID)
-        )
-
-        enqueue(operation: operation, task: .addTags(remoteID: remoteID, tags: tags))
     }
 
     public func deleteTag(tag: Tag) {
-        guard let remoteID = tag.remoteID else { return }
+        space.performAndWait {
+            guard let tag = space.backgroundObject(with: tag.objectID) as? Tag,
+                  let remoteID = tag.remoteID else { return }
 
-        try? space.deleteTag(byID: remoteID)
-        try? space.save()
+            try? space.deleteTag(byID: remoteID)
+            try? space.save()
 
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: DeleteTagMutation(id: remoteID)
-        )
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: DeleteTagMutation(id: remoteID)
+            )
 
-        enqueue(operation: operation, task: .deleteTag(remoteID: remoteID))
+            enqueue(operation: operation, task: .deleteTag(remoteID: remoteID))
+        }
     }
 
     public func renameTag(from oldTag: Tag, to name: String) {
-        guard let remoteID = oldTag.remoteID else { return }
+        space.performAndWait {
+            guard let oldTag = space.backgroundObject(with: oldTag.objectID) as? Tag,
+                  let remoteID = oldTag.remoteID else { return }
 
-        let fetchedTag = try? space.fetchTag(byID: remoteID)
-        fetchedTag?.name = name
-        try? space.save()
+            let fetchedTag = try? space.fetchTag(byID: remoteID)
+            fetchedTag?.name = name
+            try? space.save()
 
-        let operation = operations.savedItemMutationOperation(
-            apollo: apollo,
-            events: _events,
-            mutation: TagUpdateMutation(input: TagUpdateInput(id: remoteID, name: name))
-        )
+            let operation = operations.savedItemMutationOperation(
+                apollo: apollo,
+                events: _events,
+                mutation: TagUpdateMutation(input: TagUpdateInput(id: remoteID, name: name))
+            )
 
-        enqueue(operation: operation, task: .renameTag(remoteID: remoteID, name: name))
+            enqueue(operation: operation, task: .renameTag(remoteID: remoteID, name: name))
+        }
     }
 
     public func retrieveTags(excluding tags: [String]) -> [Tag]? {
@@ -468,7 +498,11 @@ extension PocketSource {
         }
 
         try space.performAndWait {
-            item.update(remote: remoteItem, with: space)
+            guard let backgroundItem = space.backgroundObject(with: item.objectID) as? Item else {
+                Log.capture(message: "Could not fetch a background item when fetching details for Recommendations")
+                return
+            }
+            backgroundItem.update(remote: remoteItem, with: space)
             try space.save()
         }
     }
@@ -632,27 +666,33 @@ extension PocketSource {
 // MARK: - Recommendations
 extension PocketSource {
     public func save(recommendation: Recommendation) {
-        guard let item = recommendation.item, item.bestURL != nil else {
-            return
-        }
+        space.performAndWait {
+            guard let recommendation = space.backgroundObject(with: recommendation.objectID) as? Recommendation,
+                  let item = recommendation.item, item.bestURL != nil else {
+                return
+            }
 
-        if let savedItem = recommendation.item?.savedItem {
-            unarchive(item: savedItem)
-        } else {
-            let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: item.givenURL)
-            savedItem.update(from: recommendation)
-            try? space.save()
+            if let savedItem = recommendation.item?.savedItem {
+                unarchive(item: savedItem)
+            } else {
+                let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: item.givenURL)
+                savedItem.update(from: recommendation)
+                try? space.save()
 
-            save(item: savedItem)
+                save(item: savedItem)
+            }
         }
     }
 
     public func archive(recommendation: Recommendation) {
-        guard let savedItem = recommendation.item?.savedItem, savedItem.isArchived == false else {
-            return
-        }
+        space.performAndWait {
+            guard let recommendation = space.backgroundObject(with: recommendation.objectID) as? Recommendation,
+                  let savedItem = recommendation.item?.savedItem, savedItem.isArchived == false else {
+                return
+            }
 
-        archive(item: savedItem)
+            archive(item: savedItem)
+        }
     }
 
     public func remove(recommendation: Recommendation) {
@@ -675,15 +715,17 @@ extension PocketSource {
 // MARK: - URL
 extension PocketSource {
     public func save(url: URL) {
-        if let savedItem = try? space.fetchSavedItem(byURL: url) {
-            unarchive(item: savedItem)
-        } else {
-            let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: url)
-            savedItem.url = url
-            savedItem.createdAt = Date()
-            try? space.save()
+        space.performAndWait {
+            if let savedItem = try? space.fetchSavedItem(byURL: url) {
+                unarchive(item: savedItem)
+            } else {
+                let savedItem: SavedItem = SavedItem(context: space.backgroundContext, url: url)
+                savedItem.url = url
+                savedItem.createdAt = Date()
+                try? space.save()
 
-            save(item: savedItem)
+                save(item: savedItem)
+            }
         }
     }
 }
@@ -711,20 +753,6 @@ extension PocketSource {
         try? space.save()
 
         return remoteSavedItem
-    }
-}
-
-extension PocketSource {
-//    public func performAndWait<T>(_ block: () throws -> T) rethrows -> T {
-//        return try space.performAndWait(block)
-//    }
-//    
-//    public func perform<T>(schedule: NSManagedObjectContext.ScheduledTaskType = .immediate, _ block: @escaping () throws -> T) async rethrows -> T {
-//        return try await space.perform(schedule: schedule, block)
-//    }
-
-    public func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool) {
-        space.viewContext.refresh(object, mergeChanges: flag)
     }
 }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -11,7 +11,7 @@ extension SlateLineup {
         experimentID = remote.experimentId
 
         slates = try? NSOrderedSet(array: remote.slates.map { remoteSlate in
-            let slate = try space.fetchSlate(byRemoteID: remoteSlate.id) ?? Slate(context: space.context, remoteID: remoteSlate.id, expermimentID: remoteSlate.experimentId, requestID: remoteSlate.requestId)
+            let slate = try space.fetchSlate(byRemoteID: remoteSlate.id) ?? Slate(context: space.backgroundContext, remoteID: remoteSlate.id, expermimentID: remoteSlate.experimentId, requestID: remoteSlate.requestId)
             slate.update(from: remoteSlate.fragments.slateParts, in: space)
 
             return slate
@@ -31,7 +31,7 @@ extension Slate {
 
         recommendations = NSOrderedSet(array: remote.recommendations.compactMap { remote in
             guard let remoteID = remote.id,
-                  let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID) ?? Recommendation(context: space.context, remoteID: remoteID) else {
+                  let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID) ?? Recommendation(context: space.backgroundContext, remoteID: remoteID) else {
                 return nil
             }
             recommendation.update(from: remote, in: space)
@@ -55,7 +55,7 @@ extension Recommendation {
         excerpt = remote.curatedInfo?.excerpt
         imageURL = remote.curatedInfo?.imageSrc.flatMap(URL.init)
 
-        let recommendationItem = (try? space.fetchItem(byRemoteID: remote.item.remoteID)) ?? Item(context: space.context, givenURL: url, remoteID: remoteID)
+        let recommendationItem = (try? space.fetchItem(byRemoteID: remote.item.remoteID)) ?? Item(context: space.backgroundContext, givenURL: url, remoteID: remoteID)
         recommendationItem.update(from: remote.item.fragments.itemSummary, with: space)
         item = recommendationItem
     }

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -42,20 +42,22 @@ class APISlateService: SlateService {
         try await handle(remote: remote)
     }
 
-    @MainActor
     private func handle(remote: GetSlateLineupQuery.Data.GetSlateLineup) throws {
-        let lineup = (try? space.fetchSlateLineup(byRemoteID: remote.id)) ?? SlateLineup(context: space.context, remoteID: remote.id, expermimentID: remote.experimentId, requestID: remote.requestId)
-        lineup.update(from: remote, in: space)
+        space.performAndWait {
+            let lineup = (try? space.fetchSlateLineup(byRemoteID: remote.id)) ?? SlateLineup(context: space.backgroundContext, remoteID: remote.id, expermimentID: remote.experimentId, requestID: remote.requestId)
+            lineup.update(from: remote, in: space)
+        }
 
         try space.save()
         try space.batchDeleteOrphanedSlates()
         try space.batchDeleteOrphanedItems()
     }
 
-    @MainActor
     private func handle(remote: SlateParts) throws {
-        let slate = (try? space.fetchSlate(byRemoteID: remote.id)) ?? Slate(context: space.context, remoteID: remote.id, expermimentID: remote.experimentId, requestID: remote.requestId)
-        slate.update(from: remote, in: space)
+        space.performAndWait {
+            let slate = (try? space.fetchSlate(byRemoteID: remote.id)) ?? Slate(context: space.backgroundContext, remoteID: remote.id, expermimentID: remote.experimentId, requestID: remote.requestId)
+            slate.update(from: remote, in: space)
+        }
 
         try space.save()
     }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -37,7 +37,7 @@ public protocol Source {
     func object<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
     func refreshSaves(completion: (() -> Void)?)
-    
+
     func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
     func refreshArchive(completion: (() -> Void)?)

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -18,10 +18,6 @@ public protocol Source {
 
     var initialArchiveDownloadState: CurrentValueSubject<InitialDownloadState, Never> { get }
 
-//    func performAndWait<T>(_ block: () throws -> T) rethrows -> T
-//
-//    func perform<T>(schedule: NSManagedObjectContext.ScheduledTaskType, _ block: @escaping () throws -> T) async rethrows -> T
-
     func clear()
 
     func deleteAccount() async throws
@@ -34,11 +30,15 @@ public protocol Source {
 
     func makeUndownloadedImagesController() -> ImagesController
 
-    func object<T: NSManagedObject>(id: NSManagedObjectID) -> T?
-
     func refreshSaves(completion: (() -> Void)?)
 
+    func backgroundObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
+
     func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
+
+    func backgroundRefresh(_ object: NSManagedObject, mergeChanges: Bool)
+
+    func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool)
 
     func refreshArchive(completion: (() -> Void)?)
 
@@ -73,8 +73,6 @@ public protocol Source {
     func fetchSlate(_ slateID: String) async throws
 
     func restore()
-
-    func refresh(_ object: NSManagedObject, mergeChanges: Bool)
 
     func resolveUnresolvedSavedItems()
 
@@ -111,8 +109,6 @@ public protocol Source {
     /// Get the count of unread saves
     /// - Returns: Int of unread saves
     func unreadSaves() throws -> Int
-
-    func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool)
 }
 
 public extension Source {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -10,13 +10,17 @@ public enum InitialDownloadState {
 }
 
 public protocol Source {
-    var mainContext: NSManagedObjectContext { get }
+    var viewContext: NSManagedObjectContext { get }
 
     var events: AnyPublisher<SyncEvent, Never> { get }
 
     var initialSavesDownloadState: CurrentValueSubject<InitialDownloadState, Never> { get }
 
     var initialArchiveDownloadState: CurrentValueSubject<InitialDownloadState, Never> { get }
+
+//    func performAndWait<T>(_ block: () throws -> T) rethrows -> T
+//
+//    func perform<T>(schedule: NSManagedObjectContext.ScheduledTaskType, _ block: @escaping () throws -> T) async rethrows -> T
 
     func clear()
 
@@ -33,6 +37,8 @@ public protocol Source {
     func object<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
     func refreshSaves(completion: (() -> Void)?)
+    
+    func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
     func refreshArchive(completion: (() -> Void)?)
 
@@ -91,6 +97,22 @@ public protocol Source {
     func searchSaves(search: String) -> [SavedItem]?
 
     func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem?
+
+    /// Gets the recent saves a User has made
+    /// - Parameter limit: Number of recent saves to fetch
+    /// - Returns: Recently saved items
+    func recentSaves(limit: Int) throws -> [SavedItem]
+
+    /// Fetches a slate lineup
+    /// - Parameter identifier: The identifier of the slate lineup to grab
+    /// - Returns: A slatelineup
+    func slateLineup(identifier: String) throws -> SlateLineup?
+
+    /// Get the count of unread saves
+    /// - Returns: Int of unread saves
+    func unreadSaves() throws -> Int
+
+    func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool)
 }
 
 public extension Source {

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -4,42 +4,40 @@
 
 import CoreData
 
+/// Handles all dabatabase operations within Pocket app.
+/// This should only ever be used and injected into the PocketSource class.
+/// Pocket Source should proxy all requests to this class and handle the updating of data.
 public class Space {
-    let context: NSManagedObjectContext
+    let backgroundContext: NSManagedObjectContext
+    let viewContext: NSManagedObjectContext
 
-    required public init(context: NSManagedObjectContext) {
-        self.context = context
-        context.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
+    required public init(backgroundContext: NSManagedObjectContext, viewContext: NSManagedObjectContext) {
+        self.backgroundContext = backgroundContext
+        self.viewContext = viewContext
     }
 
     func managedObjectID(forURL url: URL) -> NSManagedObjectID? {
-        context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url)
+        backgroundContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url)
     }
 
     func fetchSavedItem(byRemoteID remoteID: String) throws -> SavedItem? {
-        let request = Requests.fetchSavedItem(byRemoteID: remoteID)
-        return try context.fetch(request).first
+        return try fetch(Requests.fetchSavedItem(byRemoteID: remoteID)).first
     }
 
     func fetchSavedItem(byRemoteItemID remoteItemID: String) throws -> SavedItem? {
-        let request = Requests.fetchSavedItem(byRemoteItemID: remoteItemID)
-        return try context.fetch(request).first
+        return try fetch(Requests.fetchSavedItem(byRemoteItemID: remoteItemID)).first
     }
 
     func fetchSavedItem(byURL url: URL) throws -> SavedItem? {
-        let request = Requests.fetchSavedItem(byURL: url)
-        return try context.fetch(request).first
+        return try fetch(Requests.fetchSavedItem(byURL: url)).first
     }
 
     func fetchSavedItems(bySearchTerm searchTerm: String, userPremium isPremium: Bool) throws -> [SavedItem]? {
-        let request = Requests.fetchSavedItems(bySearchTerm: searchTerm, userPremium: isPremium)
-        return try context.fetch(request)
+        return try fetch(Requests.fetchSavedItems(bySearchTerm: searchTerm, userPremium: isPremium))
     }
 
     func fetchSavedItems() throws -> [SavedItem] {
-        let request = Requests.fetchSavedItems()
-        let results = try context.fetch(request)
-        return results
+        return try fetch(Requests.fetchSavedItems())
     }
 
     func fetchArchivedItems() throws -> [SavedItem] {
@@ -123,7 +121,7 @@ public class Space {
     func fetchOrCreateTag(byName name: String) -> Tag {
         let fetchRequest = Requests.fetchTag(byName: name)
         fetchRequest.fetchLimit = 1
-        let fetchedTag = (try? fetch(fetchRequest).first) ?? Tag(context: context)
+        let fetchedTag = (try? fetch(fetchRequest).first) ?? Tag(context: backgroundContext)
         guard fetchedTag.name == nil else { return fetchedTag }
         fetchedTag.name = name
         return fetchedTag
@@ -144,7 +142,7 @@ public class Space {
     func deleteTag(byID id: String) throws {
         let fetchRequest = Requests.fetchTag(byID: id)
         fetchRequest.fetchLimit = 1
-        let tag = try context.fetch(fetchRequest)
+        let tag = try fetch(fetchRequest)
         delete(tag)
     }
 
@@ -153,15 +151,15 @@ public class Space {
     }
 
     func fetch<T>(_ request: NSFetchRequest<T>) throws -> [T] {
-        try context.fetch(request)
+        try backgroundContext.performAndWait { try backgroundContext.fetch(request) }
     }
 
     func delete(_ object: NSManagedObject) {
-        context.delete(object)
+        backgroundContext.performAndWait { backgroundContext.delete(object) }
     }
 
     func delete(_ objects: [NSManagedObject]) {
-        objects.forEach(context.delete(_:))
+        backgroundContext.performAndWait { objects.forEach(backgroundContext.delete(_:)) }
     }
 
     func deleteUnsavedItems() throws {
@@ -169,30 +167,39 @@ public class Space {
     }
 
     func save() throws {
-        try context.obtainPermanentIDs(for: Array(context.insertedObjects))
-        try context.save()
+        try backgroundContext.performAndWait {
+            try backgroundContext.obtainPermanentIDs(for: Array(backgroundContext.insertedObjects))
+            try backgroundContext.save()
+        }
+    }
+
+    func performAndWait<T>(_ block: () throws -> T) rethrows -> T {
+        return try backgroundContext.performAndWait(block)
+    }
+
+    func perform<T>(schedule: NSManagedObjectContext.ScheduledTaskType = .immediate, _ block: @escaping () throws -> T) async rethrows -> T {
+        return try await backgroundContext.perform(schedule: schedule, block)
     }
 
     func clear() throws {
-        try context.performAndWait {
-            guard let objectModel = context.persistentStoreCoordinator?.managedObjectModel else {
+        try backgroundContext.performAndWait {
+            guard let objectModel = backgroundContext.persistentStoreCoordinator?.managedObjectModel else {
                 return
             }
 
             for entity in objectModel.entities {
                 let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entity.name!)
                 let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-                try context.execute(deleteRequest)
+                try backgroundContext.execute(deleteRequest)
             }
-
-            context.reset()
+            backgroundContext.reset()
         }
     }
 
     func makeItemsController() -> NSFetchedResultsController<SavedItem> {
         NSFetchedResultsController(
             fetchRequest: Requests.fetchSavedItems(),
-            managedObjectContext: context,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
@@ -201,7 +208,7 @@ public class Space {
     func makeArchivedItemsController(filters: [NSPredicate] = []) -> NSFetchedResultsController<SavedItem> {
         NSFetchedResultsController(
             fetchRequest: Requests.fetchArchivedItems(filters: filters),
-            managedObjectContext: context,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
@@ -213,7 +220,7 @@ public class Space {
         request.sortDescriptors = [NSSortDescriptor(key: "requestID", ascending: true)]
         return NSFetchedResultsController(
             fetchRequest: request,
-            managedObjectContext: context,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
@@ -224,7 +231,7 @@ public class Space {
         request.sortDescriptors = [NSSortDescriptor(key: "remoteID", ascending: true)]
         return NSFetchedResultsController(
             fetchRequest: request,
-            managedObjectContext: context,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
@@ -235,26 +242,37 @@ public class Space {
         request.sortDescriptors = [NSSortDescriptor(key: "source.absoluteString", ascending: true)]
         return NSFetchedResultsController(
             fetchRequest: request,
-            managedObjectContext: context,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
     }
 
     func object<T: NSManagedObject>(with id: NSManagedObjectID) -> T? {
-        context.object(with: id) as? T
+        backgroundContext.performAndWait {
+            backgroundContext.object(with: id) as? T
+        }
+    }
+
+    func viewObject<T: NSManagedObject>(with id: NSManagedObjectID) -> T? {
+        viewContext.performAndWait {
+            viewContext.object(with: id) as? T
+        }
     }
 
     func refresh(_ object: NSManagedObject, mergeChanges: Bool) {
-        context.refresh(object, mergeChanges: mergeChanges)
+        backgroundContext.performAndWait {
+            backgroundContext.refresh(object, mergeChanges: mergeChanges)
+        }
     }
 
     func batchDeleteOrphanedSlates() throws {
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = Slate.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "slateLineup = NULL")
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-
-        try context.execute(deleteRequest)
+        _ = try backgroundContext.performAndWait {
+            try backgroundContext.execute(deleteRequest)
+        }
     }
 
     func batchDeleteOrphanedItems() throws {
@@ -262,6 +280,8 @@ public class Space {
         fetchRequest.predicate = NSPredicate(format: "recommendation = NULL && savedItem = NULL")
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
 
-        try context.execute(deleteRequest)
+        _ = try backgroundContext.performAndWait {
+            try backgroundContext.execute(deleteRequest)
+        }
     }
 }

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -10,22 +10,10 @@ import Combine
 public class Space {
     let backgroundContext: NSManagedObjectContext
     let viewContext: NSManagedObjectContext
-    private var subscriptions: [AnyCancellable] = []
 
     required public init(backgroundContext: NSManagedObjectContext, viewContext: NSManagedObjectContext) {
         self.backgroundContext = backgroundContext
         self.viewContext = viewContext
-
-        // The background context automatically recieves saves from the view context,
-        // but the view context doesn't respond to background context saves by default.
-        NotificationCenter.default.publisher(
-            for: NSManagedObjectContext.didSaveObjectsNotification,
-            object: self.backgroundContext
-        )
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] notification in
-            self?.viewContext.mergeChanges(fromContextDidSave: notification)
-        }.store(in: &subscriptions)
     }
 
     func managedObjectID(forURL url: URL) -> NSManagedObjectID? {

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -15,40 +15,41 @@ final class AppBadgeTrackerTests: XCTestCase {
     private var userDefaults: UserDefaults!
     private var accountViewModel: AccountViewModel!
     private var badgeProvider: MockBadgeProvider!
-    private var savedItem: NSManagedObject!
-    private var archivedItem: NSManagedObject!
 
     override func setUp() {
         space = .testSpace()
         source = MockSource()
-        source.mainContext = space.context
-        savedItem = space.buildSavedItem()
-        archivedItem = space.buildSavedItem(isArchived: true)
+        source.viewContext = space.viewContext
 
         userDefaults = UserDefaults()
         badgeProvider = MockBadgeProvider()
+
+        source.stubUnreadSaves {
+            try! self.space.fetchSavedItems().count
+        }
     }
 
     private func subject(completion: (() -> Void)? = nil) -> AppBadgeSetup {
         return AppBadgeSetup(source: source, userDefaults: userDefaults, badgeProvider: badgeProvider, completion: completion)
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         userDefaults.removeObject(forKey: AccountViewModel.ToggleAppBadgeKey)
+        try space.clear()
+        try space.save()
     }
 
-    func test_on_savedItemsUpdated_noSubscriberCalled() {
+    func test_on_savedItemsUpdated_noSubscriberCalled() throws {
         userDefaults.setValue(false, forKey: AccountViewModel.ToggleAppBadgeKey)
-
-        source.mainContext.insert(savedItem)
+        space.buildSavedItem()
+        try space.save()
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 0)
-        source.mainContext.delete(savedItem)
     }
 
-    func test_on_savedItemsUpdated_subscribersCalledAddingElement() {
+    func test_on_savedItemsUpdated_subscribersCalledAddingElement() throws {
         let badgeExpectation = expectation(description: "expected badge count to be updated")
         let subject = subject {
             badgeExpectation.fulfill()
@@ -57,18 +58,17 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         userDefaults.setValue(true, forKey: AccountViewModel.ToggleAppBadgeKey)
 
-        source.mainContext.insert(savedItem)
-        source.mainContext.insert(archivedItem)
+        space.buildSavedItem()
+        space.buildSavedItem(isArchived: true)
+        try space.save()
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
         wait(for: [badgeExpectation], timeout: 1)
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 1)
-        source.mainContext.delete(savedItem)
-        source.mainContext.delete(archivedItem)
     }
 
-    func test_on_savedItemsUpdated_subscribersCalledAddingAndDeleting() {
+    func test_on_savedItemsUpdated_subscribersCalledAddingAndDeleting() throws {
         let badgeExpectation = expectation(description: "expected badge count to be updated")
         let subject = subject {
             badgeExpectation.fulfill()
@@ -77,9 +77,11 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         userDefaults.setValue(true, forKey: AccountViewModel.ToggleAppBadgeKey)
 
-        source.mainContext.insert(savedItem)
+        let savedItem = space.buildSavedItem()
+        try space.save()
+        space.delete(savedItem)
+        try space.save()
 
-        source.mainContext.delete(savedItem)
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
         wait(for: [badgeExpectation], timeout: 1)

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -6,6 +6,7 @@ import PocketGraph
 @testable import Sync
 @testable import PocketKit
 
+@MainActor
 class HomeViewModelTests: XCTestCase {
     var source: MockSource!
     var tracker: MockTracker!

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -105,8 +105,8 @@ class PocketAddTagsViewModelTests: XCTestCase {
         expectRetrieveTagsCall.assertForOverFulfill = false
         source.stubRetrieveTags { [weak self] _ in
             defer { expectRetrieveTagsCall.fulfill() }
-            let tag2: Tag = Tag(context: self!.space.context)
-            let tag3: Tag = Tag(context: self!.space.context)
+            let tag2: Tag = Tag(context: self!.space.backgroundContext)
+            let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
             tag3.name = "tag 3"
             return [tag2, tag3]
@@ -152,8 +152,8 @@ class PocketAddTagsViewModelTests: XCTestCase {
         }
 
         source.stubFilterTags { [weak self] _ in
-            let tag2: Tag = Tag(context: self!.space.context)
-            let tag3: Tag = Tag(context: self!.space.context)
+            let tag2: Tag = Tag(context: self!.space.backgroundContext)
+            let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
             tag3.name = "tag 3"
             return [tag2, tag3]
@@ -181,8 +181,8 @@ class PocketAddTagsViewModelTests: XCTestCase {
         }
 
         source.stubFilterTags { [weak self] _ in
-            let tag2: Tag = Tag(context: self!.space.context)
-            let tag3: Tag = Tag(context: self!.space.context)
+            let tag2: Tag = Tag(context: self!.space.backgroundContext)
+            let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
             tag3.name = "tag 3"
             return [tag2, tag3]

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -224,7 +224,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         let snapshotSent = expectation(description: "snapshotSent")
         viewModel.snapshot.dropFirst().sink { [unowned self] snapshot in
-            XCTAssertEqual(self.source.fetchViewRefresh(at: 0)?.object, savedItem)
+            XCTAssertEqual(self.source.fetchViewRefresh(at: 0)?.object.objectID, savedItem.objectID)
             XCTAssertEqual(snapshot.reloadedItemIdentifiers, [.item(savedItem.objectID)])
             snapshotSent.fulfill()
         }.store(in: &subscriptions)

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -32,6 +32,14 @@ class SavedItemsListViewModelTests: XCTestCase {
         source.stubMakeArchiveController {
             self.itemsController
         }
+
+        source.stubViewObject { identifier in
+            self.space.viewObject(with: identifier)
+        }
+
+        source.stubBackgroundObject { identifier in
+            self.space.backgroundObject(with: identifier)
+        }
     }
 
     override func tearDownWithError() throws {
@@ -84,32 +92,27 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotSent], timeout: 1)
     }
 
-    func test_shouldSelectCell_whenItemIsPending_returnsFalse() {
+    func test_shouldSelectCell_whenItemIsPending_returnsFalse() throws {
         let viewModel = subject()
         let item = space.buildPendingSavedItem()
-
-        source.stubObject { _ in
-            item
-        }
+        try space.save()
 
         XCTAssertFalse(viewModel.shouldSelectCell(with: .item(item.objectID)))
     }
 
-    func test_shouldSelectCell_whenItemIsNotPending_returnsFalse() {
+    func test_shouldSelectCell_whenItemIsNotPending_returnsFalse() throws {
         let viewModel = subject()
 
         let item = space.buildSavedItem(item: nil)
-
-        source.stubObject { _ in item }
+        try space.save()
 
         XCTAssertTrue(viewModel.shouldSelectCell(with: .item(item.objectID)))
     }
 
-    func test_selectCell_whenItemIsArticle_setsSelectedItemToReaderView() {
+    func test_selectCell_whenItemIsArticle_setsSelectedItemToReaderView() throws {
         let viewModel = subject()
         let item = space.buildPendingSavedItem()
-
-        source.stubObject { _ in item }
+        try space.save()
         viewModel.selectCell(with: .item(item.objectID), sender: UIView())
 
         guard let selectedItem = viewModel.selectedItem else {
@@ -125,13 +128,13 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertNotNil(item)
     }
 
-    func test_selectCell_whenItemIsNotAnArticle_setsSelectedItemToWebView() {
+    func test_selectCell_whenItemIsNotAnArticle_setsSelectedItemToWebView() throws {
         let viewModel = subject()
         let item = space.buildItem(isArticle: false)
         let savedItem = space.buildSavedItem(item: item)
+        try space.save()
 
-        source.stubObject { _ in savedItem }
-        viewModel.selectCell(with: .item(item.objectID), sender: UIView())
+        viewModel.selectCell(with: .item(savedItem.objectID), sender: UIView())
 
         guard let selectedItem = viewModel.selectedItem else {
             XCTFail("Received nil for selectedItem")
@@ -215,13 +218,13 @@ class SavedItemsListViewModelTests: XCTestCase {
         itemsController.stubPerformFetch {
             self.itemsController.fetchedObjects = [savedItem]
         }
-        source.stubRefreshObject { _, _ in }
+        source.stubViewRefresh { _, _ in }
 
         let viewModel = subject()
 
         let snapshotSent = expectation(description: "snapshotSent")
         viewModel.snapshot.dropFirst().sink { [unowned self] snapshot in
-            XCTAssertEqual(self.source.refreshObjectCall(at: 0)?.object, savedItem)
+            XCTAssertEqual(self.source.fetchViewRefresh(at: 0)?.object, savedItem)
             XCTAssertEqual(snapshot.reloadedItemIdentifiers, [.item(savedItem.objectID)])
             snapshotSent.fulfill()
         }.store(in: &subscriptions)
@@ -416,9 +419,10 @@ class SavedItemsListViewModelTests: XCTestCase {
 
 // MARK: - Tags
 extension SavedItemsListViewModelTests {
-    func test_addTagsAction_sendsAddTagsViewModel() {
+    func test_addTagsAction_sendsAddTagsViewModel() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
-        source.stubObject { _ in item }
+        try space.save()
+
         source.stubRetrieveTags { _ in return nil }
         let viewModel = subject()
 

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -6,6 +6,6 @@ extension PersistentContainer {
 
 extension Space {
     static func testSpace() -> Space {
-        Space(context: PersistentContainer.testContainer.viewContext)
+        Space(backgroundContext: PersistentContainer.testContainer.newBackgroundContext(), viewContext: PersistentContainer.testContainer.viewContext)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -15,7 +15,7 @@ extension Space {
         tags: [String]? = nil,
         item: Item? = nil
     ) throws -> SavedItem {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let savedItem = buildSavedItem(
                 remoteID: remoteID,
                 url: url,
@@ -27,7 +27,7 @@ extension Space {
                 tags: tags,
                 item: item
             )
-            try save()
+            try backgroundContext.save()
 
             return savedItem
         }
@@ -45,10 +45,10 @@ extension Space {
         tags: [String]? = nil,
         item: Item? = nil
     ) -> SavedItem {
-        context.performAndWait {
-            let savedItem: SavedItem = SavedItem(context: context, url: URL(string: url)!)
+        backgroundContext.performAndWait {
+            let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: url)!)
             let tags: [Tag]? = tags?.map { tag -> Tag in
-                let newTag: Tag = Tag(context: context)
+                let newTag: Tag = Tag(context: backgroundContext)
                 newTag.name = tag
                 return newTag
             }
@@ -60,7 +60,7 @@ extension Space {
             savedItem.url = URL(string: url)!
             savedItem.cursor = cursor
             savedItem.tags = NSOrderedSet(array: tags ?? [])
-            savedItem.item = item ?? Item(context: context, givenURL: URL(string: url)!, remoteID: remoteID)
+            savedItem.item = item ?? Item(context: backgroundContext, givenURL: URL(string: url)!, remoteID: remoteID)
 
             return savedItem
         }
@@ -68,8 +68,8 @@ extension Space {
 
     @discardableResult
         func buildPendingSavedItem() -> SavedItem {
-            context.performAndWait {
-                let savedItem: SavedItem = SavedItem(context: context, url: URL(string: "https://mozilla.com/example")!)
+            backgroundContext.performAndWait {
+                let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: "https://mozilla.com/example")!)
                 return savedItem
             }
         }
@@ -90,7 +90,7 @@ extension Space {
             url = URL(string: "https://example.com/items/item-1")
         }
 
-        return try context.performAndWait {
+        return try backgroundContext.performAndWait {
             let item = buildItem(
                 remoteID: remoteID,
                 title: title,
@@ -98,7 +98,7 @@ extension Space {
                 isArticle: isArticle,
                 article: article
             )
-            try save()
+            try backgroundContext.save()
 
             return item
         }
@@ -121,8 +121,8 @@ extension Space {
             url = URL(string: "https://example.com/items/item-1")
         }
 
-        return context.performAndWait {
-            let item: Item = Item(context: context, givenURL: url!, remoteID: remoteID)
+        return backgroundContext.performAndWait {
+            let item: Item = Item(context: backgroundContext, givenURL: url!, remoteID: remoteID)
             item.remoteID = remoteID
             item.title = title
             item.resolvedURL = resolvedURL
@@ -145,7 +145,7 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) throws -> SlateLineup {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slateLineup = buildSlateLineup(
                 remoteID: remoteID,
                 requestID: requestID,
@@ -153,7 +153,7 @@ extension Space {
                 slates: slates
             )
 
-            try save()
+            try backgroundContext.save()
             return slateLineup
         }
     }
@@ -165,8 +165,8 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) -> SlateLineup {
-        context.performAndWait {
-            let lineup: SlateLineup = SlateLineup(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let lineup: SlateLineup = SlateLineup(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             lineup.slates = NSOrderedSet(array: slates)
 
             return lineup
@@ -185,7 +185,7 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) throws -> Slate {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slate = buildSlate(
                 experimentID: experimentID,
                 remoteID: remoteID,
@@ -195,7 +195,7 @@ extension Space {
                 recommendations: recommendations
             )
 
-            try save()
+            try backgroundContext.save()
             return slate
         }
     }
@@ -209,8 +209,8 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) -> Slate {
-        context.performAndWait {
-            let slate: Slate = Slate(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let slate: Slate = Slate(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             slate.name = name
             slate.slateDescription = slateDescription
             slate.recommendations = NSOrderedSet(array: recommendations)
@@ -227,13 +227,13 @@ extension Space {
         remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) throws -> Recommendation {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
                 remoteID: remoteID,
                 item: item
             )
 
-            try save()
+            try backgroundContext.save()
             return recommendation
         }
     }
@@ -246,8 +246,8 @@ extension Space {
         title: String? = nil,
         excerpt: String?  = nil
     ) -> Recommendation {
-        context.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: context, remoteID: remoteID)
+        backgroundContext.performAndWait {
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
             recommendation.item = item
             recommendation.title = title
             recommendation.excerpt = excerpt
@@ -267,8 +267,8 @@ extension Space {
         excerpt: String? = nil,
         publisherName: String? = nil
     ) -> SyndicatedArticle {
-        context.performAndWait {
-            let syndicatedArticle: SyndicatedArticle = SyndicatedArticle(context: context)
+        backgroundContext.performAndWait {
+            let syndicatedArticle: SyndicatedArticle = SyndicatedArticle(context: backgroundContext)
             syndicatedArticle.title = title
             syndicatedArticle.imageURL = imageURL
             syndicatedArticle.excerpt  = excerpt
@@ -285,8 +285,8 @@ extension Space {
         source: URL?,
         isDownloaded: Bool = false
     ) -> Image {
-        return context.performAndWait {
-            let image: Image = Image(context: context)
+        return backgroundContext.performAndWait {
+            let image: Image = Image(context: backgroundContext)
             image.source = source
             image.isDownloaded = isDownloaded
 
@@ -299,9 +299,9 @@ extension Space {
         source: URL?,
         isDownloaded: Bool = false
     ) throws -> Image {
-        return try context.performAndWait {
+        return try backgroundContext.performAndWait {
             let image = buildImage(source: source, isDownloaded: isDownloaded)
-            try save()
+            try backgroundContext.save()
 
             return image
         }

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -65,13 +65,14 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
-    func test_addTags_delegatesToSaveServiceAndCallsSaveAction() {
+    func test_addTags_delegatesToSaveServiceAndCallsSaveAction() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
-        let viewModel = subject(item: item) { tags in
+        try space.save()
+        let viewModel = subject(item: space.viewObject(with: item.objectID) as! SavedItem) { tags in
             XCTAssert(true, "expect call to save action")
             var tags: [Tag] = []
             for index in 1...2 {
-                let tag: Tag = Tag(context: self.space.context)
+                let tag: Tag = Tag(context: self.space.viewContext)
                 tag.name = "tag \(index)"
                 tags.append(tag)
             }
@@ -82,14 +83,15 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(item.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"])
     }
 
-    func test_allOtherTags_retrievesValidTagNames() {
+    func test_allOtherTags_retrievesValidTagNames() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
+        try space.save()
         let viewModel = subject(
-            item: item,
+            item: space.viewObject(with: item.objectID) as! SavedItem,
             retrieveAction: { _ in
             var tags: [Tag] = []
             for index in 2...3 {
-                let tag: Tag = Tag(context: self.space.context)
+                let tag: Tag = Tag(context: self.space.viewContext)
                 tag.name = "tag \(index)"
                 tags.append(tag)
             }
@@ -103,9 +105,10 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.otherTags, ["tag 2", "tag 3"])
     }
 
-    func test_removeTag_withValidName_updatesTags() {
+    func test_removeTag_withValidName_updatesTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
-        let viewModel = subject(item: item) { _ in }
+        try space.save()
+        let viewModel = subject(item: space.viewObject(with: item.objectID) as! SavedItem) { _ in }
         viewModel.tags = ["tag 1", "tag 2", "tag 3"]
         viewModel.removeTag(with: "tag 2")
 
@@ -113,23 +116,25 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.otherTags, ["tag 2"])
     }
 
-    func test_removeTag_withNotExistingName_updatesTags() {
+    func test_removeTag_withNotExistingName_updatesTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
-        let viewModel = subject(item: item) { _ in }
+        try space.save()
+        let viewModel = subject(item: space.viewObject(with: item.objectID) as! SavedItem) { _ in }
         viewModel.tags = ["tag 1", "tag 2", "tag 3"]
         viewModel.removeTag(with: "tag 4")
 
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2", "tag 3"])
     }
 
-    func test_newTagInput_withTags_showFiltersTags() {
+    func test_newTagInput_withTags_showFiltersTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
+        try space.save()
         let viewModel = subject(
-            item: item,
+            item: space.viewObject(with: item.objectID) as! SavedItem,
             filterAction: { _, _  in
                 var tags: [Tag] = []
                 for index in 2...3 {
-                    let tag: Tag = Tag(context: self.space.context)
+                    let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
                     tags.append(tag)
                 }
@@ -151,14 +156,15 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         wait(for: [expectFilterTagsCall], timeout: 1)
     }
 
-    func test_newTagInput_withNoTags_showAllTags() {
+    func test_newTagInput_withNoTags_showAllTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
+        try space.save()
         let viewModel = subject(
-            item: item,
+            item: space.viewObject(with: item.objectID) as! SavedItem,
             filterAction: { _, _  in
                 var tags: [Tag] = []
                 for index in 2...3 {
-                    let tag: Tag = Tag(context: self.space.context)
+                    let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
                     tags.append(tag)
                 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -72,7 +72,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
             XCTAssert(true, "expect call to save action")
             var tags: [Tag] = []
             for index in 1...2 {
-                let tag: Tag = Tag(context: self.space.viewContext)
+                let tag: Tag = Tag(context: self.space.backgroundContext)
                 tag.name = "tag \(index)"
                 tags.append(tag)
             }

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -39,7 +39,7 @@ class SavedItemViewModelTests: XCTestCase {
         consumerKey = "test-key"
         space = .testSpace()
 
-        let savedItem = SavedItem(context: space.context, url: URL(string: "http://mozilla.com")!)
+        let savedItem = SavedItem(context: space.backgroundContext, url: URL(string: "http://mozilla.com")!)
         saveService.stubSave { _ in .newItem(savedItem) }
     }
 
@@ -183,7 +183,7 @@ extension SavedItemViewModelTests {
             accessToken: "mock-access-token",
             userIdentifier: "mock-user-identifier"
         )
-        let savedItem = SavedItem(context: self.space.context, url: URL(string: "http://mozilla.com")!)
+        let savedItem = SavedItem(context: self.space.backgroundContext, url: URL(string: "http://mozilla.com")!)
         saveService.stubSave { _ in .existingItem(savedItem) }
 
         let provider = MockItemProvider()
@@ -288,7 +288,7 @@ extension SavedItemViewModelTests {
     func test_retrieveTags_updatesInfoViewModel() async {
         let viewModel = subject()
         saveService.stubRetrieveTags { _ in
-            let tag: Tag = Tag(context: self.space.context)
+            let tag: Tag = Tag(context: self.space.backgroundContext)
             tag.name = "tag 1"
             return [tag]
         }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -6,6 +6,6 @@ extension PersistentContainer {
 
 extension Space {
     static func testSpace() -> Space {
-        Space(context: PersistentContainer.testContainer.viewContext)
+        Space(backgroundContext: PersistentContainer.testContainer.newBackgroundContext(), viewContext: PersistentContainer.testContainer.viewContext)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -46,9 +46,9 @@ extension Space {
         item: Item? = nil
     ) -> SavedItem {
         backgroundContext.performAndWait {
-            let savedItem: SavedItem = SavedItem(context: viewContext, url: URL(string: url)!, remoteID: remoteID)
+            let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: url)!, remoteID: remoteID)
             let tags: [Tag]? = tags?.map { tag -> Tag in
-                let newTag: Tag = Tag(context: viewContext)
+                let newTag: Tag = Tag(context: backgroundContext)
                 newTag.name = tag
                 return newTag
             }
@@ -60,7 +60,7 @@ extension Space {
             savedItem.url = URL(string: url)!
             savedItem.cursor = cursor
             savedItem.tags = NSOrderedSet(array: tags ?? [])
-            savedItem.item = item ?? Item(context: viewContext, givenURL: URL(string: url)!, remoteID: remoteID)
+            savedItem.item = item ?? Item(context: backgroundContext, givenURL: URL(string: url)!, remoteID: remoteID)
 
             return savedItem
         }
@@ -101,7 +101,7 @@ extension Space {
         article: Article? = nil
     ) -> Item {
         backgroundContext.performAndWait {
-            let item: Item = Item(context: viewContext, givenURL: givenURL!, remoteID: remoteID)
+            let item: Item = Item(context: backgroundContext, givenURL: givenURL!, remoteID: remoteID)
             item.remoteID = remoteID
             item.title = title
             item.resolvedURL = resolvedURL
@@ -143,7 +143,7 @@ extension Space {
         slates: [Slate] = []
     ) -> SlateLineup {
         backgroundContext.performAndWait {
-            let lineup: SlateLineup = SlateLineup(context: viewContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+            let lineup: SlateLineup = SlateLineup(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             lineup.slates = NSOrderedSet(array: slates)
 
             return lineup
@@ -187,7 +187,7 @@ extension Space {
         recommendations: [Recommendation] = []
     ) -> Slate {
         backgroundContext.performAndWait {
-            let slate: Slate = Slate(context: viewContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+            let slate: Slate = Slate(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             slate.name = name
             slate.slateDescription = slateDescription
             slate.recommendations = NSOrderedSet(array: recommendations)
@@ -221,7 +221,7 @@ extension Space {
         item: Item? = nil
     ) -> Recommendation {
         backgroundContext.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: viewContext, remoteID: remoteID)
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
             recommendation.item = item
 
             return recommendation
@@ -237,7 +237,7 @@ extension Space {
         isDownloaded: Bool = false
     ) -> Image {
         return backgroundContext.performAndWait {
-            let image: Image = Image(context: viewContext)
+            let image: Image = Image(context: backgroundContext)
             image.source = source
             image.isDownloaded = isDownloaded
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -15,7 +15,7 @@ extension Space {
         tags: [String]? = nil,
         item: Item? = nil
     ) throws -> SavedItem {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let savedItem = buildSavedItem(
                 remoteID: remoteID,
                 url: url,
@@ -45,10 +45,10 @@ extension Space {
         tags: [String]? = nil,
         item: Item? = nil
     ) -> SavedItem {
-        context.performAndWait {
-            let savedItem: SavedItem = SavedItem(context: context, url: URL(string: url)!, remoteID: remoteID)
+        backgroundContext.performAndWait {
+            let savedItem: SavedItem = SavedItem(context: viewContext, url: URL(string: url)!, remoteID: remoteID)
             let tags: [Tag]? = tags?.map { tag -> Tag in
-                let newTag: Tag = Tag(context: context)
+                let newTag: Tag = Tag(context: viewContext)
                 newTag.name = tag
                 return newTag
             }
@@ -60,7 +60,7 @@ extension Space {
             savedItem.url = URL(string: url)!
             savedItem.cursor = cursor
             savedItem.tags = NSOrderedSet(array: tags ?? [])
-            savedItem.item = item ?? Item(context: context, givenURL: URL(string: url)!, remoteID: remoteID)
+            savedItem.item = item ?? Item(context: viewContext, givenURL: URL(string: url)!, remoteID: remoteID)
 
             return savedItem
         }
@@ -77,7 +77,7 @@ extension Space {
         isArticle: Bool = true,
         article: Article? = nil
     ) throws -> Item {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let item = buildItem(
                 remoteID: remoteID,
                 title: title,
@@ -100,8 +100,8 @@ extension Space {
         isArticle: Bool = true,
         article: Article? = nil
     ) -> Item {
-        context.performAndWait {
-            let item: Item = Item(context: context, givenURL: givenURL!, remoteID: remoteID)
+        backgroundContext.performAndWait {
+            let item: Item = Item(context: viewContext, givenURL: givenURL!, remoteID: remoteID)
             item.remoteID = remoteID
             item.title = title
             item.resolvedURL = resolvedURL
@@ -122,7 +122,7 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) throws -> SlateLineup {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slateLineup = buildSlateLineup(
                 remoteID: remoteID,
                 requestID: requestID,
@@ -142,8 +142,8 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) -> SlateLineup {
-        context.performAndWait {
-            let lineup: SlateLineup = SlateLineup(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let lineup: SlateLineup = SlateLineup(context: viewContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             lineup.slates = NSOrderedSet(array: slates)
 
             return lineup
@@ -162,7 +162,7 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) throws -> Slate {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slate = buildSlate(
                 experimentID: experimentID,
                 remoteID: remoteID,
@@ -186,8 +186,8 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) -> Slate {
-        context.performAndWait {
-            let slate: Slate = Slate(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let slate: Slate = Slate(context: viewContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             slate.name = name
             slate.slateDescription = slateDescription
             slate.recommendations = NSOrderedSet(array: recommendations)
@@ -204,7 +204,7 @@ extension Space {
         remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) throws -> Recommendation {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
                 remoteID: remoteID,
                 item: item
@@ -220,8 +220,8 @@ extension Space {
         remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) -> Recommendation {
-        context.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: context, remoteID: remoteID)
+        backgroundContext.performAndWait {
+            let recommendation: Recommendation = Recommendation(context: viewContext, remoteID: remoteID)
             recommendation.item = item
 
             return recommendation
@@ -236,8 +236,8 @@ extension Space {
         source: URL?,
         isDownloaded: Bool = false
     ) -> Image {
-        return context.performAndWait {
-            let image: Image = Image(context: context)
+        return backgroundContext.performAndWait {
+            let image: Image = Image(context: viewContext)
             image.source = source
             image.isDownloaded = isDownloaded
 
@@ -250,7 +250,7 @@ extension Space {
         source: URL?,
         isDownloaded: Bool = false
     ) throws -> Image {
-        return try context.performAndWait {
+        return try backgroundContext.performAndWait {
             let image = buildImage(source: source, isDownloaded: isDownloaded)
             try save()
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -14,7 +14,7 @@ class APISlateServiceTests: XCTestCase {
 
         apollo = MockApolloClient()
         space = .testSpace()
-        try space.context.performAndWait {
+        try space.backgroundContext.performAndWait {
             try space.clear()
             try space.save()
         }

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -383,9 +383,9 @@ extension PocketSaveServiceTests {
     }
 
     func test_retrieveTags_updatesInfoViewModel() {
-        let tag: Tag = Tag(context: space.context)
+        let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 1"
-        let tag2: Tag = Tag(context: space.context)
+        let tag2: Tag = Tag(context: space.backgroundContext)
         tag2.name = "tag 2"
         let service = subject()
         let tags = service.retrieveTags(excluding: ["tag 1"])
@@ -394,9 +394,9 @@ extension PocketSaveServiceTests {
     }
 
     func test_filterTags_retrievesFilteredTags() {
-        let tag: Tag = Tag(context: space.context)
+        let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 1"
-        let tag2: Tag = Tag(context: space.context)
+        let tag2: Tag = Tag(context: space.backgroundContext)
         tag2.name = "tag 2"
         let service = subject()
         let tags = service.filterTags(with: "t", excluding: ["tag 2"])

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
@@ -34,7 +34,7 @@ extension PocketSourceTests {
             receivedNotification.fulfill()
         }.store(in: &subscriptions)
 
-        let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.context)
+        let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
         notification.savedItem = savedItem
         try! space.save()
 
@@ -43,7 +43,7 @@ extension PocketSourceTests {
 
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications, [])
-        XCTAssertFalse(space.context.hasChanges)
+        XCTAssertFalse(space.backgroundContext.hasChanges)
     }
 
     func test_events_whenOSNotificationCenterPostsUnresolvedItemCreatedNotification_enqueuesASaveItemOperation() throws {
@@ -57,7 +57,7 @@ extension PocketSourceTests {
         var source: PocketSource? = subject()
 
         let savedItem = try! space.createSavedItem()
-        let unresolved: UnresolvedSavedItem = UnresolvedSavedItem(context: space.context)
+        let unresolved: UnresolvedSavedItem = UnresolvedSavedItem(context: space.backgroundContext)
         unresolved.savedItem = savedItem
         try space.save()
 
@@ -78,11 +78,11 @@ extension PocketSourceTests {
         let source = subject()
 
         let savedItem = try! space.createSavedItem()
-        let notification1: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.context)
+        let notification1: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
         notification1.savedItem = savedItem
         try! space.save()
 
-        let notification2: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.context)
+        let notification2: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
         notification2.savedItem = savedItem
         try space.save()
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -267,10 +267,11 @@ class PocketSourceTests: XCTestCase {
     func test_itemsController_returnsAFetchedResultsController() throws {
         let source = subject()
         let item1 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(1)), item: space.buildItem(title: "Item 1"))
+        try space.save()
 
         let itemResultsController = source.makeSavesController()
         try itemResultsController.performFetch()
-        XCTAssertEqual(itemResultsController.fetchedObjects, [item1])
+        XCTAssertEqual(itemResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID])
 
         let expectationForUpdatedItems = expectation(description: "updated items")
         let delegate = TestSavedItemsControllerDelegate {
@@ -279,9 +280,10 @@ class PocketSourceTests: XCTestCase {
         itemResultsController.delegate = delegate
 
         let item2 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(title: "Item 2"))
+        try space.save()
 
         wait(for: [expectationForUpdatedItems], timeout: 1)
-        XCTAssertEqual(itemResultsController.fetchedObjects, [item1, item2])
+        XCTAssertEqual(itemResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID, item2.objectID])
     }
 
     func test_resolveUnresolvedSavedItems_enqueuesSaveItemOperation() throws {
@@ -295,7 +297,7 @@ class PocketSourceTests: XCTestCase {
         let source = subject()
 
         let savedItem = try! space.createSavedItem()
-        let unresolved: UnresolvedSavedItem = UnresolvedSavedItem(context: space.context)
+        let unresolved: UnresolvedSavedItem = UnresolvedSavedItem(context: space.backgroundContext)
         unresolved.savedItem = savedItem
         try space.save()
 
@@ -392,7 +394,7 @@ class PocketSourceTests: XCTestCase {
     }
 
     func test_downloadImage_updatesIsDownloadedProperty() throws {
-        let image: Image = Image(context: space.context)
+        let image: Image = Image(context: space.backgroundContext)
 
         let source = subject()
         source.download(images: [image])
@@ -414,7 +416,7 @@ class PocketSourceTests: XCTestCase {
         let source = subject()
         try await source.fetchDetails(for: savedItem)
 
-        space.refresh(savedItem, mergeChanges: true)
+        space.backgroundRefresh(savedItem, mergeChanges: true)
         XCTAssertNotNil(savedItem.item)
         XCTAssertFalse(savedItem.hasChanges)
     }
@@ -433,7 +435,7 @@ class PocketSourceTests: XCTestCase {
         let source = subject()
         try await source.fetchDetails(for: recommendation)
 
-        space.refresh(recommendation, mergeChanges: true)
+        space.backgroundRefresh(recommendation, mergeChanges: true)
         XCTAssertNotNil(recommendation.item?.article)
         XCTAssertFalse(recommendation.hasChanges)
     }
@@ -608,7 +610,7 @@ extension PocketSourceTests {
     }
 
     func test_renameTag_executesUpdateTagMutation() throws {
-        let tag1: Tag = Tag(context: space.context)
+        let tag1: Tag = Tag(context: space.backgroundContext)
         tag1.remoteID = "id 1"
         tag1.name = "tag 1"
         let source = subject()
@@ -630,7 +632,7 @@ extension PocketSourceTests {
     private func createItemsWithTags(_ number: Int, isArchived: Bool = false) -> [SavedItem] {
         guard number > 0 else { return [] }
         return (1...number).compactMap { num in
-            let tag: Tag = Tag(context: space.context)
+            let tag: Tag = Tag(context: space.backgroundContext)
             tag.remoteID = "id \(num)"
             tag.name = "tag \(num)"
             return space.buildSavedItem(isArchived: isArchived, tags: [tag])

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -4,18 +4,20 @@ import XCTest
 import CoreData
 
 class SpaceTests: XCTestCase {
-    var context: NSManagedObjectContext!
+    var viewContext: NSManagedObjectContext!
+    var backgroundContext: NSManagedObjectContext!
 
     override func setUp() {
-        context = PersistentContainer.testContainer.viewContext
+        viewContext = PersistentContainer.testContainer.viewContext
+        backgroundContext = PersistentContainer.testContainer.newBackgroundContext()
     }
 
     override func tearDownWithError() throws {
         try Space.testSpace().clear()
     }
 
-    func subject(context: NSManagedObjectContext? = nil) -> Space {
-        Space(context: context ?? self.context)
+    func subject() -> Space {
+        Space(backgroundContext: backgroundContext, viewContext: viewContext)
     }
 
     func testDeleteTags() throws {
@@ -32,7 +34,7 @@ class SpaceTests: XCTestCase {
 
     func testFetchTagsForSavedAndArchivedItems() throws {
         let space = subject()
-        let tag: Tag = Tag(context: space.context)
+        let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 0"
         _ = space.buildSavedItem(tags: [tag])
         _ = createItemsWithTags(2, isArchived: true)
@@ -43,7 +45,7 @@ class SpaceTests: XCTestCase {
 
     func testFetchOrCreateTags() throws {
         let space = subject()
-        let tag1: Tag = Tag(context: space.context)
+        let tag1: Tag = Tag(context: space.backgroundContext)
         tag1.name = "tag 1"
 
         let fetchedTag1 = space.fetchOrCreateTag(byName: "tag 1")
@@ -56,7 +58,7 @@ class SpaceTests: XCTestCase {
 
     func testFetchTagsByID() throws {
         let space = subject()
-        let tag1: Tag = Tag(context: space.context)
+        let tag1: Tag = Tag(context: space.backgroundContext)
         tag1.remoteID = "id 1"
         tag1.name = "tag 1"
 
@@ -99,7 +101,7 @@ class SpaceTests: XCTestCase {
         guard number > 0 else { return [] }
         return (1...number).compactMap { num in
             let space = subject()
-            let tag: Tag = Tag(context: space.context)
+            let tag: Tag = Tag(context: space.backgroundContext)
             tag.remoteID = "id \(num)"
             tag.name = "tag \(num)"
             return space.buildSavedItem(isArchived: isArchived, tags: [tag])

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -321,9 +321,9 @@ class FetchSavesTests: XCTestCase {
         let fetchCall2 = apollo.fetchCall(withQueryType: TagsQuery.self, at: 1)
         XCTAssertEqual(fetchCall2?.query.pagination.unwrapped?.after.unwrapped, "tag-2-cursor")
 
-        let tags = try space.context.fetch(Tag.fetchRequest())
+        let tags = try space.backgroundContext.fetch(Tag.fetchRequest())
         XCTAssertEqual(tags.count, 4)
-        XCTAssertFalse(space.context.hasChanges)
+        XCTAssertFalse(space.backgroundContext.hasChanges)
     }
 
     func test_refresh_whenIsInitialDownload_sendsAppropriateEvents() async {

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -8,6 +8,6 @@ extension PersistentContainer {
 
 extension Space {
     static func testSpace() -> Space {
-        Space(context: PersistentContainer.testContainer.viewContext)
+        Space(backgroundContext: PersistentContainer.testContainer.newBackgroundContext(), viewContext: PersistentContainer.testContainer.viewContext)
     }
 }

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -15,7 +15,7 @@ extension Space {
         tags: [Tag]? = nil,
         item: Item? = nil
     ) throws -> SavedItem {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let savedItem = buildSavedItem(
                 remoteID: remoteID,
                 url: url,
@@ -27,7 +27,7 @@ extension Space {
                 tags: tags,
                 item: item
             )
-            try save()
+            try backgroundContext.save()
 
             return savedItem
         }
@@ -45,8 +45,8 @@ extension Space {
         tags: [Tag]? = nil,
         item: Item? = nil
     ) -> SavedItem {
-        context.performAndWait {
-            let savedItem: SavedItem = SavedItem(context: context, url: URL(string: url)!)
+        backgroundContext.performAndWait {
+            let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: url)!)
             savedItem.remoteID = remoteID
             savedItem.isFavorite = isFavorite
             savedItem.isArchived = isArchived
@@ -54,7 +54,7 @@ extension Space {
             savedItem.archivedAt = archivedAt
             savedItem.cursor = cursor
             savedItem.tags = NSOrderedSet(array: tags ?? [])
-            savedItem.item = item ?? Item(context: context, givenURL: URL(string: url)!, remoteID: remoteID)
+            savedItem.item = item ?? Item(context: backgroundContext, givenURL: URL(string: url)!, remoteID: remoteID)
 
             return savedItem
         }
@@ -73,7 +73,7 @@ extension Space {
         title: String? = nil,
         item: Item? = nil
     ) throws -> SyndicatedArticle {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let syndicatedArticle = buildSyndicatedArticle(
                 excerpt: excerpt,
                 imageURL: imageURL,
@@ -82,7 +82,7 @@ extension Space {
                 title: title,
                 item: item
             )
-            try save()
+            try backgroundContext.save()
 
             return syndicatedArticle
         }
@@ -97,8 +97,8 @@ extension Space {
         title: String? = nil,
         item: Item? = nil
     ) -> SyndicatedArticle {
-        context.performAndWait {
-            let syndicatedArticle: SyndicatedArticle = SyndicatedArticle(context: context)
+        backgroundContext.performAndWait {
+            let syndicatedArticle: SyndicatedArticle = SyndicatedArticle(context: backgroundContext)
             syndicatedArticle.excerpt = excerpt
             syndicatedArticle.imageURL = imageURL
             syndicatedArticle.itemID = itemID
@@ -120,7 +120,7 @@ extension Space {
         isArticle: Bool = true,
         syndicatedArticle: SyndicatedArticle? = nil
     ) throws -> Item {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let item = buildItem(
                 remoteID: remoteID,
                 title: title,
@@ -128,7 +128,7 @@ extension Space {
                 isArticle: isArticle,
                 syndicatedArticle: syndicatedArticle
             )
-            try save()
+            try backgroundContext.save()
 
             return item
         }
@@ -148,8 +148,8 @@ extension Space {
             url = URL(string: "https://example.com/items/item-1")
         }
 
-        return context.performAndWait {
-            let item: Item = Item(context: context, givenURL: url!, remoteID: remoteID)
+        return backgroundContext.performAndWait {
+            let item: Item = Item(context: backgroundContext, givenURL: url!, remoteID: remoteID)
             item.title = title
             item.resolvedURL = resolvedURL
             item.isArticle = isArticle
@@ -169,7 +169,7 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) throws -> SlateLineup {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slateLineup = buildSlateLineup(
                 remoteID: remoteID,
                 requestID: requestID,
@@ -177,7 +177,7 @@ extension Space {
                 slates: slates
             )
 
-            try save()
+            try backgroundContext.save()
             return slateLineup
         }
     }
@@ -189,8 +189,8 @@ extension Space {
         experimentID: String = "slate-lineup-1-experiment",
         slates: [Slate] = []
     ) -> SlateLineup {
-        context.performAndWait {
-            let lineup: SlateLineup = SlateLineup(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let lineup: SlateLineup = SlateLineup(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             lineup.slates = NSOrderedSet(array: slates)
 
             return lineup
@@ -209,7 +209,7 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) throws -> Slate {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let slate = buildSlate(
                 experimentID: experimentID,
                 remoteID: remoteID,
@@ -219,7 +219,7 @@ extension Space {
                 recommendations: recommendations
             )
 
-            try save()
+            try backgroundContext.save()
             return slate
         }
     }
@@ -233,8 +233,8 @@ extension Space {
         slateDescription: String = "The description of slate 1",
         recommendations: [Recommendation] = []
     ) -> Slate {
-        context.performAndWait {
-            let slate: Slate = Slate(context: context, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
+        backgroundContext.performAndWait {
+            let slate: Slate = Slate(context: backgroundContext, remoteID: remoteID, expermimentID: experimentID, requestID: requestID)
             slate.name = name
             slate.slateDescription = slateDescription
             slate.recommendations = NSOrderedSet(array: recommendations)
@@ -251,13 +251,13 @@ extension Space {
         remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) throws -> Recommendation {
-        try context.performAndWait {
+        try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
                 remoteID: remoteID,
                 item: item
             )
 
-            try save()
+            try backgroundContext.save()
             return recommendation
         }
     }
@@ -267,8 +267,8 @@ extension Space {
         remoteID: String = "slate-1-rec-1",
         item: Item? = nil
     ) -> Recommendation {
-        context.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: context, remoteID: remoteID)
+        backgroundContext.performAndWait {
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
             recommendation.item = item
 
             return recommendation

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -621,10 +621,10 @@ class SearchTests: XCTestCase {
 
         app.saves.searchView.searchResultsView.wait()
         app.saves.searchView.searchItemCell(matching: "Item 4").wait().element.swipeUp(velocity: .fast)
-        app.saves.searchView.searchItemCell(matching: "Item 10").wait().element.swipeUp(velocity: .fast)
+        app.saves.searchView.searchItemCell(matching: "Item 9").wait().element.swipeUp(velocity: .fast)
         app.saves.searchView.searchItemCell(matching: "Item 13").wait().element.swipeUp(velocity: .fast)
         app.saves.searchView.searchItemCell(matching: "Item 20").wait().element.swipeUp(velocity: .fast)
-        app.saves.searchView.searchItemCell(matching: "Item 27").wait().element.swipeUp(velocity: .fast)
+        app.saves.searchView.searchItemCell(matching: "Item 26").wait().element.swipeUp(velocity: .fast)
 
         wait(for: [firstExpectRequest, secondExpectRequest])
 


### PR DESCRIPTION
## Summary
Move all CoreData and Apollo network processing to a background queue to prevent the Main thread from hanging. 

## References 
* IN-1204

## Implementation Details
There are multiple ways we can introduce CoreData concurrency into the application. One approach could be to make each operation occur in it's own thread and NSManagedContext with the views utilizing the viewContext (main thread context). Another is to do the same thing, but instead of each operation getting it's own thread and NSManagedContext we utilize a single background thread and context.

I chose to do the later. 

Space will now take in 2 contexts, 1 for background processing, and 1 for all view models/logic. I then provided proxy functions on Space to access the two NSManagedContexts. Moving forward all Data processing and FetchedController setup should come from a function within Space so that CoreData processing and rendering is contained to a single area of the codebase.

When we pass NSManagedObjects around, we should always be aware of the thread the code will be executing on and based on the thread we are on.

If you are doing view logic you should do:

```swift
guard let savedItem = space.viewObject(with: savedItem.objectID) as? SavedItem else {
    Log.capture(message: "Could not get SavedItem from viewContext while fetching details")
    return
}
```

If you are about to do write/update work you should do it like:

```swift
try space.performAndWait {
    guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
        Log.capture(message: "Could not get SavedItem from backgroundContext while fetching details")
        return
    }
    savedItem.update(from: remoteSavedItem.fragments.savedItemParts, with: space)
    try space.save()
}
```

This will perform the data processing on the Thread that is specific to the NSManagedObjectContext. 

I also had to add `@MainActor` to all our view models and coordinators to ensure they operate on main threads.

>**Note**
All mock building functions in our test suite will build the objects in the backgroundContext. For them to be accessible to the viewContext ensure you call `space.save()` before using them. 

## Test Steps

Use app as normal.  Ensure no segfaults or crashes. This changes all underlying code.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

>**Note**
There is more refactoring that needs to be done and comments to be added so that the app architecture is clearer for new developers and those actively adding to the project. That is out of scope for this work, and I will follow up with the changes.