### PR TITLE
fix(migration): ensure that a migration posts a logged in message

### DIFF
--- a/PocketKit/Sources/PocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/PocketKit/NotificationCenter+EventNames.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension Notification.Name {
-    static let userLoggedIn = Notification.Name("com.mozilla.pocket.userLoggedIn")
-    static let userLoggedOut = Notification.Name("com.mozilla.pocket.userLoggedOut")
-    static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
-}

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -101,6 +101,7 @@ public class LegacyUserMigration {
         )
 
         updateUserDefaults()
+        NotificationCenter.default.post(name: .userLoggedIn, object: appSession.currentSession)
         return true
     }
 

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension Notification.Name {
+    public static let userLoggedIn = Notification.Name("com.mozilla.pocket.userLoggedIn")
+    public static let userLoggedOut = Notification.Name("com.mozilla.pocket.userLoggedOut")
+    public static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
+}


### PR DESCRIPTION
## Summary

Post a notification to the system that we logged in when we migrated a user. 

This will:
* Tell Braze/Instant Sync we have a user
* Kick off all the refresh data tasks

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
