### PR TITLE
Premium purchases - Subscription store refactor

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -14,6 +14,11 @@ public enum ReceiptError: Error {
 
 /// Concrete implementation that sends the App Store Receipt to the Pocket backend
 struct AppStoreReceiptService: ReceiptService {
+    private let client: V3ClientProtocol
+
+    init(client: V3ClientProtocol) {
+        self.client = client
+    }
     func send(_ product: Product?) async throws {
     #if DEBUG
         // TODO: at the moment we are not sending the receipt in debug
@@ -25,7 +30,7 @@ struct AppStoreReceiptService: ReceiptService {
         let transactionType = product != nil ? "purchase" : "restore"
         let currency = product?.priceFormatStyle.currencyCode ?? ""
 
-        try await Services.shared.v3Client.sendAppstoreReceipt(
+        try await client.sendAppstoreReceipt(
             source: source,
             transactionInfo: transactionInfo,
             amount: amount,

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -115,7 +115,7 @@ struct Services {
             userDefaults: userDefaults,
             badgeProvider: UIApplication.shared
         )
-        subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService())
+        subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService(client: Services.shared.v3Client))
 
         userManagementService = UserManagementService(appSession: appSession, user: user, notificationCenter: .default, source: source)
     }


### PR DESCRIPTION
## Summary
* This PR does a little bit of refactor to `PocketSubscriptionStore`, optimizing code and logging.

## Implementation Details
* Changes to `PocketSubscriptionStore`

## Test Steps
* Checkout this brand
* Configure `StoreKit` testing as described in #421, alternatively, use an Appstore sandbox user (contact me if you don't have one)
* Login with a free account
* tap Go Premium and make sure that the purchase flow completes successfully

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
