### PR TITLE
fix(home): ensuring home does not always refresh

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -168,6 +168,11 @@ class HomeViewController: UIViewController {
             task.setTaskCompleted(success: true)
         }
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        model.refresh { }
+    }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -132,9 +132,7 @@ class HomeViewModel: NSObject {
 
         networkPathMonitor.updateHandler = { [weak self] path in
             if path.status == .satisfied {
-                DispatchQueue.main.async {
-                    self?.refresh(isForced: true) { }
-                }
+                self?.refresh(isForced: false) { }
             }
         }
         fetch()

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -206,7 +206,7 @@ public class PocketSource: Source {
     }
 
     private func observeNetworkStatus() {
-        networkMonitor.start(queue: .main)
+        networkMonitor.start(queue: .global(qos: .background))
         networkMonitor.updateHandler = { [weak self] path in
             switch path.status {
             case .unsatisfied, .requiresConnection:


### PR DESCRIPTION
## Summary

It was reported that Home was constantly refreshing for @mkoidin. Upon 👁️ I noticed that the Network code was calling the updateHandler multiple times and we were always having home force refresh every time.

Instead forceRefresh should only be reserved for a user pulling to refresh. 

We should also always observe network status on a background queue.

## Test Steps
* Change network status and ensure that home does not do a hard refresh (where items change) when toggling network status.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
