### PR TITLE
fix(logs): adding explict logging and error handling to mutations

### DIFF
--- a/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
@@ -113,12 +113,12 @@ extension RefreshCoordinator {
     /// Submit the request to be scheduled anytime after the given interval
     private func submitRequest() {
         guard let refreshInterval else {
-            Log.info("No refresh interval set by developer, not scheduling a refresh for \(type(of: self))")
+            Log.info("No refresh interval set by developer, not scheduling a refresh for \(self.taskID)")
             return
         }
 
         guard appSession.currentSession != nil else {
-            Log.warning("No user session, so not scheduling a refresh \(type(of: self))")
+            Log.warning("No user session, so not scheduling a refresh \(self.taskID)")
             return
         }
 
@@ -134,7 +134,7 @@ extension RefreshCoordinator {
             request.earliestBeginDate = Date().addingTimeInterval(refreshInterval)
             try taskScheduler.submit(request)
         } catch {
-            Log.warning("Could not submit background task request for \(type(of: self))")
+            Log.warning("Could not submit background task request for \(self.taskID)")
             Log.capture(error: error)
         }
     }
@@ -158,6 +158,8 @@ extension RefreshCoordinator {
         task.expirationHandler = {
             task.setTaskCompleted(success: false)
         }
+
+        Log.breadcrumb(category: "background", level: .debug, message: "Starting background refresh call for \(self.taskID)")
 
         /// Call the refresh function and then upon sucess set the task completed
         self.refreshData {


### PR DESCRIPTION
## Summary

While this doesn't solve the root cause on IN-1306. It does start capturing more specific data for us. With the logging added the root problem appears to be the CoreData store SavedItem object somehow becoming invalid and causing the store save method to rollback which in turn does not update the UI. 

However when you are online the problem does not appear, because the server will do a full object refresh with the SavedItem in our store. 

--

I am also proposing that we implement the ability to post an error from Sync or similar to NotificationCenter that will trigger a banner or something to indicate there is an error like this.

## References 
* IN-1306

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Manipulate items and see breadcrumbs in the logs.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
