### PR TITLE
fix: sign out on first launch of share extension if needed

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -17,7 +17,14 @@ class MainViewController: UIViewController {
         let appSession = services.appSession
         let encryptedStore = PocketEncryptedStore()
         let userDefaults = services.userDefaults
+        let user = services.user
         let child: UIViewController
+
+        SignOutOnFirstLaunch(
+            appSession: appSession,
+            user: user,
+            userDefaults: userDefaults
+        ).signOutOnFirstLaunch()
 
         let legacyUserMigration = LegacyUserMigration(
             userDefaults: userDefaults,

--- a/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
@@ -1,15 +1,13 @@
 import Foundation
-import Sync
-import SharedPocketKit
 
-class SignOutOnFirstLaunch {
+public class SignOutOnFirstLaunch {
     static let hasAppBeenLaunchedPreviouslyKey = UserDefaults.Key.hasAppBeenLaunchedPreviously
 
     private let appSession: AppSession
     private let user: User
     private let userDefaults: UserDefaults
 
-    init(
+    public init(
         appSession: AppSession,
         user: User,
         userDefaults: UserDefaults
@@ -19,7 +17,7 @@ class SignOutOnFirstLaunch {
         self.userDefaults = userDefaults
     }
 
-    var hasAppBeenLaunchedPreviously: Bool {
+    private var hasAppBeenLaunchedPreviously: Bool {
         get {
             userDefaults.bool(forKey: Self.hasAppBeenLaunchedPreviouslyKey)
         }
@@ -28,7 +26,7 @@ class SignOutOnFirstLaunch {
         }
     }
 
-    func signOutOnFirstLaunch() {
+    public func signOutOnFirstLaunch() {
         guard !hasAppBeenLaunchedPreviously else {
             return
         }


### PR DESCRIPTION
## Summary

Fixes an issue where a login could persist between app installs if first using the share extension, and where a migrated user who launched the share extension first would not be logged in after opening the app for the first time.

## References 

IN-1329

## Implementation Details

_Important note: the keychain is not deleted on app uninstall; we have to manually clear it on first launch._

Since the keychain is not deleted, in order to ensure a clean slate on first install, the main app target would attempt to run a cleanup operation on first launch (i.e after installing). The completion of this operation is then noted in `UserDefaults` (on first launch, if this value is not found, perform the operation).

If the share extension is launched first, the user's session is migrated to the keychain. If the app is subsequently launched for the first time, this cleanup operation is performed (since it's not marked as completed), which nils out the user session from keychain. The migration is then subsequently run, which migrates the user session _back_, however the app was still set up for a nil session (i.e logged out). So, a second launch would show the user logged in.

The solution is as it is for the user migration - for either the share extension _or_ the app, run the keychain cleanup operation. This will be run only once across all targets, but will ensure we're in the right state when launching a second target.

## Test Steps

- [ ] Install production Pocket app
- [ ] Install build with this branch's fixes 
- [ ] Run the share extension **first**; the session should be migrated
- [ ] Run the app; the session should be restored and the user should be logged in

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
