### PR TITLE
fix(receipts): ensuring there is a receipt

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -27,6 +27,9 @@ class AppStoreReceiptService: NSObject, ReceiptService {
     }
 
     func send(_ product: Product?) async throws {
+        // First make sure a receipt even exists before we try and get one.
+        _ = try getReceipt()
+
         // Ensure we have a receipt to work with from StoreKit 1
         var _: SKRequest = try await withCheckedThrowingContinuation { continuation in
             storeKit1Continuation = continuation


### PR DESCRIPTION
## Summary

On iOS simulators when you are logged out of Apple, a system prompt will show if you request a receipt. Instead we should see if a recept exists first

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
