### PR TITLE
ci(tests): fix for item actions flaky test

### DIFF
--- a/Tests iOS/MyList/SavesTests.swift
+++ b/Tests iOS/MyList/SavesTests.swift
@@ -440,12 +440,16 @@ extension SavesTests {
             .wait(timeout: 10)
 
         app.shareButton.tap()
-
+        guard app.readerActionWebActivity.activityOption("Archive").wait(timeout: 5.0).isHittable else {
+            app.shareButton.tap()
+            return
+        }
+        
         app
             .readerActionWebActivity
             .activityOption("Archive")
             .wait(timeout: 5.0)
-
+        
         app
             .readerActionWebActivity
             .activityOption("Delete")


### PR DESCRIPTION
This is a small fix for test_webview_includesCustomItemActions() in SavesTests.swift

This test has been flaky failing, and I put in a small guard conditional check to make sure that the share button is tapped correctly after the view loads. I hope this fixes the flaky fails, if not I'll have to try something else.