### PR TITLE
fix(saves): ensure that dual refreshing saves does not reset the loading state

### DIFF
--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -48,6 +48,10 @@ class FetchArchive: SyncOperation {
                 }
             }
 
+            if lastRefresh.lastRefreshArchive == nil {
+                initialDownloadState.send(.started)
+            }
+
             try await fetchArchive()
 
             lastRefresh.refreshedArchive()

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -49,6 +49,10 @@ class FetchSaves: SyncOperation {
                 }
             }
 
+            if lastRefresh.lastRefreshSaves == nil {
+                initialDownloadState.send(.started)
+            }
+
             try await fetchSaves()
             lastRefresh.refreshedSaves()
             return .success

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -264,10 +264,6 @@ public class PocketSource: Source {
 // MARK: - Saves/Archive items
 extension PocketSource {
     public func refreshSaves(completion: (() -> Void)? = nil) {
-        if lastRefresh.lastRefreshSaves == nil {
-            initialSavesDownloadState.send(.started)
-        }
-
         let operation = operations.fetchSaves(
             apollo: apollo,
             space: space,
@@ -280,10 +276,6 @@ extension PocketSource {
     }
 
     public func refreshArchive(completion: (() -> Void)? = nil) {
-        if lastRefresh.lastRefreshArchive == nil {
-            initialArchiveDownloadState.send(.started)
-        }
-
         let operation = operations.fetchArchive(
             apollo: apollo,
             space: space,

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -319,6 +319,9 @@ class FetchSavesTests: XCTestCase {
         user.stubSetStatus { _ in }
         initialDownloadState.send(.completed)
         apollo.setupFetchSavesSyncResponse()
+        lastRefresh.stubGetLastRefreshSaves {
+            return Date().timeIntervalSince1970
+        }
 
         let receivedEvent = expectation(description: "receivedEvent")
         receivedEvent.isInverted = true


### PR DESCRIPTION
## Summary

Moves the sending the `.start` state within our operation queue, where it is guarded from being called multiple times before it is finished loading.

## References 
* IN-1311

## Implementation Details
* we need to think about a better way to do placeholders and pagination, but not atm

## Test Steps
* Try and perform the replication as done by Matt here: https://pocket.slack.com/archives/C4DL4QSU8/p1681169244912969?thread_ts=1680970901.903769&cid=C4DL4QSU8
* Note you must pull to refresh again, as soon as you see your first set of list results.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
