### PR TITLE
fix(license): opening licesnes in reader mode

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/SFSafariView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/SFSafariView.swift
@@ -5,9 +5,17 @@ struct SFSafariView: UIViewControllerRepresentable {
     typealias UIViewControllerType = SFSafariViewController
 
     let url: URL
+    let readerMode: Bool
+
+    init(url: URL, readerMode: Bool = false) {
+        self.url = url
+        self.readerMode = readerMode
+    }
 
     func makeUIViewController(context: Context) -> SFSafariViewController {
-        let vc = SFSafariViewController(url: url)
+        let config = SFSafariViewController.Configuration()
+        config.entersReaderIfAvailable = readerMode
+        let vc = SFSafariViewController(url: url, configuration: config)
         return vc
     }
 

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -51,17 +51,17 @@ struct SettingsForm: View {
                         }
                     SettingsRowButton(title: Localization.termsOfService, icon: SFIconModel("doc.plaintext")) { model.isPresentingTerms.toggle() }
                         .sheet(isPresented: $model.isPresentingTerms) {
-                            SFSafariView(url: LinkedExternalURLS.TermsOfService)
+                            SFSafariView(url: LinkedExternalURLS.TermsOfService, readerMode: true)
                                 .edgesIgnoringSafeArea(.bottom)
                         }
                     SettingsRowButton(title: Localization.privacyPolicy, icon: SFIconModel("doc.plaintext")) { model.isPresentingPrivacy.toggle() }
                         .sheet(isPresented: $model.isPresentingPrivacy) {
-                            SFSafariView(url: LinkedExternalURLS.PrivacyPolicy)
+                            SFSafariView(url: LinkedExternalURLS.PrivacyPolicy, readerMode: true)
                                 .edgesIgnoringSafeArea(.bottom)
                         }
                     SettingsRowButton(title: Localization.Settings.openSourceLicenses, icon: SFIconModel("doc.plaintext")) { model.isPresentingLicenses.toggle() }
                         .sheet(isPresented: $model.isPresentingLicenses) {
-                            SFSafariView(url: LinkedExternalURLS.OpenSourceNotices)
+                            SFSafariView(url: LinkedExternalURLS.OpenSourceNotices, readerMode: true)
                                 .edgesIgnoringSafeArea(.bottom)
                         }
                 }.textCase(nil)


### PR DESCRIPTION
## Summary

I noticed our licenses look better in reader mode. This enables that by default.

cc @nzeltzer thoughts ?

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
