### PR TITLE
feat(saves): increase the default list size

### DIFF
--- a/PocketKit/Sources/Sync/SyncConstants.swift
+++ b/PocketKit/Sources/Sync/SyncConstants.swift
@@ -7,7 +7,7 @@ import Foundation
 struct SyncConstants {
     struct Saves {
         /// How many saves we load when a user logs in. As they save and use pocket they may accumilate more, but we only download the amount of latest saves here to start.
-        static let firstLoadMaxCount = 500
+        static let firstLoadMaxCount = 1000
 
         /// How many saves we should load on the first login request for saves, we use a small value here so the user immediately sees content.
         static let initalPageSize = 15
@@ -18,7 +18,7 @@ struct SyncConstants {
 
     struct Archive {
         /// How many archives we load when a user logs in. As they save and use pocket they may accumilate more, but we only download the amount of latest archives here to start.
-        static let firstLoadMaxCount = 500
+        static let firstLoadMaxCount = 1000
 
         /// How many archives we should load on the first login request for archives, we use a small value here so the user immediately sees content.
         static let initalPageSize = 15


### PR DESCRIPTION
## Summary

In talking with @nzeltzer we have decided that the intial list size we load will be 1000 items which covers most pocket users based on analytics.

We will raise this once we have intelligent downloading.

## Test Steps
* Load list with > 1000 items and ensure they are all visible

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
