### PR TITLE
feat(premium): update receipt encoding

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -135,7 +135,7 @@ extension PocketSubscriptionStore {
         }
         do {
             // in case no subscription was found,
-            // still send the receipt App Store receipt to the backend
+            // still send the App Store receipt to the backend
             try await receiptService.send(nil)
         } catch {
             Log.capture(error: error)

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -39,13 +39,6 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
             }
             // Restore a purchased subscription, if any
             await self.fetchActiveSubscription()
-
-            do {
-                // send App Store receipt at launch
-                try await receiptService.send(nil)
-            } catch {
-                Log.capture(error: error)
-            }
         }
     }
 
@@ -135,9 +128,17 @@ extension PocketSubscriptionStore {
         for await transaction in Transaction.currentEntitlements {
             do {
                 try await processTransaction(transaction)
+                return
             } catch {
                 Log.capture(error: error)
             }
+        }
+        do {
+            // in case no subscription was found,
+            // still send the receipt App Store receipt to the backend
+            try await receiptService.send(nil)
+        } catch {
+            Log.capture(error: error)
         }
     }
 
@@ -154,6 +155,7 @@ extension PocketSubscriptionStore {
             if let subscription = subscriptions.first(where: { $0.product.id == verifiedTransaction.productID }) {
                 state = .subscribed(subscription.type)
                 user.setPremiumStatus(true)
+                // send the App Store receipt to the backend with the current subscription
                 do {
                     try await receiptService.send(subscription.product)
                 } catch {

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -48,10 +48,6 @@ private extension AppStoreReceiptService {
         }
         let receiptString = try Data(contentsOf: appStoreReceiptURL, options: .alwaysMapped)
             .base64EncodedString(options: [])
-        /// replicates exactly the encoding in the legacy app. It's probably safe to replace with
-        /// `.addingPercentEncoding(withAllowedCharacters: .alphanumerics)`,
-        /// as this would always ensure `.utf8`, and we `CFURLCreateStringByAddingPercentEscapes` is deprecated since iOS 9.0.
-        /// At most it would result with a few more percent-encoded (non alpha) characters, which should still be decoded correctly.
         return receiptString
     }
 }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -26,10 +26,7 @@ struct AppStoreReceiptService: ReceiptService {
         let amount = product?.price != nil ? "\(product!.price)" : ""
         let transactionType = product != nil ? "purchase" : "restore"
         let currency = product?.priceFormatStyle.currencyCode ?? ""
-#if DEBUG
-        // TODO: at the moment we are not sending the receipt in debug
-        print(transactionInfo)
-#else
+
         try await client.sendAppstoreReceipt(
             source: source,
             transactionInfo: transactionInfo,
@@ -38,7 +35,6 @@ struct AppStoreReceiptService: ReceiptService {
             currency: currency,
             transactionType: transactionType
         )
-#endif
     }
 }
 
@@ -56,15 +52,6 @@ private extension AppStoreReceiptService {
         /// `.addingPercentEncoding(withAllowedCharacters: .alphanumerics)`,
         /// as this would always ensure `.utf8`, and we `CFURLCreateStringByAddingPercentEscapes` is deprecated since iOS 9.0.
         /// At most it would result with a few more percent-encoded (non alpha) characters, which should still be decoded correctly.
-        guard let legacyReceipt = CFURLCreateStringByAddingPercentEscapes(
-            kCFAllocatorDefault,
-            receiptString as CFString,
-            nil,
-            "!*'();:@&=+$,/?%#[]" as CFString,
-            CFStringBuiltInEncodings.UTF8.rawValue
-        ) else {
-            throw ReceiptError.invalidReceipt
-        }
-        return legacyReceipt as String
+        return receiptString
     }
 }


### PR DESCRIPTION
## Summary
* This PR removes the url encoding from the App Store receipt. It also optimizes the code that sends the receipt out, only sending a "restore" receipt type to the backend if no purchased product was found (in which case a "purchase" type will be sent)


## Implementation Details
* Update `AppStoreReceiptService`, remove url encoding from the receipt
* Update `PocketSubscriptionService`, send the restore request to the backend only if no active product was found.

## Test Steps
* There's not much manual testing here.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA


