### PR TITLE
refactor(analytics): change identifiers from using discover to home

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Home.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Home.swift
@@ -98,7 +98,7 @@ public extension Events.Home {
                 ContentEntity(url: url),
             uiEntity: UiEntity(
                 .card,
-                identifier: "discover.open",
+                identifier: "home.slate.article.open",
                 index: positionInList
             ),
             extraEntities: [
@@ -118,7 +118,7 @@ public extension Events.Home {
             requirement: .viewable,
             uiEntity: UiEntity(
                 .card,
-                identifier: "discover.impression",
+                identifier: "home.slate.article.impression",
                 index: positionInList
             ),
             extraEntities: [
@@ -139,8 +139,8 @@ public extension Events.Home {
                 contentEntity: ContentEntity(url: url)
             ),
             uiEntity: UiEntity(
-                .card,
-                identifier: "discover.save",
+                .button,
+                identifier: "home.slate.article.save",
                 index: positionInList
             ),
             extraEntities: [
@@ -158,8 +158,8 @@ public extension Events.Home {
         return Engagement(
             .general,
             uiEntity: UiEntity(
-                .card,
-                identifier: "discover.unsave",
+                .button,
+                identifier: "home.slate.article.unsave",
                 index: positionInList
             ),
             extraEntities: [
@@ -178,8 +178,8 @@ public extension Events.Home {
         return Engagement(
             .general,
             uiEntity: UiEntity(
-                .card,
-                identifier: "discover.archive",
+                .button,
+                identifier: "home.slate.article.archive",
                 index: positionInList
             ),
             extraEntities: [
@@ -199,7 +199,7 @@ public extension Events.Home {
             .general,
             uiEntity: UiEntity(
                 .button,
-                identifier: "discover.share",
+                identifier: "home.slate.article.share",
                 index: positionInList
             ),
             extraEntities: [
@@ -222,7 +222,7 @@ public extension Events.Home {
             ),
             uiEntity: UiEntity(
                 .dialog,
-                identifier: "discover.report"
+                identifier: "home.slate.article.report"
             )
         )
     }

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -72,10 +72,10 @@ class HomeTests: XCTestCase {
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
 
-        async let slate1Rec1 = snowplowMicro.getFirstEvent(with: "discover.impression", recommendationId: "slate-1-rec-1")
-        async let slate1Rec2 = snowplowMicro.getFirstEvent(with: "discover.impression", recommendationId: "slate-1-rec-2")
-        async let slate2Rec1 = snowplowMicro.getFirstEvent(with: "discover.impression", recommendationId: "slate-2-rec-1")
-        async let slate2Rec2 = snowplowMicro.getFirstEvent(with: "discover.impression", recommendationId: "slate-1-rec-2")
+        async let slate1Rec1 = snowplowMicro.getFirstEvent(with: "home.slate.article.impression", recommendationId: "slate-1-rec-1")
+        async let slate1Rec2 = snowplowMicro.getFirstEvent(with: "home.slate.article.impression", recommendationId: "slate-1-rec-2")
+        async let slate2Rec1 = snowplowMicro.getFirstEvent(with: "home.slate.article.impression", recommendationId: "slate-2-rec-1")
+        async let slate2Rec2 = snowplowMicro.getFirstEvent(with: "home.slate.article.impression", recommendationId: "slate-1-rec-2")
 
         let recs = await [slate1Rec1, slate1Rec2, slate2Rec1, slate2Rec2]
         let loadedSlate1Rec1 = recs[0]!

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -51,7 +51,7 @@ class ReportARecommendationTests: XCTestCase {
         report.submitButton.wait().tap()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let event = await snowplowMicro.getFirstEvent(with: "discover.report")
+        let event = await snowplowMicro.getFirstEvent(with: "home.slate.article.report")
         event!.getReportContext()!.assertHas(reason: "other")
         event!.getContentContext()!.assertHas(url: "http://localhost:8080/item-1")
     }
@@ -88,7 +88,7 @@ class ReportARecommendationTests: XCTestCase {
         report.submitButton.wait().tap()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let event = await snowplowMicro.getFirstEvent(with: "discover.report")
+        let event = await snowplowMicro.getFirstEvent(with: "home.slate.article.report")
         event!.getReportContext()!.assertHas(reason: "other")
         event!.getContentContext()!.assertHas(url: "https://example.com/item-2")
     }


### PR DESCRIPTION
## Summary
Update identifiers from using discover to home

Slack convo: https://pocket.slack.com/archives/C01UH57EJKD/p1681756969627059

## References 
IN-1344

## Implementation Details
Update identifiers in `Home.swift` from using discover terminology to home. Also noticed that we were using card instead of buttons in some cases which did not match the spreadsheet.

## Test Steps
Verify that calls are using `home.slate.article` instead of `discover`

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
