### PR TITLE
fix(slate-detail): removing extra slate detail refresh

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -115,7 +115,6 @@ class SlateDetailViewController: UIViewController {
         ])
 
         model.fetch()
-        model.refresh { }
     }
 }
 

--- a/PocketKit/Sources/Sync/SyncConstants.swift
+++ b/PocketKit/Sources/Sync/SyncConstants.swift
@@ -29,9 +29,9 @@ struct SyncConstants {
 
     struct Home {
         /// How many recomendations to pull in when we load them via getSlateLineup (ie. Home)
-        static let recomendationsPerSlateFromSlateLineup = 5
+        static let recomendationsPerSlateFromSlateLineup = 15
 
         /// How many recomendations to pull in when we load them via getSlate (ie. a detail view)
-        static let recomendationsPerSlateDetail = 25
+        static let recomendationsPerSlateDetail = 15
     }
 }

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -42,7 +42,7 @@ extension APISlateServiceTests {
         let fetchCall: MockApolloClient.FetchCall<GetSlateLineupQuery>? = apollo.fetchCall(at: 0)
         XCTAssertNotNil(fetchCall)
         XCTAssertEqual(fetchCall?.query.lineupID, "slate-lineup-identifier")
-        XCTAssertEqual(fetchCall?.query.maxRecommendations, 5)
+        XCTAssertEqual(fetchCall?.query.maxRecommendations, SyncConstants.Home.recomendationsPerSlateFromSlateLineup)
     }
 
     @MainActor
@@ -207,7 +207,7 @@ extension APISlateServiceTests {
         let fetchCall: MockApolloClient.FetchCall<GetSlateQuery>? = apollo.fetchCall(at: 0)
         XCTAssertNotNil(fetchCall)
         XCTAssertEqual(fetchCall?.query.slateID, "slate-identifier")
-        XCTAssertEqual(fetchCall?.query.recommendationCount, 25)
+        XCTAssertEqual(fetchCall?.query.recommendationCount, SyncConstants.Home.recomendationsPerSlateDetail)
     }
 
     @MainActor

--- a/Tests iOS/Fixtures/slates.json
+++ b/Tests iOS/Fixtures/slates.json
@@ -21,8 +21,8 @@
               "item": {
                 "__typename": "[some-type-name]",
                 "remoteID": "recommended-item-1",
-                "givenUrl": "http://localhost:8080/hello",
-                "resolvedUrl": "http://localhost:8080/hello",
+                "givenUrl": "http://localhost:8080/item-1",
+                "resolvedUrl": "http://localhost:8080/item-1",
                 "title": "Slate 1, Recommendation 1",
                 "language": "en",
                 "topImageUrl": "http://example.com/slate-1-rec-1/top-image.png",

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -60,6 +60,13 @@ class HomeTests: XCTestCase {
                 Fixture.data(name: "hello", ext: "html")
             }
         }
+        
+        server.routes.get("/item-1") { _, _ in
+            Response {
+                Status.ok
+                Fixture.data(name: "hello", ext: "html")
+            }
+        }
 
         try server.start()
     }
@@ -101,7 +108,7 @@ class HomeTests: XCTestCase {
         let loadedSlate2Rec1 = recs[2]!
         let loadedSlate2Rec2 = recs[3]!
 
-        snowplowMicro.assertRecommendationImpressionHasNecessaryContexts(event: loadedSlate1Rec1, url: "http://localhost:8080/hello")
+        snowplowMicro.assertRecommendationImpressionHasNecessaryContexts(event: loadedSlate1Rec1, url: "http://localhost:8080/item-1")
         snowplowMicro.assertRecommendationImpressionHasNecessaryContexts(event: loadedSlate1Rec2, url: "https://example.com/item-2")
         snowplowMicro.assertRecommendationImpressionHasNecessaryContexts(event: loadedSlate2Rec1, url: "https://example.com/item-1")
         snowplowMicro.assertRecommendationImpressionHasNecessaryContexts(event: loadedSlate2Rec2, url: "https://example.com/item-2")
@@ -203,8 +210,6 @@ class HomeTests: XCTestCase {
         home.sectionHeader("Slate 1").seeAllButton.wait().tap()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 1").wait()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 2").wait()
-        app.slateDetailView.element.swipeUp()
-        app.slateDetailView.recommendationCell("Slate 1, Recommendation 3").wait()
 
         app.navigationBar.buttons["Home"].wait().tap()
         home.element.swipeUp()
@@ -279,7 +284,7 @@ class HomeTests: XCTestCase {
             } else if apiRequest.isForArchivedContent {
                 return Response.archivedContent()
             } else if apiRequest.isToSaveAnItem {
-                XCTAssertTrue(apiRequest.contains("http:\\/\\/localhost:8080\\/hello"))
+                XCTAssertTrue(apiRequest.contains("http:\\/\\/localhost:8080\\/item-1"))
                 saveRequestExpectation.fulfill()
                 promise = loop.makePromise()
                 return promise!.futureResult
@@ -332,7 +337,7 @@ class HomeTests: XCTestCase {
             let apiRequest = ClientAPIRequest(request)
 
             if apiRequest.isToSaveAnItem {
-                if apiRequest.contains("https:\\/\\/example.com\\/item-1") {
+                if apiRequest.contains("http:\\/\\/localhost:8080\\/item-1") {
                     return Response.saveItem("save-recommendation-1")
                 } else if apiRequest.contains("https:\\/\\/example.com\\/item-2") {
                     return Response.saveItem("save-recommendation-2")

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -75,7 +75,7 @@ class ReportARecommendationTests: XCTestCase {
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let event = await snowplowMicro.getFirstEvent(with: "discover.report")
         event!.getReportContext()!.assertHas(reason: "other")
-        event!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+        event!.getContentContext()!.assertHas(url: "http://localhost:8080/item-1")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Ensure that recommendations do not reload when a user clicks into a slate detail.

## References 
* IN-1230

## Implementation Details

Per conversation with @nzeltzer we are fetching more recs on initial load of home to make it so slate details does not reorder the results.

## Test Steps
* Load home
* Go into a slate detail, you should not see them re-order.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
