### PR TITLE
fix(bitrise): build stack changes

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -278,6 +278,7 @@ workflows:
       - _pull_test_bundle
     steps:
       - xcode-test-without-building:
+          timeout: 600 #10 minutes
           title: Unit Tests
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UnitTests_iphonesimulator16.2.xctestrun'
@@ -288,11 +289,15 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UNIT_XCRESULT_PATH'
 
   run-tests-ui-1:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1-max.5core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
     steps:
       - xcode-test-without-building:
+          timeout: 1200 #20 minutes
           title: UI Test Suite 1
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests_iphonesimulator16.2-arm64-x86_64.xctestrun'
@@ -303,11 +308,15 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_1_XCRESULT_PATH'
 
   run-tests-ui-2:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1-max.5core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
     steps:
       - xcode-test-without-building:
+          timeout: 1200 #20 minutes
           title: UI Test Suite 2
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests-2_iphonesimulator16.2-arm64-x86_64.xctestrun'
@@ -318,11 +327,15 @@ workflows:
             - pipeline_intermediate_files: '$BITRISE_XCRESULT_PATH:BITRISE_UITESTS_2_XCRESULT_PATH'
 
   run-tests-ui-3:
+    meta:
+      bitrise.io:
+        machine_type_id: g2-m1-max.5core
     before_run:
       - _pull_test_bundle
       - _start_snowplow
     steps:
       - xcode-test-without-building:
+          timeout: 1200 #20 minutes
           title: UI Test Suite 3
           inputs:
             - xctestrun: '${BITRISE_TEST_BUNDLE_PATH}/Pocket (iOS)_UITests-3_iphonesimulator16.2-arm64-x86_64.xctestrun'


### PR DESCRIPTION
## Summary

Our UI tests seem to hang at times, or fail on on the lower end machines. Particularly with tests that interact with the System (Safari, Custom Actions). This bumps the machine size for the UI tests and adds a timeout.