### PR TITLE
feat(saves): update saves use NSFetchedResults diffable datasource delegate

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -183,11 +183,11 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             }
         }
 
-        model.events.sink { [weak self] event in
+        model.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             self?.handle(savesEvent: event)
         }.store(in: &subscriptions)
 
-        model.snapshot.sink { [weak self] snapshot in
+        model.snapshot.receive(on: DispatchQueue.main).sink { [weak self] snapshot in
             self?.dataSource.apply(snapshot, animatingDifferences: true)
         }.store(in: &subscriptions)
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -518,7 +518,7 @@ extension SearchViewModel: SavedItemsControllerDelegate {
         }
     }
 
-    func controllerDidChangeContent(_ controller: SavedItemsController) {
+    func controller(_ controller: SavedItemsController, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
         // no-op
     }
 

--- a/PocketKit/Sources/Sync/SavedItemsController.swift
+++ b/PocketKit/Sources/Sync/SavedItemsController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import UIKit
 
 public protocol SavedItemsControllerDelegate: AnyObject {
     func controller(
@@ -10,7 +11,7 @@ public protocol SavedItemsControllerDelegate: AnyObject {
         newIndexPath: IndexPath?
     )
 
-    func controllerDidChangeContent(_ controller: SavedItemsController)
+    func controller(_ controller: SavedItemsController, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference)
 }
 
 public protocol SavedItemsController: AnyObject {
@@ -78,7 +79,7 @@ extension FetchedSavedItemsController: NSFetchedResultsControllerDelegate {
         delegate?.controller(self, didChange: savedItem, at: indexPath, for: type, newIndexPath: newIndexPath)
     }
 
-    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        delegate?.controllerDidChangeContent(self)
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+        delegate?.controller(self, didChangeContentWith: snapshot)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -36,7 +36,7 @@ class SearchViewModelTests: XCTestCase {
 
         itemsController = MockSavedItemsController()
         itemsController.stubIndexPathForObject { _ in IndexPath(item: 0, section: 0) }
-        source.stubMakeItemsController {
+        source.stubMakeSavesController {
             self.itemsController
         }
         itemsController.stubPerformFetch {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -160,32 +160,32 @@ extension MockSource {
 
 // MARK: - Make items controller
 extension MockSource {
-    static let makeItemsController = "makeItemsController"
-    typealias MakeItemsControllerImpl = () -> SavedItemsController
+    static let makeSavesController = "makeSavesController"
+    typealias MakeSavesControllerImpl = () -> SavedItemsController
 
-    struct MakeItemsControllerCall {
+    struct MakeSavesControllerCall {
     }
 
-    func stubMakeItemsController(impl: @escaping MakeItemsControllerImpl) {
-        implementations[Self.makeItemsController] = impl
+    func stubMakeSavesController(impl: @escaping MakeSavesControllerImpl) {
+        implementations[Self.makeSavesController] = impl
     }
 
     func makeSavesController() -> SavedItemsController {
-        guard let impl = implementations[Self.makeItemsController] as? MakeItemsControllerImpl else {
+        guard let impl = implementations[Self.makeSavesController] as? MakeSavesControllerImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        calls[Self.makeItemsController] = (calls[Self.makeItemsController] ?? []) + [MakeItemsControllerCall()]
+        calls[Self.makeSavesController] = (calls[Self.makeSavesController] ?? []) + [MakeSavesControllerCall()]
 
         return impl()
     }
 
-    func makeItemsControllerCall(at index: Int) -> MakeItemsControllerCall? {
-        guard let calls = calls[Self.makeItemsController], calls.count > index else {
+    func makeSavesControllerCall(at index: Int) -> MakeSavesControllerCall? {
+        guard let calls = calls[Self.makeSavesController], calls.count > index else {
             return nil
         }
 
-        return calls[index] as? MakeItemsControllerCall
+        return calls[index] as? MakeSavesControllerCall
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,4 +1,4 @@
-import Sync
+@testable import Sync
 
 extension PersistentContainer {
     static let testContainer = PersistentContainer(storage: .inMemory, userDefaults: .standard, groupID: "group.com.ideashower.ReadItLaterPro")
@@ -6,6 +6,6 @@ extension PersistentContainer {
 
 extension Space {
     static func testSpace() -> Space {
-        Space(backgroundContext: PersistentContainer.testContainer.newBackgroundContext(), viewContext: PersistentContainer.testContainer.viewContext)
+        return PersistentContainer.testContainer.rootSpace
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -264,26 +264,27 @@ class PocketSourceTests: XCTestCase {
         XCTAssertEqual(slateService.fetchSlateCall(at: 0)?.identifier, "slate-identifier")
     }
 
-    func test_itemsController_returnsAFetchedResultsController() throws {
+    func test_savesController_returnsAFetchedResultsController() throws {
         let source = subject()
         let item1 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(1)), item: space.buildItem(title: "Item 1"))
         try space.save()
 
-        let itemResultsController = source.makeSavesController()
-        try itemResultsController.performFetch()
-        XCTAssertEqual(itemResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID])
+        let savesResultsController = source.makeSavesController()
+        try savesResultsController.performFetch()
+        XCTAssertEqual(savesResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID])
 
         let expectationForUpdatedItems = expectation(description: "updated items")
         let delegate = TestSavedItemsControllerDelegate {
             expectationForUpdatedItems.fulfill()
         }
-        itemResultsController.delegate = delegate
+        savesResultsController.delegate = delegate
 
         let item2 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(title: "Item 2"))
         try space.save()
+        try savesResultsController.performFetch()
 
         wait(for: [expectationForUpdatedItems], timeout: 1)
-        XCTAssertEqual(itemResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID, item2.objectID])
+        XCTAssertEqual(savesResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID, item2.objectID])
     }
 
     func test_resolveUnresolvedSavedItems_enqueuesSaveItemOperation() throws {

--- a/PocketKit/Tests/SyncTests/Support/TestSavedItemsControllerDelegate.swift
+++ b/PocketKit/Tests/SyncTests/Support/TestSavedItemsControllerDelegate.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 import Sync
+import UIKit
 
 class TestSavedItemsControllerDelegate: SavedItemsControllerDelegate {
     private let handler: () -> Void
@@ -9,10 +10,10 @@ class TestSavedItemsControllerDelegate: SavedItemsControllerDelegate {
         self.handler = handler
     }
 
-    func controllerDidChangeContent(_ controller: SavedItemsController) {
-        handler()
+    func controller(_ controller: SavedItemsController, didChange aSavedItem: SavedItem, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
     }
 
-    func controller(_ controller: SavedItemsController, didChange aSavedItem: SavedItem, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+    func controller(_ controller: SavedItemsController, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+        handler()
     }
 }


### PR DESCRIPTION
## Summary

Attempt to solve our biggest crash in testflight by ensuring that our SavedItemsListModel only updates its data via the DiffableDataSource delegate callback from NSFetchedResultsController. 

<img width="1108" alt="Screenshot 2023-03-21 at 8 07 05 PM" src="https://user-images.githubusercontent.com/1010384/226791764-49a27137-1952-4bad-954f-7eaabc22fb6b.png">

## Implementation Details

Before we were updating our snapshot in various places within the SavedItemsViewModel and sometimes before data was fully available for our View. This ensures that when we add/update/remove a save from our Snapshot, that request to do so came straight from our NSFetchedResultsController. Because it comes straight from NSFetchedResultsController we can expect the data to exist and not cause a crash down the line.

## Test Steps
* Ensure saves load normally.

I was able to reproduce the Crash pictured above by logging into my account and then scrolling very quickly down my saves lists.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
