### PR TITLE
feat(api): moving to api domain

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -977,7 +977,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				POCKET_API_BASE_URL = "https://getpocket.com/graphql";
+				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1035,7 +1035,7 @@
 				MARKETING_VERSION = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				POCKET_API_BASE_URL = "https://getpocket.com/graphql";
+				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -1265,7 +1265,7 @@
 				MARKETING_VERSION = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				POCKET_API_BASE_URL = "https://getpocket.com/graphql";
+				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -1482,7 +1482,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				POCKET_API_BASE_URL = "https://getpocket.com/graphql";
+				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};

--- a/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
@@ -13,7 +13,7 @@ extension ApolloClient {
     ) -> ApolloClient {
         let urlStringFromEnvironment = ProcessInfo.processInfo.environment["POCKET_CLIENT_API_URL"]
         let urlStringFromBundle = Bundle.main.infoDictionary?["PocketAPIBaseURL"] as? String
-        let urlString = urlStringFromEnvironment ?? urlStringFromBundle ?? "https://getpocket.com/graphql"
+        let urlString = urlStringFromEnvironment ?? urlStringFromBundle ?? "https://api.getpocket.com/graphql"
         let url = URL(string: urlString)!
 
         let store = ApolloStore()

--- a/Tests iOS/MyList/CoreSpotlightTests.swift
+++ b/Tests iOS/MyList/CoreSpotlightTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sails
+import Combine
+import NIO
+
+class CoreSpotlightTests: XCTestCase {
+    var server: Application!
+    var app: PocketAppElement!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let uiApp = XCUIApplication()
+        app = PocketAppElement(app: uiApp)
+
+        server = Application()
+
+        server.routes.post("/graphql") { request, _ -> Response in
+            return .fallbackResponses(apiRequest: ClientAPIRequest(request))
+        }
+
+        try server.start()
+    }
+
+    override func tearDownWithError() throws {
+        try server.stop()
+        app.terminate()
+    }
+
+    func test_openingCoreSpotlightItem_OpensToDetail() {
+        app.launch()
+        app.tabBar.savesButton.wait().tap()
+        app.saves.wait()
+        app.saves.itemView(at: 0).wait()
+        app.terminate()
+    }
+
+}


### PR DESCRIPTION
## Summary

In order to seperate traffic on the backend, we need to move clients to api.getpocket.com. Our android app has already been on this domain for a few years, and we should ensure iOS is on it before launch.