### PR TITLE
fix(orientation): allow only reader to rotate

### DIFF
--- a/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
+++ b/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
@@ -11,4 +11,10 @@ extension UIViewController {
         sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
         sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
     }
+
+    /// Locks the orientation for a specific view controller
+    /// - Parameter orientation: orientation of the view (i.e. portrait, all)
+    func lockOrientation(_ orientation: UIInterfaceOrientationMask) {
+        PocketAppDelegate.phoneOrientationLock = orientation
+    }
 }

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -46,6 +46,16 @@ class ReadableHostViewController: UIViewController {
         }.store(in: &subscriptions)
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        lockOrientation(.allButUpsideDown)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        lockOrientation(.portrait)
+        super.viewDidDisappear(animated)
+    }
+
     override func loadView() {
         view = UIView()
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -10,6 +10,8 @@ import BackgroundTasks
 import SharedPocketKit
 
 public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
+    static var phoneOrientationLock = UIInterfaceOrientationMask.portrait
+
     private let source: Source
     private let userDefaults: UserDefaults
     private let firstLaunchDefaults: UserDefaults
@@ -78,5 +80,15 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         refreshCoordinator.initialize()
 
         return true
+    }
+
+    /// Sets orientations to use for the views
+    /// - Parameters:
+    ///   - application: singleton app object
+    ///   - window: window whose interface orientations you want to retrieve
+    /// - Returns: orientations to use for the view
+    public func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return .all }
+        return PocketAppDelegate.phoneOrientationLock
     }
 }


### PR DESCRIPTION
## Summary
Fix rotation on iPhone and only allow Reader to be rotated.

## References 
IN-1134

## Implementation Details
Created static var `phoneOrientationLock` that is set to `portrait` by default for phone devices. Only case we want to be able to rotate the view is for our reader and added `lockOrientation` to be able to make the change for this view when it appears. 

## Test Steps
As a phone user, when I rotate my device to landscape orientation, the screen should not rotate, unless I am reading an article. 

1. Navigate to Premium Purchase Screen or any other screen that is not Reader
2. Attempt to rotate the screen and confirm view does not change

1. Navigate to Reader
2. Attempt to rotate the screen and confirm view does indeed change

## PR Checklist:
- [N/A] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
