### PR TITLE
fix(tests): battle hardened tests against multiple device sizes

### DIFF
--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -21,7 +21,8 @@ class TagsFilterViewModel: ObservableObject {
     }
 
     func getAllTags() -> [TagType] {
-        arrangeTags(with: fetchedTags?.compactMap({ $0.name }) ?? [])
+        // Finding unique elements using set
+        arrangeTags(with: Array(Set(fetchedTags?.compactMap({ $0.name }) ?? [])))
     }
 
     func trackEditAsOverflowAnalytics() {

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -154,7 +154,9 @@ public enum Requests {
     }
 
     public static func fetchTags() -> NSFetchRequest<Tag> {
-        Tag.fetchRequest()
+        let request = Tag.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \Tag.name, ascending: true)]
+        return request
     }
 
     public static func fetchSavedTags() -> NSFetchRequest<Tag> {

--- a/PocketKit/Sources/Textile/Views/Tags/TagType.swift
+++ b/PocketKit/Sources/Textile/Views/Tags/TagType.swift
@@ -20,15 +20,5 @@ public enum TagType: Hashable {
 /// - Parameter tags: list of users tag names
 /// - Returns: converts users tags to display a list of `TagType`
 public func arrangeTags(with tags: [String]) -> [TagType] {
-    var allTags: [String] = []
-    let fetchedTags = tags.reversed()
-    if fetchedTags.count > 3 {
-        let topRecentTags = Array(fetchedTags)[..<3]
-        let sortedTags = Array(fetchedTags)[3...].sorted()
-        allTags.append(contentsOf: topRecentTags)
-        allTags.append(contentsOf: sortedTags)
-    } else {
-        allTags.append(contentsOf: fetchedTags)
-    }
-    return allTags.compactMap { TagType.tag($0) }
+    return tags.sorted().compactMap { TagType.tag($0) }
 }

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -129,7 +129,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         viewModel.allOtherTags()
 
         wait(for: [expectRetrieveTagsCall], timeout: 10)
-        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 3"), TagType.tag("tag 2")])
+        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
         XCTAssertNotNil(source.retrieveTagsCall(at: 0))
     }
 

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -28,7 +28,7 @@ class TagsFilterViewModelTests: XCTestCase {
         TagsFilterViewModel(source: source ?? self.source, tracker: tracker ?? self.tracker, fetchedTags: fetchedTags, selectAllAction: selectAllAction)
     }
 
-    func test_getAllTags_withThreeTags_returnsMostRecentTags() {
+    func test_getAllTags_withThreeTags_returnsSortedNameTags() {
         _ = try? space.createSavedItem(createdAt: Date(), tags: ["tag 1"])
         _ = try? space.createSavedItem(createdAt: Date() + 1, tags: ["tag 2"])
         _ = try? space.createSavedItem(createdAt: Date() + 2, tags: ["tag 3"])
@@ -38,7 +38,7 @@ class TagsFilterViewModelTests: XCTestCase {
         let tags = viewModel.getAllTags()
 
         XCTAssertEqual(tags.count, 3)
-        XCTAssertEqual(tags, [TagType.tag("tag 3"), TagType.tag("tag 2"), TagType.tag("tag 1")])
+        XCTAssertEqual(tags, [TagType.tag("tag 1"), TagType.tag("tag 2"), TagType.tag("tag 3")])
     }
 
     func test_getAllTags_withMoreThan3Tags_returnsSortedOrder() {
@@ -55,7 +55,7 @@ class TagsFilterViewModelTests: XCTestCase {
         let tags = viewModel.getAllTags()
 
         XCTAssertEqual(tags.count, 5)
-        XCTAssertEqual(tags, [TagType.tag("e"), TagType.tag("d"), TagType.tag("c"), TagType.tag("a"), TagType.tag("b")])
+        XCTAssertEqual(tags, [TagType.tag("a"), TagType.tag("b"), TagType.tag("c"), TagType.tag("d"), TagType.tag("e")])
     }
 
     func test_selectedTag_withTagName_sendsPredicate() {

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -103,7 +103,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
 
         viewModel.allOtherTags()
 
-        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 3"), TagType.tag("tag 2")])
+        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
     }
 
     func test_removeTag_withValidName_updatesTags() throws {

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -188,6 +188,6 @@ class AddTagsItemTests: XCTestCase {
     }
 
     func selectTaggedFilterButton() {
-        app.saves.filterButton(for: "Tagged").tap()
+        app.saves.filterButton(for: "Tagged").wait().tap()
     }
 }

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Sails
 
 class AddTagsItemTests: XCTestCase {
-    var server: Application!
+    var server: Sails.Application!
     var app: PocketAppElement!
     var snowplowMicro = SnowplowMicro()
 
@@ -66,8 +66,11 @@ class AddTagsItemTests: XCTestCase {
         addTagsView.wait()
 
         addTagsView.tag(matching: "tag 0").wait().tap()
+
+        scrollTo(element: addTagsView.allTagsRow(matching: "tag 0"), in: addTagsView.allTagsView, direction: .up)
         addTagsView.allTagsRow(matching: "tag 0").wait()
 
+        scrollTo(element: addTagsView.allTagsRow(matching: "tag 1"), in: addTagsView.allTagsView, direction: .down)
         addTagsView.allTagsRow(matching: "tag 1").wait().tap()
         waitForDisappearance(of: addTagsView.allTagsRow(matching: "tag 1"))
 
@@ -159,6 +162,7 @@ class AddTagsItemTests: XCTestCase {
         let itemCell = app
             .saves
             .itemView(matching: "Archived Item 2")
+            .wait()
 
         itemCell
             .itemActionButton.wait()
@@ -171,6 +175,8 @@ class AddTagsItemTests: XCTestCase {
         addTagsView.newTagTextField.typeText("F")
 
         addTagsView.allTagsRow(matching: "filter tag 0").wait()
+
+        scrollTo(element: addTagsView.allTagsRow(matching: "filter tag 1"), in: addTagsView.allTagsView, direction: .up)
         addTagsView.allTagsRow(matching: "filter tag 1").wait()
         app.addTagsView.allTagsView.wait()
 

--- a/Tests iOS/MyList/SavesFiltersTests.swift
+++ b/Tests iOS/MyList/SavesFiltersTests.swift
@@ -64,6 +64,7 @@ class SavesFiltersTests: XCTestCase {
         app.launch().tabBar.savesButton.wait().tap()
         app.saves.filterButton(for: "Tagged").tap()
         let tagsFilterView = app.saves.tagsFilterView.wait()
+        tagsFilterView.tag(matching: "not tagged").wait()
 
         XCTAssertEqual(tagsFilterView.tagCells.count, 6)
 

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -49,6 +49,7 @@ class SettingsTest: XCTestCase {
         await tap_deleteOnDeleteConfirmation(deletePromise: &deletePromise)
         app.loggedOutView.wait()
         await loadExitSurvey()
+        deletePromise = nil
     }
 
     @MainActor
@@ -73,6 +74,7 @@ class SettingsTest: XCTestCase {
         await tap_deleteOnDeleteConfirmation(deletePromise: &deletePromise)
         app.loggedOutView.wait()
         await loadExitSurvey()
+        deletePromise = nil
     }
 
     @MainActor
@@ -96,6 +98,7 @@ class SettingsTest: XCTestCase {
         premiumUser_tapDeleteToggles()
         await tap_deleteOnDeleteConfirmation(deletePromise: &deletePromise, success: false)
         assertsError()
+        deletePromise = nil
     }
 
     @MainActor

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -14,4 +14,45 @@ extension XCTestCase {
     func wait(for expectations: [XCTestExpectation]) {
         wait(for: expectations, timeout: 10)
     }
+
+    /// Very basic swipe to element function. As our needs increase, we will want something like https://github.com/PGSSoft/AutoMate/blob/master/AutoMate/XCTest%20extensions/XCUIElement%2BSwipe.swift
+    /// - Parameters:
+    ///   - element: Element to scroll to
+    ///   - scrollableView: Scroll view to scroll
+    ///   - maxSwipes: Max number of swipes to try.
+    ///   - direction: Direction to swipe
+    func scrollTo(element: XCUIElement, in scrollableView: XCUIElement, maxSwipes: Int = 10, direction: SwipeDirection) {
+        var count = 0
+        while element.isHittable == false && count < maxSwipes {
+            defer { count += 1 }
+            switch direction {
+            case .up:
+                scrollableView.swipeUp(velocity: .slow)
+            case .down:
+                scrollableView.swipeDown(velocity: .slow)
+            case .left:
+                scrollableView.swipeLeft(velocity: .slow)
+            case .right:
+                scrollableView.swipeRight(velocity: .slow)
+            }
+        }
+    }
+}
+
+// MARK: - SwipeDirection
+/// Swipe direction.
+///
+/// - `up`: Swipe up.
+/// - `down`: Swipe down.
+/// - `left`: Swipe to the left.
+/// - `right`: Swipe to the right.
+public enum SwipeDirection {
+    /// Swipe up.
+    case up // swiftlint:disable:this identifier_name
+    /// Swipe down.
+    case down
+    /// Swipe to the left.
+    case left
+    /// Swipe to the right.
+    case right
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -212,8 +212,8 @@ workflows:
                 ## It uses the values in MICRO_IGLU_REGISTRY_URL and MICRO_IGLU_API_KEY
                 echo "Run snowplow"
                 brew install wget openjdk
-                wget https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.5.0/snowplow-micro-1.5.0.jar
-                java -jar snowplow-micro-1.5.0.jar &
+                wget https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.6.0/snowplow-micro-1.6.0.jar
+                java -jar snowplow-micro-1.6.0.jar &
 
   #Builds a release build that could be uploaded to App Store Connect
   alpha-neue-release-build:
@@ -462,6 +462,7 @@ workflows:
   run-tests-flakey:
     before_run:
       - _pull_test_bundle
+      - _start_snowplow
     steps:
       - xcode-test-without-building:
           timeout: 600 #10 minutes


### PR DESCRIPTION
## Summary

@timc-mozilla discovered that our test was not battle hardended against small device sizes. This makes use of a scrollTo function to ensure that we scroll to a specific element instead of unless scrolling or assuming something is on screen.

This will also fixes flakyness I discovered around tags where tags were always appearing in a different order. This should be fully fixed in https://github.com/Pocket/pocket-ios/pull/568 and any work here is a stop gap for tests and sanity.

## Implementation Details
There are a few helper [libraries](https://github.com/PGSSoft/AutoMate) we could import that would help with our tests, but I chose to use a very basic scrollTo function instead since the one I found had not been updated in a while.

## Test Steps
* Try the add tags tests on a iphone mini

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
