### PR TITLE
feat(analytics): track open in web from reader

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Reader.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Reader.swift
@@ -52,6 +52,7 @@ public extension Events.Reader {
             )
         )
     }
+
     /**
      Fired when a user archives an article via the top toolbar on Reader
      */
@@ -64,6 +65,19 @@ public extension Events.Reader {
             extraEntities: [
                 ContentEntity(url: url)
             ]
+        )
+    }
+
+    /**
+     Fired when the user taps on the button to open item in web view  in the `Reader`
+     */
+    static func openInWebView(url: URL) -> ContentOpen {
+        return ContentOpen(
+            contentEntity: ContentEntity(url: url),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "reader.view_original"
+            )
         )
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -61,23 +61,11 @@ extension ReadableViewModel {
 
     func openExternally(url: URL?) {
         presentedWebReaderURL = url
-
-        if let url = url {
-            trackOpen(url: url)
-        }
+        trackWebViewOpen()
     }
 
     func showWebReader() {
         openExternally(url: url)
-    }
-
-    private func trackOpen(url: URL) {
-        let additionalContexts: [Context] = [ContentContext(url: url)]
-
-        let contentOpen = ContentOpenEvent(destination: .external, trigger: .click)
-        let link = UIContext.articleView.link
-        let contexts = additionalContexts + [link]
-        tracker.track(event: contentOpen, contexts)
     }
 
     func share(additionalText: String? = nil) {
@@ -183,5 +171,14 @@ extension ReadableViewModel {
     /// - Parameter url: url of saved item
     func trackMoveFromArchiveToSavesButtonTapped(url: URL) {
         tracker.track(event: Events.Reader.moveFromArchiveToSavesClicked(url: url))
+    }
+
+    /// track when user taps on the safari button to open content in web view
+    func trackWebViewOpen() {
+        guard let url else {
+            Log.capture(message: "Reader item without an associated url, not logging analytics for openInWebView")
+            return
+        }
+        tracker.track(event: Events.Reader.openInWebView(url: url))
     }
 }

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -121,8 +121,12 @@ class ReadableHostViewController: UIViewController {
     @objc
     private func moveFromArchiveToSaves() {
         readableViewModel.moveFromArchiveToSaves { [weak self] success in
-            if success, let items = navigationItem.rightBarButtonItems, let index = items.firstIndex(of: getMoveFromArchiveToSavesButton) {
-                self?.navigationItem.rightBarButtonItems?[index] = getArchiveButton
+            if success,
+               let items = self?.navigationItem.rightBarButtonItems,
+               let getMoveFromArchiveToSavesButton = self?.getMoveFromArchiveToSavesButton,
+               let index = items.firstIndex(of: getMoveFromArchiveToSavesButton),
+               let archiveButton = self?.getArchiveButton {
+                self?.navigationItem.rightBarButtonItems?[index] = archiveButton
             }
         }
     }

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -175,10 +175,15 @@ class ReaderTests: XCTestCase {
 //        })
 //    }
 
-    func test_tappingWebViewButton_showsSafari() {
+    @MainActor
+    func test_tappingWebViewButton_showsSafari() async {
         launchApp_andOpenItem()
         tapSafariButton()
         validateSafariOpens()
+
+        let engagementEvent = await snowplowMicro.getFirstEvent(with: "reader.view_original")
+        engagementEvent!.getUIContext()!.assertHas(type: "button")
+        engagementEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
Add tracking for when user opens article in web from reader 

## References 
IN-491

## Implementation Details
Create `reader.view_original` analytics call in `Reader.swift` and add call to `openExternally`

## Test Steps
Confirm if call is being triggered when user opens article in web view.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA