### PR TITLE
fix(timeout): bumping wait timeout for test

### DIFF
--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -76,7 +76,7 @@ final class PushNotificationServiceTests: XCTestCase {
 
         NotificationCenter.default.post(name: .userLoggedOut, object: SharedPocketKit.Session(guid: "logout-test-guid", accessToken: "logout-test-access-token", userIdentifier: "logout-test-id"))
 
-        wait(for: [sessionExpectation], timeout: 10)
+        wait(for: [sessionExpectation])
 
         XCTAssertEqual(braze.loggedOutCalls(), 1)
         XCTAssertEqual(instantSync.loggedOutCalls(), 1)

--- a/Tests iOS/Support/Elements/PocketUIElement.swift
+++ b/Tests iOS/Support/Elements/PocketUIElement.swift
@@ -27,7 +27,7 @@ extension PocketUIElement {
 
     @discardableResult
     func wait(
-        timeout: TimeInterval = 3,
+        timeout: TimeInterval = 20,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Self {

--- a/Tests iOS/Support/Elements/XCUIElement+wait.swift
+++ b/Tests iOS/Support/Elements/XCUIElement+wait.swift
@@ -7,23 +7,11 @@ import XCTest
 extension XCUIElement {
     @discardableResult
     func wait(
-        timeout: TimeInterval = 10,
+        timeout: TimeInterval = 20,
         file: StaticString = #file,
         line: UInt = #line
     ) -> XCUIElement {
-        if exists {
-            XCTAssertTrue(exists)
-            return self
-        }
-
-        let cameIntoExistence = waitForExistence(timeout: timeout)
-        if cameIntoExistence {
-            XCTAssertTrue(exists)
-            return self
-        } else {
-            XCTFail("Expected \(self) to exist but it was not found.", file: file, line: line)
-        }
-
+        XCTAssertTrue(waitForExistence(timeout: timeout))
         return self
     }
 

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -12,11 +12,11 @@ extension XCTestCase {
     }
 
     func wait(for expectations: [XCTestExpectation]) {
-        wait(for: expectations, timeout: 10)
+        wait(for: expectations, timeout: 20)
     }
 
     func fulfillment(of expectations: [XCTestExpectation]) async {
-        await fulfillment(of: expectations, timeout: 10)
+        await fulfillment(of: expectations, timeout: 20)
     }
 
     /// Very basic swipe to element function. As our needs increase, we will want something like https://github.com/PGSSoft/AutoMate/blob/master/AutoMate/XCTest%20extensions/XCUIElement%2BSwipe.swift


### PR DESCRIPTION
## Summary

Sometimes some screens take a bit to load on the CI hardware. Bumping timeout to 20 to account for this.

## Implementation Details

Ideally we should move all the timeouts to a helper method, we can do that after this is successful and we do a audit of tests.