### PR TITLE
fix(home): spacing between actions and thumbnails

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
@@ -20,6 +20,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
         static let maxDetailLines = 2
         static let actionButtonImageSize = CGSize(width: 20, height: 20)
         static let layoutMargins = UIEdgeInsets(top: Margins.normal.rawValue, left: Margins.normal.rawValue, bottom: Margins.normal.rawValue, right: Margins.normal.rawValue)
+        static let stackSpacing: CGFloat = 4
     }
 
     private let titleLabel: UILabel = {
@@ -54,10 +55,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
     }()
 
     private let favoriteButton: UIButton = {
-        var config = UIButton.Configuration.plain()
-        config.contentInsets = .zero
-
-        let button = UIButton(configuration: config, primaryAction: nil)
+        let button = RecommendationButton(asset: .favorite)
         button.accessibilityIdentifier = "favorite"
         return button
     }()
@@ -69,7 +67,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
     }()
 
     private let overflowButton: UIButton = {
-        let button = RecommendationOverflowButton()
+        let button = RecommendationButton(asset: .overflow)
         button.accessibilityIdentifier = "overflow-button"
         button.showsMenuAsPrimaryAction = true
         return button
@@ -89,21 +87,22 @@ class HomeCarouselItemCell: UICollectionViewCell {
     private let bottomStack: UIStackView = {
         let stack = UIStackView()
         stack.distribution = .equalSpacing
+        stack.alignment = .bottom
         stack.axis = .horizontal
         return stack
     }()
 
     private let subtitleStack: UIStackView = {
         let stack = UIStackView()
-        stack.distribution = .fillProportionally
         stack.axis = .vertical
-        stack.spacing = 4
+        stack.spacing = Constants.stackSpacing
         return stack
     }()
 
     private let buttonStack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
+        stack.alignment = .bottom
         stack.spacing = 0
         return stack
     }()
@@ -138,7 +137,7 @@ class HomeCarouselItemCell: UICollectionViewCell {
 
             bottomStack.leadingAnchor.constraint(equalTo: mainContentStack.leadingAnchor),
             bottomStack.trailingAnchor.constraint(equalTo: mainContentStack.trailingAnchor),
-            bottomStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor).with(priority: .required),
+            bottomStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).with(priority: .required),
 
             contentView.topAnchor.constraint(equalTo: topAnchor),
             contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -165,8 +164,12 @@ extension HomeCarouselItemCell {
 
         if model.attributedTimeToRead.string.isEmpty {
             timeToReadLabel.isHidden = true
+            subtitleStack.setCustomSpacing(0, after: timeToReadLabel)
+            subtitleStack.setCustomSpacing(Constants.layoutMargins.bottom, after: domainLabel)
         } else {
             timeToReadLabel.isHidden = false
+            subtitleStack.setCustomSpacing(Constants.stackSpacing, after: domainLabel)
+            subtitleStack.setCustomSpacing(Constants.layoutMargins.bottom, after: timeToReadLabel)
         }
 
         favoriteButton.accessibilityLabel = model.favoriteAction?.title

--- a/PocketKit/Sources/PocketKit/Home/RecommendationButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationButton.swift
@@ -1,18 +1,19 @@
 import UIKit
 import Textile
 
-class RecommendationOverflowButton: UIButton {
-    init() {
+class RecommendationButton: UIButton {
+    init(asset: ImageAsset) {
         super.init(frame: .zero)
 
         configuration = .plain()
+
         configuration?.contentInsets = NSDirectionalEdgeInsets(
             top: 16,
-            leading: 8,
+            leading: 4,
             bottom: 16,
-            trailing: 8
+            trailing: 4
         )
-        configuration?.image = UIImage(asset: .overflow)
+        configuration?.image = UIImage(asset: asset)
             .resized(to: CGSize(width: 20, height: 20))
             .withTintColor(UIColor(.ui.grey5), renderingMode: .alwaysOriginal)
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -50,8 +50,8 @@ class RecommendationCell: UICollectionViewCell {
         return button
     }()
 
-    let overflowButton: RecommendationOverflowButton = {
-        let button = RecommendationOverflowButton()
+    let overflowButton: RecommendationButton = {
+        let button = RecommendationButton(asset: .overflow)
         button.accessibilityIdentifier = "overflow-button"
         button.showsMenuAsPrimaryAction = true
         return button

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCellHeroWide.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCellHeroWide.swift
@@ -57,8 +57,8 @@ class RecommendationCellHeroWide: UICollectionViewCell {
         return button
     }()
 
-    private let overflowMenuButton: RecommendationOverflowButton = {
-        let button = RecommendationOverflowButton()
+    private let overflowMenuButton: RecommendationButton = {
+        let button = RecommendationButton(asset: .overflow)
         button.accessibilityIdentifier = "overflow-button"
         button.showsMenuAsPrimaryAction = true
         return button


### PR DESCRIPTION
## Summary
Maintain consistent spacing between the actions and thumbnails by pinning the action buttons to the bottom

## References 
IN-1229

## Implementation Details
Change favorite button to use same configuration as overflow to maintain consistent padding. Align stacks to the bottom and created custom spacing so that the subtitle stack is aligned with the button stacks. They should be 16.0 from the bottom.

## Test Steps
1. Nav to Recent Saves
2. Scroll the Recent Saves
3. Notice not all of the space between the secondary actions and the images is consistent

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![image](https://user-images.githubusercontent.com/6743397/232533164-035d8f51-7651-4267-ab14-d04810a21505.png)
