### PR TITLE
fix(user): ensuring we only refresh the user when we have a session

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -13,6 +13,7 @@
 		<string>com.mozilla.pocket.refresh.archive</string>
 		<string>com.mozilla.pocket.refresh.tags</string>
 		<string>com.mozilla.pocket.refresh.unresolved</string>
+		<string>com.mozilla.pocket.refresh.user</string>
 	</array>
 	<key>BrazeAPIEndpoint</key>
 	<string>$(BRAZE_API_ENDPOINT)</string>

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS) Alpha Neue.xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS) Alpha Neue.xcscheme
@@ -338,13 +338,6 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release_AlphaNeue"

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -49,8 +49,6 @@ public class RootViewModel: ObservableObject {
             self?.handleSession(session: nil)
         }.store(in: &subscriptions)
 
-        getUserData()
-
         // Because session could already be available at init, lets try and use it.
         handleSession(session: appSession.currentSession)
     }
@@ -91,11 +89,5 @@ public class RootViewModel: ObservableObject {
 
         Log.clearUser()
         Textiles.clearImageCache()
-    }
-
-    private func getUserData() {
-        Task {
-            try? await source.fetchUserData()
-        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Sync
+import SharedPocketKit
+import Combine
+
+/// Refresh coordinator to handle the refreshing of user data
+class UserRefreshCoordinator: RefreshCoordinator {
+
+    let taskID: String = "com.mozilla.pocket.refresh.user"
+
+    let refreshInterval: TimeInterval? = 60 * 60 * 24 // once every 24 hours.
+
+    let backgroundRequestType: BackgroundRequestType = .processing
+
+    let notificationCenter: NotificationCenter
+    let taskScheduler: BGTaskSchedulerProtocol
+    let appSession: SharedPocketKit.AppSession
+    var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
+
+    private let source: Source
+
+    init(notificationCenter: NotificationCenter, taskScheduler: BGTaskSchedulerProtocol, appSession: AppSession, source: Source) {
+        self.notificationCenter = notificationCenter
+        self.taskScheduler = taskScheduler
+        self.appSession = appSession
+        self.source = source
+    }
+
+    func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
+        Task {
+            do {
+                try await self.source.fetchUserData()
+            } catch {
+                Log.capture(error: error)
+            }
+            completion()
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -25,6 +25,7 @@ struct Services {
     let tagsRefreshCoordinator: TagsRefreshCoordinator
     let unresolvedSavesRefreshCoordinator: UnresolvedSavesRefreshCoordinator
     let homeRefreshCoordinator: HomeRefreshCoordinator
+    let userRefreshCoordinator: UserRefreshCoordinator
     let refreshCoordinators: [RefreshCoordinator]
     let authClient: AuthorizationClient
     let imageManager: ImageManager
@@ -114,12 +115,20 @@ struct Services {
             lastRefresh: lastRefresh
         )
 
+        userRefreshCoordinator = UserRefreshCoordinator(
+            notificationCenter: .default,
+            taskScheduler: BGTaskScheduler.shared,
+            appSession: appSession,
+            source: source
+        )
+
         refreshCoordinators = [
             savesRefreshCoordinator,
             archiveRefreshCoordinator,
             tagsRefreshCoordinator,
             unresolvedSavesRefreshCoordinator,
-            homeRefreshCoordinator
+            homeRefreshCoordinator,
+            userRefreshCoordinator
         ]
 
         imageManager = ImageManager(


### PR DESCRIPTION
## Summary

Ensure that user data only refreshes when there is an active session.

## References 
* IN-1238

## Implementation Details
* Switched user data to the refresh coordinator pattern

## Test Steps
* Ensure there are no FetchUser errors in the console on logout and login.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
