### PR TITLE
refactor: use shared user defaults

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -321,10 +321,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "clearFirstLaunch"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "clearImageCache"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -10,6 +10,8 @@ protocol BadgeProvider: AnyObject {
 extension UIApplication: BadgeProvider { }
 
 class AppBadgeSetup {
+    static let toggleAppBadgeKey = UserDefaults.Key.toggleAppBadge
+
     private let source: Source
     private let notificationCenter: NotificationCenter
     private var subscriptions: Set<AnyCancellable> = []
@@ -45,7 +47,7 @@ class AppBadgeSetup {
 
     func manualCheckForSavedCount() {
         var numberOfSaves: Int = 0
-        let currentValue = userDefaults.bool(forKey: AccountViewModel.ToggleAppBadgeKey)
+        let currentValue = userDefaults.bool(forKey: Self.toggleAppBadgeKey)
         if currentValue != false {
             do {
                 numberOfSaves = try source.unreadSaves()

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -27,17 +27,19 @@ class RecommendationViewModel: ReadableViewModel {
     private let source: Source
     private let pasteboard: Pasteboard
     private let user: User
+    private let userDefaults: UserDefaults
     let tracker: Tracker
 
     private var savedItemCancellable: AnyCancellable?
     private var savedItemSubscriptions: Set<AnyCancellable> = []
 
-    init(recommendation: Recommendation, source: Source, tracker: Tracker, pasteboard: Pasteboard, user: User) {
+    init(recommendation: Recommendation, source: Source, tracker: Tracker, pasteboard: Pasteboard, user: User, userDefaults: UserDefaults) {
         self.recommendation = recommendation
         self.source = source
         self.tracker = tracker
         self.pasteboard = pasteboard
         self.user = user
+        self.userDefaults = userDefaults
 
         self.savedItemCancellable = recommendation.item?.publisher(for: \.savedItem).sink { [weak self] savedItem in
             self?.update(for: savedItem)
@@ -50,7 +52,7 @@ class RecommendationViewModel: ReadableViewModel {
 
     var readerSettings: ReaderSettings {
         // TODO: inject this
-        ReaderSettings()
+        ReaderSettings(userDefaults: userDefaults)
     }
 
     var textAlignment: Textile.TextAlignment {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -29,6 +29,7 @@ class SavedItemViewModel: ReadableViewModel {
     private let source: Source
     private let pasteboard: Pasteboard
     private let user: User
+    private let userDefaults: UserDefaults
     private var subscriptions: [AnyCancellable] = []
 
     init(
@@ -36,13 +37,15 @@ class SavedItemViewModel: ReadableViewModel {
         source: Source,
         tracker: Tracker,
         pasteboard: Pasteboard,
-        user: User
+        user: User,
+        userDefaults: UserDefaults
     ) {
         self.item = item
         self.source = source
         self.tracker = tracker
         self.pasteboard = pasteboard
         self.user = user
+        self.userDefaults = userDefaults
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()
@@ -55,7 +58,7 @@ class SavedItemViewModel: ReadableViewModel {
 
     var readerSettings: ReaderSettings {
         // TODO: inject this
-        ReaderSettings()
+        ReaderSettings(userDefaults: userDefaults)
     }
 
     var components: [ArticleComponent]? {

--- a/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/SignOutOnFirstLaunch.swift
@@ -3,7 +3,7 @@ import Sync
 import SharedPocketKit
 
 class SignOutOnFirstLaunch {
-    static let hasAppBeenLaunchedPreviouslyKey = "hasAppBeenLaunchedPreviously"
+    static let hasAppBeenLaunchedPreviouslyKey = UserDefaults.Key.hasAppBeenLaunchedPreviously
 
     private let appSession: AppSession
     private let user: User

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -96,6 +96,7 @@ class HomeViewModel: NSObject {
     private let source: Source
     let tracker: Tracker
     private let user: User
+    private let userDefaults: UserDefaults
     private let networkPathMonitor: NetworkPathMonitor
     private let homeRefreshCoordinator: HomeRefreshCoordinatorProtocol
     private var subscriptions: [AnyCancellable] = []
@@ -109,7 +110,8 @@ class HomeViewModel: NSObject {
         tracker: Tracker,
         networkPathMonitor: NetworkPathMonitor,
         homeRefreshCoordinator: HomeRefreshCoordinatorProtocol,
-        user: User
+        user: User,
+        userDefaults: UserDefaults
     ) {
         self.source = source
         self.tracker = tracker
@@ -117,6 +119,7 @@ class HomeViewModel: NSObject {
         networkPathMonitor.start(queue: .global(qos: .utility))
         self.homeRefreshCoordinator = homeRefreshCoordinator
         self.user = user
+        self.userDefaults = userDefaults
 
         self.snapshot = {
             return Self.loadingSnapshot()
@@ -252,7 +255,8 @@ extension HomeViewModel {
             slate: slate,
             source: source,
             tracker: tracker.childTracker(hosting: .slateDetail.screen),
-            user: user
+            user: user,
+            userDefaults: userDefaults
         ))
     }
 
@@ -262,7 +266,8 @@ extension HomeViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .articleView.screen),
             pasteboard: UIPasteboard.general,
-            user: user
+            user: user,
+            userDefaults: userDefaults
         )
 
         guard let item = recommendation.item else {
@@ -293,7 +298,8 @@ extension HomeViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .articleView.screen),
             pasteboard: UIPasteboard.general,
-            user: user
+            user: user,
+            userDefaults: userDefaults
         )
 
         if let item = savedItem.item, item.shouldOpenInWebView {

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -27,13 +27,15 @@ class SlateDetailViewModel {
     private let source: Source
     private let tracker: Tracker
     private let user: User
+    private let userDefaults: UserDefaults
     private var subscriptions: [AnyCancellable] = []
 
-    init(slate: Slate, source: Source, tracker: Tracker, user: User) {
+    init(slate: Slate, source: Source, tracker: Tracker, user: User, userDefaults: UserDefaults) {
         self.slate = slate
         self.source = source
         self.tracker = tracker
         self.user = user
+        self.userDefaults = userDefaults
         self.snapshot = Self.loadingSnapshot()
 
         NotificationCenter.default.publisher(
@@ -108,7 +110,8 @@ extension SlateDetailViewModel {
                 source: source,
                 tracker: tracker.childTracker(hosting: .articleView.screen),
                 pasteboard: UIPasteboard.general,
-                user: user
+                user: user,
+                userDefaults: userDefaults
             )
 
             tracker.track(

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -43,17 +43,19 @@ class MainViewModel: ObservableObject {
                     source: Services.shared.source,
                     tracker: Services.shared.tracker.childTracker(hosting: .saves.saves),
                     viewType: .saves,
-                    listOptions: .saved,
+                    listOptions: .saved(userDefaults: Services.shared.userDefaults),
                     notificationCenter: .default,
-                    user: Services.shared.user
+                    user: Services.shared.user,
+                    userDefaults: Services.shared.userDefaults
                 ),
                 archivedItemsList: SavedItemsListViewModel(
                     source: Services.shared.source,
                     tracker: Services.shared.tracker.childTracker(hosting: .saves.archive),
                     viewType: .archive,
-                    listOptions: .archived,
+                    listOptions: .archived(userDefaults: Services.shared.userDefaults),
                     notificationCenter: .default,
-                    user: Services.shared.user
+                    user: Services.shared.user,
+                    userDefaults: Services.shared.userDefaults
                 )
             ),
             home: HomeViewModel(
@@ -61,7 +63,8 @@ class MainViewModel: ObservableObject {
                 tracker: Services.shared.tracker.childTracker(hosting: .home.screen),
                 networkPathMonitor: NWPathMonitor(),
                 homeRefreshCoordinator: Services.shared.homeRefreshCoordinator,
-                user: Services.shared.user
+                user: Services.shared.user,
+                userDefaults: Services.shared.userDefaults
             ),
             account: AccountViewModel(
                 appSession: Services.shared.appSession,

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -21,7 +21,7 @@ public class RootViewModel: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
 
     public convenience init() {
-        self.init(appSession: Services.shared.appSession, tracker: Services.shared.tracker, source: Services.shared.source, userDefaults: .standard)
+        self.init(appSession: Services.shared.appSession, tracker: Services.shared.tracker, source: Services.shared.source, userDefaults: Services.shared.userDefaults)
     }
 
     init(

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -91,7 +91,7 @@ public class RootViewModel: ObservableObject {
     private func tearDownSession() {
         source.clear()
 
-        userDefaults.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+        userDefaults.resetKeys()
         tracker.resetPersistentEntities([
             APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey)
         ])

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -70,6 +70,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     private let tracker: Tracker
     private let itemsController: SavedItemsController
     private let user: User
+    private let userDefaults: UserDefaults
     private var subscriptions: [AnyCancellable] = []
 
     private var selectedFilters: Set<ItemsListFilter>
@@ -77,7 +78,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     private let notificationCenter: NotificationCenter
     private let viewType: SavesViewType
 
-    init(source: Source, tracker: Tracker, viewType: SavesViewType, listOptions: ListOptions, notificationCenter: NotificationCenter, user: User) {
+    init(source: Source, tracker: Tracker, viewType: SavesViewType, listOptions: ListOptions, notificationCenter: NotificationCenter, user: User, userDefaults: UserDefaults) {
         self.source = source
         self.tracker = tracker
         self.selectedFilters = [.all]
@@ -85,6 +86,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         self.viewType = viewType
         self.listOptions = listOptions
         self.user = user
+        self.userDefaults = userDefaults
 
         switch self.viewType {
         case .saves:
@@ -533,7 +535,8 @@ extension SavedItemsListViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .articleView.screen),
             pasteboard: UIPasteboard.general,
-            user: user
+            user: user,
+            userDefaults: userDefaults
         )
 
         if savedItem.shouldOpenInWebView {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -400,7 +400,8 @@ extension SearchViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .articleView.screen),
             pasteboard: UIPasteboard.general,
-            user: user
+            user: user,
+            userDefaults: userDefaults
         )
 
         trackOpenSearchItem(url: savedItem.url, index: index)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -31,7 +31,8 @@ enum SearchViewState {
 
 /// View model that holds business logic for the SearchView
 class SearchViewModel: ObservableObject {
-    static let recentSearchesKey = "Search.recentSearches"
+    static let recentSearchesKey = UserDefaults.Key.recentSearches
+
     private var subscriptions: [AnyCancellable] = []
     private let networkPathMonitor: NetworkPathMonitor
     private var lastPathStatus: NWPath.Status?

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
@@ -32,7 +32,7 @@ class ListOptions: ObservableObject {
 }
 
 class SavedListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage("listSelectedSortForSaved")
+    @AppStorage(UserDefaults.Key.listSelectedSortForSaved)
     var selectedSortOption: SortOption  = .newest
 
     private var cancellable: AnyCancellable?
@@ -50,7 +50,7 @@ class SavedListOptions: ObservableObject, ListOptionsHolder {
 }
 
 class ArchiveListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage("listSelectedSortForArchive")
+    @AppStorage(UserDefaults.Key.listSelectedSortForArchive)
     var selectedSortOption: SortOption  = .newest
 
     private var cancellable: AnyCancellable?

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
@@ -8,8 +8,13 @@ protocol ListOptionsHolder: AnyObject {
 }
 
 class ListOptions: ObservableObject {
-    static let saved = ListOptions(holder: SavedListOptions())
-    static let archived = ListOptions(holder: ArchiveListOptions())
+    static func saved(userDefaults: UserDefaults) -> ListOptions {
+        return ListOptions(holder: SavedListOptions(userDefaults: userDefaults))
+    }
+
+    static func archived(userDefaults: UserDefaults) -> ListOptions {
+        return ListOptions(holder: ArchiveListOptions(userDefaults: userDefaults))
+    }
 
     private let holder: any ListOptionsHolder
     private var cancellable: AnyCancellable?
@@ -32,8 +37,8 @@ class ListOptions: ObservableObject {
 }
 
 class SavedListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage(UserDefaults.Key.listSelectedSortForSaved)
-    var selectedSortOption: SortOption  = .newest
+    @AppStorage
+    var selectedSortOption: SortOption
 
     private var cancellable: AnyCancellable?
     private let _publisher: PassthroughSubject<Void, Never>
@@ -41,7 +46,9 @@ class SavedListOptions: ObservableObject, ListOptionsHolder {
         _publisher.eraseToAnyPublisher()
     }
 
-    init() {
+    init(userDefaults: UserDefaults) {
+        _selectedSortOption = AppStorage(wrappedValue: SortOption.newest, UserDefaults.Key.listSelectedSortForSaved, store: userDefaults)
+
         _publisher = .init()
         cancellable = objectWillChange.sink { [weak self] in
             self?._publisher.send()
@@ -50,8 +57,8 @@ class SavedListOptions: ObservableObject, ListOptionsHolder {
 }
 
 class ArchiveListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage(UserDefaults.Key.listSelectedSortForArchive)
-    var selectedSortOption: SortOption  = .newest
+    @AppStorage
+    var selectedSortOption: SortOption
 
     private var cancellable: AnyCancellable?
     private let _publisher: PassthroughSubject<Void, Never>
@@ -59,7 +66,9 @@ class ArchiveListOptions: ObservableObject, ListOptionsHolder {
         _publisher.eraseToAnyPublisher()
     }
 
-    init() {
+    init(userDefaults: UserDefaults) {
+        _selectedSortOption = AppStorage(wrappedValue: SortOption.newest, UserDefaults.Key.listSelectedSortForArchive, store: userDefaults)
+
         _publisher = .init()
         cancellable = objectWillChange.sink { [weak self] in
             self?._publisher.send()

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -41,7 +41,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if CommandLine.arguments.contains("clearUserDefaults") {
-            userDefaults.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+            userDefaults.resetKeys()
         }
 
         if CommandLine.arguments.contains("clearCoreData") {

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -88,7 +88,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             if attempted {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
                 // Legacy cleanup
-                LegacyCleanupService(groupID: Keys.shared.groupID).cleanUp()
+                LegacyCleanupService().cleanUp()
             } else {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -15,7 +15,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
 
     private let source: Source
     private let userDefaults: UserDefaults
-    private let firstLaunchDefaults: UserDefaults
     private let refreshCoordinator: RefreshCoordinator
     private let appSession: AppSession
     internal let notificationService: PushNotificationService
@@ -28,7 +27,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     init(services: Services) {
         self.source = services.source
         self.userDefaults = services.userDefaults
-        self.firstLaunchDefaults = services.firstLaunchDefaults
         self.refreshCoordinator = services.refreshCoordinator
         self.appSession = services.appSession
         self.notificationService = services.notificationService
@@ -46,12 +44,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             userDefaults.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
         }
 
-        if CommandLine.arguments.contains("clearFirstLaunch") {
-            firstLaunchDefaults.removePersistentDomain(
-                forName: "\(Bundle.main.bundleIdentifier!).first-launch"
-            )
-        }
-
         if CommandLine.arguments.contains("clearCoreData") {
             source.clear()
         }
@@ -63,7 +55,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         SignOutOnFirstLaunch(
             appSession: appSession,
             user: user,
-            userDefaults: firstLaunchDefaults
+            userDefaults: userDefaults
         ).signOutOnFirstLaunch()
 
         if let guid = ProcessInfo.processInfo.environment["sessionGUID"],

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
@@ -7,10 +7,10 @@ import Textile
 import SwiftUI
 
 class ReaderSettings: StylerModifier, ObservableObject {
-    @AppStorage("readerFontSizeAdjustment")
+    @AppStorage(UserDefaults.Key.readerFontSizeAdjustment)
     var fontSizeAdjustment: Int = 0
 
-    @AppStorage("readerFontFamily")
+    @AppStorage(UserDefaults.Key.readerFontFamily)
     var fontFamily: FontDescriptor.Family = .blanco
 
     var currentStyling: FontStyling {

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
@@ -7,11 +7,11 @@ import Textile
 import SwiftUI
 
 class ReaderSettings: StylerModifier, ObservableObject {
-    @AppStorage(UserDefaults.Key.readerFontSizeAdjustment)
-    var fontSizeAdjustment: Int = 0
+    @AppStorage
+    var fontSizeAdjustment: Int
 
-    @AppStorage(UserDefaults.Key.readerFontFamily)
-    var fontFamily: FontDescriptor.Family = .blanco
+    @AppStorage
+    var fontFamily: FontDescriptor.Family
 
     var currentStyling: FontStyling {
         if fontFamily == .graphik {
@@ -19,6 +19,11 @@ class ReaderSettings: StylerModifier, ObservableObject {
         } else {
             return BlancoOSFStyling()
         }
+    }
+
+    init(userDefaults: UserDefaults) {
+        _fontSizeAdjustment = AppStorage(wrappedValue: 0, UserDefaults.Key.readerFontSizeAdjustment, store: userDefaults)
+        _fontFamily = AppStorage(wrappedValue: .blanco, UserDefaults.Key.readerFontSizeAdjustment, store: userDefaults)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -8,7 +8,8 @@ protocol HomeRefreshCoordinatorProtocol {
 }
 
 class HomeRefreshCoordinator: HomeRefreshCoordinatorProtocol {
-    static let dateLastRefreshKey = "HomeRefreshCoordinator.dateLastRefreshKey"
+    static let dateLastRefreshKey = UserDefaults.Key.dateLastRefresh
+
     private let notificationCenter: NotificationCenter
     private let userDefaults: UserDefaults
     private let source: Source

--- a/PocketKit/Sources/PocketKit/SceneTracker.swift
+++ b/PocketKit/Sources/PocketKit/SceneTracker.swift
@@ -19,9 +19,11 @@ class SceneTracker {
 
     private var subscriptions: Set<AnyCancellable> = []
 
-    @AppStorage private var dateLastOpened: Date?
+    @AppStorage
+    private var dateLastOpened: Date?
 
-    @AppStorage private var dateLastBackgrounded: Date?
+    @AppStorage
+    private var dateLastBackgrounded: Date?
 
     init(tracker: Tracker, userDefaults: UserDefaults, notificationCenter: NotificationCenter = .default) {
         self.tracker = tracker

--- a/PocketKit/Sources/PocketKit/SceneTracker.swift
+++ b/PocketKit/Sources/PocketKit/SceneTracker.swift
@@ -8,8 +8,8 @@ import SwiftUI
 import Combine
 
 class SceneTracker {
-    static let dateLastOpenedKey = "SceneTracker.dateLastOpened"
-    static let dateLastBackgroundedKey = "SceneTracker.dateLastBackgrounded"
+    static let dateLastOpenedKey = UserDefaults.Key.dateLastOpened
+    static let dateLastBackgroundedKey = UserDefaults.Key.dateLastBackgrounded
 
     private let tracker: Tracker
     private let userDefaults: UserDefaults

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -14,7 +14,6 @@ struct Services {
     static let shared: Services = { Services() }()
 
     let userDefaults: UserDefaults
-    let firstLaunchDefaults: UserDefaults
     let appSession: AppSession
     let user: User
     let urlSession: URLSessionProtocol
@@ -36,11 +35,12 @@ struct Services {
     private let persistentContainer: PersistentContainer
 
     private init() {
-        userDefaults = .standard
-        firstLaunchDefaults = UserDefaults(
-            suiteName: "\(Bundle.main.bundleIdentifier!).first-launch"
-        )!
-        persistentContainer = .init(storage: .shared, userDefaults: firstLaunchDefaults, groupID: Keys.shared.groupID)
+        guard let sharedUserDefaults = UserDefaults(suiteName: Keys.shared.groupID) else {
+            fatalError("UserDefaults with suite name \(Keys.shared.groupID) must exist.")
+        }
+        userDefaults = sharedUserDefaults
+
+        persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupID)
 
         urlSession = URLSession.shared
 

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -38,8 +38,8 @@ class AccountViewModel: ObservableObject {
     @Published var isPresentingPremiumStatus = false
     @Published var isPresentingHooray = false
 
-    @AppStorage(UserDefaults.Key.toggleAppBadge)
-    public var appBadgeToggle: Bool = false
+    @AppStorage
+    public var appBadgeToggle: Bool
 
     private var userStatusListener: AnyCancellable?
 
@@ -69,6 +69,8 @@ class AccountViewModel: ObservableObject {
         self.premiumStatusViewModelFactory = premiumStatusViewModelFactory
         self.isPremium = user.status == .premium
         self.networkPathMonitor = networkPathMonitor
+
+        _appBadgeToggle = AppStorage(wrappedValue: false, UserDefaults.Key.toggleAppBadge, store: userDefaults)
 
         userStatusListener = user
             .statusPublisher

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -7,7 +7,8 @@ import Textile
 import Network
 
 class AccountViewModel: ObservableObject {
-    static let ToggleAppBadgeKey = "AccountViewModel.ToggleAppBadge"
+    static let ToggleAppBadgeKey = UserDefaults.Key.toggleAppBadge
+
     private let user: User
     private let tracker: Tracker
     private let userDefaults: UserDefaults
@@ -37,7 +38,7 @@ class AccountViewModel: ObservableObject {
     @Published var isPresentingPremiumStatus = false
     @Published var isPresentingHooray = false
 
-    @AppStorage("Settings.ToggleAppBadge")
+    @AppStorage(UserDefaults.Key.toggleAppBadge)
     public var appBadgeToggle: Bool = false
 
     private var userStatusListener: AnyCancellable?

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -31,7 +31,7 @@ class MainViewController: UIViewController {
             if attempted {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
                 // Legacy cleanup
-                LegacyCleanupService(groupID: Keys.shared.groupdId).cleanUp()
+                LegacyCleanupService().cleanUp()
             } else {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -10,7 +10,6 @@ struct Services {
     let appSession: AppSession
     let saveService: PocketSaveService
     let tracker: Tracker
-    let firstLaunchDefaults: UserDefaults
     let userDefaults: UserDefaults
 
     private let persistentContainer: PersistentContainer
@@ -18,10 +17,12 @@ struct Services {
     private init() {
         Log.start(dsn: Keys.shared.sentryDSN)
 
-        firstLaunchDefaults = UserDefaults(
-            suiteName: "\(Bundle.main.bundleIdentifier!).first-launch"
-        )!
-        persistentContainer = .init(storage: .shared, userDefaults: firstLaunchDefaults, groupID: Keys.shared.groupdId)
+        guard let sharedUserDefaults = UserDefaults(suiteName: Keys.shared.groupdId) else {
+            fatalError("UserDefaults with suite name \(Keys.shared.groupdId) must exist.")
+        }
+        userDefaults = sharedUserDefaults
+
+        persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupdId)
 
         appSession = AppSession(groupID: Keys.shared.groupdId)
 
@@ -34,7 +35,5 @@ struct Services {
             consumerKey: Keys.shared.pocketApiConsumerKey,
             expiringActivityPerformer: ProcessInfo.processInfo
         )
-
-        userDefaults = .standard
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/Migrations/Cleanup/LegacyCleanupService.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/Cleanup/LegacyCleanupService.swift
@@ -16,27 +16,13 @@ public enum CleanupError: LoggableError {
 
 /// Service that cleans up legacy data
 public struct LegacyCleanupService {
-    private let grouoID: String
-
-    public init(groupID: String) {
-        self.grouoID = groupID
-    }
+    public init() { }
 
     public func cleanUp() {
-        cleanupLegacyUserDefaults()
         deleteSqliteDataBase()
         deleteImageCache()
         deleteAudioCache()
         deleteLogFiles()
-    }
-
-    /// Remove legacy `UserDefaults` suite
-    private func cleanupLegacyUserDefaults() {
-        guard let legacyDefaults = UserDefaults(suiteName: Legacy.groupID) else {
-            // Legacy dictionary does not exist, no cleanup or migration possible
-            return
-        }
-        legacyDefaults.removePersistentDomain(forName: Legacy.groupID)
     }
 
     /// Delete legacy log files

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -19,7 +19,10 @@ public enum LegacyUserMigrationError: LoggableError {
 }
 
 public class LegacyUserMigration {
-    static let migrationKey = "com.mozilla.pocket.next.migration.legacyUser"
+    static let migrationKey = UserDefaults.Key.legacyUserMigration
+    // These are required for legacy migration as one-offs, and thus, should not be removed
+    // from user defaults (since legacy user defaults are within the current app group)
+    // So, you won't find these defined in UserDefaults.Key
     static let versionKey = "version"
     static let decryptionKey = "kPKTCryptoKey"
 

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -25,9 +25,9 @@ public class PocketUser: User, ObservableObject {
     public var statusPublisher: Published<Status>.Publisher { $status }
     @AppStorage private var storedStatus: Status
 
-    private static let userStatusKey = "User.statusKey"
-    private static let userNameKey = "User.nameKey"
-    private static let displayNameKey = "User.displayNameKey"
+    private static let userStatusKey = UserDefaults.Key.userStatus
+    private static let userNameKey = UserDefaults.Key.userName
+    private static let displayNameKey = UserDefaults.Key.displayName
 
     public init(status: Status = .unknown, userDefaults: UserDefaults, userName: String = "", displayName: String = "") {
         _storedStatus = AppStorage(wrappedValue: status, Self.userStatusKey, store: userDefaults)

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -20,10 +20,13 @@ public protocol User {
 
 public class PocketUser: User, ObservableObject {
     @Published public private(set) var status: Status = .unknown
-    @AppStorage public var userName: String
-    @AppStorage public var displayName: String
+    @AppStorage
+    public var userName: String
+    @AppStorage
+    public var displayName: String
     public var statusPublisher: Published<Status>.Publisher { $status }
-    @AppStorage private var storedStatus: Status
+    @AppStorage
+    private var storedStatus: Status
 
     private static let userStatusKey = UserDefaults.Key.userStatus
     private static let userNameKey = UserDefaults.Key.userName

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+public extension UserDefaults {
+    enum Key: String, CaseIterable {
+        case hasAppBeenLaunchedPreviously = "hasAppBeenLaunchedPreviously"
+        case recentSearches = "Search.recentSearches"
+        case toggleAppBadge = "AccountViewModel.ToggleAppBadge"
+        case appBadgeToggle = "Settings.ToggleAppBadge"
+        case legacyUserMigration = "com.mozilla.pocket.next.migration.legacyUser"
+        case dateLastRefresh = "HomeRefreshCoordinator.dateLastRefreshKey"
+        case lastRefreshedTagsAt = "lastRefreshedTagsAt"
+        case lastRefreshedArchiveAt = "lastRefreshedArchiveAt"
+        case lastRefreshedSavesAt = "lastRefreshedSavesAt"
+        case listSelectedSortForSaved = "listSelectedSortForSaved"
+        case listSelectedSortForArchive = "listSelectedSortForArchive"
+        case readerFontSizeAdjustment = "readerFontSizeAdjustment"
+        case readerFontFamily = "readerFontFamily"
+        case dateLastOpened = "dateLastOpened"
+        case dateLastBackgrounded = "dateLastBackgrounded"
+        case userStatus = "User.statusKey"
+        case userName = "User.nameKey"
+        case displayName = "User.displayNameKey"
+
+        var isRemovable: Bool {
+            switch self {
+            case .hasAppBeenLaunchedPreviously: return false // This must remain in-tact for the "SignOutOnFirstLaunch" to be run exactly one time per app install
+            default: return true
+            }
+        }
+    }
+
+    func resetKeys() {
+        UserDefaults.Key.allCases
+            .filter { $0.isRemovable }
+            .forEach { removeObject(forKey: $0) }
+    }
+}
+
+public extension UserDefaults {
+    func set(_ value: Any?, forKey key: UserDefaults.Key) {
+        set(value, forKey: key.rawValue)
+    }
+
+    func setValue(_ value: Any?, forKey key: UserDefaults.Key) {
+        setValue(value, forKey: key.rawValue)
+    }
+
+    func bool(forKey key: UserDefaults.Key) -> Bool {
+        return bool(forKey: key.rawValue)
+    }
+
+    func stringArray(forKey key: UserDefaults.Key) -> [String]? {
+        return stringArray(forKey: key.rawValue)
+    }
+
+    func object(forKey key: UserDefaults.Key) -> Any? {
+        return object(forKey: key.rawValue)
+    }
+
+    func string(forKey key: UserDefaults.Key) -> String? {
+        return string(forKey: key.rawValue)
+    }
+
+    func integer(forKey key: UserDefaults.Key) -> Int {
+        return integer(forKey: key.rawValue)
+    }
+
+    func value(forKey key: UserDefaults.Key) -> Any? {
+        return value(forKey: key.rawValue)
+    }
+
+    func removeObject(forKey key: UserDefaults.Key) {
+        removeObject(forKey: key.rawValue)
+    }
+}
+
+public extension AppStorage {
+    init(wrappedValue: Value, _ key: UserDefaults.Key, store: UserDefaults? = nil) where Value: RawRepresentable, Value.RawValue == String {
+        self.init(wrappedValue: wrappedValue, key.rawValue, store: store)
+    }
+
+    init(wrappedValue: Value, _ key: UserDefaults.Key, store: UserDefaults? = nil) where Value == Int {
+        self.init(wrappedValue: wrappedValue, key.rawValue, store: store)
+    }
+
+    init(wrappedValue: Value, _ key: UserDefaults.Key, store: UserDefaults? = nil) where Value == Bool {
+        self.init(wrappedValue: wrappedValue, key.rawValue, store: store)
+    }
+
+    init(wrappedValue: Value, _ key: UserDefaults.Key, store: UserDefaults? = nil) where Value == String {
+        self.init(wrappedValue: wrappedValue, key.rawValue, store: store)
+    }
+
+    init<R>(_ key: UserDefaults.Key, store: UserDefaults? = nil) where Value == R?, R: RawRepresentable, R.RawValue == String {
+        self.init(key.rawValue, store: store)
+    }
+}

--- a/PocketKit/Sources/Sync/LastRefresh.swift
+++ b/PocketKit/Sources/Sync/LastRefresh.swift
@@ -27,7 +27,7 @@ struct UserDefaultsLastRefresh: LastRefresh {
 // MARK: Saves
 
 extension UserDefaultsLastRefresh {
-    private static let lastRefreshedSavesAtKey = "lastRefreshedSavesAt"
+    private static let lastRefreshedSavesAtKey = UserDefaults.Key.lastRefreshedSavesAt
 
     var lastRefreshSaves: Int? {
         if hasRefreshedSaves {
@@ -48,7 +48,7 @@ extension UserDefaultsLastRefresh {
 
 // MARK: Archive
 extension UserDefaultsLastRefresh {
-    private static let lastRefreshedArchiveAtKey = "lastRefreshedArchiveAt"
+    private static let lastRefreshedArchiveAtKey = UserDefaults.Key.lastRefreshedArchiveAt
 
     var lastRefreshArchive: Int? {
         if hasRefreshedArchive {
@@ -69,7 +69,7 @@ extension UserDefaultsLastRefresh {
 
 // MARK: Tags
 extension UserDefaultsLastRefresh {
-    private static let lastRefreshedTagsAtKey = "lastRefreshedTagsAt"
+    private static let lastRefreshedTagsAtKey = UserDefaults.Key.lastRefreshedTagsAt
 
     var lastRefreshTags: Int? {
         if hasRefreshedArchive {

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -23,11 +23,7 @@ public class PersistentContainer: NSPersistentContainer {
         case shared
     }
 
-    let userDefaults: UserDefaults
-
-    public init(storage: Storage = .shared, userDefaults: UserDefaults, groupID: String) {
-        self.userDefaults = userDefaults
-
+    public init(storage: Storage = .shared, groupID: String) {
         ValueTransformer.setValueTransformer(ArticleTransformer(), forName: .articleTransfomer)
         ValueTransformer.setValueTransformer(SyncTaskTransformer(), forName: .syncTaskTransformer)
 

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -18,6 +18,7 @@ class HomeViewModelTests: XCTestCase {
     var homeController: RichFetchedResultsController<Recommendation>!
     var recentSavesController: NSFetchedResultsController<SavedItem>!
     var user: User!
+    var userDefaults: UserDefaults!
 
     override func setUp() async throws {
         subscriptions = []
@@ -27,7 +28,8 @@ class HomeViewModelTests: XCTestCase {
         homeRefreshCoordinator = MockHomeRefreshCoordinator()
         homeController = space.makeRecomendationsSlateLineupController(by: SyncConstants.Home.slateLineupIdentifier)
         recentSavesController = space.makeRecentSavesController(limit: 5)
-        user = PocketUser(userDefaults: UserDefaults())
+        userDefaults = .standard
+        user = PocketUser(userDefaults: userDefaults)
 
         tracker = MockTracker()
 
@@ -60,14 +62,16 @@ class HomeViewModelTests: XCTestCase {
         tracker: Tracker? = nil,
         networkPathMonitor: NetworkPathMonitor? = nil,
         homeRefreshCoordinator: HomeRefreshCoordinatorProtocol? = nil,
-        user: User? = nil
+        user: User? = nil,
+        userDefaults: UserDefaults? = nil
     ) -> HomeViewModel {
         HomeViewModel(
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             homeRefreshCoordinator: homeRefreshCoordinator ?? self.homeRefreshCoordinator,
-            user: user ?? self.user
+            user: user ?? self.user,
+            userDefaults: userDefaults ?? self.userDefaults
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
@@ -16,7 +16,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
 
         XCTAssertEqual(presenter.shouldHideCaption, false)
     }
@@ -30,7 +30,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
 
         XCTAssertEqual(presenter.shouldHideCaption, true)
     }
@@ -44,7 +44,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: 0, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
@@ -59,7 +59,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: 0, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
@@ -74,7 +74,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: -1, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.ui.grey7))
@@ -89,7 +89,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: URL(string: "http://example.com")!
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: -1, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
@@ -104,7 +104,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: nil
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: -1, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
@@ -119,7 +119,7 @@ extension ImageComponentPresenterTests {
             id: 3,
             source: nil
         )
-        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings()) { }
+        let presenter = ImageComponentPresenter(component: component, readerSettings: ReaderSettings(userDefaults: .standard)) { }
         let imageSize = CGSize(width: -1, height: 0)
 
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -12,6 +12,7 @@ class RecommendationViewModelTests: XCTestCase {
     private var tracker: MockTracker!
     private var pasteboard: MockPasteboard!
     private var user: User!
+    private var userDefaults: UserDefaults!
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -20,7 +21,8 @@ class RecommendationViewModelTests: XCTestCase {
         tracker = MockTracker()
         pasteboard = MockPasteboard()
         space = .testSpace()
-        user = PocketUser(userDefaults: UserDefaults())
+        userDefaults = .standard
+        user = PocketUser(userDefaults: userDefaults)
 
         continueAfterFailure = false
     }
@@ -35,14 +37,16 @@ class RecommendationViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil,
         pasteboard: Pasteboard? = nil,
-        user: User? = nil
+        user: User? = nil,
+        userDefaults: UserDefaults? = nil
     ) -> RecommendationViewModel {
         RecommendationViewModel(
             recommendation: recommendation,
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             pasteboard: pasteboard ?? self.pasteboard,
-            user: user ?? self.user
+            user: user ?? self.user,
+            userDefaults: userDefaults ?? self.userDefaults
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -12,6 +12,7 @@ class SavedItemViewModelTests: XCTestCase {
     private var space: Space!
     private var pasteboard: Pasteboard!
     private var user: User!
+    private var userDefaults: UserDefaults!
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -21,6 +22,7 @@ class SavedItemViewModelTests: XCTestCase {
         pasteboard = MockPasteboard()
         space = .testSpace()
         user = PocketUser(userDefaults: UserDefaults())
+        userDefaults = .standard
     }
 
     override func tearDown() async throws {
@@ -40,7 +42,8 @@ class SavedItemViewModelTests: XCTestCase {
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             pasteboard: pasteboard ?? self.pasteboard,
-            user: user ?? self.user
+            user: user ?? self.user,
+            userDefaults: userDefaults ?? self.userDefaults
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -16,16 +16,18 @@ class SavedItemsListViewModelTests: XCTestCase {
     var viewType: SavesViewType!
     var subscriptions: [AnyCancellable]!
     var user: User!
+    var userDefaults: UserDefaults!
 
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
         space = .testSpace()
         subscriptions = []
-        listOptions = .saved
-        listOptions.selectedSortOption = .newest
         viewType = .saves
-        user = PocketUser(userDefaults: UserDefaults())
+        userDefaults = .standard
+        user = PocketUser(userDefaults: userDefaults)
+        listOptions = .saved(userDefaults: userDefaults)
+        listOptions.selectedSortOption = .newest
 
         itemsController = FetchedSavedItemsController(resultsController: NSFetchedResultsController(
             fetchRequest: Requests.fetchSavedItems(),
@@ -63,7 +65,8 @@ class SavedItemsListViewModelTests: XCTestCase {
         tracker: Tracker? = nil,
         listOptions: ListOptions? = nil,
         viewType: SavesViewType? = nil,
-        user: User? = nil
+        user: User? = nil,
+        userDefaults: UserDefaults? = nil
     ) -> SavedItemsListViewModel {
         SavedItemsListViewModel(
             source: source ?? self.source,
@@ -71,7 +74,8 @@ class SavedItemsListViewModelTests: XCTestCase {
             viewType: viewType ?? self.viewType,
             listOptions: listOptions ?? self.listOptions,
             notificationCenter: .default,
-            user: user ?? self.user
+            user: user ?? self.user,
+            userDefaults: userDefaults ?? self.userDefaults
         )
     }
 
@@ -390,7 +394,7 @@ class SavedItemsListViewModelTests: XCTestCase {
     func test_receivedSnapshots_whenArchiveInitialDownloadIsStarted_insertsPlaceholderCells() throws {
         source.initialArchiveDownloadState.send(.started)
 
-        let viewModel = subject(listOptions: .archived, viewType: .archive)
+        let viewModel = subject(listOptions: .archived(userDefaults: userDefaults), viewType: .archive)
 
         let receivedSnapshot = expectation(description: "receivedSnapshot")
         viewModel.snapshot.dropFirst().sink { snapshot in

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -14,12 +14,14 @@ class SlateDetailViewModelTests: XCTestCase {
     var tracker: MockTracker!
     var subscriptions: Set<AnyCancellable> = []
     var user: User!
+    var userDefaults: UserDefaults!
 
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
         space = .testSpace()
-        user = PocketUser(userDefaults: UserDefaults())
+        userDefaults = .standard
+        user = PocketUser(userDefaults: userDefaults)
         source.stubViewObject { identifier in
             self.space.viewObject(with: identifier)
         }
@@ -38,13 +40,15 @@ class SlateDetailViewModelTests: XCTestCase {
         slate: Slate,
         source: Source? = nil,
         tracker: Tracker? = nil,
-        user: User? = nil
+        user: User? = nil,
+        userDefaults: UserDefaults? = nil
     ) -> SlateDetailViewModel {
         SlateDetailViewModel(
             slate: slate,
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
-            user: user ?? self.user
+            user: user ?? self.user,
+            userDefaults: userDefaults ?? self.userDefaults
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
@@ -14,7 +14,7 @@ class SortMenuViewModelTests: XCTestCase {
     override func setUp() {
         source = MockSource()
         tracker = MockTracker()
-        listOptions = .saved
+        listOptions = .saved(userDefaults: .standard)
         listOptions.selectedSortOption = .newest
     }
 

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,7 +1,7 @@
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, userDefaults: .standard, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
 }
 
 extension Space {

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,7 +1,7 @@
 import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, userDefaults: .standard, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
 }
 
 extension Space {

--- a/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
@@ -9,7 +9,7 @@ class PocketUserTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        UserDefaults.standard.removePersistentDomain(forName: "PocketUserTests")
+        userDefaults.resetKeys()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -3,7 +3,7 @@ import CoreData
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, userDefaults: .standard, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
 }
 
 extension Space {


### PR DESCRIPTION
## Summary

Use shared user defaults rather than separate ones (for things such as first sign out). Additionally, do not clean up legacy user defaults (since these will be needed until full app migration / transition). This also introduces the use of a new enum, `UserDefaults.Key`, to consolidate our "library" of Pocket-used keys, and also aid in clearing `UserDefaults` of our used keys as necessary.

## References 

IN-1201

## Implementation Details

- Consolidates all usage of `UserDefaults` throughout the app into a single suite - the shared app group.

- Introduce `UserDefaults.Key`
  - A consolidated set of all `UserDefaults` keys that are used within the Pocket project
  - Extends `UserDefaults` to support the use of `Key` rather than `String`
  - Extends `AppStorage` to support the use of `Key` rather than `String`
  - Adds `UserDefaults.resetKeys()` to remove all (permitted) keys from an instance of `UserDefaults`

Currently, the keys' raw values match the existing keys used in the app prior to this pull request.

## Test Steps

- [ ] Basic app regression testing

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
