### PR TITLE
fix(scheme): set OS_ACTIVITY_MODE to disable

### DIFF
--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -333,6 +333,11 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "SNOWPLOW_ENDPOINT"
             value = "http://127.0.0.1:9090"
             isEnabled = "NO">


### PR DESCRIPTION
## Summary
Added an environment variable to our Scheme in order to remove some Xcode logs that was bloating up our console. 

## References 
Slack Convo: https://pocket.slack.com/archives/C01UH57EJKD/p1679931937517129
Stack-overflow Post: https://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-logs

## Implementation Details
Add environment variable `OS_ACTIVITY_MODE` and set value to `disable`

## Test Steps
Check and uncheck this environment variable and confirm whether additional logs appear or disappear. We should see less noisy logs in the console.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
