### PR TITLE
fix(analytics): update selected tags tracking calls

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Tags.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Tags.swift
@@ -117,22 +117,57 @@ public extension Events.Tags {
         )
     }
 
-    static func addTagsRecentTagTapped() -> Event {
+    /// Fired when a user taps on a general tag from `Add Tags` screen
+    static func selectTagToAddToItem() -> Event {
         return Engagement(
             .general,
             uiEntity: UiEntity(
                 .button,
-                identifier: "global-nav.addTags.recentTags"
+                identifier: "global-nav.addTags.selectTag"
             )
         )
     }
 
-    static func filterTagsRecentTagTapped() -> Event {
+    /// Fired when a user taps on a recent tag from `Add Tags` screen
+    static func selectRecentTagToAddToItem() -> Event {
         return Engagement(
             .general,
             uiEntity: UiEntity(
                 .button,
-                identifier: "global-nav.filterTags.recentTags"
+                identifier: "global-nav.addTags.selectRecentTag"
+            )
+        )
+    }
+
+    /// Fired when a user selects on a general tag using the `Tags` screen after tapping on `Tagged` filter
+    static func selectTagToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.filterTags.selectTag"
+            )
+        )
+    }
+
+    /// Fired when a user selects `not tagged` using the `Tags` screen after tapping on `Tagged` filter
+    static func selectNotTaggedToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.filterTags.selectNotTagged"
+            )
+        )
+    }
+
+    /// Fired when a user selects on a recent tag using the `Tags` screen after tapping on `Tagged` filter
+    static func selectRecentTagToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "global-nav.filterTags.selectRecentTag"
             )
         )
     }

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -147,8 +147,14 @@ extension PocketAddTagsViewModel {
         tracker.track(event: Events.Tags.filteredTagsImpression(itemUrl: item.url))
     }
 
-    func trackRecentTagsTapped(with tag: TagType) {
-        guard case .recent = tag else { return }
-        tracker.track(event: Events.Tags.addTagsRecentTagTapped())
+    func trackExistingTagTapped(with tagType: TagType) {
+        switch tagType {
+        case .notTagged:
+            return
+        case .recent:
+            tracker.track(event: Events.Tags.selectRecentTagToAddToItem())
+        case .tag:
+            tracker.track(event: Events.Tags.selectTagToAddToItem())
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -45,18 +45,8 @@ class TagsFilterViewModel: ObservableObject {
     }
 
     func selectTag(_ tag: TagType) {
-        var tagContext = UIContext.button(identifier: .selectedTag)
-        if case .notTagged = tag {
-            tagContext = UIContext.button(identifier: .notTagged)
-        }
-        sendSelectedTagAnalytics(context: tagContext)
         selectedTag = tag
-        trackRecentTagsTapped(with: tag)
-    }
-
-    private func sendSelectedTagAnalytics(context: Context) {
-        let event = SnowplowEngagement(type: .general, value: nil)
-        tracker.track(event: event, [context])
+        trackSelectedTag(with: tag)
     }
 
     func delete(tags: [String]) {
@@ -81,7 +71,14 @@ class TagsFilterViewModel: ObservableObject {
 
 // MARK: Analytics
 extension TagsFilterViewModel {
-    func trackRecentTagsTapped(with tag: TagType) {
-        tracker.track(event: Events.Tags.filterTagsRecentTagTapped())
+    func trackSelectedTag(with tagType: TagType) {
+        switch tagType {
+        case .notTagged:
+            tracker.track(event: Events.Tags.selectNotTaggedToFilter())
+        case .recent:
+            tracker.track(event: Events.Tags.selectRecentTagToFilter())
+        case .tag:
+            tracker.track(event: Events.Tags.selectTagToFilter())
+        }
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -145,8 +145,14 @@ extension SaveToAddTagsViewModel {
         tracker.track(event: Events.Tags.filteredTagsImpression(itemUrl: url))
     }
 
-    func trackRecentTagsTapped(with tag: TagType) {
-        guard case .recent = tag else { return }
-        tracker.track(event: Events.Tags.addTagsRecentTagTapped())
+    func trackExistingTagTapped(with tagType: TagType) {
+        switch tagType {
+        case .notTagged:
+            return
+        case .recent:
+            tracker.track(event: Events.Tags.selectRecentTagToAddToItem())
+        case .tag:
+            tracker.track(event: Events.Tags.selectTagToAddToItem())
+        }
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
@@ -22,7 +22,7 @@ public protocol AddTagsViewModel: ObservableObject {
     func removeTag(with tag: String)
     func trackAddTag()
     func trackRemoveTag()
-    func trackRecentTagsTapped(with tag: TagType)
+    func trackExistingTagTapped(with tag: TagType)
 }
 
 public extension AddTagsViewModel {
@@ -51,7 +51,7 @@ public extension AddTagsViewModel {
     /// - Parameter tag: tag name user tapped on in the list
     func addExistingTag(with tag: TagType) {
         addTag(with: tag.name)
-        trackRecentTagsTapped(with: tag)
+        trackExistingTagTapped(with: tag)
     }
 
     /// Add tag to the input area and remove from the list

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -86,7 +86,11 @@ class AddTagsItemTests: XCTestCase {
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
 
-        let events = await [snowplowMicro.getFirstEvent(with: "global-nav.addTags.removeInputTag"), snowplowMicro.getFirstEvent(with: "global-nav.addTags.addTag")]
+        let events = await [
+            snowplowMicro.getFirstEvent(with: "global-nav.addTags.removeInputTag"),
+            snowplowMicro.getFirstEvent(with: "global-nav.addTags.addTag"),
+            snowplowMicro.getFirstEvent(with: "global-nav.addTags.selectTag")
+        ]
 
         let removeTagEvent = events[0]!
         removeTagEvent.getUIContext()!.assertHas(type: "button")
@@ -95,6 +99,9 @@ class AddTagsItemTests: XCTestCase {
         let addTagEvent = events[1]!
         addTagEvent.getUIContext()!.assertHas(type: "button")
         addTagEvent.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
+
+        let addExistingTagEvent = events[2]!
+        addExistingTagEvent.getUIContext()!.assertHas(type: "button")
     }
 
     @MainActor
@@ -188,7 +195,7 @@ class AddTagsItemTests: XCTestCase {
         addTagsView.recentTagCells.element(boundBy: 0).tap()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
-        let tagEvent = await snowplowMicro.getFirstEvent(with: "global-nav.addTags.recentTags")
+        let tagEvent = await snowplowMicro.getFirstEvent(with: "global-nav.addTags.selectRecentTag")
         tagEvent!.getUIContext()!.assertHas(type: "button")
     }
 

--- a/Tests iOS/MyList/SavesFiltersTests.swift
+++ b/Tests iOS/MyList/SavesFiltersTests.swift
@@ -64,7 +64,8 @@ class SavesFiltersTests: XCTestCase {
         XCTAssertEqual(app.saves.wait().itemCells.count, 2)
     }
 
-    func test_savesView_tappingTaggedPill_withFreeUser_showsFilteredItems() {
+    @MainActor
+    func test_savesView_tappingTaggedPill_withFreeUser_showsFilteredItems() async {
         app.launch().tabBar.savesButton.wait().tap()
         app.saves.filterButton(for: "Tagged").tap()
         let tagsFilterView = app.saves.tagsFilterView.wait()
@@ -81,5 +82,38 @@ class SavesFiltersTests: XCTestCase {
         app.saves.selectedTagChip(for: "not tagged").wait()
         app.saves.selectedTagChip(for: "not tagged").buttons.element(boundBy: 0).tap()
         XCTAssertEqual(app.saves.wait().itemCells.count, 2)
+
+        app.saves.filterButton(for: "Tagged").wait().tap()
+        tagsFilterView.wait().tag(matching: "filter tag 0").wait().tap()
+        XCTAssertEqual(app.saves.wait().itemCells.count, 1)
+
+        let events = await [
+            snowplowMicro.getFirstEvent(with: "global-nav.filterTags.selectNotTagged"),
+            snowplowMicro.getFirstEvent(with: "global-nav.filterTags.selectTag")
+        ]
+
+        let tagEvent = events[0]!
+        tagEvent.getUIContext()!.assertHas(type: "button")
+
+        let tagEvent1 = events[1]!
+        tagEvent1.getUIContext()!.assertHas(type: "button")
+    }
+
+    @MainActor
+    func test_savesView_tappingTaggedPill_withPremiumUser_showsFilteredItems() async {
+        server.routes.post("/graphql") { request, _ -> Response in
+            let apiRequest = ClientAPIRequest(request)
+            if apiRequest.isForUserDetails {
+                return Response.premiumUserDetails()
+            }
+            return .fallbackResponses(apiRequest: ClientAPIRequest(request))
+        }
+        app.launch().tabBar.savesButton.wait().tap()
+        app.saves.filterButton(for: "Tagged").tap()
+        let tagsFilterView = app.saves.tagsFilterView.wait()
+        tagsFilterView.recentTagCells.element(boundBy: 0).wait().tap()
+
+        let tagEvent = await snowplowMicro.getFirstEvent(with: "global-nav.filterTags.selectRecentTag")
+        tagEvent!.getUIContext()!.assertHas(type: "button")
     }
 }


### PR DESCRIPTION
## Summary
Update and add new calls to track a user selecting tags from `Add Tags` screen and filter `Tags` screen

## References 
IN-1268

## Implementation Details
Added following tracking calls: 
```
global-nav.filterTags.selectTag
global-nav.filterTags.selectRecentTag
global-nav.filterTags.selectNotTagged
global-nav.addTags.selectTag
global-nav.addTags.selectRecentTag
```
See Analytics Actions spreadsheet for confirmation

## Test Steps
Verify that the tracking calls are being triggered from the right actions

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
