### PR TITLE
fix(storekit1): add storekit 1 methods

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -168,7 +168,7 @@ class HomeViewController: UIViewController {
             task.setTaskCompleted(success: true)
         }
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         model.refresh { }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -13,13 +13,27 @@ public enum ReceiptError: Error {
 }
 
 /// Concrete implementation that sends the App Store Receipt to the Pocket backend
-struct AppStoreReceiptService: ReceiptService {
+class AppStoreReceiptService: NSObject, ReceiptService {
     private let client: V3ClientProtocol
+
+    private let receiptRequest: SKReceiptRefreshRequest
+
+    private var storeKit1Continuation: CheckedContinuation<SKRequest, Error>?
 
     init(client: V3ClientProtocol) {
         self.client = client
+        self.receiptRequest = SKReceiptRefreshRequest()
+        super.init()
     }
+
     func send(_ product: Product?) async throws {
+        // Ensure we have a receipt to work with from StoreKit 1
+        var _: SKRequest = try await withCheckedThrowingContinuation { continuation in
+            storeKit1Continuation = continuation
+            self.receiptRequest.delegate = self
+            self.receiptRequest.start()
+        }
+
         let transactionInfo = try getReceipt()
         let source = "itunes"
         let productId = product?.id ?? ""
@@ -35,6 +49,17 @@ struct AppStoreReceiptService: ReceiptService {
             currency: currency,
             transactionType: transactionType
         )
+    }
+}
+
+// MARK: StoreKit 1 delegate
+extension AppStoreReceiptService: SKRequestDelegate {
+    func requestDidFinish(_ request: SKRequest) {
+        storeKit1Continuation?.resume(returning: request)
+    }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        storeKit1Continuation?.resume(throwing: error)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/ImageManagerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageManagerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import Sync
 
 // Commenting out for now
-//class ImageManagerTests: XCTestCase {
+// class ImageManagerTests: XCTestCase {
 //    var imagesController: MockImagesController!
 //    var imageCache: MockImageCache!
 //    var imageRetriever: MockImageRetriever!
@@ -130,4 +130,4 @@ import XCTest
 //            expectedKey
 //        )
 //    }
-//}
+// }


### PR DESCRIPTION
## Summary

Pocket's backend only knows about StoreKit 1 for the time being. It seems the receipt that gets saved in the receipt URL area is a storeKit 2 receipt and is not compatible with our backend.

So we need to explcitly create a StoreKit 1 receipt request and send that to our backend.


## Implementation Details
* Checked continuations are so cool.

## Test Steps
* Test out purchasing and it should succeed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
