### PR TITLE
fix(schema): updating schema with new changes

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
@@ -61,13 +61,13 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Recommendation }
     public static var __selections: [ApolloAPI.Selection] { [
-      .field("id", PocketGraph.ID?.self),
+      .field("id", PocketGraph.ID.self),
       .field("item", Item.self),
       .field("curatedInfo", CuratedInfo?.self),
     ] }
 
     /// A generated id from the Data and Learning team that represents the Recommendation
-    public var id: PocketGraph.ID? { __data["id"] }
+    public var id: PocketGraph.ID { __data["id"] }
     /// The Recommendation entity is owned by the Recommendation API service.
     /// We extend it in this service to add an extra field ('curationInfo') to the Recommendation entity.
     /// The key for this entity is the 'itemId' found within the Item entity which is owned by the Parser service.

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -33,8 +33,8 @@ extension Slate {
 
         var i = 1
         recommendations = NSOrderedSet(array: remote.recommendations.compactMap { remote in
-            guard let remoteID = remote.id,
-                  let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID) ?? Recommendation(context: space.backgroundContext, remoteID: remoteID) else {
+            let remoteID = remote.id
+            guard let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID) ?? Recommendation(context: space.backgroundContext, remoteID: remoteID) else {
                 return nil
             }
             recommendation.update(from: remote, in: space)
@@ -49,7 +49,8 @@ extension Recommendation {
     public typealias RemoteRecommendation = SlateParts.Recommendation
 
     func update(from remote: RemoteRecommendation, in space: Space) {
-        guard let id = remote.id, let url = URL(string: remote.item.givenUrl) else {
+        let id = remote.id
+        guard let url = URL(string: remote.item.givenUrl) else {
             // TODO: Daniel work to make id non-null in the API Layer.
             Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Recomendation because \(remote.item.givenUrl) is not valid url")
             return


### PR DESCRIPTION
## Summary

Updates GraphQL schemas to use a non-optional ID.

## Implementation Details

- There was a backend change made and merged that made IDs non-optional. Our code was relying on optional IDs (see: remoteID). This is a simple update to handle remote IDs as non-optional, removing them from guards.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
