### PR TITLE
Core Data - Cleanup Source, PocketSource

### DIFF
--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -197,20 +197,12 @@ public class PocketSource: Source {
         space.makeRecomendationsSlateLineupController(by: SyncConstants.Home.slateLineupIdentifier)
     }
 
-    public func backgroundObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
-        space.backgroundObject(with: id)
-    }
-
     public func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
         space.viewObject(with: id)
     }
 
     public func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool) {
         space.viewContext.refresh(object, mergeChanges: flag)
-    }
-
-    public func backgroundRefresh(_ object: NSManagedObject, mergeChanges: Bool) {
-        space.backgroundRefresh(object, mergeChanges: mergeChanges)
     }
 
     public func retryImmediately() {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -34,11 +34,7 @@ public protocol Source {
 
     func makeImagesController() -> ImagesController
 
-    func backgroundObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
-
     func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
-
-    func backgroundRefresh(_ object: NSManagedObject, mergeChanges: Bool)
 
     func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool)
 


### PR DESCRIPTION
## Summary
* Cleaning up `Source` and `PocketSource` a bit

## Implementation Details
* Update `Source`, `PocketSource`, remove unused methods `backgroundObject` and `backgroundRefresh`

## Test Steps
* Make sure this branch builds properly

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
