### PR TITLE
fix(concurrency): clean up some of our threading and calls

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -202,7 +202,6 @@ extension HomeViewModel {
 
         for slateSection in slateSections {
             guard var recommendations = slateSection.objects as? [Recommendation],
-                    !recommendations.isEmpty,
                   let slateId = recommendations.first?.slate?.objectID
             else {
                 continue

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -105,7 +105,7 @@ class HomeViewModel: NSObject {
     private var recentSavesCount: Int = 0
 
     private let recentSavesController: NSFetchedResultsController<SavedItem>
-    private let recomendationsController: NSFetchedResultsController<Recommendation>
+    private let recomendationsController: RichFetchedResultsController<Recommendation>
 
     init(
         source: Source,
@@ -203,40 +203,27 @@ extension HomeViewModel {
         for slateSection in slateSections {
             guard var recommendations = slateSection.objects as? [Recommendation],
                     !recommendations.isEmpty,
-                  let firstRecommendation = recommendations.first,
-                  let slate = firstRecommendation.slate
+                  let slateId = recommendations.first?.slate?.objectID
             else {
                 continue
             }
 
-            let slateId: NSManagedObjectID = slate.objectID
-
-            let slateSectionId: Section = .slateHero(slateId)
-
             let hero = recommendations.removeFirst()
-            if snapshot.indexOfSection(slateSectionId) == nil {
-                snapshot.appendSections([slateSectionId])
-            }
+            snapshot.appendSections([.slateHero(slateId)])
             snapshot.appendItems(
                 [.recommendationHero(hero.objectID)],
-                toSection: slateSectionId
+                toSection: .slateHero(slateId)
             )
-            // Set a rec to always reload so it gets the latest save state. This is because NSFetchedResultsController is not listening for SavedItem changes on recs
-            snapshot.reloadItems([.recommendationHero(hero.objectID)])
 
             guard !recommendations.isEmpty else {
                 continue
             }
 
-            if snapshot.indexOfSection(.slateCarousel(slate.objectID)) == nil {
-                snapshot.appendSections([.slateCarousel(slate.objectID)])
-            }
+            snapshot.appendSections([.slateCarousel(slateId)])
             snapshot.appendItems(
                 recommendations.prefix(4).map { .recommendationCarousel($0.objectID) },
                 toSection: .slateCarousel(slateId)
             )
-            // Set a rec to always reload so it gets the latest save state. This is because NSFetchedResultsController is not listening for SavedItem changes on recs
-            snapshot.reloadItems(recommendations.prefix(4).map { .recommendationCarousel($0.objectID) })
         }
 
         return snapshot

--- a/PocketKit/Sources/PocketKit/ImageManager.swift
+++ b/PocketKit/Sources/PocketKit/ImageManager.swift
@@ -117,7 +117,7 @@ private extension ImageManager {
         // Images are removed via `removeFromImages` when Items are updated
         // This nullifies the item relationship from Image -> Item
         // Therefore, we want to retrieve orphaned Images so we can delete them
-        let orphans = images.filter { $0.item == nil }
+        let orphans = images.filter { $0.item == nil && $0.recommendation == nil && $0.syndicatedArticle == nil }
 
         let allURLs = Set(images.compactMap { $0.source })
         let orphanURLs = Set(orphans.compactMap { $0.source })

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -208,10 +208,6 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         model.fetch()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        model.fetch()
-    }
-
     private func handleRefresh() {
         model.refresh { [weak self] in
             self?.handleRefreshCompletion()

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -584,13 +584,6 @@ extension SavedItemsListViewModel {
         guard !reTappedTagFilter else { return }
 
         switch filter {
-<<<<<<< HEAD
-=======
-        case .listen:
-            presentedListenViewModel = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects)
-            selectedFilters.remove(.listen)
-            return
->>>>>>> 519e45d6 (fix(performance): cleaning up some threads)
         case .search:
             presentedSearch = true
         case .all:

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -584,6 +584,13 @@ extension SavedItemsListViewModel {
         guard !reTappedTagFilter else { return }
 
         switch filter {
+<<<<<<< HEAD
+=======
+        case .listen:
+            presentedListenViewModel = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects)
+            selectedFilters.remove(.listen)
+            return
+>>>>>>> 519e45d6 (fix(performance): cleaning up some threads)
         case .search:
             presentedSearch = true
         case .all:

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -73,8 +73,8 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             )
         }
 
+        self.refreshCoordinator.initialize()
         DispatchQueue.global(qos: .background).async { [weak self] in
-            self?.refreshCoordinator.initialize()
             self?.source.restore()
         }
         Textiles.initialize()

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -73,9 +73,11 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             )
         }
 
-        source.restore()
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            self?.refreshCoordinator.initialize()
+            self?.source.restore()
+        }
         Textiles.initialize()
-        refreshCoordinator.initialize()
 
         return true
     }

--- a/PocketKit/Sources/Sync/CoreData+Relationships/README.md
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/README.md
@@ -1,0 +1,10 @@
+#  CoreData Relationships
+
+At Pocket we use NSFetchedResultsControllers to power our data views. These work great and update our views only when the object they are observing updates it's values. However it has a downside where CoreData will not tell NSFetchedResultsController to update if the object it is montioring has an update to any of its related objects.
+
+For Pocket this causes problem for our Home screen where our root object is Recommendation, but we need to display changes to the Recommendation if the user clicks Save, which in itself is a completely different object.
+
+The code in this directory is modified from https://www.avanderlee.com/swift/nsfetchedresultscontroller-observe-relationship-changes/ which describes the problem in more detail. This lets us build a FetchRequest and NSFetchedResultsController that can monitor changes in the entity relationships. 
+
+However, it only originally supported 1 level deep of relationships and for Recommendations we need to support at least 2 levels, where the levels are Recommendations -> Item -> SavedItem.  
+

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipExtensions.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipExtensions.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+
+extension Set where Element: NSManagedObject {
+    /// Iterates over the objects and returns the object IDs that matched our observing keyPaths.
+    /// - Parameter keyPaths: The keyPaths to observe changes for.
+    func updatedObjectIDs(for keyPaths: Set<RelationshipKeyPath>) -> Set<NSManagedObjectID>? {
+        var objectIDs: Set<NSManagedObjectID> = []
+        forEach { object in
+            guard let changedRelationshipKeyPath = object.changedKeyPath(from: keyPaths) else { return }
+
+            let splitKeys = changedRelationshipKeyPath.inverseRelationshipKeyPath.split(separator: ".")
+            var value = object.value(forKey: String(splitKeys.first!))
+
+            // Loop through inverse relationship until we hit the root object we are observing
+            splitKeys.dropFirst().forEach { keyPath in
+                guard let object = value as? NSManagedObject else {
+                    Log.warning("Updated object is not a NSManagedObject")
+                    return
+                }
+
+                value = object.value(forKey: String(keyPath))
+            }
+
+            if let toManyObjects = value as? Set<NSManagedObject> {
+                toManyObjects.forEach {
+                    objectIDs.insert($0.objectID)
+                }
+            } else if let toOneObject = value as? NSManagedObject {
+                objectIDs.insert(toOneObject.objectID)
+            } else {
+                return
+            }
+        }
+
+        return objectIDs
+    }
+}
+
+private extension NSManagedObject {
+    /// Matches the given key paths to the current changes of this `NSManagedObject`.
+    /// - Parameter keyPaths: The key paths to match the changes for.
+    /// - Returns: The matching relationship key path if found. Otherwise, `nil`.
+    func changedKeyPath(from keyPaths: Set<RelationshipKeyPath>) -> RelationshipKeyPath? {
+        return keyPaths.first { keyPath -> Bool in
+            guard keyPath.destinationEntityName == entity.name! || keyPath.destinationEntityName == entity.superentity?.name else { return false }
+            return changedValues().keys.contains(keyPath.destinationPropertyName)
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipKeyPath.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipKeyPath.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+
+/// Describes a relationship key path for a Core Data entity.
+public struct RelationshipKeyPath: Hashable {
+    /// The source property name of the relationship entity we're observing.
+    let sourcePropertyName: String
+
+    let destinationEntityName: String
+
+    /// The destination property name we're observing
+    let destinationPropertyName: String
+
+    /// The inverse property name of this relationship. Can be used to get the affected object IDs.
+    let inverseRelationshipKeyPath: String
+
+    public init(keyPath: String, relationships: [String: NSRelationshipDescription]) {
+        let splittedKeyPath = keyPath.split(separator: ".")
+
+        if splittedKeyPath.count == 2 {
+            // Original code from https://www.avanderlee.com/swift/nsfetchedresultscontroller-observe-relationship-changes/ to monitor 1 level deep of relationships
+            sourcePropertyName = String(splittedKeyPath.first!)
+            destinationPropertyName = String(splittedKeyPath.last!)
+            let relationship = relationships[sourcePropertyName]!
+            destinationEntityName = relationship.destinationEntity!.name!
+            inverseRelationshipKeyPath = relationship.inverseRelationship!.name
+        } else if splittedKeyPath.count == 3 {
+            // Modified code to monitor 2 level deep of relationships.
+            // There is probaly a better way to do this with recursion and supporting more layers, but right now we only need 2, and, well, this works. 😅
+
+            let firstPropertyName = String(splittedKeyPath.first!)
+            sourcePropertyName = String(splittedKeyPath[1])
+
+            let relationship = relationships[firstPropertyName]!
+            let firstInverseKeyPath = relationship.inverseRelationship!.name
+
+            guard let secondRelationships = relationship.inverseRelationship?.entity.relationshipsByName else {
+                fatalError("Developer error, you should have a relationship if you are monitoring this path")
+            }
+
+            let secondRelationship = secondRelationships[sourcePropertyName]!
+
+            destinationPropertyName = String(splittedKeyPath.last!)
+            destinationEntityName = secondRelationship.destinationEntity!.name!
+            inverseRelationshipKeyPath = "\(secondRelationship.inverseRelationship!.name).\(firstInverseKeyPath)"
+        } else {
+            // Developer error trying to monitor more then 2 levels deep of nesting of relationships. See comment above.
+            fatalError("We only support observing 2 levels of nesting")
+        }
+
+        [sourcePropertyName, destinationEntityName, destinationPropertyName].forEach { property in
+            assert(!property.isEmpty, "Invalid key path is used")
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipKeyPathObserver.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipKeyPathObserver.swift
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+
+/// Observes relationship key paths and refreshes Core Data objects accordingly once the related managed object context saves.
+public final class RelationshipKeyPathsObserver<ResultType: NSFetchRequestResult>: NSObject {
+    private let keyPaths: Set<RelationshipKeyPath>
+    private unowned let fetchedResultsController: RichFetchedResultsController<ResultType>
+
+    private var updatedObjectIDs: Set<NSManagedObjectID> = []
+
+    public init?(keyPaths: Set<String>, fetchedResultsController: RichFetchedResultsController<ResultType>) {
+        guard !keyPaths.isEmpty else { return nil }
+
+        let relationships = fetchedResultsController.fetchRequest.entity!.relationshipsByName
+        self.keyPaths = Set(keyPaths.map { keyPath in
+            return RelationshipKeyPath(keyPath: keyPath, relationships: relationships)
+        })
+        self.fetchedResultsController = fetchedResultsController
+
+        super.init()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(contextDidChangeNotification(notification:)), name: NSNotification.Name.NSManagedObjectContextObjectsDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(contextDidSaveNotification(notification:)), name: NSNotification.Name.NSManagedObjectContextDidSave, object: nil)
+    }
+
+    @objc private func contextDidChangeNotification(notification: NSNotification) {
+        guard let context = notification.object as? NSManagedObjectContext else {
+            return
+        }
+
+        let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let deletedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let updatedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let objects = insertedObjects.union(deletedObjects).union(updatedObjects)
+
+        context.performAndWait { [weak self] in
+            guard let self else {
+                return
+            }
+            guard let objectIDs = objects.updatedObjectIDs(for: keyPaths), !objectIDs.isEmpty else { return }
+            self.updatedObjectIDs = self.updatedObjectIDs.union(objectIDs)
+        }
+    }
+
+    /// Context saved, so take any pending objects that we are montiroing and trigger a refresh in their context.
+    /// - Parameter notification: notification from NSNotificationCenter
+    @objc private func contextDidSaveNotification(notification: NSNotification) {
+        guard !updatedObjectIDs.isEmpty else { return }
+        guard let fetchedObjects = fetchedResultsController.fetchedObjects as? [NSManagedObject], !fetchedObjects.isEmpty else { return }
+
+        fetchedObjects.forEach { object in
+            guard updatedObjectIDs.contains(object.objectID) else { return }
+            fetchedResultsController.managedObjectContext.refresh(object, mergeChanges: true)
+        }
+        updatedObjectIDs.removeAll()
+    }
+}

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RichFetchRequest.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RichFetchRequest.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+
+/// An enhanced `NSFetchRequest` that has extra functionality.
+public final class RichFetchRequest<ResultType>: NSFetchRequest<NSFetchRequestResult> where ResultType: NSFetchRequestResult {
+    /// A set of relationship key paths to observe when using a `RichFetchedResultsController`.
+    public var relationshipKeyPathsForRefreshing: Set<String> = []
+}

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RichNSFetchedResultsController.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RichNSFetchedResultsController.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+
+/// An enhanced `NSFetchedResultsController` that has extra functionality.
+public class RichFetchedResultsController<ResultType: NSFetchRequestResult>: NSFetchedResultsController<NSFetchRequestResult> {
+    /// The relationship key paths observer that is only initialised if the fetch request has a `relationshipKeyPathsForRefreshing` set.
+    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver<ResultType>?
+
+    public init(fetchRequest: RichFetchRequest<ResultType>, managedObjectContext context: NSManagedObjectContext, sectionNameKeyPath: String?, cacheName name: String?) {
+        super.init(fetchRequest: fetchRequest, managedObjectContext: context, sectionNameKeyPath: sectionNameKeyPath, cacheName: name)
+
+        relationshipKeyPathsObserver = RelationshipKeyPathsObserver<ResultType>(keyPaths: fetchRequest.relationshipKeyPathsForRefreshing, fetchedResultsController: self)
+    }
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -17,5 +17,6 @@ extension Recommendation {
     @NSManaged public var title: String?
     @NSManaged public var item: Item?
     @NSManaged public var slate: Slate?
+    @NSManaged public var image: Image?
     @NSManaged public var sortIndex: NSNumber?
 }

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -73,8 +73,13 @@ class FetchArchive: SyncOperation {
                pagination.cursor == nil {
                 initialDownloadState.send(.paginating(totalCount: min(totalCount, pagination.maxItems)))
             }
-
-            try updateLocalStorage(result: result)
+            DispatchQueue.global(qos: .background).async { [weak self] in
+                do {
+                    try self?.updateLocalStorage(result: result)
+                } catch {
+                    Log.capture(error: error)
+                }
+            }
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Archive.pageSize)
             Log.breadcrumb(category: "sync.archive", level: .debug, message: "Finished loading page \(i)")
             i = i + 1

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -27,14 +27,15 @@ class FetchArchive: SyncOperation {
 
     func execute() async -> SyncOperationResult {
         do {
-            
-            guard let lastRefreshTime = lastRefresh.lastRefreshArchive, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Archive.timeMustPass else {
-                Log.info("Not refreshing archives from server, last refresh is not above tolerance of \(SyncConstants.Archive.timeMustPass) seconds")
-                // Future TODO: We should have a new result called too soon that the ui can act on.
-                // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
-                return .success
+            if lastRefresh.lastRefreshArchive != nil {
+                guard let lastRefreshTime = lastRefresh.lastRefreshArchive, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Archive.timeMustPass else {
+                    Log.info("Not refreshing archives from server, last refresh is not above tolerance of \(SyncConstants.Archive.timeMustPass) seconds")
+                    // Future TODO: We should have a new result called too soon that the ui can act on.
+                    // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
+                    return .success
+                }
             }
-            
+
             try await fetchArchive()
 
             lastRefresh.refreshedArchive()

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -27,6 +27,14 @@ class FetchArchive: SyncOperation {
 
     func execute() async -> SyncOperationResult {
         do {
+            
+            guard let lastRefreshTime = lastRefresh.lastRefreshArchive, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Archive.timeMustPass else {
+                Log.info("Not refreshing archives from server, last refresh is not above tolerance of \(SyncConstants.Archive.timeMustPass) seconds")
+                // Future TODO: We should have a new result called too soon that the ui can act on.
+                // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
+                return .success
+            }
+            
             try await fetchArchive()
 
             lastRefresh.refreshedArchive()

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -82,13 +82,7 @@ class FetchArchive: SyncOperation {
                pagination.cursor == nil {
                 initialDownloadState.send(.paginating(totalCount: min(totalCount, pagination.maxItems)))
             }
-            DispatchQueue.global(qos: .background).async { [weak self] in
-                do {
-                    try self?.updateLocalStorage(result: result)
-                } catch {
-                    Log.capture(error: error)
-                }
-            }
+            try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Archive.pageSize)
             Log.breadcrumb(category: "sync.archive", level: .debug, message: "Finished loading page \(i)")
             i = i + 1

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -72,9 +72,9 @@ class FetchArchive: SyncOperation {
     private func fetchArchive() async throws {
         var pagination = PaginationSpec(maxItems: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize)
 
-        var i = 1
+        var pageNumber = 1
         repeat {
-            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Loading page \(i)")
+            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Loading page \(pageNumber)")
             let result = try await fetchPage(pagination)
 
             if case .started = initialDownloadState.value,
@@ -84,8 +84,8 @@ class FetchArchive: SyncOperation {
             }
             try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Archive.pageSize)
-            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Finished loading page \(i)")
-            i = i + 1
+            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Finished loading page \(pageNumber)")
+            pageNumber += 1
         } while pagination.shouldFetchNextPage
 
         initialDownloadState.send(.completed)

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -63,7 +63,9 @@ class FetchArchive: SyncOperation {
     private func fetchArchive() async throws {
         var pagination = PaginationSpec(maxItems: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize)
 
+        var i = 1
         repeat {
+            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Loading page \(i)")
             let result = try await fetchPage(pagination)
 
             if case .started = initialDownloadState.value,
@@ -74,6 +76,8 @@ class FetchArchive: SyncOperation {
 
             try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Archive.pageSize)
+            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Finished loading page \(i)")
+            i = i + 1
         } while pagination.shouldFetchNextPage
 
         initialDownloadState.send(.completed)

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -30,6 +30,14 @@ class FetchSaves: SyncOperation {
 
     func execute() async -> SyncOperationResult {
         do {
+            
+            guard let lastRefreshTime = lastRefresh.lastRefreshSaves, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Saves.timeMustPass else {
+                Log.info("Not refreshing saves from server, last refresh is not above tolerance of \(SyncConstants.Saves.timeMustPass) seconds")
+                // Future TODO: We should have a new result called too soon that the ui can act on.
+                // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
+                return .success
+            }
+            
             async let saves: Void = fetchSaves()
             async let tags: Void = fetchTags()
             _ = await [try saves, try tags]

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -66,8 +66,9 @@ class FetchSaves: SyncOperation {
 
     private func fetchSaves() async throws {
         var pagination = PaginationSpec(maxItems: SyncConstants.Saves.firstLoadMaxCount, pageSize: SyncConstants.Saves.initalPageSize)
-
+        var i = 1
         repeat {
+            Log.breadcrumb(category: "sync.saves", level: .debug, message: "Loading page \(i)")
             let result = try await fetchPage(pagination)
             if let isPremium = result.data?.user?.isPremium as? Bool {
                 user.setPremiumStatus(isPremium)
@@ -81,6 +82,8 @@ class FetchSaves: SyncOperation {
 
             try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Saves.pageSize)
+            Log.breadcrumb(category: "sync.saves", level: .debug, message: "Finsihed loading page \(i)")
+            i = i + 1
         } while pagination.shouldFetchNextPage
 
         initialDownloadState.send(.completed)
@@ -90,7 +93,9 @@ class FetchSaves: SyncOperation {
         var shouldFetchNextPage = true
         var pagination = PaginationInput(first: .null)
 
-        while shouldFetchNextPage {
+        var i = 1
+        repeat {
+            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Loading page \(i)")
             let query = TagsQuery(pagination: .init(pagination))
             let result = try await apollo.fetch(query: query)
             try updateLocalTags(result)
@@ -101,7 +106,9 @@ class FetchSaves: SyncOperation {
             } else {
                 shouldFetchNextPage = false
             }
-        }
+            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Finsihed loading page \(i)")
+            i = i + 1
+        } while shouldFetchNextPage
     }
 
     private func fetchPage(_ pagination: PaginationSpec) async throws -> GraphQLResult<FetchSavesQuery.Data> {

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -89,13 +89,7 @@ class FetchSaves: SyncOperation {
                 initialDownloadState.send(.paginating(totalCount: min(totalCount, pagination.maxItems)))
             }
 
-            DispatchQueue.global(qos: .background).async { [weak self] in
-                do {
-                    try self?.updateLocalStorage(result: result)
-                } catch {
-                    Log.capture(error: error)
-                }
-            }
+            try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Saves.pageSize)
             Log.breadcrumb(category: "sync.saves", level: .debug, message: "Finsihed loading page \(i)")
             i = i + 1

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -30,14 +30,15 @@ class FetchSaves: SyncOperation {
 
     func execute() async -> SyncOperationResult {
         do {
-            
-            guard let lastRefreshTime = lastRefresh.lastRefreshSaves, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Saves.timeMustPass else {
-                Log.info("Not refreshing saves from server, last refresh is not above tolerance of \(SyncConstants.Saves.timeMustPass) seconds")
-                // Future TODO: We should have a new result called too soon that the ui can act on.
-                // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
-                return .success
+            if lastRefresh.lastRefreshSaves != nil {
+                guard let lastRefreshTime = lastRefresh.lastRefreshSaves, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Saves.timeMustPass else {
+                    Log.info("Not refreshing saves from server, last refresh is not above tolerance of \(SyncConstants.Saves.timeMustPass) seconds")
+                    // Future TODO: We should have a new result called too soon that the ui can act on.
+                    // However many states may not come from a user, IE. Instant Sync, Persistent Tasks that never finished, Retries
+                    return .success
+                }
             }
-            
+
             async let saves: Void = fetchSaves()
             async let tags: Void = fetchTags()
             _ = await [try saves, try tags]

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -80,7 +80,13 @@ class FetchSaves: SyncOperation {
                 initialDownloadState.send(.paginating(totalCount: min(totalCount, pagination.maxItems)))
             }
 
-            try updateLocalStorage(result: result)
+            DispatchQueue.global(qos: .background).async { [weak self] in
+                do {
+                    try self?.updateLocalStorage(result: result)
+                } catch {
+                    Log.capture(error: error)
+                }
+            }
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Saves.pageSize)
             Log.breadcrumb(category: "sync.saves", level: .debug, message: "Finsihed loading page \(i)")
             i = i + 1

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -30,9 +30,9 @@ class FetchSaves: SyncOperation {
 
     func execute() async -> SyncOperationResult {
         do {
-            try await fetchSaves()
-            try await fetchTags()
-
+            async let saves: Void = fetchSaves()
+            async let tags: Void = fetchTags()
+            _ = await [try saves, try tags]
             lastRefresh.refreshedSaves()
             return .success
         } catch {

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -102,9 +102,9 @@ class FetchSaves: SyncOperation {
         var shouldFetchNextPage = true
         var pagination = PaginationInput(first: .null)
 
-        var i = 1
+        var pageNumber = 1
         repeat {
-            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Loading page \(i)")
+            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Loading page \(pageNumber)")
             let query = TagsQuery(pagination: .init(pagination))
             let result = try await apollo.fetch(query: query)
             try updateLocalTags(result)
@@ -115,8 +115,8 @@ class FetchSaves: SyncOperation {
             } else {
                 shouldFetchNextPage = false
             }
-            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Finsihed loading page \(i)")
-            i = i + 1
+            Log.breadcrumb(category: "sync.tags", level: .debug, message: "Finsihed loading page \(pageNumber)")
+            pageNumber += 1
         } while shouldFetchNextPage
     }
 

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -5,11 +5,17 @@
 import CoreData
 
 public class PersistentContainer: NSPersistentContainer {
-    public lazy var rootSpace = { Space(backgroundContext: backgroundContext, viewContext: viewContext) }()
+    public lazy var rootSpace = { Space(backgroundContext: backgroundContext, viewContext: modifiedViewContext) }()
 
     private lazy var backgroundContext = {
         let context = newBackgroundContext()
         return context
+    }()
+
+    lazy var modifiedViewContext: NSManagedObjectContext = {
+        viewContext.automaticallyMergesChangesFromParent = true
+        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+        return viewContext
     }()
 
     public enum Storage {
@@ -45,17 +51,10 @@ public class PersistentContainer: NSPersistentContainer {
             ]
         }
 
-        loadPersistentStores {[weak self] storeDescription, error in
+        loadPersistentStores {storeDescription, error in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-            guard let self else {
-                Log.capture(message: "No strong self loading persistent store")
-                return
-            }
-
-            self.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
-            self.viewContext.automaticallyMergesChangesFromParent = true
         }
     }
 }

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -9,7 +9,6 @@ public class PersistentContainer: NSPersistentContainer {
 
     private lazy var backgroundContext = {
         let context = newBackgroundContext()
-        context.automaticallyMergesChangesFromParent = true
         return context
     }()
 

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -12,7 +12,7 @@ public class PersistentContainer: NSPersistentContainer {
         return context
     }()
 
-    lazy var modifiedViewContext: NSManagedObjectContext = {
+    private lazy var modifiedViewContext: NSManagedObjectContext = {
         viewContext.automaticallyMergesChangesFromParent = true
         viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         return viewContext

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -15,6 +15,8 @@
         <attribute name="isDownloaded" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="source" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="images" inverseEntity="Item"/>
+        <relationship name="recommendation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recommendation" inverseName="image" inverseEntity="Recommendation"/>
+        <relationship name="syndicatedArticle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyndicatedArticle" inverseName="image" inverseEntity="SyndicatedArticle"/>
     </entity>
     <entity name="Item" representedClassName="Item" syncable="YES">
         <attribute name="article" optional="YES" attributeType="Transformable" valueTransformerName="ArticleTransformer" customClassName=".Article"/>
@@ -48,6 +50,7 @@
         <attribute name="remoteID" attributeType="String"/>
         <attribute name="sortIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="recommendation" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="recommendation" inverseEntity="Item"/>
         <relationship name="slate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Slate" inverseName="recommendations" inverseEntity="Slate"/>
     </entity>
@@ -90,6 +93,7 @@
         <attribute name="itemID" optional="YES" attributeType="String"/>
         <attribute name="publisherName" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="syndicatedArticle" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="syndicatedArticle" inverseEntity="Item"/>
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES" codeGenerationType="class">

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -177,7 +177,7 @@ public class PocketSource: Source {
         space.makeRecentSavesController(limit: SyncConstants.Home.recentSaves)
     }
 
-    public func makeHomeController() -> NSFetchedResultsController<Recommendation> {
+    public func makeHomeController() -> RichFetchedResultsController<Recommendation> {
         space.makeRecomendationsSlateLineupController(by: SyncConstants.Home.slateLineupIdentifier)
     }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Image+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Image+remoteMapping.swift
@@ -13,4 +13,16 @@ extension Image {
 
         source = URL(string: remote.src)
     }
+
+    convenience init(src: String, context: NSManagedObjectContext) {
+        self.init(context: context)
+
+        source = URL(string: src)
+    }
+
+    convenience init(url: URL, context: NSManagedObjectContext) {
+        self.init(context: context)
+
+        source = url
+    }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -102,6 +102,10 @@ extension Item {
             return
         }
 
+        if let topImageURL {
+            addToImages(Image(url: topImageURL, context: context))
+        }
+
         if let metaParts = summary.domainMetadata?.fragments.domainMetadataParts {
             domainMetadata = domainMetadata ?? DomainMetadata(context: context)
             domainMetadata?.update(remote: metaParts)
@@ -138,6 +142,9 @@ extension Item {
             self.syndicatedArticle?.title = syndicatedArticle.title
             self.syndicatedArticle?.excerpt = syndicatedArticle.excerpt
             self.syndicatedArticle?.imageURL = syndicatedArticle.mainImage.flatMap(URL.init)
+            if let imageSrc = syndicatedArticle.mainImage {
+                self.syndicatedArticle?.image = Image(src: imageSrc, context: context)
+            }
         }
     }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -59,6 +59,9 @@ extension Recommendation {
         title = remote.curatedInfo?.title
         excerpt = remote.curatedInfo?.excerpt
         imageURL = remote.curatedInfo?.imageSrc.flatMap(URL.init)
+        if let imageSrc = remote.curatedInfo?.imageSrc {
+            image = Image(src: imageSrc, context: space.backgroundContext)
+        }
 
         let recommendationItem = (try? space.fetchItem(byRemoteID: remote.item.remoteID)) ?? Item(context: space.backgroundContext, givenURL: url, remoteID: remoteID)
         recommendationItem.update(from: remote.item.fragments.itemSummary, with: space)

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -101,14 +101,21 @@ public enum Requests {
         Slate.fetchRequest()
     }
 
-    public static func fetchRecomendations(by lineupIdentifier: String) -> NSFetchRequest<Recommendation> {
-        let request = Recommendation.fetchRequest()
+    public static func fetchRecomendations(by lineupIdentifier: String) -> RichFetchRequest<Recommendation> {
+        let request = RichFetchRequest<Recommendation>(entityName: "Recommendation")
         request.predicate = NSPredicate(format: "slate.slateLineup.remoteID = %@", lineupIdentifier)
         request.sortDescriptors = [
             NSSortDescriptor(keyPath: \Recommendation.slate?.sortIndex, ascending: true),
             NSSortDescriptor(keyPath: \Recommendation.sortIndex, ascending: true),
-            NSSortDescriptor(keyPath: \Recommendation.item?.title, ascending: true),
-            NSSortDescriptor(keyPath: \Recommendation.item?.savedItem?.url, ascending: true),
+        ]
+        request.relationshipKeyPathsForRefreshing = [
+            #keyPath(Recommendation.slate.sortIndex),
+            // Reload the cell when the image finishes downloading. Kingfisher has a bug where the cell is not always reloaded with the image.
+            #keyPath(Recommendation.image.isDownloaded),
+            #keyPath(Recommendation.item.title),
+            #keyPath(Recommendation.item.savedItem.archivedAt),
+            #keyPath(Recommendation.item.savedItem.isFavorite),
+            #keyPath(Recommendation.item.savedItem.createdAt),
         ]
         return request
     }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -24,7 +24,7 @@ public protocol Source {
 
     func makeRecentSavesController() -> NSFetchedResultsController<SavedItem>
 
-    func makeHomeController() -> NSFetchedResultsController<Recommendation>
+    func makeHomeController() -> RichFetchedResultsController<Recommendation>
 
     func makeSavesController() -> SavedItemsController
 

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -174,7 +174,9 @@ public class Space {
     func save() throws {
         try backgroundContext.performAndWait {
             try backgroundContext.obtainPermanentIDs(for: Array(backgroundContext.insertedObjects))
-            try backgroundContext.save()
+            if backgroundContext.hasChanges {
+                try backgroundContext.save()
+            }
         }
     }
 
@@ -265,7 +267,7 @@ public class Space {
         request.sortDescriptors = [NSSortDescriptor(key: "source.absoluteString", ascending: true)]
         return NSFetchedResultsController(
             fetchRequest: request,
-            managedObjectContext: viewContext,
+            managedObjectContext: backgroundContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -221,11 +221,11 @@ public class Space {
         )
     }
 
-    func makeRecomendationsSlateLineupController(by lineupIdentifier: String) -> NSFetchedResultsController<Recommendation> {
-        NSFetchedResultsController(
+    func makeRecomendationsSlateLineupController(by lineupIdentifier: String) -> RichFetchedResultsController<Recommendation> {
+        RichFetchedResultsController(
             fetchRequest: Requests.fetchRecomendations(by: lineupIdentifier),
             managedObjectContext: viewContext,
-            sectionNameKeyPath: "slate.remoteID",
+            sectionNameKeyPath: "slate.sortIndex",
             cacheName: nil
         )
     }

--- a/PocketKit/Sources/Sync/SyncConstants.swift
+++ b/PocketKit/Sources/Sync/SyncConstants.swift
@@ -14,6 +14,9 @@ public struct SyncConstants {
 
         /// How many saves to load per subsequent page until we hit our load count.
         public  static let pageSize = 30
+        
+        /// How many seconds must pass from the last load of saves data before we allow hitting the server again.
+        public static let timeMustPass = 5.0
     }
 
     public struct Archive {
@@ -25,6 +28,9 @@ public struct SyncConstants {
 
         /// How many archives to load per subsequent page until we hit our load count.
         static let pageSize = 30
+        
+        /// How many seconds must pass from the last load of archive data before we allow hitting the server again.
+        public static let timeMustPass = 5.0
     }
 
     public struct Home {

--- a/PocketKit/Sources/Sync/SyncConstants.swift
+++ b/PocketKit/Sources/Sync/SyncConstants.swift
@@ -14,7 +14,7 @@ public struct SyncConstants {
 
         /// How many saves to load per subsequent page until we hit our load count.
         public  static let pageSize = 30
-        
+
         /// How many seconds must pass from the last load of saves data before we allow hitting the server again.
         public static let timeMustPass = 5.0
     }
@@ -28,7 +28,7 @@ public struct SyncConstants {
 
         /// How many archives to load per subsequent page until we hit our load count.
         static let pageSize = 30
-        
+
         /// How many seconds must pass from the last load of archive data before we allow hitting the server again.
         public static let timeMustPass = 5.0
     }

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -14,7 +14,7 @@ class HomeViewModelTests: XCTestCase {
     var networkPathMonitor: MockNetworkPathMonitor!
     var homeRefreshCoordinator: MockHomeRefreshCoordinator!
     var subscriptions: Set<AnyCancellable> = []
-    var homeController: NSFetchedResultsController<Recommendation>!
+    var homeController: RichFetchedResultsController<Recommendation>!
     var recentSavesController: NSFetchedResultsController<SavedItem>!
 
     override func setUp() async throws {
@@ -340,7 +340,7 @@ class HomeViewModelTests: XCTestCase {
         viewModel.fetch()
 
         let snapshotExpectation = expectation(description: "expected snapshot to update")
-        viewModel.$snapshot.dropFirst().sink { snapshot in
+        viewModel.$snapshot.dropFirst(2).sink { snapshot in
             defer { snapshotExpectation.fulfill() }
 
             XCTAssertEqual(
@@ -356,8 +356,7 @@ class HomeViewModelTests: XCTestCase {
             )
             XCTAssertEqual(
                 snapshot.reloadedItemIdentifiers,
-                [.recommendationHero(recommendations[0].objectID), .recommendationCarousel(recommendations[1].objectID)]
-            )
+                [])
         }.store(in: &subscriptions)
 
         savedItem = space.buildSavedItem()
@@ -379,6 +378,7 @@ class HomeViewModelTests: XCTestCase {
             remoteID: SyncConstants.Home.slateLineupIdentifier,
             slates: slates
         )
+        try space.save()
 
         let viewModel = subject()
         viewModel.fetch()
@@ -400,7 +400,7 @@ class HomeViewModelTests: XCTestCase {
             )
             XCTAssertEqual(
                 snapshot.reloadedItemIdentifiers,
-                [.recommendationHero(recommendations[0].objectID), .recommendationCarousel(recommendations[1].objectID)]
+                []
             )
         }.store(in: &subscriptions)
 
@@ -423,6 +423,7 @@ class HomeViewModelTests: XCTestCase {
             remoteID: SyncConstants.Home.slateLineupIdentifier,
             slates: slates
         )
+        try space.save()
 
         let viewModel = subject()
         viewModel.fetch()
@@ -445,7 +446,7 @@ class HomeViewModelTests: XCTestCase {
 
             XCTAssertEqual(
                 snapshot.reloadedItemIdentifiers,
-                [.recommendationHero(recommendations[0].objectID), .recommendationCarousel(recommendations[1].objectID)]
+                []
             )
         }.store(in: &subscriptions)
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -223,7 +223,7 @@ extension MockSource {
 // MARK: - Make home controller
 extension MockSource {
     static let makeHomeController = "makeHomeController"
-    typealias MakeHomeControllerImpl = () -> NSFetchedResultsController<Sync.Recommendation>
+    typealias MakeHomeControllerImpl = () -> RichFetchedResultsController<Sync.Recommendation>
 
     struct MakeHomeControllerCall {
     }
@@ -232,7 +232,7 @@ extension MockSource {
         implementations[Self.makeHomeController] = impl
     }
 
-    func makeHomeController() -> NSFetchedResultsController<Sync.Recommendation> {
+    func makeHomeController() -> RichFetchedResultsController<Sync.Recommendation> {
         guard let impl = implementations[Self.makeHomeController] as? MakeHomeControllerImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -75,6 +75,7 @@ extension PocketSourceTests {
 
         let source = subject()
         try source.archive(item: space.createSavedItem())
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for last refresh to be avoid its 5.0 second wait")], timeout: 10.0)
         wait(for: [firstAttempt], timeout: 1)
 
         networkMonitor.update(status: .unsatisfied)

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -46,7 +46,7 @@ extension PocketSourceTests {
         source.refreshSaves()
 
         networkMonitor.update(status: .satisfied)
-        wait(for: [expectSaveItem, expectFetchList], timeout: 1, enforceOrder: true)
+        wait(for: [expectSaveItem, expectFetchList], timeout: 1)
     }
 
     func test_whenNetworkBecomesSatisified_retriesOperationsThatAreWaitingForSignal() throws {

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
@@ -36,7 +36,8 @@ extension PocketSourceTests {
         source.restore()
         networkMonitor.update(status: .satisfied)
 
-        wait(for: [fetchList, favoriteItem, archiveItem], timeout: 1, enforceOrder: true)
+        wait(for: [favoriteItem, archiveItem], timeout: 1, enforceOrder: true)
+        wait(for: [fetchList], timeout: 1)
 
         let done = expectation(description: "done")
         source.drain { done.fulfill() }

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -60,7 +60,7 @@ class HomeTests: XCTestCase {
                 Fixture.data(name: "hello", ext: "html")
             }
         }
-        
+
         server.routes.get("/item-1") { _, _ in
             Response {
                 Status.ok

--- a/Tests iOS/PullToRefreshTests.swift
+++ b/Tests iOS/PullToRefreshTests.swift
@@ -47,6 +47,8 @@ class PullToRefreshTests: XCTestCase {
         app.tabBar.savesButton.wait().tap()
 
         let listView = app.saves.wait()
+        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait a few seconds")], timeout: 2.0)
+
         XCTAssertEqual(listView.itemCount, 2)
 
         server.routes.post("/graphql") { _, _ in

--- a/Tests iOS/PullToRefreshTests.swift
+++ b/Tests iOS/PullToRefreshTests.swift
@@ -56,6 +56,8 @@ class PullToRefreshTests: XCTestCase {
             }
         }
 
+        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait longer then the last refresh timeout")], timeout: 8.0)
+
         listView.pullToRefresh()
 
         listView


### PR DESCRIPTION
## Summary

The UI was constantly hanging for me when logging out and in during testing. I believe this came down to how we were using threads, saving data and making network calls.

In this PR i fixed a few things:
* Ensure that we do not bombard our poor server, by:
    * Allowing a refresh of data only after 5 seconds from the last refresh has passed
    * Ensure that if we are restoring a failed FetchSaves/Archive operation we do not start another one.
* Ensure Home monitors relationship changes in [NSFetchedResults Controller](https://www.avanderlee.com/swift/nsfetchedresultscontroller-observe-relationship-changes/)

* Ensure that all images we cache are saved to device, and the respective models listen for the image being downloaded.
* Speed up initial sync by giving FetchSaves & FetchArchive their own queues so they can work in parallel instead of sequentially
* Speed up initial sync by performing a fetch of tags and saves at the same time.
* Ensure Home is sorted as expected by our server
    * This fixes a few glitches where mutliple hero cards could appear. Turns out the sectionNameKeyPath of NSFetchedResultsController needs to match the first sortDescriptor to work right.
 
Things I want to re-add but pulled when I could not make the test suite work:
* Ensure we save on background thread, so the next network request does not have to wait: https://github.com/Pocket/pocket-ios/pull/515/commits/a73b909fb09c99ef63da73ba718fa59f91cbcce7
    * When this was in place I saw massive initial sync improvements, because we spend more time writing to CoreData then we do making network requests. 

Things we need to follow up with:
*  If the initial FetchSaves operation never completed, and is restored, it should continue from where it left off, not from the beginning

## Implementation Details
* Followed some patterns from https://www.avanderlee.com/swift/nsfetchedresultscontroller-observe-relationship-changes/ to observe changes to relationships in NSFetchedResultsController.

## Test Steps
* Log out and in multiple times, and while doing so make sure that the UI does not hang (or is better then before) and that there are no weird anamolities.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
