### PR TITLE
fix(listen): update listen to have a default language set

### DIFF
--- a/PocketKit/Sources/PocketKit/Listen/Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/Listen.swift
@@ -25,6 +25,8 @@ class Listen: NSObject {
         self.tracker = tracker
         self.source = source
         super.init()
+        // Set a default set of languages that the server will overwrite when it loads
+        PKTListen.supportedLanguages = ["en"]
         PKTSetConsumerKey(consumerKey)
         PKTLocalRuntime.shared().start()
         PKTListen.sharedInstance().sessionDelegate = self

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -619,7 +619,6 @@ extension SavedItemsListViewModel {
             // Remove any filters and sorts they selected and re-fetch data before showing listen.
             if !selectedFilters.isEmpty && !featureFlags.isAssigned(flag: .listenTagsPlaylists) {
                 selectedFilters.removeAll()
-                listOptions.selectedSortOption = .newest
                 applySorting()
                 fetch()
             }


### PR DESCRIPTION
## Summary

Quick fix to ensure listen has a default set of `en` for UI tests
