### PR TITLE
Premium subscriptions - revert to free if subscription expired

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -181,6 +181,9 @@ private extension PocketSubscriptionStore {
     func updateSubscriptionStatus(_ verifiedTransaction: Transaction) async {
         guard let expirationDate = verifiedTransaction.expirationDate, expirationDate > Date() else {
             await verifiedTransaction.finish()
+            // if the subscription is expired, revert to free
+            state = .unsubscribed
+            user.setPremiumStatus(false)
             Log.capture(message: "Subscription was expired")
             return
         }


### PR DESCRIPTION

## Summary
* This PR reverts to free/unsubscribed status if the subscription that comes back from the App Store has expired

## References 
* IN- 1137

## Implementation Details
* Update `PocketSubscriptionStore`, add logic in `fetchActiveSubscription()` that reverts the app to free when a subscription is expired.

## Test Steps
* Build run this branch and login with a free sandbox account
- Purchase a monthly premium subscription
- Wait 3 minutes or more (this will allow the subscription to expire)
- Restart the app and make sure you can access the premium upgrade and re-subscribe
- Make any additional tests to make sure the premium upgrade screen is accessible for free users

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
