### PR TITLE
fix(refreshing): ensuring logout/login subscribers are retained

### DIFF
--- a/PocketKit/Sources/PocketKit/Refresh/ArchiveRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/ArchiveRefreshCoordinator.swift
@@ -19,6 +19,7 @@ class ArchiveRefreshCoordinator: RefreshCoordinator {
     let taskScheduler: BGTaskSchedulerProtocol
     let appSession: SharedPocketKit.AppSession
     var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
 
     private let source: Source
 

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -20,6 +20,7 @@ class HomeRefreshCoordinator: RefreshCoordinator {
     let taskScheduler: BGTaskSchedulerProtocol
     let appSession: SharedPocketKit.AppSession
     var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
     let lastRefresh: LastRefresh
 
     private let source: Source

--- a/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
@@ -20,6 +20,7 @@ protocol RefreshCoordinator: AnyObject {
     var taskScheduler: BGTaskSchedulerProtocol { get }
     var appSession: AppSession { get }
     var subscriptions: [AnyCancellable] { get set }
+    var sessionSubscriptions: [AnyCancellable] { get set }
 
     /// The taskID to be resgistered with the system for this background task and identified in info.plist
     var taskID: String { get }
@@ -51,14 +52,14 @@ extension RefreshCoordinator {
             for: .userLoggedIn
         ).sink { [weak self] notification in
             self?.handleSession(session: notification.object as? SharedPocketKit.Session)
-        }.store(in: &subscriptions)
+        }.store(in: &sessionSubscriptions)
 
         // Register for logout notifications
         NotificationCenter.default.publisher(
             for: .userLoggedOut
         ).sink { [weak self] notification in
             self?.handleSession(session: nil)
-        }.store(in: &subscriptions)
+        }.store(in: &sessionSubscriptions)
 
         // Because session could already be available at init, lets try and use it.
         handleSession(session: appSession.currentSession)

--- a/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
@@ -20,6 +20,7 @@ class SavesRefreshCoordinator: RefreshCoordinator {
     let taskScheduler: BGTaskSchedulerProtocol
     let appSession: SharedPocketKit.AppSession
     var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
 
     private let source: Source
 

--- a/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
@@ -25,6 +25,7 @@ class TagsRefreshCoordinator: RefreshCoordinator {
     let taskScheduler: BGTaskSchedulerProtocol
     let appSession: SharedPocketKit.AppSession
     var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
 
     private var isRefreshing: Bool = false
     private let source: Source

--- a/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
@@ -20,6 +20,7 @@ class UnresolvedSavesRefreshCoordinator: RefreshCoordinator {
     let taskScheduler: BGTaskSchedulerProtocol
     let appSession: SharedPocketKit.AppSession
     var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
 
     private let source: Source
 


### PR DESCRIPTION
## Summary

Found a bug where the coordinators lost their subscribers for log out and login.

## Test Steps
* Ensure on log out and login your list downloads.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
