### PR TITLE
Core Data - Refactor entities to match required and non-nullable fields with the graph

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/ImageParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/ImageParts.graphql.swift
@@ -34,7 +34,7 @@ public struct ImageParts: PocketGraph.SelectionSet, Fragment {
   public var caption: String? { __data["caption"] }
   /// A credit for the image, typically who the image belongs to / created by
   public var credit: String? { __data["credit"] }
-  /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+  /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
   public var imageID: Int { __data["imageID"] }
   /// Absolute url to the image
   @available(*, deprecated, message: "use url property moving forward")

--- a/PocketKit/Sources/PocketGraph/Fragments/ItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/ItemParts.graphql.swift
@@ -53,7 +53,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
       }
       syndicatedArticle {
         __typename
-        itemId
+        ...SyndicatedArticleParts
       }
     }
     """ }
@@ -102,7 +102,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
   public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
   /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
   public var timeToRead: Int? { __data["timeToRead"] }
-  /// The domain, such as 'getpocket.com' of the {.resolved_url}
+  /// The domain, such as 'getpocket.com' of the resolved_url
   public var domain: String? { __data["domain"] }
   /// The date the article was published
   public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -313,7 +313,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
       public var caption: String? { __data["caption"] }
       /// A credit for the image, typically who the image belongs to / created by
       public var credit: String? { __data["credit"] }
-      /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+      /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
       public var imageID: Int { __data["imageID"] }
       /// Absolute url to the image
       @available(*, deprecated, message: "use url property moving forward")
@@ -536,7 +536,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
       public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
       /// The video's id within the service defined by type
       public var vid: String? { __data["vid"] }
-      /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+      /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
       public var videoID: Int { __data["videoID"] }
       /// If known, the width of the video in px
       public var width: Int? { __data["width"] }
@@ -754,7 +754,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
     /// Absolute url to the image
     @available(*, deprecated, message: "use url property moving forward")
     public var src: String { __data["src"] }
-    /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+    /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
     public var imageId: Int { __data["imageId"] }
 
     public init(
@@ -786,20 +786,44 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
     public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
-      .field("itemId", PocketGraph.ID?.self),
+      .fragment(SyndicatedArticleParts.self),
     ] }
 
     /// The item id of this Syndicated Article
     public var itemId: PocketGraph.ID? { __data["itemId"] }
+    /// Primary image to use in surfacing this content
+    public var mainImage: String? { __data["mainImage"] }
+    /// Title of syndicated article
+    public var title: String { __data["title"] }
+    /// Excerpt
+    public var excerpt: String? { __data["excerpt"] }
+    /// The manually set publisher information for this article
+    public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+    }
 
     public init(
-      itemId: PocketGraph.ID? = nil
+      itemId: PocketGraph.ID? = nil,
+      mainImage: String? = nil,
+      title: String,
+      excerpt: String? = nil,
+      publisher: SyndicatedArticleParts.Publisher? = nil
     ) {
       self.init(_dataDict: DataDict(data: [
         "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
         "itemId": itemId,
+        "mainImage": mainImage,
+        "title": title,
+        "excerpt": excerpt,
+        "publisher": publisher._fieldData,
         "__fulfilled": Set([
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(Self.self),
+          ObjectIdentifier(SyndicatedArticleParts.self)
         ])
       ]))
     }

--- a/PocketKit/Sources/PocketGraph/Fragments/ItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/ItemSummary.graphql.swift
@@ -40,14 +40,7 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
       }
       syndicatedArticle {
         __typename
-        itemId
-        mainImage
-        title
-        excerpt
-        publisher {
-          __typename
-          name
-        }
+        ...SyndicatedArticleParts
       }
     }
     """ }
@@ -95,7 +88,7 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
   public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
   /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
   public var timeToRead: Int? { __data["timeToRead"] }
-  /// The domain, such as 'getpocket.com' of the {.resolved_url}
+  /// The domain, such as 'getpocket.com' of the resolved_url
   public var domain: String? { __data["domain"] }
   /// The date the article was published
   public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -267,7 +260,7 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
     /// Absolute url to the image
     @available(*, deprecated, message: "use url property moving forward")
     public var src: String { __data["src"] }
-    /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+    /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
     public var imageId: Int { __data["imageId"] }
 
     public init(
@@ -299,11 +292,7 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
     public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
-      .field("itemId", PocketGraph.ID?.self),
-      .field("mainImage", String?.self),
-      .field("title", String.self),
-      .field("excerpt", String?.self),
-      .field("publisher", Publisher?.self),
+      .fragment(SyndicatedArticleParts.self),
     ] }
 
     /// The item id of this Syndicated Article
@@ -315,14 +304,21 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
     /// Excerpt 
     public var excerpt: String? { __data["excerpt"] }
     /// The manually set publisher information for this article
-    public var publisher: Publisher? { __data["publisher"] }
+    public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+    }
 
     public init(
       itemId: PocketGraph.ID? = nil,
       mainImage: String? = nil,
       title: String,
       excerpt: String? = nil,
-      publisher: Publisher? = nil
+      publisher: SyndicatedArticleParts.Publisher? = nil
     ) {
       self.init(_dataDict: DataDict(data: [
         "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
@@ -332,38 +328,10 @@ public struct ItemSummary: PocketGraph.SelectionSet, Fragment {
         "excerpt": excerpt,
         "publisher": publisher._fieldData,
         "__fulfilled": Set([
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(Self.self),
+          ObjectIdentifier(SyndicatedArticleParts.self)
         ])
       ]))
-    }
-
-    /// SyndicatedArticle.Publisher
-    ///
-    /// Parent Type: `Publisher`
-    public struct Publisher: PocketGraph.SelectionSet {
-      public let __data: DataDict
-      public init(_dataDict: DataDict) { __data = _dataDict }
-
-      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Publisher }
-      public static var __selections: [ApolloAPI.Selection] { [
-        .field("__typename", String.self),
-        .field("name", String?.self),
-      ] }
-
-      /// Name of the publisher of the article
-      public var name: String? { __data["name"] }
-
-      public init(
-        name: String? = nil
-      ) {
-        self.init(_dataDict: DataDict(data: [
-          "__typename": PocketGraph.Objects.Publisher.typename,
-          "name": name,
-          "__fulfilled": Set([
-            ObjectIdentifier(Self.self)
-          ])
-        ]))
-      }
     }
   }
 }

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemParts.graphql.swift
@@ -189,7 +189,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
       public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
       /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
       public var timeToRead: Int? { __data["timeToRead"] }
-      /// The domain, such as 'getpocket.com' of the {.resolved_url}
+      /// The domain, such as 'getpocket.com' of the resolved_url
       public var domain: String? { __data["domain"] }
       /// The date the article was published
       public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -212,7 +212,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
       /// Array of images within an article
       public var images: [ItemParts.Image?]? { __data["images"] }
       /// If the item has a syndicated counterpart the syndication information
-      public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+      public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -240,7 +240,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
         excerpt: String? = nil,
         domainMetadata: DomainMetadata? = nil,
         images: [ItemParts.Image?]? = nil,
-        syndicatedArticle: ItemParts.SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil
       ) {
         self.init(_dataDict: DataDict(data: [
           "__typename": PocketGraph.Objects.Item.typename,
@@ -359,7 +359,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
           public var caption: String? { __data["caption"] }
           /// A credit for the image, typically who the image belongs to / created by
           public var credit: String? { __data["credit"] }
-          /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+          /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
           public var imageID: Int { __data["imageID"] }
           /// Absolute url to the image
           @available(*, deprecated, message: "use url property moving forward")
@@ -587,7 +587,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
           public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
           /// The video's id within the service defined by type
           public var vid: String? { __data["vid"] }
-          /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+          /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
           public var videoID: Int { __data["videoID"] }
           /// If known, the width of the video in px
           public var width: Int? { __data["width"] }
@@ -776,6 +776,55 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
             "__fulfilled": Set([
               ObjectIdentifier(Self.self),
               ObjectIdentifier(DomainMetadataParts.self)
+            ])
+          ]))
+        }
+      }
+
+      /// Item.AsItem.SyndicatedArticle
+      ///
+      /// Parent Type: `SyndicatedArticle`
+      public struct SyndicatedArticle: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+        /// The item id of this Syndicated Article
+        public var itemId: PocketGraph.ID? { __data["itemId"] }
+        /// Primary image to use in surfacing this content
+        public var mainImage: String? { __data["mainImage"] }
+        /// Title of syndicated article
+        public var title: String { __data["title"] }
+        /// Excerpt
+        public var excerpt: String? { __data["excerpt"] }
+        /// The manually set publisher information for this article
+        public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+        }
+
+        public init(
+          itemId: PocketGraph.ID? = nil,
+          mainImage: String? = nil,
+          title: String,
+          excerpt: String? = nil,
+          publisher: SyndicatedArticleParts.Publisher? = nil
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+            "itemId": itemId,
+            "mainImage": mainImage,
+            "title": title,
+            "excerpt": excerpt,
+            "publisher": publisher._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(SyndicatedArticleParts.self)
             ])
           ]))
         }

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
@@ -186,7 +186,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
       public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
       /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
       public var timeToRead: Int? { __data["timeToRead"] }
-      /// The domain, such as 'getpocket.com' of the {.resolved_url}
+      /// The domain, such as 'getpocket.com' of the resolved_url
       public var domain: String? { __data["domain"] }
       /// The date the article was published
       public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -207,7 +207,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
       /// Array of images within an article
       public var images: [ItemSummary.Image?]? { __data["images"] }
       /// If the item has a syndicated counterpart the syndication information
-      public var syndicatedArticle: ItemSummary.SyndicatedArticle? { __data["syndicatedArticle"] }
+      public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -234,7 +234,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
         excerpt: String? = nil,
         domainMetadata: DomainMetadata? = nil,
         images: [ItemSummary.Image?]? = nil,
-        syndicatedArticle: ItemSummary.SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil
       ) {
         self.init(_dataDict: DataDict(data: [
           "__typename": PocketGraph.Objects.Item.typename,
@@ -296,6 +296,55 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
             "__fulfilled": Set([
               ObjectIdentifier(Self.self),
               ObjectIdentifier(DomainMetadataParts.self)
+            ])
+          ]))
+        }
+      }
+
+      /// Item.AsItem.SyndicatedArticle
+      ///
+      /// Parent Type: `SyndicatedArticle`
+      public struct SyndicatedArticle: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+        /// The item id of this Syndicated Article
+        public var itemId: PocketGraph.ID? { __data["itemId"] }
+        /// Primary image to use in surfacing this content
+        public var mainImage: String? { __data["mainImage"] }
+        /// Title of syndicated article
+        public var title: String { __data["title"] }
+        /// Excerpt
+        public var excerpt: String? { __data["excerpt"] }
+        /// The manually set publisher information for this article
+        public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+        }
+
+        public init(
+          itemId: PocketGraph.ID? = nil,
+          mainImage: String? = nil,
+          title: String,
+          excerpt: String? = nil,
+          publisher: SyndicatedArticleParts.Publisher? = nil
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+            "itemId": itemId,
+            "mainImage": mainImage,
+            "title": title,
+            "excerpt": excerpt,
+            "publisher": publisher._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(SyndicatedArticleParts.self)
             ])
           ]))
         }

--- a/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
@@ -144,7 +144,7 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
       public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
       /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
       public var timeToRead: Int? { __data["timeToRead"] }
-      /// The domain, such as 'getpocket.com' of the {.resolved_url}
+      /// The domain, such as 'getpocket.com' of the resolved_url
       public var domain: String? { __data["domain"] }
       /// The date the article was published
       public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -165,7 +165,7 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
       /// Array of images within an article
       public var images: [ItemSummary.Image?]? { __data["images"] }
       /// If the item has a syndicated counterpart the syndication information
-      public var syndicatedArticle: ItemSummary.SyndicatedArticle? { __data["syndicatedArticle"] }
+      public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -192,7 +192,7 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
         excerpt: String? = nil,
         domainMetadata: DomainMetadata? = nil,
         images: [ItemSummary.Image?]? = nil,
-        syndicatedArticle: ItemSummary.SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil
       ) {
         self.init(_dataDict: DataDict(data: [
           "__typename": PocketGraph.Objects.Item.typename,
@@ -253,6 +253,55 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
             "__fulfilled": Set([
               ObjectIdentifier(Self.self),
               ObjectIdentifier(DomainMetadataParts.self)
+            ])
+          ]))
+        }
+      }
+
+      /// Recommendation.Item.SyndicatedArticle
+      ///
+      /// Parent Type: `SyndicatedArticle`
+      public struct SyndicatedArticle: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+        /// The item id of this Syndicated Article
+        public var itemId: PocketGraph.ID? { __data["itemId"] }
+        /// Primary image to use in surfacing this content
+        public var mainImage: String? { __data["mainImage"] }
+        /// Title of syndicated article
+        public var title: String { __data["title"] }
+        /// Excerpt
+        public var excerpt: String? { __data["excerpt"] }
+        /// The manually set publisher information for this article
+        public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+        }
+
+        public init(
+          itemId: PocketGraph.ID? = nil,
+          mainImage: String? = nil,
+          title: String,
+          excerpt: String? = nil,
+          publisher: SyndicatedArticleParts.Publisher? = nil
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+            "itemId": itemId,
+            "mainImage": mainImage,
+            "title": title,
+            "excerpt": excerpt,
+            "publisher": publisher._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(SyndicatedArticleParts.self)
             ])
           ]))
         }

--- a/PocketKit/Sources/PocketGraph/Fragments/SyndicatedArticleParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SyndicatedArticleParts.graphql.swift
@@ -1,0 +1,93 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct SyndicatedArticleParts: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment SyndicatedArticleParts on SyndicatedArticle {
+      __typename
+      itemId
+      mainImage
+      title
+      excerpt
+      publisher {
+        __typename
+        name
+      }
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("itemId", PocketGraph.ID?.self),
+    .field("mainImage", String?.self),
+    .field("title", String.self),
+    .field("excerpt", String?.self),
+    .field("publisher", Publisher?.self),
+  ] }
+
+  /// The item id of this Syndicated Article
+  public var itemId: PocketGraph.ID? { __data["itemId"] }
+  /// Primary image to use in surfacing this content
+  public var mainImage: String? { __data["mainImage"] }
+  /// Title of syndicated article
+  public var title: String { __data["title"] }
+  /// Excerpt 
+  public var excerpt: String? { __data["excerpt"] }
+  /// The manually set publisher information for this article
+  public var publisher: Publisher? { __data["publisher"] }
+
+  public init(
+    itemId: PocketGraph.ID? = nil,
+    mainImage: String? = nil,
+    title: String,
+    excerpt: String? = nil,
+    publisher: Publisher? = nil
+  ) {
+    self.init(_dataDict: DataDict(data: [
+      "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+      "itemId": itemId,
+      "mainImage": mainImage,
+      "title": title,
+      "excerpt": excerpt,
+      "publisher": publisher._fieldData,
+      "__fulfilled": Set([
+        ObjectIdentifier(Self.self)
+      ])
+    ]))
+  }
+
+  /// Publisher
+  ///
+  /// Parent Type: `Publisher`
+  public struct Publisher: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Publisher }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .field("name", String?.self),
+    ] }
+
+    /// Name of the publisher of the article
+    public var name: String? { __data["name"] }
+
+    public init(
+      name: String? = nil
+    ) {
+      self.init(_dataDict: DataDict(data: [
+        "__typename": PocketGraph.Objects.Publisher.typename,
+        "name": name,
+        "__fulfilled": Set([
+          ObjectIdentifier(Self.self)
+        ])
+      ]))
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Fragments/VideoParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/VideoParts.graphql.swift
@@ -40,7 +40,7 @@ public struct VideoParts: PocketGraph.SelectionSet, Fragment {
   public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
   /// The video's id within the service defined by type
   public var vid: String? { __data["vid"] }
-  /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+  /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
   public var videoID: Int { __data["videoID"] }
   /// If known, the width of the video in px
   public var width: Int? { __data["width"] }

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/ReplaceSavedItemTagsMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/ReplaceSavedItemTagsMutation.graphql.swift
@@ -15,7 +15,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var input: [SavedItemTagsInput]
@@ -148,7 +148,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
           public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
           /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
           public var timeToRead: Int? { __data["timeToRead"] }
-          /// The domain, such as 'getpocket.com' of the {.resolved_url}
+          /// The domain, such as 'getpocket.com' of the resolved_url
           public var domain: String? { __data["domain"] }
           /// The date the article was published
           public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -171,7 +171,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
           /// Array of images within an article
           public var images: [ItemParts.Image?]? { __data["images"] }
           /// If the item has a syndicated counterpart the syndication information
-          public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+          public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -243,7 +243,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
               public var caption: String? { __data["caption"] }
               /// A credit for the image, typically who the image belongs to / created by
               public var credit: String? { __data["credit"] }
-              /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var imageID: Int { __data["imageID"] }
               /// Absolute url to the image
               @available(*, deprecated, message: "use url property moving forward")
@@ -387,7 +387,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
               public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
               /// The video's id within the service defined by type
               public var vid: String? { __data["vid"] }
-              /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var videoID: Int { __data["videoID"] }
               /// If known, the width of the video in px
               public var width: Int? { __data["width"] }
@@ -495,6 +495,34 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
               public init(_dataDict: DataDict) { __data = _dataDict }
 
               public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+            }
+          }
+
+          /// ReplaceSavedItemTag.Item.AsItem.SyndicatedArticle
+          ///
+          /// Parent Type: `SyndicatedArticle`
+          public struct SyndicatedArticle: PocketGraph.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+            /// The item id of this Syndicated Article
+            public var itemId: PocketGraph.ID? { __data["itemId"] }
+            /// Primary image to use in surfacing this content
+            public var mainImage: String? { __data["mainImage"] }
+            /// Title of syndicated article
+            public var title: String { __data["title"] }
+            /// Excerpt
+            public var excerpt: String? { __data["excerpt"] }
+            /// The manually set publisher information for this article
+            public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
             }
           }
         }

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/SaveItemMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/SaveItemMutation.graphql.swift
@@ -15,7 +15,7 @@ public class SaveItemMutation: GraphQLMutation {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var input: SavedItemUpsertInput
@@ -143,7 +143,7 @@ public class SaveItemMutation: GraphQLMutation {
           public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
           /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
           public var timeToRead: Int? { __data["timeToRead"] }
-          /// The domain, such as 'getpocket.com' of the {.resolved_url}
+          /// The domain, such as 'getpocket.com' of the resolved_url
           public var domain: String? { __data["domain"] }
           /// The date the article was published
           public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -166,7 +166,7 @@ public class SaveItemMutation: GraphQLMutation {
           /// Array of images within an article
           public var images: [ItemParts.Image?]? { __data["images"] }
           /// If the item has a syndicated counterpart the syndication information
-          public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+          public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -238,7 +238,7 @@ public class SaveItemMutation: GraphQLMutation {
               public var caption: String? { __data["caption"] }
               /// A credit for the image, typically who the image belongs to / created by
               public var credit: String? { __data["credit"] }
-              /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var imageID: Int { __data["imageID"] }
               /// Absolute url to the image
               @available(*, deprecated, message: "use url property moving forward")
@@ -382,7 +382,7 @@ public class SaveItemMutation: GraphQLMutation {
               public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
               /// The video's id within the service defined by type
               public var vid: String? { __data["vid"] }
-              /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var videoID: Int { __data["videoID"] }
               /// If known, the width of the video in px
               public var width: Int? { __data["width"] }
@@ -490,6 +490,34 @@ public class SaveItemMutation: GraphQLMutation {
               public init(_dataDict: DataDict) { __data = _dataDict }
 
               public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+            }
+          }
+
+          /// UpsertSavedItem.Item.AsItem.SyndicatedArticle
+          ///
+          /// Parent Type: `SyndicatedArticle`
+          public struct SyndicatedArticle: PocketGraph.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+            /// The item id of this Syndicated Article
+            public var itemId: PocketGraph.ID? { __data["itemId"] }
+            /// Primary image to use in surfacing this content
+            public var mainImage: String? { __data["mainImage"] }
+            /// Title of syndicated article
+            public var title: String { __data["title"] }
+            /// Excerpt
+            public var excerpt: String? { __data["excerpt"] }
+            /// The manually set publisher information for this article
+            public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
             }
           }
         }

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/UpdateSavedItemRemoveTagsMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/UpdateSavedItemRemoveTagsMutation.graphql.swift
@@ -15,7 +15,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var savedItemId: ID
@@ -146,7 +146,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
           public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
           /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
           public var timeToRead: Int? { __data["timeToRead"] }
-          /// The domain, such as 'getpocket.com' of the {.resolved_url}
+          /// The domain, such as 'getpocket.com' of the resolved_url
           public var domain: String? { __data["domain"] }
           /// The date the article was published
           public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -169,7 +169,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
           /// Array of images within an article
           public var images: [ItemParts.Image?]? { __data["images"] }
           /// If the item has a syndicated counterpart the syndication information
-          public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+          public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -241,7 +241,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
               public var caption: String? { __data["caption"] }
               /// A credit for the image, typically who the image belongs to / created by
               public var credit: String? { __data["credit"] }
-              /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var imageID: Int { __data["imageID"] }
               /// Absolute url to the image
               @available(*, deprecated, message: "use url property moving forward")
@@ -385,7 +385,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
               public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
               /// The video's id within the service defined by type
               public var vid: String? { __data["vid"] }
-              /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+              /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
               public var videoID: Int { __data["videoID"] }
               /// If known, the width of the video in px
               public var width: Int? { __data["width"] }
@@ -493,6 +493,34 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
               public init(_dataDict: DataDict) { __data = _dataDict }
 
               public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+            }
+          }
+
+          /// UpdateSavedItemRemoveTags.Item.AsItem.SyndicatedArticle
+          ///
+          /// Parent Type: `SyndicatedArticle`
+          public struct SyndicatedArticle: PocketGraph.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+            /// The item id of this Syndicated Article
+            public var itemId: PocketGraph.ID? { __data["itemId"] }
+            /// Primary image to use in surfacing this content
+            public var mainImage: String? { __data["mainImage"] }
+            /// Title of syndicated article
+            public var title: String { __data["title"] }
+            /// Excerpt
+            public var excerpt: String? { __data["excerpt"] }
+            /// The manually set publisher information for this article
+            public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
             }
           }
         }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
@@ -31,7 +31,7 @@ public class FetchArchiveQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SavedItemSummary.self, TagParts.self, ItemSummary.self, DomainMetadataParts.self]
+      fragments: [SavedItemSummary.self, TagParts.self, ItemSummary.self, DomainMetadataParts.self, SyndicatedArticleParts.self]
     ))
 
   public var pagination: GraphQLNullable<PaginationInput>
@@ -250,7 +250,7 @@ public class FetchArchiveQuery: GraphQLQuery {
                 public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
                 /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
                 public var timeToRead: Int? { __data["timeToRead"] }
-                /// The domain, such as 'getpocket.com' of the {.resolved_url}
+                /// The domain, such as 'getpocket.com' of the resolved_url
                 public var domain: String? { __data["domain"] }
                 /// The date the article was published
                 public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -271,7 +271,7 @@ public class FetchArchiveQuery: GraphQLQuery {
                 /// Array of images within an article
                 public var images: [ItemSummary.Image?]? { __data["images"] }
                 /// If the item has a syndicated counterpart the syndication information
-                public var syndicatedArticle: ItemSummary.SyndicatedArticle? { __data["syndicatedArticle"] }
+                public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
                 public struct Fragments: FragmentContainer {
                   public let __data: DataDict
@@ -299,6 +299,34 @@ public class FetchArchiveQuery: GraphQLQuery {
                     public init(_dataDict: DataDict) { __data = _dataDict }
 
                     public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+                  }
+                }
+
+                /// User.SavedItems.Edge.Node.Item.AsItem.SyndicatedArticle
+                ///
+                /// Parent Type: `SyndicatedArticle`
+                public struct SyndicatedArticle: PocketGraph.SelectionSet {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+                  /// The item id of this Syndicated Article
+                  public var itemId: PocketGraph.ID? { __data["itemId"] }
+                  /// Primary image to use in surfacing this content
+                  public var mainImage: String? { __data["mainImage"] }
+                  /// Title of syndicated article
+                  public var title: String { __data["title"] }
+                  /// Excerpt
+                  public var excerpt: String? { __data["excerpt"] }
+                  /// The manually set publisher information for this article
+                  public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+                  public struct Fragments: FragmentContainer {
+                    public let __data: DataDict
+                    public init(_dataDict: DataDict) { __data = _dataDict }
+
+                    public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
                   }
                 }
               }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
@@ -31,7 +31,7 @@ public class FetchSavesQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var pagination: GraphQLNullable<PaginationInput>
@@ -246,7 +246,7 @@ public class FetchSavesQuery: GraphQLQuery {
                 public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
                 /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
                 public var timeToRead: Int? { __data["timeToRead"] }
-                /// The domain, such as 'getpocket.com' of the {.resolved_url}
+                /// The domain, such as 'getpocket.com' of the resolved_url
                 public var domain: String? { __data["domain"] }
                 /// The date the article was published
                 public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -269,7 +269,7 @@ public class FetchSavesQuery: GraphQLQuery {
                 /// Array of images within an article
                 public var images: [ItemParts.Image?]? { __data["images"] }
                 /// If the item has a syndicated counterpart the syndication information
-                public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+                public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
                 public struct Fragments: FragmentContainer {
                   public let __data: DataDict
@@ -341,7 +341,7 @@ public class FetchSavesQuery: GraphQLQuery {
                     public var caption: String? { __data["caption"] }
                     /// A credit for the image, typically who the image belongs to / created by
                     public var credit: String? { __data["credit"] }
-                    /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                    /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                     public var imageID: Int { __data["imageID"] }
                     /// Absolute url to the image
                     @available(*, deprecated, message: "use url property moving forward")
@@ -485,7 +485,7 @@ public class FetchSavesQuery: GraphQLQuery {
                     public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
                     /// The video's id within the service defined by type
                     public var vid: String? { __data["vid"] }
-                    /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                    /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                     public var videoID: Int { __data["videoID"] }
                     /// If known, the width of the video in px
                     public var width: Int? { __data["width"] }
@@ -593,6 +593,34 @@ public class FetchSavesQuery: GraphQLQuery {
                     public init(_dataDict: DataDict) { __data = _dataDict }
 
                     public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+                  }
+                }
+
+                /// User.SavedItems.Edge.Node.Item.AsItem.SyndicatedArticle
+                ///
+                /// Parent Type: `SyndicatedArticle`
+                public struct SyndicatedArticle: PocketGraph.SelectionSet {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+                  /// The item id of this Syndicated Article
+                  public var itemId: PocketGraph.ID? { __data["itemId"] }
+                  /// Primary image to use in surfacing this content
+                  public var mainImage: String? { __data["mainImage"] }
+                  /// Title of syndicated article
+                  public var title: String { __data["title"] }
+                  /// Excerpt
+                  public var excerpt: String? { __data["excerpt"] }
+                  /// The manually set publisher information for this article
+                  public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+                  public struct Fragments: FragmentContainer {
+                    public let __data: DataDict
+                    public init(_dataDict: DataDict) { __data = _dataDict }
+
+                    public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
                   }
                 }
               }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateLineupQuery.graphql.swift
@@ -24,7 +24,7 @@ public class GetSlateLineupQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SlateParts.self, ItemSummary.self, DomainMetadataParts.self, CuratedInfoParts.self]
+      fragments: [SlateParts.self, ItemSummary.self, DomainMetadataParts.self, SyndicatedArticleParts.self, CuratedInfoParts.self]
     ))
 
   public var lineupID: String

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetSlateQuery.graphql.swift
@@ -15,7 +15,7 @@ public class GetSlateQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SlateParts.self, ItemSummary.self, DomainMetadataParts.self, CuratedInfoParts.self]
+      fragments: [SlateParts.self, ItemSummary.self, DomainMetadataParts.self, SyndicatedArticleParts.self, CuratedInfoParts.self]
     ))
 
   public var slateID: String

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/ItemByIDQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/ItemByIDQuery.graphql.swift
@@ -15,7 +15,7 @@ public class ItemByIDQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self]
+      fragments: [ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self]
     ))
 
   public var id: ID
@@ -35,7 +35,7 @@ public class ItemByIDQuery: GraphQLQuery {
       .field("itemByItemId", ItemByItemId?.self, arguments: ["id": .variable("id")]),
     ] }
 
-    /// Look up {Item} info by ID.
+    /// Look up Item info by ID.
     public var itemByItemId: ItemByItemId? { __data["itemByItemId"] }
 
     /// ItemByItemId
@@ -68,7 +68,7 @@ public class ItemByIDQuery: GraphQLQuery {
       public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
       /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
       public var timeToRead: Int? { __data["timeToRead"] }
-      /// The domain, such as 'getpocket.com' of the {.resolved_url}
+      /// The domain, such as 'getpocket.com' of the resolved_url
       public var domain: String? { __data["domain"] }
       /// The date the article was published
       public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -91,7 +91,7 @@ public class ItemByIDQuery: GraphQLQuery {
       /// Array of images within an article
       public var images: [ItemParts.Image?]? { __data["images"] }
       /// If the item has a syndicated counterpart the syndication information
-      public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+      public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -163,7 +163,7 @@ public class ItemByIDQuery: GraphQLQuery {
           public var caption: String? { __data["caption"] }
           /// A credit for the image, typically who the image belongs to / created by
           public var credit: String? { __data["credit"] }
-          /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+          /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
           public var imageID: Int { __data["imageID"] }
           /// Absolute url to the image
           @available(*, deprecated, message: "use url property moving forward")
@@ -307,7 +307,7 @@ public class ItemByIDQuery: GraphQLQuery {
           public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
           /// The video's id within the service defined by type
           public var vid: String? { __data["vid"] }
-          /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+          /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
           public var videoID: Int { __data["videoID"] }
           /// If known, the width of the video in px
           public var width: Int? { __data["width"] }
@@ -415,6 +415,34 @@ public class ItemByIDQuery: GraphQLQuery {
           public init(_dataDict: DataDict) { __data = _dataDict }
 
           public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+        }
+      }
+
+      /// ItemByItemId.SyndicatedArticle
+      ///
+      /// Parent Type: `SyndicatedArticle`
+      public struct SyndicatedArticle: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+        /// The item id of this Syndicated Article
+        public var itemId: PocketGraph.ID? { __data["itemId"] }
+        /// Primary image to use in surfacing this content
+        public var mainImage: String? { __data["mainImage"] }
+        /// Title of syndicated article
+        public var title: String { __data["title"] }
+        /// Excerpt
+        public var excerpt: String? { __data["excerpt"] }
+        /// The manually set publisher information for this article
+        public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
         }
       }
     }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/SavedItemByIDQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/SavedItemByIDQuery.graphql.swift
@@ -18,7 +18,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var id: ID
@@ -162,7 +162,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
             public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
             /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
             public var timeToRead: Int? { __data["timeToRead"] }
-            /// The domain, such as 'getpocket.com' of the {.resolved_url}
+            /// The domain, such as 'getpocket.com' of the resolved_url
             public var domain: String? { __data["domain"] }
             /// The date the article was published
             public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -185,7 +185,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
             /// Array of images within an article
             public var images: [ItemParts.Image?]? { __data["images"] }
             /// If the item has a syndicated counterpart the syndication information
-            public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+            public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
             public struct Fragments: FragmentContainer {
               public let __data: DataDict
@@ -257,7 +257,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
                 public var caption: String? { __data["caption"] }
                 /// A credit for the image, typically who the image belongs to / created by
                 public var credit: String? { __data["credit"] }
-                /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                 public var imageID: Int { __data["imageID"] }
                 /// Absolute url to the image
                 @available(*, deprecated, message: "use url property moving forward")
@@ -401,7 +401,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
                 public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
                 /// The video's id within the service defined by type
                 public var vid: String? { __data["vid"] }
-                /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                 public var videoID: Int { __data["videoID"] }
                 /// If known, the width of the video in px
                 public var width: Int? { __data["width"] }
@@ -509,6 +509,34 @@ public class SavedItemByIDQuery: GraphQLQuery {
                 public init(_dataDict: DataDict) { __data = _dataDict }
 
                 public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+              }
+            }
+
+            /// User.SavedItemById.Item.AsItem.SyndicatedArticle
+            ///
+            /// Parent Type: `SyndicatedArticle`
+            public struct SyndicatedArticle: PocketGraph.SelectionSet {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+              /// The item id of this Syndicated Article
+              public var itemId: PocketGraph.ID? { __data["itemId"] }
+              /// Primary image to use in surfacing this content
+              public var mainImage: String? { __data["mainImage"] }
+              /// Title of syndicated article
+              public var title: String { __data["title"] }
+              /// Excerpt
+              public var excerpt: String? { __data["excerpt"] }
+              /// The manually set publisher information for this article
+              public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+              public struct Fragments: FragmentContainer {
+                public let __data: DataDict
+                public init(_dataDict: DataDict) { __data = _dataDict }
+
+                public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
               }
             }
           }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
@@ -41,7 +41,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, PendingItemParts.self]
+      fragments: [SavedItemParts.self, TagParts.self, ItemParts.self, MarticleTextParts.self, ImageParts.self, MarticleDividerParts.self, MarticleTableParts.self, MarticleHeadingParts.self, MarticleCodeBlockParts.self, VideoParts.self, MarticleBulletedListParts.self, MarticleNumberedListParts.self, MarticleBlockquoteParts.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var term: String
@@ -261,7 +261,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                   public var topImageUrl: PocketGraph.Url? { __data["topImageUrl"] }
                   /// How long it will take to read the article (TODO in what time unit? and by what calculation?)
                   public var timeToRead: Int? { __data["timeToRead"] }
-                  /// The domain, such as 'getpocket.com' of the {.resolved_url}
+                  /// The domain, such as 'getpocket.com' of the resolved_url
                   public var domain: String? { __data["domain"] }
                   /// The date the article was published
                   public var datePublished: PocketGraph.DateString? { __data["datePublished"] }
@@ -284,7 +284,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                   /// Array of images within an article
                   public var images: [ItemParts.Image?]? { __data["images"] }
                   /// If the item has a syndicated counterpart the syndication information
-                  public var syndicatedArticle: ItemParts.SyndicatedArticle? { __data["syndicatedArticle"] }
+                  public var syndicatedArticle: SyndicatedArticle? { __data["syndicatedArticle"] }
 
                   public struct Fragments: FragmentContainer {
                     public let __data: DataDict
@@ -356,7 +356,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                       public var caption: String? { __data["caption"] }
                       /// A credit for the image, typically who the image belongs to / created by
                       public var credit: String? { __data["credit"] }
-                      /// The id for placing within an Article View. {articleView.article} will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                      /// The id for placing within an Article View. Item.article will have placeholders of <div id='RIL_IMG_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                       public var imageID: Int { __data["imageID"] }
                       /// Absolute url to the image
                       @available(*, deprecated, message: "use url property moving forward")
@@ -500,7 +500,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                       public var type: GraphQLEnum<PocketGraph.VideoType> { __data["type"] }
                       /// The video's id within the service defined by type
                       public var vid: String? { __data["vid"] }
-                      /// The id of the video within Article View. {articleView.article} will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
+                      /// The id of the video within Article View. Item.article will have placeholders of <div id='RIL_VID_X' /> where X is this id. Apps can download those images as needed and populate them in their article view.
                       public var videoID: Int { __data["videoID"] }
                       /// If known, the width of the video in px
                       public var width: Int? { __data["width"] }
@@ -608,6 +608,34 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                       public init(_dataDict: DataDict) { __data = _dataDict }
 
                       public var domainMetadataParts: DomainMetadataParts { _toFragment() }
+                    }
+                  }
+
+                  /// User.SearchSavedItems.Edge.Node.SavedItem.Item.AsItem.SyndicatedArticle
+                  ///
+                  /// Parent Type: `SyndicatedArticle`
+                  public struct SyndicatedArticle: PocketGraph.SelectionSet {
+                    public let __data: DataDict
+                    public init(_dataDict: DataDict) { __data = _dataDict }
+
+                    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+
+                    /// The item id of this Syndicated Article
+                    public var itemId: PocketGraph.ID? { __data["itemId"] }
+                    /// Primary image to use in surfacing this content
+                    public var mainImage: String? { __data["mainImage"] }
+                    /// Title of syndicated article
+                    public var title: String { __data["title"] }
+                    /// Excerpt
+                    public var excerpt: String? { __data["excerpt"] }
+                    /// The manually set publisher information for this article
+                    public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+                    public struct Fragments: FragmentContainer {
+                      public let __data: DataDict
+                      public init(_dataDict: DataDict) { __data = _dataDict }
+
+                      public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
                     }
                   }
                 }

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/Video.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/Video.graphql.swift
@@ -4,7 +4,7 @@
 import ApolloAPI
 
 public extension Objects {
-  /// A Video, typically within an Article View of an {Item} or if the Item is a video itself.
+  /// A Video, typically within an Article View of an Item or if the Item is a video itself.
   static let Video = Object(
     typename: "Video",
     implementedInterfaces: []

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/itemFragments.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/itemFragments.graphql
@@ -44,13 +44,23 @@ fragment ItemParts on Item {
   }
   syndicatedArticle {
     __typename
-    itemId
+    ...SyndicatedArticleParts
   }
 }
 
 fragment DomainMetadataParts on DomainMetadata {
   name
   logo
+}
+
+fragment SyndicatedArticleParts on SyndicatedArticle {
+    itemId
+    mainImage
+    title
+    excerpt
+    publisher {
+      name
+    }
 }
 
 fragment PendingItemParts on PendingItem {
@@ -88,12 +98,6 @@ fragment ItemSummary on Item {
     imageId
   }
   syndicatedArticle {
-    itemId
-    mainImage
-    title
-    excerpt
-    publisher {
-      name
-    }
+    ...SyndicatedArticleParts
   }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -41,13 +41,13 @@ class RecommendationViewModel: ReadableViewModel {
         self.user = user
         self.userDefaults = userDefaults
 
-        self.savedItemCancellable = recommendation.item?.publisher(for: \.savedItem).sink { [weak self] savedItem in
+        self.savedItemCancellable = recommendation.item.publisher(for: \.savedItem).sink { [weak self] savedItem in
             self?.update(for: savedItem)
         }
     }
 
     var components: [ArticleComponent]? {
-        recommendation.item?.article?.components
+        recommendation.item.article?.components
     }
 
     var readerSettings: ReaderSettings {
@@ -56,7 +56,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     var textAlignment: Textile.TextAlignment {
-        TextAlignment(language: recommendation.item?.language)
+        TextAlignment(language: recommendation.item.language)
     }
 
     var title: String? {
@@ -64,7 +64,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     var authors: [ReadableAuthor]? {
-        recommendation.item?.authors?.compactMap { $0 as? Author }
+        recommendation.item.authors?.compactMap { $0 as? Author }
     }
 
     var domain: String? {
@@ -72,15 +72,15 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     var publishDate: Date? {
-        recommendation.item?.datePublished
+        recommendation.item.datePublished
     }
 
     var url: URL? {
-        recommendation.item?.bestURL
+        recommendation.item.bestURL
     }
 
     var isArchived: Bool {
-        return recommendation.item?.savedItem?.isArchived ?? false
+        return recommendation.item.savedItem?.isArchived ?? false
     }
 
     var premiumURL: URL? {
@@ -88,7 +88,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     func moveToSaves() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             return
         }
 
@@ -96,7 +96,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     func delete() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             return
         }
 
@@ -105,7 +105,7 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     func fetchDetailsIfNeeded() {
-        guard recommendation.item?.article == nil else {
+        guard recommendation.item.article == nil else {
             _events.send(.contentUpdated)
             return
         }
@@ -156,7 +156,7 @@ class RecommendationViewModel: ReadableViewModel {
 
 extension RecommendationViewModel {
     private func buildActions() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             _actions = [
                 .displaySettings { [weak self] _ in self?.displaySettings() },
                 .save { [weak self] _ in self?.save() },
@@ -206,7 +206,7 @@ extension RecommendationViewModel {
     }
 
     func favorite() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             return
         }
 
@@ -215,7 +215,7 @@ extension RecommendationViewModel {
     }
 
     func unfavorite() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             return
         }
 
@@ -231,7 +231,7 @@ extension RecommendationViewModel {
     }
 
     func moveFromArchiveToSaves(completion: (Bool) -> Void) {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             Log.capture(message: "Could not get SavedItem so unarchive action not taken")
             completion(false)
             return
@@ -242,7 +242,7 @@ extension RecommendationViewModel {
     }
 
     func archive() {
-        guard let savedItem = recommendation.item?.savedItem else {
+        guard let savedItem = recommendation.item.savedItem else {
             Log.capture(message: "Could not get SavedItem so archive action not taken")
             return
         }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -68,7 +68,7 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     var components: [ArticleComponent]? {
-        item.item?.article?.components
+        item.item.article?.components
     }
 
     var textAlignment: Textile.TextAlignment {
@@ -76,19 +76,19 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     var title: String? {
-        item.item?.title
+        item.item.title
     }
 
     var authors: [ReadableAuthor]? {
-        item.item?.authors?.compactMap { $0 as? Author }
+        item.item.authors?.compactMap { $0 as? Author }
     }
 
     var domain: String? {
-        item.item?.domainMetadata?.name ?? item.item?.domain ?? item.host
+        item.item.domainMetadata?.name ?? item.item.domain ?? item.host
     }
 
     var publishDate: Date? {
-        item.item?.datePublished
+        item.item.datePublished
     }
 
     var url: URL? {
@@ -113,7 +113,7 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     func fetchDetailsIfNeeded() {
-        guard item.item?.article == nil else {
+        guard item.item.article == nil else {
             _events.send(.contentUpdated)
             return
         }

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellHeroWideViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellHeroWideViewModel.swift
@@ -26,8 +26,8 @@ extension HomeRecommendationCellHeroWideViewModel {
     }
 
     var saveButtonMode: RecommendationSaveButton.Mode {
-        if recommendation.item?.savedItem != nil &&
-            recommendation.item?.savedItem?.isArchived == false {
+        if recommendation.item.savedItem != nil &&
+            recommendation.item.savedItem?.isArchived == false {
             return .saved
         } else {
             return .save
@@ -53,7 +53,7 @@ extension HomeRecommendationCellHeroWideViewModel {
     }
 
     var attributedAuthor: NSAttributedString? {
-        recommendation.item?.authors.flatMap { authorSet in
+        recommendation.item.authors.flatMap { authorSet in
             let names = authorSet.compactMap { ($0 as? Author)?.name }
             let formatted = ListFormatter.localizedString(byJoining: names)
             return NSAttributedString(string: formatted, style: .author)

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -11,8 +11,8 @@ class HomeRecommendationCellViewModel {
     let primaryAction: ItemAction?
 
     var isSaved: Bool {
-        recommendation.item?.savedItem != nil &&
-        recommendation.item?.savedItem?.isArchived == false
+        recommendation.item.savedItem != nil &&
+        recommendation.item.savedItem?.isArchived == false
     }
 
     init(
@@ -56,7 +56,7 @@ extension HomeRecommendationCellViewModel: RecommendationCellViewModel {
     }
 
     var timeToRead: String? {
-        guard let timeToRead = recommendation.item?.timeToRead,
+        guard let timeToRead = recommendation.item.timeToRead,
               timeToRead.intValue > 0 else {
             return nil
         }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -272,11 +272,7 @@ extension HomeViewModel {
             user: user,
             userDefaults: userDefaults
         )
-
-        guard let item = recommendation.item else {
-            Log.capture(message: "Selected recommendation without an associated item")
-            return
-        }
+        let item = recommendation.item
 
         if item.shouldOpenInWebView {
             selectedReadableType = .webViewRecommendation(viewModel)
@@ -307,7 +303,7 @@ extension HomeViewModel {
             userDefaults: userDefaults
         )
 
-        if let item = savedItem.item, item.shouldOpenInWebView {
+        if savedItem.item.shouldOpenInWebView {
             selectedReadableType = .webViewSavedItem(viewModel)
         } else {
             selectedReadableType = .savedItem(viewModel)
@@ -498,8 +494,8 @@ extension HomeViewModel {
         }
 
         return .recommendationPrimary { [weak self] _ in
-            let isSaved = recommendation.item?.savedItem != nil
-            && recommendation.item?.savedItem?.isArchived == false
+            let isSaved = recommendation.item.savedItem != nil
+            && recommendation.item.savedItem?.isArchived == false
 
             if isSaved {
                 self?.archive(recommendation, at: indexPath)
@@ -515,14 +511,13 @@ extension HomeViewModel {
 
     private func share(_ recommendation: Recommendation, at indexPath: IndexPath, with sender: Any?) {
         // This view model is used within the context of a view that is presented within Saves
-        self.sharedActivity = PocketItemActivity.fromHome(url: recommendation.item?.bestURL, sender: sender)
-
+        self.sharedActivity = PocketItemActivity.fromHome(url: recommendation.item.bestURL, sender: sender)
+        let item = recommendation.item
         guard
-            let item = recommendation.item,
             let slate = recommendation.slate,
             let slateLineup = slate.slateLineup
         else {
-            Log.capture(message: "Shared recommendation without an associated item, slate and slatelineup, not logging analytics")
+            Log.capture(message: "Shared recommendation without slate and slatelineup, not logging analytics")
             return
         }
 
@@ -538,13 +533,12 @@ extension HomeViewModel {
 
     private func save(_ recommendation: Recommendation, at indexPath: IndexPath) {
         source.save(recommendation: recommendation)
-
+        let item = recommendation.item
         guard
-            let item = recommendation.item,
             let slate = recommendation.slate,
             let slateLineup = slate.slateLineup
         else {
-            Log.capture(message: "Saved recommendation without an associated item, slate and slatelineup, not logging analytics")
+            Log.capture(message: "Saved recommendation slate and slatelineup, not logging analytics")
             return
         }
 
@@ -553,13 +547,12 @@ extension HomeViewModel {
 
     private func archive(_ recommendation: Recommendation, at indexPath: IndexPath) {
         source.archive(recommendation: recommendation)
-
+        let item = recommendation.item
         guard
-            let item = recommendation.item,
             let slate = recommendation.slate,
             let slateLineup = slate.slateLineup
         else {
-            Log.capture(message: "Archived recommendation without an associated item, slate and slatelineup, not logging analytics")
+            Log.capture(message: "Archived recommendation without slate and slatelineup, not logging analytics")
             return
         }
 
@@ -592,13 +585,12 @@ extension HomeViewModel {
                 Log.capture(message: "Recommendation is null on willDisplay Home Recommendation")
                 return
             }
-
+            let item = recommendation.item
             guard
-                let item = recommendation.item,
                 let slate = recommendation.slate,
                 let slateLineup = slate.slateLineup
             else {
-                Log.capture(message: "Tried to display recommendation without an associated item, slate and slatelineup, not logging analytics")
+                Log.capture(message: "Tried to display recommendation without slate and slatelineup, not logging analytics")
                 return
             }
 

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -95,8 +95,8 @@ extension SlateDetailViewModel {
             event: SnowplowEngagement(type: .general, value: nil),
             contexts(for: recommendation, at: indexPath)
         )
-
-        if let item = recommendation.item, item.shouldOpenInWebView {
+        let item = recommendation.item
+        if item.shouldOpenInWebView {
             let url = pocketPremiumURL(item.bestURL, user: user)
             presentedWebReaderURL = url
 
@@ -141,15 +141,15 @@ extension SlateDetailViewModel {
             overflowActions: [
                 .share { [weak self] sender in
                     // This view model is used within the context of a view that is presented within Home
-                    self?.sharedActivity = PocketItemActivity.fromHome(url: recommendation.item?.bestURL, sender: sender)
+                    self?.sharedActivity = PocketItemActivity.fromHome(url: recommendation.item.bestURL, sender: sender)
                 },
                 .report { [weak self] _ in
                     self?.report(recommendation, at: indexPath)
                 }
             ],
             primaryAction: .recommendationPrimary { [weak self] _ in
-                let isSaved = recommendation.item?.savedItem != nil
-                && recommendation.item?.savedItem?.isArchived == false
+                let isSaved = recommendation.item.savedItem != nil
+                && recommendation.item.savedItem?.isArchived == false
 
                 if isSaved {
                     self?.archive(recommendation, at: indexPath)
@@ -190,7 +190,7 @@ extension SlateDetailViewModel {
     }
 
     private func contexts(for recommendation: Recommendation, at indexPath: IndexPath) -> [Context] {
-        guard let recommendationURL = recommendation.item?.bestURL else {
+        guard let recommendationURL = recommendation.item.bestURL else {
             return []
         }
 

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -8,11 +8,11 @@ import Sync
 
 public extension SavedItem {
     var textAlignment: TextAlignment {
-        TextAlignment(language: item?.language)
+        TextAlignment(language: item.language)
     }
 
     var bestURL: URL? {
-        item?.bestURL ?? url
+        item.bestURL ?? url
     }
 
     var isPending: Bool {
@@ -20,11 +20,11 @@ public extension SavedItem {
     }
 
     var shouldOpenInWebView: Bool {
-        item?.shouldOpenInWebView == true
+        item.shouldOpenInWebView == true
     }
 
     var isSyndicated: Bool {
-        item?.isSyndicated == true
+        item.isSyndicated == true
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -32,7 +32,7 @@ class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
                 return false
             }
 
-            return savedItem.item?.isArticle ?? false
+            return savedItem.item.isArticle ?? false
         }).compactMap({item in
             let v = PKTListenKusariCreate(item.albumID!, PKTListenQueueSectionType.item.rawValue, item, config)
             return v

--- a/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
@@ -28,16 +28,16 @@ extension SavedItem: PKTListenItem {
     }
 
     public var albumLanguage: String? {
-        self.item?.language
+        self.item.language
     }
 
     public var estimatedAlbumDuration: TimeInterval {
-        if let wordCount = item?.wordCount?.intValue, wordCount > 0 {
+        if let wordCount = item.wordCount?.intValue, wordCount > 0 {
             let wordsPerMinute = 155
             return Double(wordCount/wordsPerMinute * 60).rounded()
         }
 
-        if let timeToRead = item?.timeToRead?.intValue, timeToRead > 0 {
+        if let timeToRead = item.timeToRead?.intValue, timeToRead > 0 {
             return Double(timeToRead * 60)
         }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -8,23 +8,23 @@ extension SavedItem: ItemsListItem {
     }
 
     var domain: String? {
-        item?.domain
+        item.domain
     }
 
     var topImageURL: URL? {
-        item?.topImageURL
+        item.topImageURL
     }
 
     var timeToRead: Int? {
-        item?.timeToRead?.intValue
+        item.timeToRead?.intValue
     }
 
     var displayTitle: String {
-        item?.title ?? item?.bestURL?.absoluteString ?? ""
+        item.title ?? item.bestURL?.absoluteString ?? ""
     }
 
     var displayDomain: String? {
-        item?.domainMetadata?.name ?? item?.domain ?? host
+        item.domainMetadata?.name ?? item.domain ?? host
     }
 
     var displayDetail: String {
@@ -40,7 +40,7 @@ extension SavedItem: ItemsListItem {
     }
 
     var displayAuthors: String? {
-        let authors: [String]? = item?.authors?.compactMap { ($0 as? Author)?.name }
+        let authors: [String]? = item.authors?.compactMap { ($0 as? Author)?.name }
         return authors?.joined(separator: ", ")
     }
 
@@ -53,7 +53,7 @@ extension SavedItem: ItemsListItem {
     }
 
     var cursor: String? {
-        item?.savedItem?.cursor
+        item.savedItem?.cursor
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -584,7 +584,7 @@ extension SavedItemsListViewModel {
 
         switch listOptions.selectedSortOption {
         case .longestToRead, .shortestToRead:
-            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.item?.timeToRead, ascending: (listOptions.selectedSortOption == .shortestToRead))
+            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.item.timeToRead, ascending: (listOptions.selectedSortOption == .shortestToRead))
         case .newest, .oldest:
 
             switch self.viewType {

--- a/PocketKit/Sources/PocketKit/Recommendation/Recommendation+Extenstions.swift
+++ b/PocketKit/Sources/PocketKit/Recommendation/Recommendation+Extenstions.swift
@@ -3,7 +3,7 @@ import Sync
 
 extension Recommendation {
     var bestImageURL: URL? {
-        guard let topImageURL = imageURL ?? item?.syndicatedArticle?.imageURL ?? item?.topImageURL ?? (item?.images?.firstObject as? Image)?.source else {
+        guard let topImageURL = imageURL ?? item.syndicatedArticle?.imageURL ?? item.topImageURL ?? (item.images?.firstObject as? Image)?.source else {
             return nil
         }
 
@@ -11,14 +11,14 @@ extension Recommendation {
     }
 
     var bestDomain: String? {
-        item?.syndicatedArticle?.publisherName ?? item?.domainMetadata?.name ?? item?.domain ?? item?.bestURL?.host
+        item.syndicatedArticle?.publisherName ?? item.domainMetadata?.name ?? item.domain ?? item.bestURL?.host
     }
 
     var bestTitle: String? {
-        title ?? item?.syndicatedArticle?.title ?? item?.title
+        title ?? item.syndicatedArticle?.title ?? item.title
     }
 
     var bestExcerpt: String? {
-        excerpt ?? item?.syndicatedArticle?.excerpt ?? item?.excerpt
+        excerpt ?? item.syndicatedArticle?.excerpt ?? item.excerpt
     }
 }

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -90,13 +90,8 @@ struct ReportRecommendationView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
             dismiss()
         }
+        let item = recommendation.item
 
-        guard
-            let item = recommendation.item
-        else {
-            Log.capture(message: "Reported recommendation without an associated item, not logging analytics")
-            return
-        }
         // NOTE: As of 2/17/2023 The report view can only be called from the Home screen, so we assume that the SlateArticleReport event is the correct one.
         tracker.track(event: Events.Home.SlateArticleReport(url: item.givenURL, reason: reason, comment: comment))
     }

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -99,7 +99,7 @@ class PocketAddTagsViewModel: AddTagsViewModel {
     /// Fetch all tags associated with an item to show user
     func allOtherTags() {
         // TODO: Remove ! when we have non-null on tagName
-        otherTags = source.retrieveTags(excluding: tags)?.compactMap({ .tag($0.name!) }).sorted() ?? []
+        otherTags = source.retrieveTags(excluding: tags)?.compactMap({ .tag($0.name) }).sorted() ?? []
         trackAllTagsImpression()
     }
 

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterView.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterView.swift
@@ -43,7 +43,7 @@ struct TagsFilterView: View {
                     TagsSectionView(
                         showRecentTags: !isEditing && !viewModel.recentTags.isEmpty,
                         recentTags: viewModel.recentTags,
-                        allTags: tags.map { .tag($0.name!) },
+                        allTags: tags.map { .tag($0.name) },
                         tagAction: tagAction
                     ).disabled(isEditing)
                 }

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -35,7 +35,7 @@ class TagsFilterViewModel: ObservableObject {
         self.userDefaults = userDefaults
         self.user = user
         self.recentTagsFactory = RecentTagsProvider(userDefaults: userDefaults, key: UserDefaults.Key.recentTags)
-        recentTagsFactory.getInitialRecentTags(with: self.fetchedTags.map({ $0.name! }))
+        recentTagsFactory.getInitialRecentTags(with: self.fetchedTags.map({ $0.name }))
     }
 
     func trackEditAsOverflowAnalytics() {

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -73,7 +73,7 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
     /// Fetch all tags associated with an item to show user
     func allOtherTags() {
         // TODO: Remove ! when we have non-null on tagName
-        otherTags = retrieveAction(tags)?.map { .tag($0.name!) } ?? []
+        otherTags = retrieveAction(tags)?.map { .tag($0.name) } ?? []
         trackAllTagsImpression()
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(Author)
+public class Author: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataProperties.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension Author {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Author> {
+        return NSFetchRequest<Author>(entityName: "Author")
+    }
+
+    @NSManaged public var id: String
+    @NSManaged public var name: String?
+    @NSManaged public var url: URL?
+    @NSManaged public var item: Item?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(DomainMetadata)
+public class DomainMetadata: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
@@ -13,5 +13,5 @@ extension DomainMetadata {
 
     @NSManaged public var logo: URL?
     @NSManaged public var name: String?
-    @NSManaged public var item: Item?
+    @NSManaged public var item: Item
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension DomainMetadata {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DomainMetadata> {
+        return NSFetchRequest<DomainMetadata>(entityName: "DomainMetadata")
+    }
+
+    @NSManaged public var logo: URL?
+    @NSManaged public var name: String?
+    @NSManaged public var item: Item?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(FeatureFlag)
+public class FeatureFlag: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataProperties.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension FeatureFlag {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<FeatureFlag> {
+        return NSFetchRequest<FeatureFlag>(entityName: "FeatureFlag")
+    }
+    @NSManaged public var assigned: Bool
+    @NSManaged public var name: String?
+    @NSManaged public var payloadValue: String?
+    @NSManaged public var variant: String?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(Image)
+public class Image: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataProperties.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension Image {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Image> {
+        return NSFetchRequest<Image>(entityName: "Image")
+    }
+
+    @NSManaged public var isDownloaded: Bool
+    @NSManaged public var source: URL?
+    @NSManaged public var item: Item?
+    @NSManaged public var recommendation: Recommendation?
+    @NSManaged public var syndicatedArticle: SyndicatedArticle?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(PersistentSyncTask)
+public class PersistentSyncTask: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataProperties.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension PersistentSyncTask {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PersistentSyncTask> {
+        return NSFetchRequest<PersistentSyncTask>(entityName: "PersistentSyncTask")
+    }
+
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var currentCursor: String?
+    @NSManaged public var syncTaskContainer: SyncTaskContainer?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -15,7 +15,7 @@ extension Recommendation {
     @NSManaged public var imageURL: URL?
     @NSManaged public var remoteID: String
     @NSManaged public var title: String?
-    @NSManaged public var item: Item?
+    @NSManaged public var item: Item
     @NSManaged public var slate: Slate?
     @NSManaged public var image: Image?
     @NSManaged public var sortIndex: NSNumber?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataClass.swift
@@ -24,7 +24,7 @@ public class SavedItem: NSManagedObject {
     public init(
         context: NSManagedObjectContext,
         url: URL,
-        remoteID: String = ""
+        remoteID: String? = nil
     ) {
         let entity = NSEntityDescription.entity(forEntityName: "SavedItem", in: context)!
         super.init(entity: entity, insertInto: context)

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataClass.swift
@@ -24,7 +24,7 @@ public class SavedItem: NSManagedObject {
     public init(
         context: NSManagedObjectContext,
         url: URL,
-        remoteID: String? = nil
+        remoteID: String = ""
     ) {
         let entity = NSEntityDescription.entity(forEntityName: "SavedItem", in: context)!
         super.init(entity: entity, insertInto: context)

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
@@ -18,7 +18,7 @@ extension SavedItem {
     @NSManaged public var deletedAt: Date?
     @NSManaged public var isArchived: Bool
     @NSManaged public var isFavorite: Bool
-    @NSManaged public var remoteID: String?
+    @NSManaged public var remoteID: String
     @NSManaged public var url: URL
     @NSManaged public var item: Item?
     @NSManaged public var savedItemUpdatedNotification: SavedItemUpdatedNotification?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
@@ -18,7 +18,7 @@ extension SavedItem {
     @NSManaged public var deletedAt: Date?
     @NSManaged public var isArchived: Bool
     @NSManaged public var isFavorite: Bool
-    @NSManaged public var remoteID: String
+    @NSManaged public var remoteID: String?
     @NSManaged public var url: URL
     @NSManaged public var item: Item
     @NSManaged public var savedItemUpdatedNotification: SavedItemUpdatedNotification?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
@@ -13,14 +13,14 @@ extension SavedItem {
     }
 
     @NSManaged public var archivedAt: Date?
-    @NSManaged public var createdAt: Date?
+    @NSManaged public var createdAt: Date
     @NSManaged public var cursor: String?
     @NSManaged public var deletedAt: Date?
     @NSManaged public var isArchived: Bool
     @NSManaged public var isFavorite: Bool
     @NSManaged public var remoteID: String
     @NSManaged public var url: URL
-    @NSManaged public var item: Item?
+    @NSManaged public var item: Item
     @NSManaged public var savedItemUpdatedNotification: SavedItemUpdatedNotification?
     @NSManaged public var tags: NSOrderedSet?
     @NSManaged public var unresolvedSavedItem: UnresolvedSavedItem?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(SavedItemUpdatedNotification)
+public class SavedItemUpdatedNotification: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataProperties.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension SavedItemUpdatedNotification {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SavedItemUpdatedNotification> {
+        return NSFetchRequest<SavedItemUpdatedNotification>(entityName: "SavedItemUpdatedNotification")
+    }
+
+    @NSManaged public var savedItem: SavedItem?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(SyndicatedArticle)
+public class SyndicatedArticle: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
@@ -16,7 +16,7 @@ extension SyndicatedArticle {
     @NSManaged public var itemID: String
     @NSManaged public var publisherName: String?
     #warning("TODO - CORE DATA: title should not be optional")
-    @NSManaged public var title: String?
+    @NSManaged public var title: String
     @NSManaged public var image: Image?
     @NSManaged public var item: Item?
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension SyndicatedArticle {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SyndicatedArticle> {
+        return NSFetchRequest<SyndicatedArticle>(entityName: "SyndicatedArticle")
+    }
+
+    @NSManaged public var excerpt: String?
+    @NSManaged public var imageURL: URL?
+    @NSManaged public var itemID: String
+    @NSManaged public var publisherName: String?
+    #warning("TODO - CORE DATA: title should not be optional")
+    @NSManaged public var title: String?
+    @NSManaged public var image: Image?
+    @NSManaged public var item: Item?
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(Tag)
+public class Tag: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
@@ -11,8 +11,8 @@ extension Tag {
         return NSFetchRequest<Tag>(entityName: "Tag")
     }
 
-    @NSManaged public var name: String?
-    @NSManaged public var remoteID: String?
+    @NSManaged public var name: String
+    @NSManaged public var remoteID: String
     @NSManaged public var savedItems: NSOrderedSet?
 
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension Tag {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Tag> {
+        return NSFetchRequest<Tag>(entityName: "Tag")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var remoteID: String?
+    @NSManaged public var savedItems: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for savedItems
+extension Tag {
+
+    @objc(insertObject:inSavedItemsAtIndex:)
+    @NSManaged public func insertIntoSavedItems(_ value: SavedItem, at idx: Int)
+
+    @objc(removeObjectFromSavedItemsAtIndex:)
+    @NSManaged public func removeFromSavedItems(at idx: Int)
+
+    @objc(insertSavedItems:atIndexes:)
+    @NSManaged public func insertIntoSavedItems(_ values: [SavedItem], at indexes: NSIndexSet)
+
+    @objc(removeSavedItemsAtIndexes:)
+    @NSManaged public func removeFromSavedItems(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInSavedItemsAtIndex:withObject:)
+    @NSManaged public func replaceSavedItems(at idx: Int, with value: SavedItem)
+
+    @objc(replaceSavedItemsAtIndexes:withSavedItems:)
+    @NSManaged public func replaceSavedItems(at indexes: NSIndexSet, with values: [SavedItem])
+
+    @objc(addSavedItemsObject:)
+    @NSManaged public func addToSavedItems(_ value: SavedItem)
+
+    @objc(removeSavedItemsObject:)
+    @NSManaged public func removeFromSavedItems(_ value: SavedItem)
+
+    @objc(addSavedItems:)
+    @NSManaged public func addToSavedItems(_ values: NSOrderedSet)
+
+    @objc(removeSavedItems:)
+    @NSManaged public func removeFromSavedItems(_ values: NSOrderedSet)
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
@@ -12,7 +12,7 @@ extension Tag {
     }
 
     @NSManaged public var name: String
-    @NSManaged public var remoteID: String
+    @NSManaged public var remoteID: String?
     @NSManaged public var savedItems: NSOrderedSet?
 
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataClass.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+@objc(UnresolvedSavedItem)
+public class UnresolvedSavedItem: NSManagedObject {
+
+}

--- a/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataProperties.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import CoreData
+
+extension UnresolvedSavedItem {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<UnresolvedSavedItem> {
+        return NSFetchRequest<UnresolvedSavedItem>(entityName: "UnresolvedSavedItem")
+    }
+
+    @NSManaged public var savedItem: SavedItem?
+}

--- a/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
+++ b/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
@@ -27,10 +27,8 @@ class CoreDataSpotlightDelegate: NSCoreDataCoreSpotlightDelegate {
     /// Helper function to turn a SavedItem into a CSSearchableItemAttributeSet
     /// - Parameter savedItem: The saved item to search
     /// - Returns: The CoreSpotlight result
-    private func csSearchableItemAttributeSet(for savedItem: SavedItem) -> CSSearchableItemAttributeSet? {
-        guard let identifier = savedItem.remoteID else {
-            return nil
-        }
+    private func csSearchableItemAttributeSet(for savedItem: SavedItem) -> CSSearchableItemAttributeSet {
+        let identifier = savedItem.remoteID
         let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
         attributeSet.identifier = identifier
         attributeSet.displayName = savedItem.item?.title

--- a/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
+++ b/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
@@ -31,13 +31,13 @@ class CoreDataSpotlightDelegate: NSCoreDataCoreSpotlightDelegate {
         let identifier = savedItem.remoteID
         let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
         attributeSet.identifier = identifier
-        attributeSet.displayName = savedItem.item?.title
-        attributeSet.publishers = (savedItem.item?.authors?.array as? [Author] ?? []).compactMap { $0.name }
-        attributeSet.thumbnailURL = savedItem.item?.topImageURL // TODO: Image cache url..
+        attributeSet.displayName = savedItem.item.title
+        attributeSet.publishers = (savedItem.item.authors?.array as? [Author] ?? []).compactMap { $0.name }
+        attributeSet.thumbnailURL = savedItem.item.topImageURL // TODO: Image cache url..
         attributeSet.contentURL = savedItem.url
-        attributeSet.contentDescription = savedItem.item?.excerpt
-        attributeSet.title = savedItem.item?.title
-        attributeSet.contentCreationDate = savedItem.item?.datePublished
+        attributeSet.contentDescription = savedItem.item.excerpt
+        attributeSet.title = savedItem.item.title
+        attributeSet.contentCreationDate = savedItem.item.datePublished
 
         return attributeSet
     }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -69,7 +69,7 @@
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
         <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
-        <attribute name="remoteID" attributeType="String" defaultValueString="" spotlightIndexingEnabled="YES"/>
+        <attribute name="remoteID" attributeType="String" spotlightIndexingEnabled="YES"/>
         <attribute name="url" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item" spotlightIndexingEnabled="YES"/>
         <relationship name="savedItemUpdatedNotification" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItemUpdatedNotification" inverseName="savedItem" inverseEntity="SavedItemUpdatedNotification"/>
@@ -78,6 +78,9 @@
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="remoteID"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="url"/>
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -130,7 +130,7 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
-    <entity name="Tag" representedClassName="Tag" syncable="YES" codeGenerationType="class">
+    <entity name="Tag" representedClassName="Tag" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -121,7 +121,7 @@
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="itemID" attributeType="String"/>
         <attribute name="publisherName" optional="YES" attributeType="String"/>
-        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
         <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="syndicatedArticle" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="syndicatedArticle" inverseEntity="Item"/>
         <uniquenessConstraints>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -131,8 +131,8 @@
         </uniquenessConstraints>
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES">
-        <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="remoteID" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="remoteID" attributeType="String"/>
         <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
         <uniquenessConstraints>
             <uniquenessConstraint>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -6,7 +6,7 @@
         <attribute name="url" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="authors" inverseEntity="Item"/>
     </entity>
-    <entity name="DomainMetadata" representedClassName="DomainMetadata" syncable="YES" codeGenerationType="class">
+    <entity name="DomainMetadata" representedClassName="DomainMetadata" syncable="YES">
         <attribute name="logo" optional="YES" attributeType="URI"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="domainMetadata" inverseEntity="Item"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -116,12 +116,12 @@
         <attribute name="requestID" attributeType="String"/>
         <relationship name="slates" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Slate" inverseName="slateLineup" inverseEntity="Slate"/>
     </entity>
-    <entity name="SyndicatedArticle" representedClassName="SyndicatedArticle" syncable="YES" codeGenerationType="class">
+    <entity name="SyndicatedArticle" representedClassName="SyndicatedArticle" syncable="YES">
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="itemID" attributeType="String"/>
         <attribute name="publisherName" optional="YES" attributeType="String"/>
-        <attribute name="title" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
         <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="syndicatedArticle" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="syndicatedArticle" inverseEntity="Item"/>
         <uniquenessConstraints>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -11,7 +11,7 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="domainMetadata" inverseEntity="Item"/>
     </entity>
-    <entity name="FeatureFlag" representedClassName="FeatureFlag" syncable="YES" codeGenerationType="class">
+    <entity name="FeatureFlag" representedClassName="FeatureFlag" syncable="YES">
         <attribute name="assigned" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="payloadValue" optional="YES" attributeType="String"/>
@@ -55,7 +55,7 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
-    <entity name="PersistentSyncTask" representedClassName="PersistentSyncTask" syncable="YES" codeGenerationType="class">
+    <entity name="PersistentSyncTask" representedClassName="PersistentSyncTask" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="666643260" usesScalarValueType="NO"/>
         <attribute name="currentCursor" optional="YES" attributeType="String"/>
         <attribute name="syncTaskContainer" attributeType="Transformable" valueTransformerName="SyncTaskTransformer" customClassName="SyncTaskContainer"/>
@@ -97,7 +97,7 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
-    <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
+    <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="savedItemUpdatedNotification" inverseEntity="SavedItem"/>
     </entity>
     <entity name="Slate" representedClassName="Slate" syncable="YES">
@@ -140,7 +140,7 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
-    <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES" codeGenerationType="class">
+    <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="unresolvedSavedItem" inverseEntity="SavedItem"/>
     </entity>
 </model>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -17,7 +17,7 @@
         <attribute name="payloadValue" optional="YES" attributeType="String"/>
         <attribute name="variant" optional="YES" attributeType="String"/>
     </entity>
-    <entity name="Image" representedClassName="Image" syncable="YES" codeGenerationType="class">
+    <entity name="Image" representedClassName="Image" syncable="YES">
         <attribute name="isDownloaded" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="source" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="images" inverseEntity="Item"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -82,16 +82,13 @@
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
         <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
-        <attribute name="remoteID" attributeType="String" spotlightIndexingEnabled="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="String" spotlightIndexingEnabled="YES"/>
         <attribute name="url" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item" spotlightIndexingEnabled="YES"/>
         <relationship name="savedItemUpdatedNotification" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItemUpdatedNotification" inverseName="savedItem" inverseEntity="SavedItemUpdatedNotification"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Tag" inverseName="savedItems" inverseEntity="Tag"/>
         <relationship name="unresolvedSavedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UnresolvedSavedItem" inverseName="savedItem" inverseEntity="UnresolvedSavedItem"/>
         <uniquenessConstraints>
-            <uniquenessConstraint>
-                <constraint value="remoteID"/>
-            </uniquenessConstraint>
             <uniquenessConstraint>
                 <constraint value="url"/>
             </uniquenessConstraint>
@@ -132,13 +129,8 @@
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES">
         <attribute name="name" attributeType="String"/>
-        <attribute name="remoteID" attributeType="String"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
         <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
-        <uniquenessConstraints>
-            <uniquenessConstraint>
-                <constraint value="remoteID"/>
-            </uniquenessConstraint>
-        </uniquenessConstraints>
     </entity>
     <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="unresolvedSavedItem" inverseEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="Author" representedClassName="Author" syncable="YES" codeGenerationType="class">
-        <attribute name="id" optional="YES" attributeType="String"/>
+    <entity name="Author" representedClassName="Author" syncable="YES">
+        <attribute name="id" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="authors" inverseEntity="Item"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -64,17 +64,22 @@
     </entity>
     <entity name="SavedItem" representedClassName="SavedItem" syncable="YES">
         <attribute name="archivedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="cursor" optional="YES" attributeType="String"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="isArchived" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
-        <attribute name="isFavorite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
-        <attribute name="remoteID" optional="YES" attributeType="String" spotlightIndexingEnabled="YES"/>
+        <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" spotlightIndexingEnabled="YES"/>
+        <attribute name="remoteID" attributeType="String" defaultValueString="" spotlightIndexingEnabled="YES"/>
         <attribute name="url" attributeType="URI"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="savedItem" inverseEntity="Item" spotlightIndexingEnabled="YES"/>
         <relationship name="savedItemUpdatedNotification" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItemUpdatedNotification" inverseName="savedItem" inverseEntity="SavedItemUpdatedNotification"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Tag" inverseName="savedItems" inverseEntity="Tag"/>
         <relationship name="unresolvedSavedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UnresolvedSavedItem" inverseName="savedItem" inverseEntity="UnresolvedSavedItem"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="remoteID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="SavedItemUpdatedNotification" representedClassName="SavedItemUpdatedNotification" syncable="YES" codeGenerationType="class">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="savedItemUpdatedNotification" inverseEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -131,6 +131,11 @@
         <attribute name="name" attributeType="String"/>
         <attribute name="remoteID" optional="YES" attributeType="String"/>
         <relationship name="savedItems" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SavedItem" inverseName="tags" inverseEntity="SavedItem"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="name"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="UnresolvedSavedItem" representedClassName="UnresolvedSavedItem" syncable="YES">
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="unresolvedSavedItem" inverseEntity="SavedItem"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -33,7 +33,7 @@
         <attribute name="imageness" optional="YES" attributeType="String"/>
         <attribute name="isArticle" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="language" optional="YES" attributeType="String"/>
-        <attribute name="remoteID" optional="YES" attributeType="String"/>
+        <attribute name="remoteID" attributeType="String"/>
         <attribute name="resolvedURL" optional="YES" attributeType="URI"/>
         <attribute name="timeToRead" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
@@ -46,6 +46,14 @@
         <relationship name="recommendation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recommendation" inverseName="item" inverseEntity="Recommendation"/>
         <relationship name="savedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SavedItem" inverseName="item" inverseEntity="SavedItem"/>
         <relationship name="syndicatedArticle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SyndicatedArticle" inverseName="item" inverseEntity="SyndicatedArticle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="givenURL"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="remoteID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="PersistentSyncTask" representedClassName="PersistentSyncTask" syncable="YES" codeGenerationType="class">
         <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="666643260" usesScalarValueType="NO"/>
@@ -61,6 +69,11 @@
         <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="recommendation" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="recommendation" inverseEntity="Item"/>
         <relationship name="slate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Slate" inverseName="recommendations" inverseEntity="Slate"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="remoteID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="SavedItem" representedClassName="SavedItem" syncable="YES">
         <attribute name="archivedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -106,11 +119,16 @@
     <entity name="SyndicatedArticle" representedClassName="SyndicatedArticle" syncable="YES" codeGenerationType="class">
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
-        <attribute name="itemID" optional="YES" attributeType="String"/>
+        <attribute name="itemID" attributeType="String"/>
         <attribute name="publisherName" optional="YES" attributeType="String"/>
-        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
         <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Image" inverseName="syndicatedArticle" inverseEntity="Image"/>
         <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="syndicatedArticle" inverseEntity="Item"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="itemID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES" codeGenerationType="class">
         <attribute name="name" optional="YES" attributeType="String"/>

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -121,7 +121,8 @@ public class PocketSaveService: SaveService {
                 return
             }
 
-            guard let tags = savedItem.tags, let remoteID = savedItem.remoteID else { return }
+            guard let tags = savedItem.tags else { return }
+            let remoteID = savedItem.remoteID
             let names = Array(tags).compactMap { ($0 as? Tag)?.name }
 
             if names.isEmpty {

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -121,8 +121,7 @@ public class PocketSaveService: SaveService {
                 return
             }
 
-            guard let tags = savedItem.tags else { return }
-            let remoteID = savedItem.remoteID
+            guard let tags = savedItem.tags, let remoteID = savedItem.remoteID else { return }
             let names = Array(tags).compactMap { ($0 as? Tag)?.name }
 
             if names.isEmpty {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -293,12 +293,11 @@ extension PocketSource {
     public func favorite(item: SavedItem) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Favoriting item with id \(String(describing: item.remoteID))")
         space.performAndWait {
-            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
-                  let remoteID = item.remoteID else {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
-
+            let remoteID = item.remoteID
             item.isFavorite = true
             do {
                 try space.save()
@@ -319,12 +318,11 @@ extension PocketSource {
     public func unfavorite(item: SavedItem) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Unfavoriting item with id \(String(describing: item.remoteID))")
         space.performAndWait {
-            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
-                  let remoteID = item.remoteID else {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
-
+            let remoteID = item.remoteID
             item.isFavorite = false
             do {
                 try space.save()
@@ -344,11 +342,11 @@ extension PocketSource {
     public func delete(item savedItem: SavedItem) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Deleting item with id \(String(describing: savedItem.remoteID))")
         space.performAndWait {
-            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem,
-                  let remoteID = savedItem.remoteID else {
+            guard let savedItem = space.backgroundObject(with: savedItem.objectID) as? SavedItem else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
+            let remoteID = savedItem.remoteID
 
             let item = savedItem.item
 
@@ -377,11 +375,11 @@ extension PocketSource {
     public func archive(item: SavedItem) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Archiving item with id \(String(describing: item.remoteID))")
         space.performAndWait {
-            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
-                  let remoteID = item.remoteID else {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
+            let remoteID = item.remoteID
 
             item.isArchived = true
             item.archivedAt = Date()
@@ -446,11 +444,11 @@ extension PocketSource {
     public func addTags(item: SavedItem, tags: [String]) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Adding tags to item with id \(String(describing: item.remoteID))")
         space.performAndWait {
-            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem,
-                  let remoteID = item.remoteID else {
+            guard let item = space.backgroundObject(with: item.objectID) as? SavedItem else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
+            let remoteID = item.remoteID
 
             item.tags = NSOrderedSet(array: tags.compactMap { $0 }.map({ tag in
                 space.fetchOrCreateTag(byName: tag)
@@ -541,9 +539,7 @@ extension PocketSource {
     public func fetchDetails(for savedItem: SavedItem) async throws {
         Log.breadcrumb(category: "sync", level: .debug, message: "Fetching detals for item with id \(String(describing: savedItem.remoteID))")
 
-        guard let remoteID = savedItem.remoteID else {
-            return
-        }
+        let remoteID = savedItem.remoteID
 
         guard let remoteSavedItem = try await apollo
             .fetch(query: SavedItemByIDQuery(id: remoteID))

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -507,6 +507,11 @@ extension PocketSource {
                 return
             }
 
+            guard (try? space.fetchTag(by: name)) == nil else {
+                Log.capture(message: "A tag with the selected name already exists")
+                return
+            }
+
             let fetchedTag = try? space.fetchTag(by: oldTag.name)
             fetchedTag?.name = name
 

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -473,12 +473,11 @@ extension PocketSource {
     public func deleteTag(tag: Tag) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Deleting tags")
         space.performAndWait {
-            guard let tag = space.backgroundObject(with: tag.objectID) as? Tag,
-                  let remoteID = tag.remoteID else {
+            guard let tag = space.backgroundObject(with: tag.objectID) as? Tag else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
-
+            let remoteID = tag.remoteID
             do {
                 try space.deleteTag(byID: remoteID)
                 try space.save()
@@ -499,12 +498,11 @@ extension PocketSource {
     public func renameTag(from oldTag: Tag, to name: String) {
         Log.breadcrumb(category: "sync", level: .debug, message: "Renaming tag")
         space.performAndWait {
-            guard let oldTag = space.backgroundObject(with: oldTag.objectID) as? Tag,
-                  let remoteID = oldTag.remoteID else {
+            guard let oldTag = space.backgroundObject(with: oldTag.objectID) as? Tag else {
                 Log.capture(message: "Could not retreive item from background context for mutation")
                 return
             }
-
+            let remoteID = oldTag.remoteID
             let fetchedTag = try? space.fetchTag(byID: remoteID)
             fetchedTag?.name = name
 

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -352,7 +352,7 @@ extension PocketSource {
 
             space.delete(savedItem)
 
-            if let item = item, item.recommendation == nil {
+            if item.recommendation == nil {
                 space.delete(item)
             }
 

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -507,7 +507,7 @@ extension PocketSource {
                 return
             }
 
-            let fetchedTag = try? space.fetchTag(byID: remoteID)
+            let fetchedTag = try? space.fetchTag(by: oldTag.name)
             fetchedTag?.name = name
 
             do {

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -77,6 +77,7 @@ extension Item {
         if let syndicatedArticle = remote.syndicatedArticle, let itemId = syndicatedArticle.itemId {
             self.syndicatedArticle = (try? space.fetchSyndicatedArticle(byItemId: itemId, context: context)) ?? SyndicatedArticle(context: context)
             self.syndicatedArticle?.itemID = itemId
+            self.syndicatedArticle?.title = syndicatedArticle.title
         }
     }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -55,21 +55,21 @@ extension SavedItem {
             return fetchedTag
         } ?? [])
 
-        let itemToUpdate = try? space.fetchItem(byRemoteID: itemParts.remoteID, context: context) ?? Item(context: context, givenURL: itemUrl, remoteID: itemParts.remoteID)
-        itemToUpdate?.update(remote: itemParts, with: space)
+        let itemToUpdate = (try? space.fetchItem(byRemoteID: itemParts.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemParts.remoteID)
+        itemToUpdate.update(remote: itemParts, with: space)
         item = itemToUpdate
     }
 
     public func update(from recommendation: Recommendation) {
-        guard let url = recommendation.item?.bestURL else {
-            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Recommendation \(recommendation.remoteID) from SavedItem \(self.remoteID) because \(recommendation.item?.bestURL) is not valid url")
+        guard let item = recommendation.item, let url = item.bestURL else {
+            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Recommendation \(recommendation.remoteID) from SavedItem \(self.remoteID). Reason: item and/or url is invalid.")
             return
         }
 
         self.url = url
         self.createdAt = Date()
 
-        item = recommendation.item
+        self.item = item
     }
 
     public func update(from summary: SavedItemSummary, with space: Space) {
@@ -103,8 +103,8 @@ extension SavedItem {
             return tag
         } ?? [])
 
-        let itemToUpdate = try? space.fetchItem(byRemoteID: itemSummary.remoteID, context: context) ?? Item(context: context, givenURL: itemUrl, remoteID: itemSummary.remoteID)
-        itemToUpdate?.update(from: itemSummary, with: space)
+        let itemToUpdate = (try? space.fetchItem(byRemoteID: itemSummary.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemSummary.remoteID)
+        itemToUpdate.update(from: itemSummary, with: space)
         item = itemToUpdate
     }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -69,7 +69,7 @@ extension SavedItem {
         self.url = url
         self.createdAt = Date()
 
-        self.item = item
+        self.item = recommendation.item
     }
 
     public func update(from summary: SavedItemSummary, with space: Space) {

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -61,7 +61,7 @@ extension SavedItem {
     }
 
     public func update(from recommendation: Recommendation) {
-        guard let item = recommendation.item, let url = item.bestURL else {
+        guard let url = recommendation.item.bestURL else {
             Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Recommendation \(recommendation.remoteID) from SavedItem \(self.remoteID). Reason: item and/or url is invalid.")
             return
         }

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -393,12 +393,14 @@ extension Space {
         }
         let createTag = Tag(context: context)
         createTag.name = name
-        createTag.remoteID = "remoteID\(name)"
         return createTag
     }
 
-    func fetchTag(byID id: String) throws -> Tag? {
-        try fetch(Requests.fetchTag(byID: id)).first
+    func fetchTag(by name: String, context: NSManagedObjectContext? = nil) throws -> Tag? {
+        let context = context ?? backgroundContext
+        let fetchRequest = Requests.fetchTag(byName: name)
+        fetchRequest.fetchLimit = 1
+        return try fetch(fetchRequest, context: context).first
     }
 
     func retrieveTags(excluding tags: [String]) throws -> [Tag] {

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -388,10 +388,13 @@ extension Space {
         let context = context ?? backgroundContext
         let fetchRequest = Requests.fetchTag(byName: name)
         fetchRequest.fetchLimit = 1
-        let fetchedTag = (try? fetch(fetchRequest, context: context).first) ?? Tag(context: context)
-        guard fetchedTag.name == nil else { return fetchedTag }
-        fetchedTag.name = name
-        return fetchedTag
+        if let fetchedTag = (try? fetch(fetchRequest, context: context).first) {
+            return fetchedTag
+        }
+        let createTag = Tag(context: context)
+        createTag.name = name
+        createTag.remoteID = "remoteID\(name)"
+        return createTag
     }
 
     func fetchTag(byID id: String) throws -> Tag? {

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -59,8 +59,8 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         userDefaults.setValue(true, forKey: AccountViewModel.ToggleAppBadgeKey)
 
-        space.buildSavedItem()
-        space.buildSavedItem(isArchived: true)
+        space.buildSavedItem(item: try space.createItem())
+        space.buildSavedItem(remoteID: "saved-item-2", url: "http://example.com/item-2", isArchived: true, item: try space.createItem(remoteID: "item-2", givenURL: URL(string: "http://example.com/item-2")))
         try space.save()
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -135,11 +135,11 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag2: Tag = Tag(context: self.space.backgroundContext)
             let tag3: Tag = Tag(context: self.space.backgroundContext)
             tag1.name = "tag 1"
-            tag1.remoteID = tag1.name?.uppercased()
+            tag1.remoteID = tag1.name.uppercased()
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
-            tag3.remoteID = tag3.name?.uppercased()
+            tag3.remoteID = tag3.name.uppercased()
             return [tag1, tag2, tag3]
         }
 
@@ -164,13 +164,13 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag3: Tag = Tag(context: self.space.backgroundContext)
             let tag4: Tag = Tag(context: self.space.backgroundContext)
             tag1.name = "tag 1"
-            tag1.remoteID = tag1.name?.uppercased()
+            tag1.remoteID = tag1.name.uppercased()
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
-            tag3.remoteID = tag3.name?.uppercased()
+            tag3.remoteID = tag3.name.uppercased()
             tag4.name = "tag 4"
-            tag4.remoteID = tag4.name?.uppercased()
+            tag4.remoteID = tag4.name.uppercased()
             return [tag1, tag2, tag3, tag4]
         }
 
@@ -195,13 +195,13 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag3: Tag = Tag(context: self.space.backgroundContext)
             let tag4: Tag = Tag(context: self.space.backgroundContext)
             tag1.name = "tag 1"
-            tag1.remoteID = tag1.name?.uppercased()
+            tag1.remoteID = tag1.name.uppercased()
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
-            tag3.remoteID = tag3.name?.uppercased()
+            tag3.remoteID = tag3.name.uppercased()
             tag4.name = "tag 4"
-            tag4.remoteID = tag4.name?.uppercased()
+            tag4.remoteID = tag4.name.uppercased()
             return [tag1, tag2, tag3, tag4]
         }
 
@@ -219,7 +219,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag2: Tag = Tag(context: self!.space.backgroundContext)
             let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
             return [tag2, tag3]
         }
@@ -270,9 +270,9 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag2: Tag = Tag(context: self!.space.backgroundContext)
             let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
-            tag3.remoteID = tag3.name?.uppercased()
+            tag3.remoteID = tag3.name.uppercased()
             return [tag2, tag3]
         }
 
@@ -302,9 +302,9 @@ class PocketAddTagsViewModelTests: XCTestCase {
             let tag2: Tag = Tag(context: self!.space.backgroundContext)
             let tag3: Tag = Tag(context: self!.space.backgroundContext)
             tag2.name = "tag 2"
-            tag2.remoteID = tag2.name?.uppercased()
+            tag2.remoteID = tag2.name.uppercased()
             tag3.name = "tag 3"
-            tag3.remoteID = tag3.name?.uppercased()
+            tag3.remoteID = tag3.name.uppercased()
             return [tag2, tag3]
         }
 

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -63,8 +63,9 @@ class RecommendationViewModelTests: XCTestCase {
 
         // not-favorited, not-archived
         do {
-            let item = space.buildItem()
-            let recommendation = space.buildRecommendation(item: item)
+            let item = space.buildItem(remoteID: "item-2", givenURL: URL(string: "https://example.com/items/item-2"))
+            let recommendation = space.buildRecommendation(remoteID: "rec-2", item: item)
+
             try space.createSavedItem(isFavorite: false, isArchived: false, item: item)
 
             let viewModel = subject(recommendation: recommendation)
@@ -76,8 +77,10 @@ class RecommendationViewModelTests: XCTestCase {
 
         // favorited, archived
         do {
-            let item = space.buildItem()
-            let recommendation = space.buildRecommendation(item: item)
+
+            let item = space.buildItem(remoteID: "item-3", givenURL: URL(string: "https://example.com/items/item-2"))
+            let recommendation = space.buildRecommendation(remoteID: "rec-3", item: item)
+
             try space.createSavedItem(isFavorite: true, isArchived: true, item: item)
 
             let viewModel = subject(recommendation: recommendation)
@@ -313,6 +316,7 @@ class RecommendationViewModelTests: XCTestCase {
         let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
+
         viewModel.invokeAction(from: actions, title: "Copy Link")
 
         XCTAssertEqual(pasteboard.url, url)

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -302,7 +302,7 @@ class RecommendationViewModelTests: XCTestCase {
     func test_externalSave_forwardsToSource() throws {
         source.stubSaveURL { _ in }
 
-        let viewModel = try subject(recommendation: space.createRecommendation())
+        let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Save")
@@ -310,7 +310,7 @@ class RecommendationViewModelTests: XCTestCase {
     }
 
     func test_externalCopy_copiesToClipboard() throws {
-        let viewModel = try subject(recommendation: space.createRecommendation())
+        let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Copy Link")
@@ -319,7 +319,7 @@ class RecommendationViewModelTests: XCTestCase {
     }
 
     func test_externalShare_updatesSharedActivity() throws {
-        let viewModel = try subject(recommendation: space.createRecommendation())
+        let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Share")
@@ -327,7 +327,7 @@ class RecommendationViewModelTests: XCTestCase {
     }
 
     func test_externalOpen_updatesPresentedWebReaderURL() throws {
-        let viewModel = try subject(recommendation: space.createRecommendation())
+        let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://example.com")!
         let actions = viewModel.externalActions(for: url)
         viewModel.invokeAction(from: actions, title: "Open")
@@ -339,7 +339,7 @@ class RecommendationViewModelTests: XCTestCase {
             item: space.buildItem()
         )
         source.stubFetchDetailsForRecommendation { rec in
-            rec.item?.article = .some(Article(components: []))
+            rec.item.article = .some(Article(components: []))
         }
 
         let viewModel = subject(recommendation: recommendation)
@@ -354,7 +354,7 @@ class RecommendationViewModelTests: XCTestCase {
 
         viewModel.fetchDetailsIfNeeded()
         wait(for: [receivedEvent], timeout: 10)
-        XCTAssertNotNil(recommendation.item?.article)
+        XCTAssertNotNil(recommendation.item.article)
     }
 
     func test_fetchDetailsIfNeeded_whenMarticleIsPresent_immediatelySendsContentUpdatedEvent() {
@@ -389,7 +389,7 @@ class RecommendationViewModelTests: XCTestCase {
             return recommendation.item
         }
 
-        let webViewActivityList = viewModel.webViewActivityItems(url: recommendation.item!.givenURL)
+        let webViewActivityList = viewModel.webViewActivityItems(url: recommendation.item.givenURL)
         XCTAssertEqual(webViewActivityList[0].activityTitle, "Save")
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Report")
 
@@ -411,7 +411,7 @@ class RecommendationViewModelTests: XCTestCase {
             return recommendation.item
         }
 
-        let webViewActivityList = viewModel.webViewActivityItems(url: recommendation.item!.givenURL)
+        let webViewActivityList = viewModel.webViewActivityItems(url: recommendation.item.givenURL)
         XCTAssertEqual(webViewActivityList[0].activityTitle, "Archive")
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -97,7 +97,7 @@ class SavedItemViewModelTests: XCTestCase {
         source.stubFetchDetails { _ in }
 
         let savedItem = space.buildSavedItem()
-        savedItem.item?.article = nil
+        savedItem.item.article = nil
         try space.save()
 
         let viewModel = subject(item: savedItem)

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -148,9 +148,10 @@ class SavedItemsListViewModelTests: XCTestCase {
 
     func test_selectCell_whenItemIsArticle_setsSelectedItemToReaderView() throws {
         let viewModel = subject()
-        let item = space.buildPendingSavedItem()
+        let savedItem = space.buildPendingSavedItem()
+        savedItem.item = space.buildItem()
         try space.save()
-        viewModel.selectCell(with: .item(item.objectID), sender: UIView())
+        viewModel.selectCell(with: .item(savedItem.objectID), sender: UIView())
 
         guard let selectedItem = viewModel.selectedItem else {
             XCTFail("Received nil for selectedItem")

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -72,8 +72,8 @@ class SlateDetailViewModelTests: XCTestCase {
 
     func test_fetch_sendsSnapshotWithItemForEachRecommendation() throws {
         let recommendations: [Recommendation] = [
-            space.buildRecommendation(remoteID: "slate-1-recommendation-1"),
-            space.buildRecommendation(remoteID: "slate-1-recommendation-2")
+            space.buildRecommendation(remoteID: "slate-1-recommendation-1", item: space.buildItem()),
+            space.buildRecommendation(remoteID: "slate-1-recommendation-2", item: space.buildItem())
         ]
 
         let slate: Slate = try space.createSlate(
@@ -136,7 +136,7 @@ class SlateDetailViewModelTests: XCTestCase {
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
-        let recommendation = space.buildRecommendation()
+        let recommendation = space.buildRecommendation(item: space.buildItem())
         let slate = try space.createSlate(recommendations: [recommendation])
         try space.save()
         let viewModel = subject(slate: space.viewObject(with: slate.objectID) as! Slate)

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -136,7 +136,8 @@ class SlateDetailViewModelTests: XCTestCase {
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
-        let recommendation = space.buildRecommendation(item: space.buildItem())
+        let savedItem = try space.createSavedItem(item: space.buildItem())
+        let recommendation = space.buildRecommendation(item: savedItem.item)
         let slate = try space.createSlate(recommendations: [recommendation])
         try space.save()
         let viewModel = subject(slate: space.viewObject(with: slate.objectID) as! Slate)

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -239,7 +239,7 @@ extension Space {
     @discardableResult
     func createRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil
+        item: Item
     ) throws -> Recommendation {
         try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
@@ -255,7 +255,7 @@ extension Space {
     @discardableResult
     func buildRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil,
+        item: Item,
         imageURL: URL? = nil,
         title: String? = nil,
         excerpt: String?  = nil

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -71,6 +71,7 @@ extension Space {
         func buildPendingSavedItem() -> SavedItem {
             backgroundContext.performAndWait {
                 let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: "https://mozilla.com/example")!)
+                savedItem.createdAt = Date()
                 return savedItem
             }
         }
@@ -266,7 +267,6 @@ extension Space {
             recommendation.title = title
             recommendation.excerpt = excerpt
             recommendation.imageURL = imageURL
-
             return recommendation
         }
     }

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -91,7 +91,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
             for index in 1...2 {
                 let tag: Tag = Tag(context: self.space.backgroundContext)
                 tag.name = "tag \(index)"
-                tag.remoteID = tag.name?.uppercased()
+                tag.remoteID = tag.name.uppercased()
                 tags.append(tag)
             }
             item.tags = NSOrderedSet(array: tags.compactMap { $0 })
@@ -112,7 +112,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 1...3 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags
@@ -133,7 +133,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 1...4 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags
@@ -154,7 +154,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 1...4 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags
@@ -174,7 +174,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 1...3 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags
@@ -194,7 +194,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
             for index in 2...3 {
                 let tag: Tag = Tag(context: self.space.viewContext)
                 tag.name = "tag \(index)"
-                tag.remoteID = tag.name?.uppercased()
+                tag.remoteID = tag.name.uppercased()
                 tags.append(tag)
             }
                 return tags
@@ -237,7 +237,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 2...3 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags
@@ -268,7 +268,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 for index in 2...3 {
                     let tag: Tag = Tag(context: self.space.viewContext)
                     tag.name = "tag \(index)"
-                    tag.remoteID = tag.name?.uppercased()
+                    tag.remoteID = tag.name.uppercased()
                     tags.append(tag)
                 }
                 return tags

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -325,7 +325,7 @@ extension SavedItemViewModelTests {
         saveService.stubRetrieveTags { _ in
             let tag: Tag = Tag(context: self.space.backgroundContext)
             tag.name = "tag 1"
-            tag.remoteID = tag.name?.uppercased()
+            tag.remoteID = tag.name.uppercased()
             return [tag]
         }
         let tags = viewModel.retrieveTags(excluding: [])

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -203,7 +203,7 @@ extension Space {
     @discardableResult
     func createRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil
+        item: Item
     ) throws -> Recommendation {
         try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
@@ -219,7 +219,7 @@ extension Space {
     @discardableResult
     func buildRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil
+        item: Item
     ) -> Recommendation {
         backgroundContext.performAndWait {
             let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -81,7 +81,7 @@ extension APISlateServiceTests {
                 let item = recommendation.item
                 XCTAssertNotNil(item)
                 XCTAssertEqual(item.remoteID, "item-1")
-                XCTAssertEqual(item.givenURL.absoluteString, "https://given.example.com/rec-1")
+                XCTAssertEqual(item.givenURL.absoluteString, "https://given.example.com/slate-1-rec-1")
                 XCTAssertEqual(item.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
                 XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
                 XCTAssertEqual(item.language, "en")

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -80,23 +80,23 @@ extension APISlateServiceTests {
 
                 let item = recommendation.item
                 XCTAssertNotNil(item)
-                XCTAssertEqual(item!.remoteID, "item-1")
-                XCTAssertEqual(item!.givenURL.absoluteString, "https://given.example.com/rec-1")
-                XCTAssertEqual(item!.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
-                XCTAssertEqual(item!.title, "Slate 1, Recommendation 1")
-                XCTAssertEqual(item!.language, "en")
-                XCTAssertEqual(item!.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
-                XCTAssertEqual(item!.timeToRead, 1)
-                XCTAssertEqual(item!.excerpt, "Cursus Aenean Elit")
-                XCTAssertEqual(item!.datePublished?.timeIntervalSince1970, 1609502461)
-                XCTAssertEqual(item!.domain, "slate-1-rec-1.example.com")
-                XCTAssertEqual(item!.domainMetadata?.name, "Lifehacker")
-                XCTAssertEqual(item!.domainMetadata?.logo?.absoluteString, "https://slate-1-rec-1.example.com/logo.png")
-                XCTAssertEqual(item!.isArticle, true)
-                XCTAssertEqual(item!.hasImage, .hasImages)
-                XCTAssertEqual(item!.hasVideo, .hasVideos)
+                XCTAssertEqual(item.remoteID, "item-1")
+                XCTAssertEqual(item.givenURL.absoluteString, "https://given.example.com/rec-1")
+                XCTAssertEqual(item.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
+                XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
+                XCTAssertEqual(item.language, "en")
+                XCTAssertEqual(item.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
+                XCTAssertEqual(item.timeToRead, 1)
+                XCTAssertEqual(item.excerpt, "Cursus Aenean Elit")
+                XCTAssertEqual(item.datePublished?.timeIntervalSince1970, 1609502461)
+                XCTAssertEqual(item.domain, "slate-1-rec-1.example.com")
+                XCTAssertEqual(item.domainMetadata?.name, "Lifehacker")
+                XCTAssertEqual(item.domainMetadata?.logo?.absoluteString, "https://slate-1-rec-1.example.com/logo.png")
+                XCTAssertEqual(item.isArticle, true)
+                XCTAssertEqual(item.hasImage, .hasImages)
+                XCTAssertEqual(item.hasVideo, .hasVideos)
 
-                let images = item!.images?.compactMap { $0 as? Image } ?? []
+                let images = item.images?.compactMap { $0 as? Image } ?? []
                 XCTAssertEqual(images[0].source, URL(string: "http://example.com/rec-1/image-1.jpg"))
             }
 

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -75,7 +75,14 @@
                                 "hasVideo": "HAS_VIDEOS",
                                 "syndicatedArticle": {
                                     "__typename": "SyndicatedArticle",
-                                    "itemId": "syndicated-article-item-id"
+                                    "itemId": "syndicated-article-item-id",
+                                    "title": "syndicated-article-title",
+                                    "mainImage": "https://example.com/syndicated-article-image.jpg",
+                                    "excerpt": "syndicated-article-excerpt",
+                                    "publisher": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "syndicated-article-publisher"
+                                    }
                                 }
                             }
                         }

--- a/PocketKit/Tests/SyncTests/Fixtures/slates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slates.json
@@ -21,7 +21,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-1",
-                                "givenUrl": "https://given.example.com/rec-1",
+                                "givenUrl": "https://given.example.com/slate-1-rec-1",
                                 "resolvedUrl": "https://resolved.example.com/rec-1",
                                 "title": "Slate 1, Recommendation 1",
                                 "language": "en",
@@ -60,7 +60,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-2",
-                                "givenUrl": "https://given.example.com/rec-2",
+                                "givenUrl": "https://given.example.com/slate-1-rec-2",
                                 "resolvedUrl": "https://resolved.example.com/rec-2",
                                 "title": "Slate 1, Recommendation 2",
                                 "language": "en",
@@ -101,7 +101,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-3",
-                                "givenUrl": "https://given.example.com/rec-1",
+                                "givenUrl": "https://given.example.com/slate-2-rec-1",
                                 "resolvedUrl": "https://resolved.example.com/rec-1",
                                 "title": "Slate 2, Recommendation 1",
                                 "language": "en",

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -71,7 +71,7 @@ class SaveItemOperationTests: XCTestCase {
         XCTAssertEqual(performCall?.mutation.input.url, url.absoluteString)
 
         let item = try space.fetchSavedItem(byRemoteID: "saved-item-1")
-        XCTAssertEqual(savedItem.item?.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
+        XCTAssertEqual(savedItem.item.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
         XCTAssertNotNil(item)
     }
 

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -385,10 +385,10 @@ extension PocketSaveServiceTests {
     func test_retrieveTags_updatesInfoViewModel() {
         let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 1"
-        tag.remoteID = tag.name?.uppercased()
+        tag.remoteID = tag.name.uppercased()
         let tag2: Tag = Tag(context: space.backgroundContext)
         tag2.name = "tag 2"
-        tag2.remoteID = tag2.name?.uppercased()
+        tag2.remoteID = tag2.name.uppercased()
         let service = subject()
         let tags = service.retrieveTags(excluding: ["tag 1"])
         XCTAssertEqual(tags?.count, 1)
@@ -398,10 +398,10 @@ extension PocketSaveServiceTests {
     func test_filterTags_retrievesFilteredTags() {
         let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 1"
-        tag.remoteID = tag.name?.uppercased()
+        tag.remoteID = tag.name.uppercased()
         let tag2: Tag = Tag(context: space.backgroundContext)
         tag2.name = "tag 2"
-        tag2.remoteID = tag2.name?.uppercased()
+        tag2.remoteID = tag2.name.uppercased()
         let service = subject()
         let tags = service.filterTags(with: "t", excluding: ["tag 2"])
         XCTAssertEqual(tags?.count, 1)

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -189,8 +189,8 @@ class PocketSourceTests: XCTestCase {
         }
 
         let savedItem = try space.createSavedItem(item: space.buildItem())
-        let item = savedItem.item!
-        item.recommendation = space.buildRecommendation()
+        let item = savedItem.item
+        item.recommendation = space.buildRecommendation(item: item)
 
         let remoteItemID = item.remoteID
 
@@ -207,7 +207,7 @@ class PocketSourceTests: XCTestCase {
         }
 
         let savedItem = try space.createSavedItem(item: space.buildItem())
-        let item = savedItem.item!
+        let item = savedItem.item
 
         let remoteItemID = item.remoteID
 
@@ -385,8 +385,8 @@ class PocketSourceTests: XCTestCase {
     }
 
     func test_removeRecommendation_removesRecommendationFromSpace() throws {
-        let recommendation1 = space.buildRecommendation()
-        let recommendation2 = space.buildRecommendation()
+        let recommendation1 = space.buildRecommendation(item: space.buildItem())
+        let recommendation2 = space.buildRecommendation(item: space.buildItem())
 
         let source = subject()
         source.remove(recommendation: recommendation1)
@@ -403,7 +403,6 @@ class PocketSourceTests: XCTestCase {
         )
 
         let savedItem = try space.createSavedItem(remoteID: "a-saved-item")
-        savedItem.item = nil
         try space.save()
 
         let source = subject()
@@ -429,7 +428,7 @@ class PocketSourceTests: XCTestCase {
         try await source.fetchDetails(for: recommendation)
 
         space.backgroundRefresh(recommendation, mergeChanges: true)
-        XCTAssertNotNil(recommendation.item?.article)
+        XCTAssertNotNil(recommendation.item.article)
         XCTAssertFalse(recommendation.hasChanges)
     }
 
@@ -472,7 +471,7 @@ class PocketSourceTests: XCTestCase {
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
         XCTAssertEqual(savedItems[0].url, url)
-        XCTAssertGreaterThan(savedItems[0].createdAt!, seedDate)
+        XCTAssertGreaterThan(savedItems[0].createdAt, seedDate)
     }
 
     func test_saveURL_withArchivedSavedItem_unarchivesItem_andExecutesSaveItemOperation() throws {
@@ -703,8 +702,8 @@ extension PocketSourceTests {
         let savedItem = source.fetchOrCreateSavedItem(with: "saved-item", and: itemParts)
 
         XCTAssertEqual(savedItem?.remoteID, "saved-item")
-        XCTAssertEqual(savedItem?.item?.title, "item-title")
-        XCTAssertEqual(savedItem?.item?.bestURL?.absoluteString, "http://localhost:8080/hello")
+        XCTAssertEqual(savedItem?.item.title, "item-title")
+        XCTAssertEqual(savedItem?.item.bestURL?.absoluteString, "http://localhost:8080/hello")
     }
 
     private func setupLocalSavesSearch(with url: URL? = nil) throws {

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -280,7 +280,7 @@ class PocketSourceTests: XCTestCase {
         }
         savesResultsController.delegate = delegate
 
-        let item2 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(title: "Item 2"))
+        let item2 = try space.createSavedItem(remoteID: "saved-item-2", url: "http://example.com/item-2", createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(remoteID: "item-2", title: "Item 2", givenURL: URL(string: "https://example.com/items/item-2")))
         try space.save()
         try savesResultsController.performFetch()
 
@@ -596,7 +596,7 @@ extension PocketSourceTests {
             let tag: Tag = Tag(context: space.backgroundContext)
             tag.remoteID = "id \(num)"
             tag.name = "tag \(num)"
-            return space.buildSavedItem(isArchived: isArchived, tags: [tag])
+            return space.buildSavedItem(remoteID: "saved-item-\(num)", url: "http://example.com/item-\(num)", isArchived: isArchived, tags: [tag])
         }
     }
 }
@@ -628,8 +628,8 @@ extension PocketSourceTests {
 
     func test_savesSearches_withFreeUser_showSearchResults_searchUrl() throws {
         user.setPremiumStatus(false)
-        let url = URL(string: "testUrl.saved")
-        try setupLocalSavesSearch(with: url)
+        let urlString = "testUrl.saved"
+        try setupLocalSavesSearch(with: urlString)
 
         let source = subject()
         let results = source.searchSaves(search: "saved")
@@ -642,8 +642,8 @@ extension PocketSourceTests {
     func test_savesSearches_withPremiumUser_showSearchResults_searchUrl() throws {
         user.setPremiumStatus(true)
 
-        let url = URL(string: "testUrl.saved")
-        try setupLocalSavesSearch(with: url)
+        let urlString = "testUrl.saved"
+        try setupLocalSavesSearch(with: urlString)
 
         let source = subject()
         let results = source.searchSaves(search: "saved")
@@ -706,12 +706,17 @@ extension PocketSourceTests {
         XCTAssertEqual(savedItem?.item.bestURL?.absoluteString, "http://localhost:8080/hello")
     }
 
-    private func setupLocalSavesSearch(with url: URL? = nil) throws {
+    private func setupLocalSavesSearch(with urlString: String? = nil) throws {
+        var url: URL?
         _ = (1...2).map {
+            if let urlString {
+                url = URL(string: urlString + "-\($0)")
+            }
             space.buildSavedItem(
                 remoteID: "saved-item-\($0)",
+                url: "http://example.com/item-\($0)",
                 createdAt: Date(timeIntervalSince1970: TimeInterval($0)),
-                item: space.buildItem(title: "saved-item-\($0)", givenURL: url)
+                item: space.buildItem(remoteID: "saved-item-\($0)", title: "saved-item-\($0)", givenURL: url, num: $0)
             )
         }
         try space.save()

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -36,7 +36,7 @@ class SpaceTests: XCTestCase {
         let space = subject()
         let tag: Tag = Tag(context: space.backgroundContext)
         tag.name = "tag 0"
-        tag.remoteID = tag.name?.uppercased()
+        tag.remoteID = tag.name.uppercased()
         _ = space.buildSavedItem(tags: [tag])
         _ = createItemsWithTags(2, isArchived: true)
 
@@ -48,7 +48,7 @@ class SpaceTests: XCTestCase {
         let space = subject()
         let tag1: Tag = Tag(context: space.backgroundContext)
         tag1.name = "tag 1"
-        tag1.remoteID = tag1.name?.uppercased()
+        tag1.remoteID = tag1.name.uppercased()
 
         let fetchedTag1 = space.fetchOrCreateTag(byName: "tag 1")
         let fetchedTag2 = space.fetchOrCreateTag(byName: "tag 2")

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -61,11 +61,10 @@ class SpaceTests: XCTestCase {
     func testFetchTagsByID() throws {
         let space = subject()
         let tag1: Tag = Tag(context: space.backgroundContext)
-        tag1.remoteID = "id 1"
         tag1.name = "tag 1"
 
-        let fetchedTag1 = try space.fetchTag(byID: "id 1")
-        let fetchedTag2 = try space.fetchTag(byID: "id 2")
+        let fetchedTag1 = try space.fetchTag(by: "tag 1")
+        let fetchedTag2 = try space.fetchTag(by: "tag 2")
 
         XCTAssertEqual(fetchedTag1?.name, "tag 1")
         XCTAssertNil(fetchedTag2)

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -94,7 +94,7 @@ class FetchSavesTests: XCTestCase {
         XCTAssertEqual(savedItem.cursor, "cursor-1")
         XCTAssertEqual(savedItem.remoteID, "saved-item-1")
         XCTAssertEqual(savedItem.url, URL(string: "https://example.com/item-1")!)
-        XCTAssertEqual(savedItem.createdAt?.timeIntervalSince1970, 0)
+        XCTAssertEqual(savedItem.createdAt.timeIntervalSince1970, 0)
         XCTAssertEqual(savedItem.deletedAt?.timeIntervalSince1970, nil)
         XCTAssertEqual(savedItem.isArchived, false)
         XCTAssertTrue(savedItem.isFavorite)
@@ -104,33 +104,33 @@ class FetchSavesTests: XCTestCase {
         XCTAssertEqual(tags?[0].name, "tag-1")
 
         let item = savedItem.item
-        XCTAssertEqual(item?.remoteID, "item-1")
-        XCTAssertEqual(item?.givenURL, URL(string: "https://given.example.com/item-1")!)
-        XCTAssertEqual(item?.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
-        XCTAssertEqual(item?.title, "Item 1")
-        XCTAssertEqual(item?.topImageURL, URL(string: "https://example.com/item-1/top-image.jpg")!)
-        XCTAssertEqual(item?.domain, "example.com")
-        XCTAssertEqual(item?.language, "en")
-        XCTAssertEqual(item?.timeToRead, 6)
-        XCTAssertEqual(item?.excerpt, "Cursus Aenean Elit")
-        XCTAssertEqual(item?.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
+        XCTAssertEqual(item.remoteID, "item-1")
+        XCTAssertEqual(item.givenURL, URL(string: "https://given.example.com/item-1")!)
+        XCTAssertEqual(item.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
+        XCTAssertEqual(item.title, "Item 1")
+        XCTAssertEqual(item.topImageURL, URL(string: "https://example.com/item-1/top-image.jpg")!)
+        XCTAssertEqual(item.domain, "example.com")
+        XCTAssertEqual(item.language, "en")
+        XCTAssertEqual(item.timeToRead, 6)
+        XCTAssertEqual(item.excerpt, "Cursus Aenean Elit")
+        XCTAssertEqual(item.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
 
         let expected: [ArticleComponent] = Fixture.load(name: "marticle").decode()
-        XCTAssertEqual(item?.article?.components, expected)
+        XCTAssertEqual(item.article?.components, expected)
 
-        let authors = item?.authors?.compactMap { $0 as? Author }
+        let authors = item.authors?.compactMap { $0 as? Author }
         XCTAssertEqual(authors?[0].id, "author-1")
         XCTAssertEqual(authors?[0].name, "Eleanor")
         XCTAssertEqual(authors?[0].url, URL(string: "https://example.com/authors/eleanor")!)
 
-        let domain = item?.domainMetadata
+        let domain = item.domainMetadata
         XCTAssertEqual(domain?.name, "WIRED")
         XCTAssertEqual(domain?.logo, URL(string: "http://example.com/item-1/domain-logo.jpg")!)
 
-        let images = item?.images?.compactMap { $0 as? Image } ?? []
+        let images = item.images?.compactMap { $0 as? Image } ?? []
         XCTAssertEqual(images[0].source, URL(string: "http://example.com/item-1/image-1.jpg"))
 
-        XCTAssertEqual(item?.syndicatedArticle?.itemID, "syndicated-article-item-id")
+        XCTAssertEqual(item.syndicatedArticle?.itemID, "syndicated-article-item-id")
     }
 
     func test_refresh_whenFetchSucceeds_andResultContainsDuplicateItems_createsSingleItem() async throws {
@@ -156,7 +156,7 @@ class FetchSavesTests: XCTestCase {
         _ = await service.execute(syncTaskId: task.objectID)
 
         let item = try space.fetchSavedItem(byRemoteID: "saved-item-1")
-        XCTAssertEqual(item?.item?.title, "Updated Item 1")
+        XCTAssertEqual(item?.item.title, "Updated Item 1")
     }
 
     func test_refresh_whenFetchFails_sendsErrorOverGivenSubject() async throws {

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -141,11 +141,12 @@ extension Space {
         givenURL: URL? = URL(string: "https://example.com/items/item-1"),
         resolvedURL: URL? = nil,
         isArticle: Bool = true,
-        syndicatedArticle: SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil,
+        num: Int? = nil
     ) -> Item {
         var url = givenURL
         if url == nil {
-            url = URL(string: "https://example.com/items/item-1")
+            url = URL(string: "https://example.com/items/item-1-\(num)")
         }
 
         return backgroundContext.performAndWait {

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -68,7 +68,7 @@ extension Space {
     func createSyndicatedArticle(
         excerpt: String? = nil,
         imageURL: URL? = nil,
-        itemID: String? = nil,
+        itemID: String,
         publisherName: String? = nil,
         title: String? = nil,
         item: Item? = nil
@@ -92,7 +92,7 @@ extension Space {
     func buildSyndicatedArticle(
         excerpt: String? = nil,
         imageURL: URL? = nil,
-        itemID: String? = nil,
+        itemID: String,
         publisherName: String? = nil,
         title: String? = nil,
         item: Item? = nil
@@ -249,7 +249,7 @@ extension Space {
     @discardableResult
     func createRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil
+        item: Item
     ) throws -> Recommendation {
         try backgroundContext.performAndWait {
             let recommendation = buildRecommendation(
@@ -265,7 +265,7 @@ extension Space {
     @discardableResult
     func buildRecommendation(
         remoteID: String = "slate-1-rec-1",
-        item: Item? = nil
+        item: Item
     ) -> Recommendation {
         backgroundContext.performAndWait {
             let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -70,7 +70,7 @@ extension Space {
         imageURL: URL? = nil,
         itemID: String,
         publisherName: String? = nil,
-        title: String? = nil,
+        title: String,
         item: Item? = nil
     ) throws -> SyndicatedArticle {
         try backgroundContext.performAndWait {
@@ -94,7 +94,7 @@ extension Space {
         imageURL: URL? = nil,
         itemID: String,
         publisherName: String? = nil,
-        title: String? = nil,
+        title: String,
         item: Item? = nil
     ) -> SyndicatedArticle {
         backgroundContext.performAndWait {


### PR DESCRIPTION
## Summary
* This PR:
    - Sets the code gen to `Manual/none` for all Core Data entities
    - Matches the nullability and uniqueness of fields with the objects in the graph

## Implementation Details
* All entities were updated as described in the summary.
> **Note**
since we are updating fields, Core Data will attempt a lightweight migration. This might cause instability and/or crashes while updating from a previous build. It is recommended to delete and reinstall. This issue will not affect production users migrating from Pocket 7 since they won't have a previous version of the Core Data DB.

## Test Steps
* Build/run this branch and make sure that the app works as expected. Especially look for crashes or any data inconsistency in Home and Saves

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
