### PR TITLE
Fix a memory leak when opening the Reader

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -42,7 +42,7 @@ class ReadableViewController: UIViewController {
         collectionViewLayout: layout
     )
 
-    private lazy var layout = UICollectionViewCompositionalLayout { [self] in
+    private lazy var layout = UICollectionViewCompositionalLayout { [unowned self] in
         return self.buildSection(index: $0, environment: $1)
     }
 


### PR DESCRIPTION
## Summary
* This PR fixes a leak happening when opening an item in the reader

For reference, here's what was happening before

<p align=center>
<img width="800" src="https://user-images.githubusercontent.com/34376330/228982466-3f4d582f-7f4c-4263-bfa5-cd103299558e.png">

</p>

## Implementation Details
* Update `ReadableViewModel`, add an `unowned` reference to `self` in the closure that defines the `layout` property to avoid the cycle

## Test Steps
* If you're curious about testing, you can open an item in the reader a few times and check the memory graph making sure there's no more than one instance of `ReadableViewModel` (zero if you're not in the reader anymore)
* If you wanna see the behavior in the picture, just remove unowned and repeat the test.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
