### PR TITLE
fix(tests): upping all our timeouts

### DIFF
--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -65,7 +65,7 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
-        wait(for: [badgeExpectation], timeout: 1)
+        wait(for: [badgeExpectation], timeout: 10)
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 1)
     }
 
@@ -85,7 +85,7 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
-        wait(for: [badgeExpectation], timeout: 1)
+        wait(for: [badgeExpectation], timeout: 10)
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 0)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -76,7 +76,7 @@ extension AuthorizationClientTests {
             _ = try await self.client.logIn(from: self)
         }
 
-        wait(for: [expectSessionStart], timeout: 1)
+        wait(for: [expectSessionStart], timeout: 10)
     }
 }
 
@@ -130,7 +130,7 @@ extension AuthorizationClientTests {
             _ = try await self.client.signUp(from: self)
         }
 
-        wait(for: [expectSessionStart], timeout: 1)
+        wait(for: [expectSessionStart], timeout: 10)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -81,7 +81,7 @@ class HomeViewModelTests: XCTestCase {
             snapshotExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsLoadingSnapshot() {
@@ -95,7 +95,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedLoadingSnapshot], timeout: 1)
+        wait(for: [receivedLoadingSnapshot], timeout: 10)
     }
 
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsAvailable_sendsSnapshotWithSlates() throws {
@@ -145,7 +145,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 1)
+        wait(for: [receivedSnapshot], timeout: 10)
     }
 
     func test_fetch_whenRecentSavesAreAvailable_andSlateLineupIsUnavailable_sendsSnapshotWithRecentSaves() throws {
@@ -176,7 +176,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 1)
+        wait(for: [receivedEmptySnapshot], timeout: 10)
     }
 
     func test_fetch_whenRecentSavesAndSlateLineupAreAvailable_sendsSnapshotWithRecentSavesAndSlates() throws {
@@ -236,7 +236,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 1)
+        wait(for: [receivedEmptySnapshot], timeout: 10)
     }
 
     func test_fetch_whenSlateContainsMoreThanFiveRecommendations_sendsSnapshotFirstFiveRecommendations() throws {
@@ -265,7 +265,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 1)
+        wait(for: [receivedEmptySnapshot], timeout: 10)
     }
 
     func test_snapshot_whenSlateLineupIsUpdated_updatesSnapshot() throws {
@@ -324,7 +324,7 @@ class HomeViewModelTests: XCTestCase {
         )
         try space.save()
 
-        wait(for: [snapshotSent], timeout: 1)
+        wait(for: [snapshotSent], timeout: 10)
     }
 
     func test_snapshot_whenRecommendationIsSaved_updatesSnapshot() throws {
@@ -369,7 +369,7 @@ class HomeViewModelTests: XCTestCase {
         item.savedItem = savedItem
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_snapshot_whenRecommendationIsArchived_updatesSnapshot() throws {
@@ -413,7 +413,7 @@ class HomeViewModelTests: XCTestCase {
         item.savedItem?.isArchived = true
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_snapshot_whenRecommendationIsDeleted_updatesSnapshot() throws {
@@ -460,7 +460,7 @@ class HomeViewModelTests: XCTestCase {
         XCTAssertNotNil(item.savedItem?.item)
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_snapshot_whenSavedItemIsFavorited_updatesSnapshot() throws {
@@ -493,7 +493,7 @@ class HomeViewModelTests: XCTestCase {
         savedItem.isFavorite = true
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
      func test_snapshot_whenNetworkIsInitiallyAvailable_hasCorrectSnapshot() {
@@ -528,7 +528,7 @@ class HomeViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetch()
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_refresh_whenNetworkIsUnavailable_updatesSnapshot() {
@@ -546,7 +546,7 @@ class HomeViewModelTests: XCTestCase {
         networkPathMonitor.update(status: .unsatisfied)
         viewModel.refresh { }
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_refresh_delegatesToHomeRefreshCoordinator() {
@@ -556,7 +556,7 @@ class HomeViewModelTests: XCTestCase {
 
         let viewModel = subject()
         viewModel.refresh { }
-        wait(for: [fetchExpectation], timeout: 1)
+        wait(for: [fetchExpectation], timeout: 10)
 
         XCTAssertNotNil(homeRefreshCoordinator.refreshCall(at: 0))
     }
@@ -595,7 +595,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [readableExpectation], timeout: 1)
+        wait(for: [readableExpectation], timeout: 10)
     }
 
     func test_selectCell_whenSelectingRecommendation_whenRecommendationIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -645,7 +645,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [urlExpectation], timeout: 1)
+        wait(for: [urlExpectation], timeout: 10)
     }
 
     func test_selectCell_whenSelectingRecentSave_recentSaveIsReadable_updatesSelectedReadable() throws {
@@ -674,7 +674,7 @@ class HomeViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [readableExpectation], timeout: 1)
+        wait(for: [readableExpectation], timeout: 10)
     }
 
     func test_selectCell_whenSelectingRecentSave_recentSaveIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -724,7 +724,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [urlExpectation], timeout: 1)
+        wait(for: [urlExpectation], timeout: 10)
     }
 
     func test_selectSection_whenSelectingSlateSection_updatesSelectedSlateDetailViewModel() throws {
@@ -751,7 +751,7 @@ class HomeViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.sectionHeaderViewModel(for: .slateHero(slate.objectID))?.buttonAction?()
-        wait(for: [detailExpectation], timeout: 1)
+        wait(for: [detailExpectation], timeout: 10)
     }
 
     func test_reportAction_forRecommendationCells_updatesSelectedRecommendationToReport() throws {
@@ -780,7 +780,7 @@ class HomeViewModelTests: XCTestCase {
             action?.handler?(nil)
         }
 
-        wait(for: [reportExpectation], timeout: 1)
+        wait(for: [reportExpectation], timeout: 10)
     }
 
     func test_primary_whenRecommendationIsNotSaved_savesWithSource() throws {

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -78,7 +78,7 @@ extension LoggedOutViewModelTests {
         let viewModel = subject()
         await viewModel.logIn()
 
-        wait(for: [startExpectation], timeout: 1)
+        wait(for: [startExpectation], timeout: 10)
     }
 
     @MainActor
@@ -94,7 +94,7 @@ extension LoggedOutViewModelTests {
 
         viewModel.logIn()
 
-        wait(for: [alertExpectation], timeout: 1)
+        wait(for: [alertExpectation], timeout: 10)
     }
 
     @MainActor
@@ -118,7 +118,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         viewModel.logIn()
-        wait(for: [sessionExpectation], timeout: 1)
+        wait(for: [sessionExpectation], timeout: 10)
     }
 }
 
@@ -140,7 +140,7 @@ extension LoggedOutViewModelTests {
         let viewModel = subject()
         await viewModel.signUp()
 
-        wait(for: [startExpectation], timeout: 1)
+        wait(for: [startExpectation], timeout: 10)
     }
 
     @MainActor
@@ -155,7 +155,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         viewModel.signUp()
-        wait(for: [alertExpectation], timeout: 1)
+        wait(for: [alertExpectation], timeout: 10)
     }
 
     @MainActor
@@ -179,7 +179,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         viewModel.signUp()
-        wait(for: [sessionExpectation], timeout: 1)
+        wait(for: [sessionExpectation], timeout: 10)
     }
 }
 
@@ -195,7 +195,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         await viewModel.logIn()
-        wait(for: [offlineExpectation], timeout: 1)
+        wait(for: [offlineExpectation], timeout: 10)
     }
 
     func test_logIn_whenOffline_thenReconnects_setsPresentOfflineViewToFalse() async {
@@ -218,7 +218,7 @@ extension LoggedOutViewModelTests {
 
         await viewModel.logIn()
         networkPathMonitor.update(status: .satisfied)
-        wait(for: [offlineExpectation, onlineExpectation], timeout: 1, enforceOrder: true)
+        wait(for: [offlineExpectation, onlineExpectation], timeout: 10, enforceOrder: true)
     }
 
     func test_signUp_whenOffline_setsPresentOfflineViewToTrue() async {
@@ -232,7 +232,7 @@ extension LoggedOutViewModelTests {
         }.store(in: &subscriptions)
 
         await viewModel.signUp()
-        wait(for: [offlineExpectation], timeout: 1)
+        wait(for: [offlineExpectation], timeout: 10)
     }
 
     func test_signUp_whenOffline_thenReconnects_setsPresentOfflineViewToFalse() async {
@@ -255,7 +255,7 @@ extension LoggedOutViewModelTests {
 
         await viewModel.signUp()
         networkPathMonitor.update(status: .satisfied)
-        wait(for: [offlineExpectation, onlineExpectation], timeout: 1, enforceOrder: true)
+        wait(for: [offlineExpectation, onlineExpectation], timeout: 10, enforceOrder: true)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -52,7 +52,7 @@ final class PushNotificationServiceTests: XCTestCase {
 
         NotificationCenter.default.post(name: .userLoggedIn, object: session)
 
-        wait(for: [sessionExpectation], timeout: 2)
+        wait(for: [sessionExpectation], timeout: 10)
 
         XCTAssertEqual(braze.loggedInCalls(), 2)
         XCTAssertEqual(instantSync.loggedInCalls(), 2)
@@ -76,7 +76,7 @@ final class PushNotificationServiceTests: XCTestCase {
 
         NotificationCenter.default.post(name: .userLoggedOut, object: SharedPocketKit.Session(guid: "logout-test-guid", accessToken: "logout-test-access-token", userIdentifier: "logout-test-id"))
 
-        wait(for: [sessionExpectation], timeout: 2)
+        wait(for: [sessionExpectation], timeout: 10)
 
         XCTAssertEqual(braze.loggedOutCalls(), 1)
         XCTAssertEqual(instantSync.loggedOutCalls(), 1)

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -96,7 +96,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
 
         viewModel.addTags()
 
-        wait(for: [expectAddTagsCall], timeout: 1)
+        wait(for: [expectAddTagsCall], timeout: 10)
         XCTAssertNotNil(source.addTagsToSavedItemCall(at: 0))
     }
 
@@ -116,7 +116,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         let viewModel = subject(item: item) { }
         viewModel.allOtherTags()
 
-        wait(for: [expectRetrieveTagsCall], timeout: 1)
+        wait(for: [expectRetrieveTagsCall], timeout: 10)
         XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 3"), TagType.tag("tag 2")])
         XCTAssertNotNil(source.retrieveTagsCall(at: 0))
     }
@@ -172,7 +172,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 1)
+        wait(for: [expectFilterTagsCall], timeout: 10)
     }
 
     func test_newTagInput_withNoTags_showAllTags() {
@@ -201,6 +201,6 @@ class PocketAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 1)
+        wait(for: [expectFilterTagsCall], timeout: 10)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -148,7 +148,7 @@ class RecommendationViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Favorite")
 
-        wait(for: [expectFavorite], timeout: 1)
+        wait(for: [expectFavorite], timeout: 10)
     }
 
     func test_unfavorite_delegatesToSource() {
@@ -166,7 +166,7 @@ class RecommendationViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Unfavorite")
 
-        wait(for: [expectUnfavorite], timeout: 1)
+        wait(for: [expectUnfavorite], timeout: 10)
     }
 
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
@@ -194,7 +194,7 @@ class RecommendationViewModelTests: XCTestCase {
         viewModel.invokeAction(title: "Delete")
         viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
 
-        wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 10)
     }
 
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
@@ -220,7 +220,7 @@ class RecommendationViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.archive()
-        wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 10)
     }
 
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
@@ -237,7 +237,7 @@ class RecommendationViewModelTests: XCTestCase {
         let viewModel = subject(recommendation: recommendation)
         viewModel.moveFromArchiveToSaves { _ in }
 
-        wait(for: [expectMoveFromArchiveToSaves], timeout: 1)
+        wait(for: [expectMoveFromArchiveToSaves], timeout: 10)
     }
 
     func test_share_updatesSharedActivity() {
@@ -277,7 +277,7 @@ class RecommendationViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Save")
 
-        wait(for: [expectSave], timeout: 1)
+        wait(for: [expectSave], timeout: 10)
     }
 
     func test_report_updatesSelectedRecommendationToReport() {
@@ -292,7 +292,7 @@ class RecommendationViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.invokeAction(title: "Report")
-        wait(for: [reportExpectation], timeout: 1)
+        wait(for: [reportExpectation], timeout: 10)
     }
 
     func test_externalSave_forwardsToSource() throws {
@@ -349,7 +349,7 @@ class RecommendationViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [receivedEvent], timeout: 1)
+        wait(for: [receivedEvent], timeout: 10)
         XCTAssertNotNil(recommendation.item?.article)
     }
 
@@ -369,7 +369,7 @@ class RecommendationViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [receivedEvent], timeout: 1)
+        wait(for: [receivedEvent], timeout: 10)
     }
 
     func test_webActivitiesActions_whenRecommendation_notSaved() {
@@ -389,7 +389,7 @@ class RecommendationViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[0].activityTitle, "Save")
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Report")
 
-        wait(for: [webActivitiesExpectation], timeout: 1)
+        wait(for: [webActivitiesExpectation], timeout: 10)
     }
 
     func test_webActivitiesActions_whenRecommendation_isSaved() throws {
@@ -412,7 +412,7 @@ class RecommendationViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 1)
+        wait(for: [webActivitiesExpectation], timeout: 10)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -50,7 +50,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 1)
+        wait(for: [expectRefresh], timeout: 10)
         XCTAssertNotNil(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey))
     }
 
@@ -79,7 +79,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 1)
+        wait(for: [expectRefresh], timeout: 10)
         XCTAssertNotEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
     }
 
@@ -96,7 +96,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh(isForced: true) {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 1)
+        wait(for: [expectRefresh], timeout: 10)
     }
 
     func test_refresh_delegatesToSource() {
@@ -106,7 +106,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         let coordinator = subject()
 
         coordinator.refresh(isForced: true) { }
-        wait(for: [fetchExpectation], timeout: 2)
+        wait(for: [fetchExpectation], timeout: 10)
 
         XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
     }
@@ -133,7 +133,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         let coordinator = subject()
         notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
 
-        wait(for: [fetchExpectation], timeout: 2)
+        wait(for: [fetchExpectation], timeout: 10)
         XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
         XCTAssertNotEqual(userDefaults.object(forKey: HomeRefreshCoordinator.dateLastRefreshKey) as? Date, date)
     }

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -101,7 +101,7 @@ class SavedItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [eventSent], timeout: 2)
+        wait(for: [eventSent], timeout: 10)
 
         let call = source.fetchDetailsCall(at: 0)
         XCTAssertNotNil(call)
@@ -129,7 +129,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         viewModel.fetchDetailsIfNeeded()
 
-        wait(for: [contentUpdatedSent], timeout: 1)
+        wait(for: [contentUpdatedSent], timeout: 10)
         XCTAssertNil(source.fetchDetailsCall(at: 0))
     }
 
@@ -152,7 +152,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: item)
         viewModel.invokeAction(title: "Favorite")
 
-        wait(for: [expectFavorite], timeout: 1)
+        wait(for: [expectFavorite], timeout: 10)
     }
 
     func test_unfavorite_delegatesToSource() {
@@ -167,7 +167,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: item)
         viewModel.invokeAction(title: "Unfavorite")
 
-        wait(for: [expectUnfavorite], timeout: 1)
+        wait(for: [expectUnfavorite], timeout: 10)
     }
 
     func test_addTagsAction_sendsAddTagsViewModel() {
@@ -181,7 +181,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Add Tags")
 
-        wait(for: [expectAddTags], timeout: 1)
+        wait(for: [expectAddTags], timeout: 10)
     }
 
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
@@ -207,7 +207,7 @@ class SavedItemViewModelTests: XCTestCase {
         viewModel.invokeAction(title: "Delete")
         viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
 
-        wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 10)
     }
 
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
@@ -232,7 +232,7 @@ class SavedItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.archive()
-        wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 10)
     }
 
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
@@ -248,7 +248,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: savedItem)
         viewModel.moveFromArchiveToSaves { _ in }
 
-        wait(for: [expectMoveFromArchiveToSaves], timeout: 1)
+        wait(for: [expectMoveFromArchiveToSaves], timeout: 10)
     }
 
     func test_share_updatesSharedActivity() {
@@ -315,7 +315,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 1)
+        wait(for: [webActivitiesExpectation], timeout: 10)
     }
 
     func test_webActivitiesActions_whenItemIsArchive_canMoveToSaves() throws {
@@ -335,7 +335,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 1)
+        wait(for: [webActivitiesExpectation], timeout: 10)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -98,7 +98,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         listOptions.selectedSortOption = .oldest
 
-        wait(for: [snapshotSent], timeout: 1)
+        wait(for: [snapshotSent], timeout: 10)
     }
 
     func test_shouldSelectCell_whenItemIsPending_returnsFalse() throws {
@@ -171,7 +171,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = nil
-        wait(for: [eventSent], timeout: 1)
+        wait(for: [eventSent], timeout: 10)
     }
 
     func test_selectedItem_whenReaderView_doesNotSendSelectionCleared() {
@@ -185,7 +185,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = .readable(nil)
-        wait(for: [eventSent], timeout: 1)
+        wait(for: [eventSent], timeout: 10)
     }
 
     func test_selectedItem_whenWebView_doesNotSendSelectionCleared() {
@@ -199,7 +199,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = .webView(nil)
-        wait(for: [eventSent], timeout: 1)
+        wait(for: [eventSent], timeout: 10)
     }
 
     func test_sourceEvents_whenEventIsSavedItemCreated_sendsSnapshotWithNewItem() {
@@ -217,7 +217,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         try? space.save()
         source._events.send(.savedItemCreated)
 
-        wait(for: [snapshotSent], timeout: 1)
+        wait(for: [snapshotSent], timeout: 10)
     }
 
     func test_sourceEvents_whenEventIsSavedItemUpdated_sendsSnapshotWithUpdatedItem() {
@@ -234,7 +234,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         source._events.send(.savedItemsUpdated([savedItem]))
 
-        wait(for: [snapshotSent], timeout: 1)
+        wait(for: [snapshotSent], timeout: 10)
     }
 
     func test_receivedSnapshots_withNoItems_includesSavesEmptyState() {
@@ -252,7 +252,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_receivedSnapshots_withNoItems_includesFavoritesEmptyState() {
@@ -271,7 +271,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_receivedSnapshots_withNoItems_includesTagsEmptyState() {
@@ -293,7 +293,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_receivedSnapshots_withItems_doesNotIncludeSavesEmptyState() {
@@ -312,7 +312,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_receivedSnapshots_withItems_doesNotIncludeFavoritesEmptyState() {
@@ -333,7 +333,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_refreshSaves_callsRetryImmediatelyOnSource() {
@@ -365,7 +365,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         source.initialSavesDownloadState.send(.paginating(totalCount: 2))
         try? itemsController.performFetch()
 
-        wait(for: [receivedSnapshot], timeout: 1)
+        wait(for: [receivedSnapshot], timeout: 10)
     }
 
     func test_receivedSnapshots_whenSavesInitialDownloadIsStarted_insertsPlaceholderCells() throws {
@@ -384,7 +384,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 1)
+        wait(for: [receivedSnapshot], timeout: 10)
     }
 
     func test_receivedSnapshots_whenArchiveInitialDownloadIsStarted_insertsPlaceholderCells() throws {
@@ -403,7 +403,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 1)
+        wait(for: [receivedSnapshot], timeout: 10)
     }
 }
 
@@ -426,7 +426,7 @@ extension SavedItemsListViewModelTests {
             .first { $0.title == "Add Tags" }?
             .handler?(nil)
 
-        wait(for: [expectAddTags], timeout: 1)
+        wait(for: [expectAddTags], timeout: 10)
     }
 
     func test_fetch_whenTaggedSelected_sendsTagsFilterViewModel() throws {
@@ -443,7 +443,7 @@ extension SavedItemsListViewModelTests {
 
         viewModel.selectCell(with: .filterButton(.tagged))
 
-        wait(for: [expectTagFiltersCall], timeout: 1)
+        wait(for: [expectTagFiltersCall], timeout: 10)
     }
 
     func test_tagModel_calculatesTagHeightAndWidth() {

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModel.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModel.swift
@@ -57,7 +57,7 @@ class PocketItemViewModelTests: XCTestCase {
 
         _ = viewModel.favoriteAction().handler?(nil)
 
-        wait(for: [expectFavoriteCall, expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectFavoriteCall, expectFetchSavedItemCall], timeout: 10)
         XCTAssertEqual(source.favoriteSavedItemCall(at: 0)?.item, item)
         XCTAssertTrue(viewModel.isFavorite)
     }
@@ -81,7 +81,7 @@ class PocketItemViewModelTests: XCTestCase {
 
         _ = viewModel.favoriteAction().handler?(nil)
 
-        wait(for: [expectUnfavoriteCall, expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectUnfavoriteCall, expectFetchSavedItemCall], timeout: 10)
         XCTAssertEqual(source.unfavoriteSavedItemCall(at: 0)?.item, item)
         XCTAssertFalse(viewModel.isFavorite)
     }
@@ -110,7 +110,7 @@ class PocketItemViewModelTests: XCTestCase {
             XCTFail("Should not be nil")
             return
         }
-        wait(for: [expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectFetchSavedItemCall], timeout: 10)
         XCTAssertEqual(tagsViewModel.tags, ["tag-0"])
     }
 
@@ -131,7 +131,7 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.archive()
 
-        wait(for: [expectArchive, expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectArchive, expectFetchSavedItemCall], timeout: 10)
     }
 
     func test_unarchiveAction_delegatesToSource() {
@@ -151,7 +151,7 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.moveToSaves()
 
-        wait(for: [expectUnarchive, expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectUnarchive, expectFetchSavedItemCall], timeout: 10)
     }
 
     func test_deleteAction_delegatesToSource() {
@@ -172,6 +172,6 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.delete()
 
-        wait(for: [expectDelete, expectFetchSavedItemCall], timeout: 1)
+        wait(for: [expectDelete, expectFetchSavedItemCall], timeout: 10)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -184,7 +184,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     func test_updateScope_forFreeUser_withAllAndTerm_showsGetPremiumEmptyState() async {
@@ -224,7 +224,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     func test_updateScope_forPremiumUser_withArchiveAndTerm_showsResults() async {
@@ -248,7 +248,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     func test_updateScope_forPremiumUser_withAllAndTerm_showsResults() async {
@@ -272,7 +272,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     // MARK: - Update Search Results
@@ -342,7 +342,7 @@ class SearchViewModelTests: XCTestCase {
         searchService.stubSearch { _, _ in }
         searchService._results = []
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     func test_updateSearchResults_forPremiumUser_withItems_showsResults() async {
@@ -367,7 +367,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     // MARK: - Offline States
@@ -584,11 +584,11 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchResultsExpectation], timeout: 1.0, enforceOrder: false)
+        wait(for: [searchResultsExpectation], timeout: 10.0, enforceOrder: false)
 
         viewModel.clear()
 
-        wait(for: [recentSearchesExpectation], timeout: 1.0, enforceOrder: false)
+        wait(for: [recentSearchesExpectation], timeout: 10.0, enforceOrder: false)
     }
 
     func test_search_whenDeviceRegainsInternetConnection_submitsSearch() async {
@@ -628,7 +628,7 @@ class SearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: "search-term")
 
-        wait(for: [offlineExpectation, onlineExpectation], timeout: 1, enforceOrder: true)
+        wait(for: [offlineExpectation, onlineExpectation], timeout: 10, enforceOrder: true)
     }
 
     // MARK: - Error Handling
@@ -657,7 +657,7 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .saves, searchTerm: "saved")
 
-        wait(for: [errorExpectation, localSavesExpectation], timeout: 1)
+        wait(for: [errorExpectation, localSavesExpectation], timeout: 10)
     }
 
     func test_updateSearchResults_withInternetConnectionError_showsOfflineView() async throws {
@@ -681,7 +681,7 @@ class SearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .archive, searchTerm: "search-term")
 
-        wait(for: [searchErrorExpectation, errorExpectation], timeout: 1, enforceOrder: true)
+        wait(for: [searchErrorExpectation, errorExpectation], timeout: 10, enforceOrder: true)
     }
 
     // MARK: Load More Search Results (Pagination)
@@ -711,7 +711,7 @@ class SearchViewModelTests: XCTestCase {
         viewModel.loadMoreSearchResults(with: pocketItem, at: 0)
         await setupOnlineSearch(with: term)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
     }
 
     private func setupLocalSavesSearch(with url: URL? = nil) throws {

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -58,7 +58,7 @@ class SlateDetailViewModelTests: XCTestCase {
         }
         viewModel.refresh { }
 
-        wait(for: [fetchExpectation], timeout: 1)
+        wait(for: [fetchExpectation], timeout: 10)
         XCTAssertEqual(source.fetchSlateCall(at: 0)?.identifier, "abcde")
     }
 
@@ -77,7 +77,7 @@ class SlateDetailViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedLoadingSnapshot], timeout: 1)
+        wait(for: [receivedLoadingSnapshot], timeout: 10)
     }
 
     func test_fetch_sendsSnapshotWithItemForEachRecommendation() throws {
@@ -108,7 +108,7 @@ class SlateDetailViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetch()
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_snapshot_whenRecommendationIsSaved_updatesSnapshot() throws {
@@ -142,7 +142,7 @@ class SlateDetailViewModelTests: XCTestCase {
         item.savedItem = space.buildSavedItem()
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 1)
+        wait(for: [snapshotExpectation], timeout: 10)
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
@@ -161,7 +161,7 @@ class SlateDetailViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [readableExpectation], timeout: 1)
+        wait(for: [readableExpectation], timeout: 10)
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -201,7 +201,7 @@ class SlateDetailViewModelTests: XCTestCase {
             viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
         }
 
-        wait(for: [urlExpectation], timeout: 1)
+        wait(for: [urlExpectation], timeout: 10)
     }
 
     func test_reportAction_forRecommendation_updatesSelectedRecommendationToReport() throws {
@@ -224,7 +224,7 @@ class SlateDetailViewModelTests: XCTestCase {
         XCTAssertNotNil(action)
 
         action?.handler?(nil)
-        wait(for: [reportExpectation], timeout: 1)
+        wait(for: [reportExpectation], timeout: 10)
     }
 
     func test_primaryAction_whenRecommendationIsNotSaved_savesWithSource() throws {

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -110,7 +110,7 @@ class TagsFilterViewModelTests: XCTestCase {
         viewModel.delete(tags: ["b", "e", "q"])
 
         XCTAssertEqual(deletedTags, ["b", "e"])
-        wait(for: [expectDelete], timeout: 1)
+        wait(for: [expectDelete], timeout: 10)
     }
 
     func test_renameTag_showsNewName() {
@@ -126,6 +126,6 @@ class TagsFilterViewModelTests: XCTestCase {
         let viewModel = subject(fetchedTags: savedTags) { }
         viewModel.rename(from: "tag 1", to: "tag 0")
 
-        wait(for: [expectRename], timeout: 1)
+        wait(for: [expectRename], timeout: 10)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
@@ -21,6 +21,6 @@ extension LoggedOutViewModelTests {
 
         viewModel.viewWillAppear(context: context, origin: self)
 
-        wait(for: [completeRequestExpectation], timeout: 1)
+        wait(for: [completeRequestExpectation], timeout: 10)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -154,7 +154,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 1)
+        wait(for: [expectFilterTagsCall], timeout: 10)
     }
 
     func test_newTagInput_withNoTags_showAllTags() throws {
@@ -184,6 +184,6 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 1)
+        wait(for: [expectFilterTagsCall], timeout: 10)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -87,7 +87,7 @@ extension SavedItemViewModelTests {
         }
 
         await viewModel.save(from: context)
-        wait(for: [completeRequestExpectation], timeout: 1)
+        wait(for: [completeRequestExpectation], timeout: 10)
     }
 }
 
@@ -174,7 +174,7 @@ extension SavedItemViewModelTests {
 
         await viewModel.save(from: context)
 
-        wait(for: [completeRequestExpectation], timeout: 1)
+        wait(for: [completeRequestExpectation], timeout: 10)
     }
 
     func test_save_whenResavingExistingItem_updatesInfoViewModel() async {
@@ -208,7 +208,7 @@ extension SavedItemViewModelTests {
         context.stubCompleteRequest { _, _ in }
 
         await viewModel.save(from: context)
-        wait(for: [infoViewModelChanged], timeout: 1)
+        wait(for: [infoViewModelChanged], timeout: 10)
         subscription.cancel()
     }
 
@@ -237,7 +237,7 @@ extension SavedItemViewModelTests {
         context.stubCompleteRequest { _, _ in }
 
         await viewModel.save(from: context)
-        wait(for: [infoViewModelChanged], timeout: 1)
+        wait(for: [infoViewModelChanged], timeout: 10)
         subscription.cancel()
     }
 }
@@ -259,7 +259,7 @@ extension SavedItemViewModelTests {
 
         viewModel.showAddTagsView(from: context)
 
-        wait(for: [expectAddTags], timeout: 1)
+        wait(for: [expectAddTags], timeout: 10)
         subscription.cancel()
     }
 
@@ -281,7 +281,7 @@ extension SavedItemViewModelTests {
             do { infoViewModelChanged.fulfill() }
         }
 
-        wait(for: [infoViewModelChanged], timeout: 1)
+        wait(for: [infoViewModelChanged], timeout: 10)
         subscription.cancel()
     }
 

--- a/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
+++ b/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
@@ -19,7 +19,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [notificationWasHandled], timeout: 1)
+        wait(for: [notificationWasHandled], timeout: 10)
     }
 
     func test_register_whenAlreadyRegistered_addsBothObservers() {
@@ -36,7 +36,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [notificationWasHandled, notificationWasHandled2], timeout: 1)
+        wait(for: [notificationWasHandled, notificationWasHandled2], timeout: 10)
     }
 
     func test_remove_removesGivenObserverForGivenNotification() {
@@ -55,7 +55,7 @@ class OSNotificationCenterTests: XCTestCase {
         center.remove(observer: observers[0], name: .testNotification)
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [observer2HandledNotification], timeout: 1)
+        wait(for: [observer2HandledNotification], timeout: 10)
     }
 
     func test_remove_whenObservingWithMultipleHandlers_removesAllHandlers() {
@@ -77,7 +77,7 @@ class OSNotificationCenterTests: XCTestCase {
         DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 1) {
             pause.fulfill()
         }
-        wait(for: [pause], timeout: 2)
+        wait(for: [pause], timeout: 10)
     }
 
     func test_remove_doesNotRemoveHandlerForOtherNotifications() {
@@ -97,7 +97,7 @@ class OSNotificationCenterTests: XCTestCase {
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
         CFNotificationCenterPostNotification(cfCenter, .anotherTestNotification, nil, nil, true)
 
-        wait(for: [wasNotifiedOfAnotherTestNotification], timeout: 1)
+        wait(for: [wasNotifiedOfAnotherTestNotification], timeout: 10)
     }
 
     func test_remove_doesNotRetainObservers() {
@@ -135,7 +135,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [receivedNotification], timeout: 1)
+        wait(for: [receivedNotification], timeout: 10)
     }
 }
 

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -68,11 +68,11 @@ class RetriableOperationTests: XCTestCase {
         let queue = OperationQueue()
         queue.addOperation(executor)
 
-        wait(for: [firstAttempt], timeout: 1)
+        wait(for: [firstAttempt], timeout: 10)
         // NOTE: We need to await after the firstAttempt because it takes a few ms for the
         // retrySubscritpion to get setup after firstAttempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
-        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 10)
         retrySignal.send()
         wait(for: [secondAttempt, completed], timeout: 5, enforceOrder: true)
         XCTAssertEqual(try space.fetchPersistentSyncTasks().count, 0)
@@ -107,34 +107,15 @@ class RetriableOperationTests: XCTestCase {
         queue.addOperation(executor)
 
         expectations.forEach {
-            wait(for: [$0], timeout: 1)
+            wait(for: [$0], timeout: 10)
             // NOTE: We need to await after each attempt because it takes a few ms for the
             // retrySubscritpion to get setup after the attempt is fullfilled.
             // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
-            _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
+            _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 10)
             retrySignal.send()
         }
 
-        wait(for: [completed], timeout: 1, enforceOrder: true)
-        XCTAssertEqual(try space.fetchPersistentSyncTasks().count, 0)
-    }
-
-    func test_main_protectsOperationWithBackgroundTask() {
-        let beganOperation = expectation(description: "began operation")
-        let operation = TestSyncOperation {
-            beganOperation.fulfill()
-        }
-
-        let executor = subject(operation: operation)
-
-        let queue = OperationQueue()
-        queue.addOperation(executor)
-
-        wait(for: [beganOperation], timeout: 1)
-        XCTAssertNotNil(backgroundTaskManager.beginTaskCall(at: 0))
-
-        queue.waitUntilAllOperationsAreFinished()
-        XCTAssertEqual(backgroundTaskManager.endTaskCall(at: 0)?.identifier, 0)
+        wait(for: [completed], timeout: 10, enforceOrder: true)
         XCTAssertEqual(try space.fetchPersistentSyncTasks().count, 0)
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -57,7 +57,7 @@ class PocketSaveServiceTests: XCTestCase {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 1)
+        wait(for: [performCalled], timeout: 10)
         let performCall: MockApolloClient.PerformCall<SaveItemMutation>? = client.performCall(at: 0)
         XCTAssertEqual(performCall?.mutation.input.url, "https://getpocket.com")
     }
@@ -79,7 +79,7 @@ class PocketSaveServiceTests: XCTestCase {
             XCTFail("Expected existingItem, but was \(result)")
             return
         }
-        wait(for: [savedItemUpdated], timeout: 1)
+        wait(for: [savedItemUpdated], timeout: 10)
 
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications?.isEmpty, false)
@@ -114,14 +114,14 @@ class PocketSaveServiceTests: XCTestCase {
         _ = service.save(url: url)
 
         do {
-            wait(for: [performMutationWasCalled], timeout: 1)
+            wait(for: [performMutationWasCalled], timeout: 10)
             let savedItem = try space.fetchSavedItem(byURL: url)
             XCTAssertNotNil(savedItem)
             XCTAssertFalse(savedItem!.hasChanges)
         }
 
         do {
-            wait(for: [performMutationCompleted], timeout: 1)
+            wait(for: [performMutationCompleted], timeout: 10)
             let savedItem = try space.fetchSavedItem(byRemoteID: "saved-item-1")
             XCTAssertNotNil(savedItem?.item)
         }
@@ -150,7 +150,7 @@ class PocketSaveServiceTests: XCTestCase {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 1)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.url, url)
@@ -180,7 +180,7 @@ class PocketSaveServiceTests: XCTestCase {
             finishedActivity.fulfill()
         }
 
-        wait(for: [performMutationCalled], timeout: 1)
+        wait(for: [performMutationCalled], timeout: 10)
 
         let finishedCancellingActivity = expectation(description: "finished cancelling the activity")
         queue.async {
@@ -189,7 +189,7 @@ class PocketSaveServiceTests: XCTestCase {
             finishedCancellingActivity.fulfill()
         }
 
-        wait(for: [finishedActivity, finishedCancellingActivity], timeout: 1)
+        wait(for: [finishedActivity, finishedCancellingActivity], timeout: 10)
     }
 
     func test_cancellationOfExpiringActivity_setsSkeletonItemAsUnresolved_andPostsNotification() throws {
@@ -216,12 +216,12 @@ class PocketSaveServiceTests: XCTestCase {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled], timeout: 1)
+        wait(for: [performMutationCalled], timeout: 10)
 
         DispatchQueue(label: "cancel task").async {
             expiringActivity?(true)
         }
-        wait(for: [notificationReceived], timeout: 1)
+        wait(for: [notificationReceived], timeout: 10)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.url, url)
@@ -256,13 +256,13 @@ class PocketSaveServiceTests: XCTestCase {
 
         let service = subject()
         _ = service.save(url: URL(string: "https://getpocket.com")!)
-        wait(for: [performCalled, savedItemCreated], timeout: 1)
+        wait(for: [performCalled, savedItemCreated], timeout: 10)
 
         DispatchQueue.main.async {
             mutationCompletion?(.success(Fixture.load(name: "save-item").asGraphQLResult(from: mutation!)))
         }
 
-        wait(for: [savedItemUpdated], timeout: 1)
+        wait(for: [savedItemUpdated], timeout: 10)
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications?.isEmpty, false)
     }
@@ -292,7 +292,7 @@ extension PocketSaveServiceTests {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 1)
+        wait(for: [performCalled], timeout: 10)
         let performCall: MockApolloClient.PerformCall<ReplaceSavedItemTagsMutation>? = client.performCall(at: 0)
         XCTAssertEqual(performCall?.mutation.input.compactMap { $0.tags }, [["tag 1", "tag 2"]])
     }
@@ -319,7 +319,7 @@ extension PocketSaveServiceTests {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 1)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"] )
@@ -348,7 +348,7 @@ extension PocketSaveServiceTests {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 1)
+        wait(for: [performCalled], timeout: 10)
         let performCall: MockApolloClient.PerformCall<UpdateSavedItemRemoveTagsMutation>? = client.performCall(at: 0)
         XCTAssertNotNil(performCall?.mutation.savedItemId)
     }
@@ -375,7 +375,7 @@ extension PocketSaveServiceTests {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 1)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, [] )

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -46,7 +46,7 @@ extension PocketSourceTests {
         source.refreshSaves()
 
         networkMonitor.update(status: .satisfied)
-        wait(for: [expectSaveItem, expectFetchList], timeout: 1)
+        wait(for: [expectSaveItem, expectFetchList], timeout: 10)
     }
 
     func test_whenNetworkBecomesSatisified_retriesOperationsThatAreWaitingForSignal() throws {
@@ -75,12 +75,12 @@ extension PocketSourceTests {
 
         let source = subject()
         try source.archive(item: space.createSavedItem())
-        _ = XCTWaiter.wait(for: [expectation(description: "wait for last refresh to be avoid its 5.0 second wait")], timeout: 10.0)
-        wait(for: [firstAttempt], timeout: 1)
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for last refresh to be avoid its 5.0 second wait")], timeout: 100.0)
+        wait(for: [firstAttempt], timeout: 10)
 
         networkMonitor.update(status: .unsatisfied)
         networkMonitor.update(status: .satisfied)
-        wait(for: [retrySignalSent], timeout: 1)
+        wait(for: [retrySignalSent], timeout: 10)
     }
 
     func test_whenAnActionIsTaken_andNetworkPathIsSatisified_retriesOperationsThatAreWaitingForSignal() throws {
@@ -118,13 +118,13 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 1)
+        wait(for: [firstAttempt], timeout: 10)
         // NOTE: We need to await after each attempt because it takes a few ms for the
         // retrySubscritpion to get setup after the attempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
-        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 10)
         source.favorite(item: item)
-        wait(for: [retrySignalSent, attemptFavorite], timeout: 1, enforceOrder: true)
+        wait(for: [retrySignalSent, attemptFavorite], timeout: 10, enforceOrder: true)
     }
 
     func test_whenAnActionIsTaken_andNetworkPathIsNotSatisified_doesNotRetryOperationsThatAreWaitingForSignal() throws {
@@ -153,7 +153,7 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 1)
+        wait(for: [firstAttempt], timeout: 10)
 
         networkMonitor.update(status: .unsatisfied)
         source.favorite(item: item)
@@ -189,12 +189,12 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 1)
+        wait(for: [firstAttempt], timeout: 10)
         // NOTE: We need to await after each attempt because it takes a few ms for the
         // retrySubscritpion to get setup after the attempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
-        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
+        _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 10)
         source.retryImmediately()
-        wait(for: [retrySignalSent], timeout: 1)
+        wait(for: [retrySignalSent], timeout: 10)
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
@@ -17,7 +17,7 @@ extension PocketSourceTests {
         }.store(in: &subscriptions)
 
         osNotificationCenter.post(name: .savedItemCreated)
-        wait(for: [receivedNotification], timeout: 1)
+        wait(for: [receivedNotification], timeout: 10)
     }
 
     func test_events_whenOSNotificationCenterPostsSavedItemUpdatedNotification_publishesAnEvent_andDeletesNotificationRecords() {
@@ -40,7 +40,7 @@ extension PocketSourceTests {
         try! space.save()
 
         osNotificationCenter.post(name: .savedItemUpdated)
-        wait(for: [receivedNotification], timeout: 1)
+        wait(for: [receivedNotification], timeout: 10)
 
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications, [])
@@ -64,7 +64,7 @@ extension PocketSourceTests {
 
         osNotificationCenter.post(name: .unresolvedSavedItemCreated)
 
-        wait(for: [operationStarted], timeout: 1)
+        wait(for: [operationStarted], timeout: 10)
 
         try XCTAssertEqual(space.fetchUnresolvedSavedItems(), [])
 
@@ -100,7 +100,7 @@ extension PocketSourceTests {
 
         osNotificationCenter.post(name: .savedItemUpdated)
 
-        wait(for: [expectEvent], timeout: 1)
+        wait(for: [expectEvent], timeout: 10)
         sub.cancel()
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -110,7 +110,7 @@ class PocketSourceTests: XCTestCase {
             expectationToRunOperation.fulfill()
         }
 
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_refresh_whenTokenIsNil_callsCompletion() {
@@ -126,7 +126,7 @@ class PocketSourceTests: XCTestCase {
             expectationToRunOperation.fulfill()
         }
 
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_favorite_togglesIsFavorite_andExecutesFavoriteMutation() throws {
@@ -176,7 +176,7 @@ class PocketSourceTests: XCTestCase {
         let fetchedItem = try space.fetchSavedItem(byRemoteID: "delete-me")
         XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.hasChanges)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_delete_ifSavedItemItemHasRecommendation_doesNotDeleteSavedItemItem() throws {
@@ -229,7 +229,7 @@ class PocketSourceTests: XCTestCase {
         XCTAssertTrue(item.isArchived)
         XCTAssertFalse(item.hasChanges)
         XCTAssertNotNil(item.archivedAt)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_unarchive_executesSaveItemMutation_andUpdatesCreatedAtField() throws {
@@ -250,7 +250,7 @@ class PocketSourceTests: XCTestCase {
         XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.isArchived)
         XCTAssertNotNil(item.createdAt)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_fetchSlateLineup_forwardsToSlateService() async throws {
@@ -288,7 +288,7 @@ class PocketSourceTests: XCTestCase {
         try space.save()
         try savesResultsController.performFetch()
 
-        wait(for: [expectationForUpdatedItems], timeout: 1)
+        wait(for: [expectationForUpdatedItems], timeout: 10)
         XCTAssertEqual(savesResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID, item2.objectID])
     }
 
@@ -309,7 +309,7 @@ class PocketSourceTests: XCTestCase {
 
         source.resolveUnresolvedSavedItems()
 
-        wait(for: [operationStarted], timeout: 1)
+        wait(for: [operationStarted], timeout: 10)
         try XCTAssertEqual(space.fetchUnresolvedSavedItems(), [])
     }
 
@@ -326,7 +326,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -352,7 +352,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -377,7 +377,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.archive(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let archivedItems = try space.fetchArchivedItems()
         XCTAssertEqual(archivedItems.count, 1)
@@ -449,7 +449,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.first?.url, url)
@@ -471,7 +471,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -493,7 +493,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -603,7 +603,7 @@ extension PocketSourceTests {
         source.deleteTag(tag: tag)
 
         try XCTAssertEqual(space.fetchAllTags(), [])
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     func test_renameTag_executesUpdateTagMutation() throws {
@@ -623,7 +623,7 @@ extension PocketSourceTests {
         source.renameTag(from: tag1, to: "tag 3")
 
         try XCTAssertEqual(space.fetchAllTags().compactMap { $0.name }, ["tag 3"])
-        wait(for: [expectationToRunOperation], timeout: 1)
+        wait(for: [expectationToRunOperation], timeout: 10)
     }
 
     private func createItemsWithTags(_ number: Int, isArchived: Bool = false) -> [SavedItem] {

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -335,7 +335,7 @@ class FetchSavesTests: XCTestCase {
         let service = subject()
         _ = await service.execute(syncTaskId: task.objectID)
 
-        wait(for: [receivedEvent], timeout: 1)
+        wait(for: [receivedEvent], timeout: 10)
     }
 
     func test_refresh_whenUpdatedSinceIsNotPresent_onlyFetchesUnreadItems() async {
@@ -407,7 +407,7 @@ class FetchSavesTests: XCTestCase {
         let service = subject()
         _ = await service.execute(syncTaskId: task.objectID)
 
-        wait(for: [receivedFirstPageEvent, receivedCompletedEvent], timeout: 1)
+        wait(for: [receivedFirstPageEvent, receivedCompletedEvent], timeout: 10)
     }
 
     func test_refresh_whenResultsAreEmpty_finishesOperationSuccessfully() async {

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -37,7 +37,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .saves)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -55,7 +55,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .archive)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -73,7 +73,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .all)
 
-        wait(for: [searchExpectation], timeout: 1)
+        wait(for: [searchExpectation], timeout: 10)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -116,7 +116,7 @@ class PocketSearchServiceTests: XCTestCase {
         try await service.search(for: "search-term", scope: .all)
         XCTAssertEqual(self.apollo.fetchCalls(withQueryType: SearchSavedItemsQuery.self).count, 3)
 
-        wait(for: [firstPaginationExpectation, secondPaginationExpectation, thirdPaginationExpectation], timeout: 1)
+        wait(for: [firstPaginationExpectation, secondPaginationExpectation, thirdPaginationExpectation], timeout: 10)
     }
 
     // MARK: Error

--- a/Tests iOS/ArchiveAnItemTests.swift
+++ b/Tests iOS/ArchiveAnItemTests.swift
@@ -65,7 +65,7 @@ class ArchiveAnItemTests: XCTestCase {
         }
 
         app.archiveButton.wait().tap()
-        wait(for: [expectRequest], timeout: 1)
+        wait(for: [expectRequest], timeout: 10)
         waitForDisappearance(of: itemCell)
     }
 
@@ -93,7 +93,7 @@ class ArchiveAnItemTests: XCTestCase {
             .archiveSwipeButton.wait()
             .tap()
 
-        wait(for: [expectRequest], timeout: 1)
+        wait(for: [expectRequest], timeout: 10)
         waitForDisappearance(of: itemCell)
     }
 
@@ -120,7 +120,7 @@ class ArchiveAnItemTests: XCTestCase {
         archiveNavButton.wait().tap()
         app.saves.wait()
 
-        wait(for: [expectRequest], timeout: 1)
+        wait(for: [expectRequest], timeout: 10)
         listView.wait()
         waitForDisappearance(of: itemCell)
     }

--- a/Tests iOS/DeleteAnItemTests.swift
+++ b/Tests iOS/DeleteAnItemTests.swift
@@ -66,7 +66,7 @@ class DeleteAnItemTests: XCTestCase {
 
         app.deleteButton.wait().tap()
         app.alert.yes.wait().tap()
-        wait(for: [expectRequest], timeout: 1)
+        wait(for: [expectRequest], timeout: 10)
         waitForDisappearance(of: itemCell)
     }
 
@@ -100,7 +100,7 @@ class DeleteAnItemTests: XCTestCase {
 
         app.deleteButton.wait().tap()
         app.alert.yes.wait().tap()
-        wait(for: [expectRequest], timeout: 1)
+        wait(for: [expectRequest], timeout: 10)
 
         app.saves.wait()
         waitForDisappearance(of: itemCell)
@@ -137,7 +137,7 @@ class DeleteAnItemTests: XCTestCase {
         app.deleteButton.wait().tap()
         app.alert.yes.wait().tap()
 
-        wait(for: [receivedDeleteRequest], timeout: 1)
+        wait(for: [receivedDeleteRequest], timeout: 10)
         waitForDisappearance(of: cell)
     }
 }

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -444,7 +444,7 @@ extension HomeTests {
         let doesExist = expectation(for: exists, evaluatedWith: overscrollView)
         let isHittable = NSPredicate(format: "isHittable == 1")
         let hittable = expectation(for: isHittable, evaluatedWith: overscrollView)
-        wait(for: [doesExist, hittable], timeout: 20)
+        wait(for: [doesExist, hittable], timeout: 100)
     }
 }
 

--- a/Tests iOS/PullToRefreshTests.swift
+++ b/Tests iOS/PullToRefreshTests.swift
@@ -47,7 +47,7 @@ class PullToRefreshTests: XCTestCase {
         app.tabBar.savesButton.wait().tap()
 
         let listView = app.saves.wait()
-        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait a few seconds")], timeout: 2.0)
+        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait a few seconds")], timeout: 10.0)
 
         XCTAssertEqual(listView.itemCount, 2)
 

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -189,7 +189,7 @@ class ReaderTests: XCTestCase {
     @MainActor
     func test_tappingUnsupportedElementButton_showsSafari() async {
         launchApp_andOpenItem()
-        app.readerView.unsupportedElementOpenButton.tap()
+        app.readerView.unsupportedElementOpenButton.wait().tap()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let impressionEvent = await snowplowMicro.getFirstEvent(with: "reader.unsupportedContent")
@@ -206,8 +206,8 @@ class ReaderTests: XCTestCase {
     func test_tappingDeleteNo_dismissesDeleteConfirmation() {
         launchApp_andOpenItem()
         openReaderOverflowMenu()
-        app.readerView.deleteButton.tap()
-        app.readerView.deleteNoButton.tap()
+        app.readerView.wait().deleteButton.wait().tap()
+        app.readerView.wait().deleteNoButton.wait().tap()
         XCTAssertTrue(app.readerView.exists)
     }
 
@@ -228,7 +228,7 @@ class ReaderTests: XCTestCase {
             }
         }
 
-        app.launch().tabBar.savesButton.wait().tap()
+        app.launch().tabBar.wait().savesButton.wait().tap()
 
         app
             .saves
@@ -243,37 +243,37 @@ class ReaderTests: XCTestCase {
     }
 
     func validateSafariOpens() {
-        XCTAssertTrue(app.readerView.safariDoneButton.wait().exists)
+        XCTAssertTrue(app.readerView.wait().safariDoneButton.wait().exists)
     }
 
     func openReaderOverflowMenu() {
-        app.readerView.overflowButton.tap()
+        app.readerView.wait().overflowButton.wait().tap()
     }
 
     func openDisplaySettings() {
-        app.readerView.displaySettingsButton.tap()
+        app.readerView.wait().displaySettingsButton.wait().tap()
     }
 
     func openFontMenu() {
-        app.readerView.fontButton.tap()
+        app.readerView.wait().fontButton.wait().tap()
     }
 
     func tapFontSizeIncreaseButton() {
-        app.readerView.fontStepperIncreaseButton.tap()
+        app.readerView.wait().fontStepperIncreaseButton.wait().tap()
     }
 
     func tapFontSizeDecreaseButton() {
-        app.readerView.fontStepperDecreaseButton.tap()
+        app.readerView.wait().fontStepperDecreaseButton.wait().tap()
     }
 
     func tapSafariButton() {
-        app.readerView.safariButton.tap()
+        app.readerView.wait().safariButton.wait().tap()
     }
 
     func launchApp_andOpenItem() {
         app.launch().tabBar.savesButton.wait().tap()
         app
-            .saves
+            .saves.wait()
             .itemView(at: 0)
             .wait()
             .tap()
@@ -283,7 +283,7 @@ class ReaderTests: XCTestCase {
         app.launch().tabBar.savesButton.wait().tap()
         app.saves.selectionSwitcher.archiveButton.tap()
         app
-            .saves
+            .saves.wait()
             .itemView(at: 0)
             .wait()
             .tap()

--- a/Tests iOS/Support/Elements/XCUIElement+wait.swift
+++ b/Tests iOS/Support/Elements/XCUIElement+wait.swift
@@ -7,7 +7,7 @@ import XCTest
 extension XCUIElement {
     @discardableResult
     func wait(
-        timeout: TimeInterval = 5,
+        timeout: TimeInterval = 10,
         file: StaticString = #file,
         line: UInt = #line
     ) -> XCUIElement {

--- a/Tests iOS/Support/SnowplowMicro.swift
+++ b/Tests iOS/Support/SnowplowMicro.swift
@@ -185,8 +185,8 @@ class SnowplowMicro {
      Make a request to snowplow micro
      */
     internal func snowplowRequest(path: String, method: String = "GET") async -> Data {
-        // For now we wait 2 seconds for snowplow data to be available because the iOS app flushes it to the server. In the future we could poll or find a way to make the make instant calls to snowplow.
-        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait 2 seconds for snowplow data to be available.")], timeout: 2.0)
+        // For now we wait 5 seconds for snowplow data to be available because the iOS app flushes it to the server. In the future we could poll or find a way to make the make instant calls to snowplow.
+        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "Wait 5 seconds for snowplow data to be available.")], timeout: 5.0)
         let data = try! await self.client.httpData(from: URL(string: "http://localhost:9090\(path)")!, method: method)
         return data
     }

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -12,6 +12,6 @@ extension XCTestCase {
     }
 
     func wait(for expectations: [XCTestExpectation]) {
-        wait(for: expectations, timeout: 3)
+        wait(for: expectations, timeout: 10)
     }
 }


### PR DESCRIPTION
## Summary

I believe that a lot of our tests are all flakey because the timeout is too tight.

Our tests should not test performance, hence our timeouts should be allowed to be looser.

## Implementation Details
In the words of @nzeltzer 
> The reason to include timeouts is so that tests fail, not to enforce performance expectations. It’s reasonable to expect that if a test doesn’t pass in 10 seconds that it never will. A 1 second wait suggests to me that we’re simultaneously trying to test that something is happening fast enough. We should test performance explicitly through performance monitoring tests and tools, not incidentally as part of a test of works/fails.

