### PR TITLE
fix(extension): address feedly bug

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/InfoView.swift
+++ b/PocketKit/Sources/SaveToPocketKit/InfoView.swift
@@ -57,6 +57,7 @@ class InfoView: UIView {
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
+        accessibilityIdentifier = "save-extension-info-view"
     }
 
     required init?(coder: NSCoder) {

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -143,7 +143,7 @@ extension SavedItemViewModel {
 
             if provider.hasItemConformingToTypeIdentifier(plainTextUTI) {
                 guard let string = try? await provider.loadItem(forTypeIdentifier: plainTextUTI, options: nil) as? String,
-                      let url = URL(string: string) else {
+                      let url = retrieveURLFromString(with: string) else {
                     continue
                 }
 
@@ -159,6 +159,24 @@ extension SavedItemViewModel {
             }
         }
 
+        return nil
+    }
+
+    /// Modified from https://www.hackingwithswift.com/example-code/strings/how-to-detect-a-url-in-a-string-using-nsdatadetector
+    /// - Parameter inputString: string input used to search for a URL
+    /// - Returns: URL found within the string
+    private func retrieveURLFromString(with inputString: String) -> URL? {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            Log.capture(message: "Unable to initialize detector")
+            return nil
+        }
+        let matches = detector.matches(in: inputString, options: [], range: NSRange(location: 0, length: inputString.utf16.count))
+
+        for match in matches {
+            guard let range = Range(match.range, in: inputString) else { continue }
+            let string = String(inputString[range])
+            return URL(string: string)
+        }
         return nil
     }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -155,6 +155,32 @@ extension SavedItemViewModelTests {
         XCTAssertEqual(saveService.saveCall(at: 0)?.url, URL(string: "https://getpocket.com")!)
     }
 
+    func test_save_withStringContainingURL_sendsCorrectURLToService() async {
+        let appSession = AppSession(keychain: MockKeychain(), groupID: "group.com.ideashower.ReadItLaterPro")
+        appSession.currentSession = Session(
+            guid: "mock-guid",
+            accessToken: "mock-access-token",
+            userIdentifier: "mock-user-identifier"
+        )
+        let viewModel = subject(appSession: appSession)
+
+        let provider = MockItemProvider()
+        provider.stubHasItemConformingToTypeIdentifier { identifier in
+            return identifier == "public.plain-text"
+        }
+        provider.stubLoadItem { _, _ in
+            "Get Pocket https://getpocket.com" as NSSecureCoding
+        }
+
+        let extensionItem = MockExtensionItem(itemProviders: [provider])
+
+        let context = MockExtensionContext(extensionItems: [extensionItem])
+        context.stubCompleteRequest { _, _ in }
+
+        await viewModel.save(from: context)
+        XCTAssertEqual(saveService.saveCall(at: 0)?.url, URL(string: "https://getpocket.com")!)
+    }
+
     func test_save_ifValidSessionAndURL_automaticallyCompletesRequest() async {
         let appSession = AppSession(keychain: MockKeychain(), groupID: "group.com.ideashower.ReadItLaterPro")
         appSession.currentSession = Session(

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -24,6 +24,8 @@ class SaveToPocketTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
+        reminders.terminate()
     }
 
     func test_whenLoggedOut_userTapsLogIn_opensApp() {
@@ -75,6 +77,46 @@ class SaveToPocketTests: XCTestCase {
 
         addTagsView.saveButton.wait().tap()
         safari.staticTexts["Hello, world"].wait()
+    }
+
+    func test_userSharesTextWithValidURL_showsConfirmationView() {
+        app.launch(arguments: .firstLaunch, environment: .withSession)
+        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
+        reminders.launch()
+        if !reminders.buttons["New Reminder"].isHittable {
+            reminders.buttons["Continue"].wait().tap()
+        }
+        reminders.buttons["New Reminder"].wait().tap()
+        reminders.typeText("Get Pocket https://getpocket.com")
+        reminders.textFields.firstMatch.wait().tap()
+        reminders.textFields.firstMatch.wait().tap()
+        reminders.menuItems["Select All"].wait().tap()
+        reminders.buttons["Forward"].wait().tap()
+        reminders.collectionViews.staticTexts["Share…"].tap()
+        let activityView = reminders.descendants(matching: .other)["ActivityListView"].wait()
+        activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 2).wait().tap()
+        reminders.otherElements["save-extension-info-view"].staticTexts["Saved to Pocket"].wait()
+        reminders.terminate()
+    }
+
+    func test_userSharesTextWithNoURL_showsErrorView() {
+        app.launch(arguments: .firstLaunch, environment: .withSession)
+        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
+        reminders.launch()
+        if !reminders.buttons["New Reminder"].isHittable {
+            reminders.buttons["Continue"].wait().tap()
+        }
+        reminders.buttons["New Reminder"].wait().tap()
+        reminders.typeText("Get Pocket")
+        reminders.textFields.firstMatch.wait().tap()
+        reminders.textFields.firstMatch.wait().tap()
+        reminders.menuItems["Select All"].wait().tap()
+        reminders.buttons["Forward"].wait().tap()
+        reminders.collectionViews.staticTexts["Share…"].tap()
+        let activityView = reminders.descendants(matching: .other)["ActivityListView"].wait()
+        activityView.cells.matching(identifier: "XCElementSnapshotPrivilegedValuePlaceholder").element(boundBy: 2).wait().tap()
+        reminders.otherElements["save-extension-info-view"].staticTexts["Pocket couldn't save this link"].wait()
+        reminders.terminate()
     }
 
     func tapPocketShareMenuIcon() {


### PR DESCRIPTION
## Summary
Fix bug where we cannot save from Feedly due to URL initialization returning nil

## References 
* IN-1254

## Implementation Details
Create a helper function to parse a URL from a string. Modified from https://www.hackingwithswift.com/example-code/strings/how-to-detect-a-url-in-a-string-using-nsdatadetector

This only applied to the items that are of the type `public.plain-text`

## Test Steps
Nav to the Feedly app
Share any item to Pocket
Verify that error no longer appears and you are able to save the item

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA