### PR TITLE
feat(spotlight): adding in spotlight indexing.

### DIFF
--- a/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
+++ b/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+import CoreSpotlight
+
+/// Delegate to listen to callbacks from CoreData when something needs to be indexed
+class CoreDataSpotlightDelegate: NSCoreDataCoreSpotlightDelegate {
+    override func domainIdentifier() -> String {
+        return "com.mozilla.pocket"
+    }
+
+    override func indexName() -> String? {
+        return "pocket-index"
+    }
+
+    override func attributeSet(for object: NSManagedObject) -> CSSearchableItemAttributeSet? {
+        if let savedItem = object as? SavedItem {
+            return csSearchableItemAttributeSet(for: savedItem)
+        }
+
+        return nil
+    }
+    
+    /// Helper function to turn a SavedItem into a CSSearchableItemAttributeSet
+    /// - Parameter savedItem: The saved item to search
+    /// - Returns: The CoreSpotlight result
+    private func csSearchableItemAttributeSet(for savedItem: SavedItem) -> CSSearchableItemAttributeSet? {
+        guard let identifier = savedItem.remoteID else {
+            return nil
+        }
+        let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
+        attributeSet.identifier = identifier
+        attributeSet.displayName = savedItem.item?.title
+        attributeSet.publishers = (savedItem.item?.authors?.array as? [Author] ?? []).compactMap { $0.name }
+        attributeSet.thumbnailURL = savedItem.item?.topImageURL // TODO: Image cache url..
+        attributeSet.contentURL = savedItem.url
+        attributeSet.contentDescription = savedItem.item?.excerpt
+        attributeSet.title = savedItem.item?.title
+        attributeSet.contentCreationDate = savedItem.item?.datePublished
+
+        return attributeSet
+    }
+
+}

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -60,11 +60,11 @@
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="cursor" optional="YES" attributeType="String"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="isArchived" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="isFavorite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="remoteID" optional="YES" attributeType="String"/>
+        <attribute name="isArchived" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
+        <attribute name="isFavorite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="String" spotlightIndexingEnabled="YES"/>
         <attribute name="url" attributeType="URI"/>
-        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item" spotlightIndexingEnabled="YES"/>
         <relationship name="savedItemUpdatedNotification" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItemUpdatedNotification" inverseName="savedItem" inverseEntity="SavedItemUpdatedNotification"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Tag" inverseName="savedItems" inverseEntity="Tag"/>
         <relationship name="unresolvedSavedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UnresolvedSavedItem" inverseName="savedItem" inverseEntity="UnresolvedSavedItem"/>


### PR DESCRIPTION
## Summary

I was playing with apple apis and discovered its very easy to add in core spotlight! So why not! 

## References 
* https://developer.apple.com/videos/play/wwdc2021/10098/

## Implementation Details
* Picked out basic fields for the search attributes, we can iterate on these in the future. 
* For now this only indexes spotlight, but in the future we could use CoreSpotlight for our free search instead of our wild card core data search. (see last 5 minutes of wwdc video)
* I did not write tests, because this is a system delegate callback.

## Test Steps
* Log in on a fresh user, wait for the list to load. Try searching for the item using the title in the pull down search in iOS system. (may take a bit for indexed results to appear)

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
