### PR TITLE
fix(background): ensuring all background tasks have time to end

### DIFF
--- a/PocketKit/Sources/Sync/Log.swift
+++ b/PocketKit/Sources/Sync/Log.swift
@@ -181,6 +181,11 @@ public class Log {
         Log.sentryCapture(message: message)
         Log.warning(message, filename: filename, line: line, column: column, funcName: funcName)
     }
+
+    /// Helper function to capture an error that a statement tried to execute with a weak self.
+    public class func captureNilWeakSelf(filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
+        Log.capture(message: "Nil weak self, this should not happen", filename: filename, line: line, column: column, funcName: funcName)
+    }
 }
 
 /// Wrapping Swift.print() within DEBUG flag

--- a/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 open class AsyncOperation: Operation {

--- a/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
@@ -41,4 +41,9 @@ open class AsyncOperation: Operation {
         isExecuting = false
         isFinished = true
     }
+
+    public func cancelOperation() {
+        isExecuting = false
+        self.cancel()
+    }
 }

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreData
 
 enum SyncOperationResult {
     case retry(Error)
@@ -6,59 +7,101 @@ enum SyncOperationResult {
     case failure(Error)
 }
 
+/// Protocol that all operations in the Pocket code base follows for syncing data
 protocol SyncOperation {
     func execute() async -> SyncOperationResult
 }
 
+/// A NSOperation that retries its operation thread if needed.
+/// The code operates as follows:
+///     - If the underlying SyncOperation returns a retryStatus code, the NSOperation will begin listening to a RetrySignal publisher (passed in)
+///     - Wait to retry until it receives such signal.
+///     - Retry up to 3 times
+/// This class will also perform its main() logic using a BackgroundTask from UIApplication, so we also listen incase it will expire and in that case will cancel the whole operation
+/// Once the operation finishes it will remove the PersistentSyncTask from CoreData so that it is not restored.
+/// Because we hold the retries in memory and do not persist to disk there are scenarios where if a operation is marked to Retry, and the user backgrounds the app when they open the app the retry counter will be reset.
+///    For now this is ok, because it is a way to manually tell the app to retry operations. In the future we may want to do more with Circuit Breakers and Exponential Backoffs
 class RetriableOperation: AsyncOperation {
     typealias RetrySignal = AnyPublisher<Void, Never>
-
-    enum Status {
-        case failed
-        case retry
-        case success
-    }
 
     private let operation: SyncOperation
     private let retrySignal: RetrySignal
     private let backgroundTaskManager: BackgroundTaskManager
+    private let space: Space
+    private let syncTaskId: NSManagedObjectID
     private var retries = 0
     private var subscription: AnyCancellable?
 
     init(
         retrySignal: RetrySignal,
         backgroundTaskManager: BackgroundTaskManager,
-        operation: SyncOperation
+        operation: SyncOperation,
+        space: Space,
+        syncTaskId: NSManagedObjectID
     ) {
         self.retrySignal = retrySignal
         self.backgroundTaskManager = backgroundTaskManager
         self.operation = operation
+        self.space = space
+        self.syncTaskId = syncTaskId
     }
 
+    /// Performs all the main work for this operation
     override func main() {
+        /// Wrap the code in a Task so that it is Async, Apple by default does not provide an Async capable NSOperation.
+        /// But they provide a variable to make one Async.
+        /// See AsyncOperation which makes NSOperation Async
         Task {
-            let taskID = backgroundTaskManager.beginTask()
+            let taskID = backgroundTaskManager.beginTask(withName: String(describing: type(of: operation))) { [weak self] in
+                guard let self else {
+                    Log.captureNilWeakSelf()
+                    return
+                }
+                cancelOperation()
+            }
 
             switch await operation.execute() {
             case .retry(let error):
+                Log.info("Retrying persistent task with objectID \(String(describing: syncTaskId)) due to \(String(describing: error))")
                 retry(error)
             case .failure(let error):
-                Log.breadcrumb(category: "sync", level: .error, message: error.localizedDescription)
+                Log.warning("Failed persistent task with objectID \(String(describing: syncTaskId)) due to \(String(describing: error))")
                 Log.capture(error: error)
-                finishOperation()
+                doneWithTask()
             case .success:
-                finishOperation()
+                Log.info("Successfully finished persistent task with objectID \(String(describing: syncTaskId))")
+                doneWithTask()
             }
             backgroundTaskManager.endTask(taskID)
         }
     }
 
+    /// Signals that we are done with the task and will perform all clean up operations
+    private func doneWithTask() {
+        clearPersistentTask()
+        finishOperation()
+    }
+
+    /// Removes the persistent task from CoreData so that it is not executed again
+    private func clearPersistentTask() {
+        do {
+            Log.info("Deleting persistent task with objectID \(self.syncTaskId)")
+            try space.delete([self.syncTaskId], for: PersistentSyncTask.entity())
+        } catch {
+            Log.capture(error: error)
+        }
+    }
+
+    /// Sets up a subscriber to listen for a RetrySignal
+    /// - Parameter error: The error that the underlying operation sent
     private func retry(_ error: Error?) {
         subscription = retrySignal.sink { [weak self] in
             self?._retry(error)
         }
     }
 
+    /// Called when we recieve a signal to retry.
+    /// - Parameter error: The error from the last run of the operation
     private func _retry(_ error: Error?) {
         guard retries < 2 else {
             Log.breadcrumb(
@@ -67,10 +110,10 @@ class RetriableOperation: AsyncOperation {
                 message: "Retriable operation \"\(operation)\" exceeded maximum number of retries"
             )
 
-            if let error = error {
+            if let error {
                 Log.capture(error: error)
             }
-
+            clearPersistentTask()
             finishOperation()
             return
         }

--- a/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
@@ -21,7 +21,7 @@ protocol SyncOperation {
 ///     - If the underlying SyncOperation returns a retryStatus code, the NSOperation will begin listening to a RetrySignal publisher (passed in)
 ///     - Wait to retry until it receives such signal.
 ///     - Retry up to 3 times
-/// This class will also perform its main() logic using a BackgroundTask from UIApplication, so we also listen incase it will expire and in that case will cancel the whole operation
+/// This class will also perform its main() logic using a BackgroundTask from UIApplication, so we also listen in case it will expire and in that case will cancel the whole operation
 /// Once the operation finishes it will remove the PersistentSyncTask from CoreData so that it is not restored.
 /// Because we hold the retries in memory and do not persist to disk there are scenarios where if a operation is marked to Retry, and the user backgrounds the app when they open the app the retry counter will be reset.
 ///    For now this is ok, because it is a way to manually tell the app to retry operations. In the future we may want to do more with Circuit Breakers and Exponential Backoffs

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import CoreData

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -30,7 +30,7 @@ class SaveItemOperation: SyncOperation {
 
         do {
             let result = try await apollo.perform(mutation: mutation)
-            await handle(result: result)
+            handle(result: result)
             return .success
         } catch {
             switch error {

--- a/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Apollo
 import ApolloAPI

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -166,7 +166,7 @@ public class Space {
     func delete(_ byIDs: [NSManagedObjectID], for entity: NSEntityDescription) throws {
         try backgroundContext.performAndWait {
             let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entity.name!)
-            fetchRequest.predicate = NSPredicate(format: "(objectID IN %@)", byIDs)
+            fetchRequest.predicate = NSPredicate(format: "SELF IN %@", byIDs)
             let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
             try backgroundContext.execute(deleteRequest)
             try backgroundContext.save()

--- a/PocketKit/Sources/Sync/Space.swift
+++ b/PocketKit/Sources/Sync/Space.swift
@@ -163,6 +163,16 @@ public class Space {
         }
     }
 
+    func delete(_ byIDs: [NSManagedObjectID], for entity: NSEntityDescription) throws {
+        try backgroundContext.performAndWait {
+            let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entity.name!)
+            fetchRequest.predicate = NSPredicate(format: "(objectID IN %@)", byIDs)
+            let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+            try backgroundContext.execute(deleteRequest)
+            try backgroundContext.save()
+        }
+    }
+
     func delete(_ objects: [NSManagedObject]) {
         backgroundContext.performAndWait { objects.compactMap({ backgroundObject(with: $0.objectID) }).forEach(backgroundContext.delete(_:)) }
     }

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -71,7 +71,8 @@ class RetriableOperationTests: XCTestCase {
         wait(for: [firstAttempt], timeout: 1)
         // NOTE: We need to await after the firstAttempt because it takes a few ms for the
         // retrySubscritpion to get setup after firstAttempt is fullfilled.
-        _ = XCTWaiter.wait(for: [expectation(description: "test")], timeout: 1)
+        // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
         retrySignal.send()
         wait(for: [secondAttempt, completed], timeout: 5, enforceOrder: true)
         XCTAssertEqual(try space.fetchPersistentSyncTasks().count, 0)
@@ -109,7 +110,8 @@ class RetriableOperationTests: XCTestCase {
             wait(for: [$0], timeout: 1)
             // NOTE: We need to await after each attempt because it takes a few ms for the
             // retrySubscritpion to get setup after the attempt is fullfilled.
-            _ = XCTWaiter.wait(for: [expectation(description: "test")], timeout: 1)
+            // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
+            _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
             retrySignal.send()
         }
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -119,7 +119,10 @@ extension PocketSourceTests {
         let source = subject()
         source.archive(item: item)
         wait(for: [firstAttempt], timeout: 1)
-
+        // NOTE: We need to await after each attempt because it takes a few ms for the
+        // retrySubscritpion to get setup after the attempt is fullfilled.
+        // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
         source.favorite(item: item)
         wait(for: [retrySignalSent, attemptFavorite], timeout: 1, enforceOrder: true)
     }
@@ -187,7 +190,10 @@ extension PocketSourceTests {
         let source = subject()
         source.archive(item: item)
         wait(for: [firstAttempt], timeout: 1)
-
+        // NOTE: We need to await after each attempt because it takes a few ms for the
+        // retrySubscritpion to get setup after the attempt is fullfilled.
+        // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
         source.retryImmediately()
         wait(for: [retrySignalSent], timeout: 1)
     }

--- a/Tests iOS/Support/Elements/XCUIElement+wait.swift
+++ b/Tests iOS/Support/Elements/XCUIElement+wait.swift
@@ -12,6 +12,7 @@ extension XCUIElement {
         line: UInt = #line
     ) -> XCUIElement {
         if exists {
+            XCTAssertTrue(exists)
             return self
         }
 


### PR DESCRIPTION
## Summary

Ensure that Operations have time to delete their Operations from CoreData by moving the PersistentTaskCleanup logic into RetriableOperation.


## Implementation Details
* I want to move the operation queuing logic out of PocketSource into it's own isolated class but will do that in a followup pr to keep changes small.

## Test Steps
* This is a hard one to test unfortunately, so im gonna go tried and true and rely on our test suite.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
