### PR TITLE
fix(cache): improve caching and deletion of images

### DIFF
--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -85,7 +85,7 @@ struct Services {
         )
 
         imageManager = ImageManager(
-            imagesController: source.makeUndownloadedImagesController(),
+            imagesController: source.makeImagesController(),
             imageRetriever: KingfisherManager.shared,
             source: source
         )

--- a/PocketKit/Sources/Sync/ImagesController.swift
+++ b/PocketKit/Sources/Sync/ImagesController.swift
@@ -2,14 +2,6 @@ import Foundation
 import CoreData
 
 public protocol ImagesControllerDelegate: AnyObject {
-    func controller(
-        _ controller: ImagesController,
-        didChange image: Image,
-        at indexPath: IndexPath?,
-        for type: NSFetchedResultsChangeType,
-        newIndexPath: IndexPath?
-    )
-
     func controllerDidChangeContent(_ controller: ImagesController)
 }
 
@@ -44,26 +36,6 @@ class FetchedImagesController: NSObject, ImagesController {
 }
 
 extension FetchedImagesController: NSFetchedResultsControllerDelegate {
-    func controller(
-        _ controller: NSFetchedResultsController<NSFetchRequestResult>,
-        didChange anObject: Any,
-        at indexPath: IndexPath?,
-        for type: NSFetchedResultsChangeType,
-        newIndexPath: IndexPath?
-    ) {
-        guard let image = anObject as? Image else {
-            return
-        }
-
-        delegate?.controller(
-            self,
-            didChange: image,
-            at: indexPath,
-            for: type,
-            newIndexPath: newIndexPath
-        )
-    }
-
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         delegate?.controllerDidChangeContent(self)
     }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -150,8 +150,8 @@ public class PocketSource: Source {
         PocketSearchService(apollo: apollo)
     }
 
-    public func makeUndownloadedImagesController() -> ImagesController {
-        FetchedImagesController(resultsController: space.makeUndownloadedImagesController())
+    public func makeImagesController() -> ImagesController {
+        FetchedImagesController(resultsController: space.makeImagesController())
     }
 
     public func makeRecentSavesController() -> NSFetchedResultsController<SavedItem> {
@@ -716,11 +716,8 @@ extension PocketSource {
 
 // MARK: - Image
 extension PocketSource {
-    public func download(images: [Image]) {
-        images.forEach {
-            $0.isDownloaded = true
-        }
-
+    public func delete(images: [Image]) {
+        space.delete(images)
         try? space.save()
     }
 }

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -203,9 +203,7 @@ public enum Requests {
     }
 
     public static func fetchUndownloadedImages() -> NSFetchRequest<Image> {
-        let request = Image.fetchRequest()
-        request.predicate = NSPredicate(format: "isDownloaded = NO")
-        return request
+        return Image.fetchRequest()
     }
 
     public static func fetchSavedItem(for item: Item) -> NSFetchRequest<SavedItem> {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -32,7 +32,7 @@ public protocol Source {
 
     func makeSearchService() -> SearchService
 
-    func makeUndownloadedImagesController() -> ImagesController
+    func makeImagesController() -> ImagesController
 
     func refreshSaves(completion: (() -> Void)?)
 
@@ -86,7 +86,7 @@ public protocol Source {
 
     func remove(recommendation: Recommendation)
 
-    func download(images: [Image])
+    func delete(images: [Image])
 
     func fetchDetails(for savedItem: SavedItem) async throws
 

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -260,7 +260,7 @@ public class Space {
         )
     }
 
-    func makeUndownloadedImagesController() -> NSFetchedResultsController<Image> {
+    func makeImagesController() -> NSFetchedResultsController<Image> {
         let request = Requests.fetchUndownloadedImages()
         request.sortDescriptors = [NSSortDescriptor(key: "source.absoluteString", ascending: true)]
         return NSFetchedResultsController(

--- a/PocketKit/Tests/PocketKitTests/Support/MockImageDownloader.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockImageDownloader.swift
@@ -67,6 +67,41 @@ extension MockImageCache {
     }
 }
 
+extension MockImageCache {
+    private static let isCached = "isCached"
+
+    typealias IsCachedImpl = (String, String) -> Bool
+
+    struct IsCachedCall {
+        let key: String
+        let processIdentifier: String
+    }
+
+    func stubIsCached(_ impl: @escaping IsCachedImpl) {
+        implementations[Self.isCached] = impl
+    }
+
+    func isCachedCall(at index: Int) -> IsCachedCall? {
+        guard let calls = calls[Self.isCached], index < calls.count else {
+            return nil
+        }
+
+        return calls[index] as? IsCachedCall
+    }
+
+    func isCached(forKey key: String, processorIdentifier identifier: String) -> Bool {
+        guard let impl = implementations[Self.isCached] as? IsCachedImpl else {
+            fatalError("\(Self.self).\(#function) is not stubbed")
+        }
+
+        calls[Self.isCached] = (calls[Self.isCached] ?? []) + [
+            IsCachedCall(key: key, processIdentifier: identifier)
+        ]
+
+        return impl(key, identifier)
+    }
+}
+
 class MockImageRetriever: ImageRetriever {
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -306,15 +306,15 @@ extension MockSource {
 
 // MARK: - Make images controller
 extension MockSource {
-    static let makeUndownloadedImagesController = "makeUndownloadedImagesController"
-    typealias MakeUndownloadedImagesControllerImpl = () -> ImagesController
+    static let makeImagesController = "makeImagesController"
+    typealias MakeImagesControllerImpl = () -> ImagesController
 
-    func stubMakeUndownloadedImagesController(impl: @escaping MakeUndownloadedImagesControllerImpl) {
-        implementations[Self.makeUndownloadedImagesController] = impl
+    func stubMakeImagesController(impl: @escaping MakeImagesControllerImpl) {
+        implementations[Self.makeImagesController] = impl
     }
 
-    func makeUndownloadedImagesController() -> ImagesController {
-        guard let impl = implementations[Self.makeUndownloadedImagesController] as? MakeUndownloadedImagesControllerImpl else {
+    func makeImagesController() -> ImagesController {
+        guard let impl = implementations[Self.makeImagesController] as? MakeImagesControllerImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
@@ -1012,33 +1012,33 @@ extension MockSource {
 }
 
 extension MockSource {
-    private static let downloadImages = "downloadImages"
-    typealias DownloadImagesImpl = ([Image]) -> Void
-    struct DownloadImagesCall {
+    private static let deleteImages = "deleteImages"
+    typealias DeleteImagesImpl = ([Image]) -> Void
+    struct DeleteImagesCall {
         let images: [Image]
     }
 
-    func stubDownloadImages(_ impl: @escaping DownloadImagesImpl) {
-        implementations[Self.downloadImages] = impl
+    func stubDeleteImages(_ impl: @escaping DeleteImagesImpl) {
+        implementations[Self.deleteImages] = impl
     }
 
-    func downloadImagesCall(at index: Int) -> DownloadImagesCall? {
-        guard let calls = calls[Self.downloadImages],
+    func deleteImagesCall(at index: Int) -> DeleteImagesCall? {
+        guard let calls = calls[Self.deleteImages],
               index < calls.count,
-              let call = calls[index] as? DownloadImagesCall else {
+              let call = calls[index] as? DeleteImagesCall else {
             return nil
         }
 
         return call
     }
 
-    func download(images: [Image]) {
-        guard let impl = implementations[Self.downloadImages] as? DownloadImagesImpl else {
+    func delete(images: [Image]) {
+        guard let impl = implementations[Self.deleteImages] as? DeleteImagesImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        calls[Self.downloadImages] = (calls[Self.downloadImages] ?? []) + [
-            DownloadImagesCall(images: images)
+        calls[Self.deleteImages] = (calls[Self.deleteImages] ?? []) + [
+            DeleteImagesCall(images: images)
         ]
 
         impl(images)

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -296,12 +296,14 @@ extension Space {
     @discardableResult
     func buildImage(
         source: URL?,
-        isDownloaded: Bool = false
+        isDownloaded: Bool = false,
+        item: Item? = nil
     ) -> Image {
         return backgroundContext.performAndWait {
             let image: Image = Image(context: backgroundContext)
             image.source = source
             image.isDownloaded = isDownloaded
+            image.item = item
 
             return image
         }
@@ -310,10 +312,15 @@ extension Space {
     @discardableResult
     func createImage(
         source: URL?,
-        isDownloaded: Bool = false
+        isDownloaded: Bool = false,
+        item: Item? = nil
     ) throws -> Image {
         return try backgroundContext.performAndWait {
-            let image = buildImage(source: source, isDownloaded: isDownloaded)
+            let image = buildImage(
+                source: source,
+                isDownloaded: isDownloaded,
+                item: item
+            )
             try backgroundContext.save()
 
             return image

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -394,15 +394,6 @@ class PocketSourceTests: XCTestCase {
         XCTAssertEqual(fetched, [recommendation2])
     }
 
-    func test_downloadImage_updatesIsDownloadedProperty() throws {
-        let image: Image = Image(context: space.backgroundContext)
-
-        let source = subject()
-        source.download(images: [image])
-
-        XCTAssertTrue(image.isDownloaded)
-    }
-
     @MainActor
     func test_fetchOfflineContent_fetchesOfflineContent() async throws {
         apollo.stubFetch(


### PR DESCRIPTION
## Summary

Improve how images are (un)cached when there are Image changes in Source.

## References 

IN-1222

## Implementation Details

The usage of `ImagesController` is now simplified - we will handle Image changes when all changes have been saved, rather than on each insert / delete / etc. There is now some additional logic for when images should be downloaded:

1. Checked for any orphaned Images (Images that have no `.item`)
2. Generate a set of all URLs for the latest Images
3. Generate a set of all URLs for orphaned Images
4. Create sets of URLs that should be downloaded, skipped, and deleted
5. Delete the appropriate cached Images, download the appropriate uncached Images, and delete all orphan Images from source

## Test Steps

- [ ] Log in to Pocket
- [ ] Let Home / Saves load, and let thumbnails load for some (or all) items
  - A spinner should appear while a thumbnail is downloading
- [ ] Close and reopen the application
- [ ] Let Home / Saves appear, and thumbnails should be immediately loaded if previously visible; no spinner should appear

## PR Checklist:

- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
