### PR TITLE
project(log): move Log to SharedPocketKit

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -73,7 +73,8 @@ let package = Package(
             dependencies: [
                 "Textile",
                 "Localization",
-                "RNCryptor"
+                "RNCryptor",
+                .product(name: "Sentry", package: "sentry-cocoa")
             ]
         ),
         .testTarget(
@@ -101,7 +102,6 @@ let package = Package(
             name: "Sync",
             dependencies: [
                 .product(name: "Apollo", package: "apollo-ios"),
-                .product(name: "Sentry", package: "sentry-cocoa"),
                 "PocketGraph",
                 "SharedPocketKit"
             ],

--- a/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
@@ -5,6 +5,7 @@
 import SnowplowTracker
 import Sync
 import Foundation
+import SharedPocketKit
 
 public class PocketTracker: Tracker {
     private let snowplow: SnowplowTracker

--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -2,6 +2,7 @@ import Foundation
 import Sync
 import UIKit
 import Combine
+import SharedPocketKit
 
 protocol BadgeProvider: AnyObject {
     var applicationIconBadgeNumber: Int { get set }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -5,6 +5,7 @@ import Textile
 import UIKit
 import Analytics
 import Localization
+import SharedPocketKit
 
 protocol ReadableViewModel: ReadableViewControllerDelegate {
     typealias EventPublisher = AnyPublisher<ReadableEvent, Never>

--- a/PocketKit/Sources/PocketKit/Listen/ListenRuntime.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenRuntime.swift
@@ -6,6 +6,7 @@ import Foundation
 import PKTListen
 import Sync
 import Kingfisher
+import SharedPocketKit
 
 /// Older Pocket runtime which configures the legacy pocket app hooks used by Listen
 /// NOT USED FOR NOW.

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Sync
 import PKTListen
+import SharedPocketKit
 
 class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
     static func source(savedItems: [SavedItem]?) -> ListenViewModel {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketGraph
 import Sync
 import Localization
+import SharedPocketKit
 
 extension SearchSavedItem: ItemsListItem {
     var displayTitle: String {

--- a/PocketKit/Sources/PocketKit/Notifications/PocketAppDelegate+PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketAppDelegate+PocketNotificationService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import Sync
+import SharedPocketKit
 
 /**
  Extend the App Delegate so that we can add in the notification methods

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -3,6 +3,7 @@ import Sync
 import Analytics
 import Textile
 import Localization
+import SharedPocketKit
 
 struct ReportRecommendationView: View {
     private struct Constants {

--- a/PocketKit/Sources/SharedPocketKit/Log.swift
+++ b/PocketKit/Sources/SharedPocketKit/Log.swift
@@ -251,7 +251,7 @@ extension Log {
     }
 
     public class func setUserID(_ userID: String) {
-        SentrySDK.setUser(User(userId: userID))
+        SentrySDK.setUser(Sentry.User(userId: userID))
     }
 
     /**

--- a/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
@@ -5,6 +5,7 @@
 import Apollo
 import ApolloAPI
 import Foundation
+import SharedPocketKit
 
 extension ApolloClient {
     static func createDefault(

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -5,6 +5,7 @@
 import Apollo
 import ApolloAPI
 import Foundation
+import SharedPocketKit
 
 public extension ApolloClientProtocol {
     func fetch<Query: GraphQLQuery>(query: Query, queue: DispatchQueue = .global(qos: .utility), resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {

--- a/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipExtensions.swift
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/RelationshipExtensions.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import CoreData
+import SharedPocketKit
 
 extension Set where Element: NSManagedObject {
     /// Iterates over the objects and returns the object IDs that matched our observing keyPaths.

--- a/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
@@ -4,6 +4,7 @@
 
 import Combine
 import CoreData
+import SharedPocketKit
 
 enum SyncOperationResult {
     case retry(Error)

--- a/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
@@ -6,6 +6,7 @@ import Combine
 import Apollo
 import ApolloAPI
 import CoreData
+import SharedPocketKit
 
 class AnyMutation {
     let perform: (ApolloClientProtocol) async throws -> Void

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import CoreData
+import SharedPocketKit
 
 public class PersistentContainer: NSPersistentContainer {
     public lazy var rootSpace = { Space(backgroundContext: backgroundContext, viewContext: modifiedViewContext) }()

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Apollo
 import PocketGraph
+import SharedPocketKit
 
 public class PocketSaveService: SaveService {
     private let apollo: ApolloClientProtocol

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import Apollo
 import PocketGraph
+import SharedPocketKit
 
 extension Item {
     func update(remote: ItemParts, with space: Space) {

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -5,6 +5,7 @@
 import Foundation
 import CoreData
 import PocketGraph
+import SharedPocketKit
 
 extension SavedItem {
     typealias SavedItemEdge = FetchSavesQuery.Data.User.SavedItems.Edge

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 import PocketGraph
+import SharedPocketKit
 
 extension SlateLineup {
     public typealias RemoteSlateLineup = GetSlateLineupQuery.Data.GetSlateLineup

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -1,6 +1,7 @@
 import Apollo
 import Foundation
 import PocketGraph
+import SharedPocketKit
 
 protocol SlateService {
     func fetchSlateLineup(_ identifier: String) async throws

--- a/PocketKit/Sources/Sync/Space/DerivedSpace.swift
+++ b/PocketKit/Sources/Sync/Space/DerivedSpace.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import CoreData
+import SharedPocketKit
 
 /// Protocol representing a type that exposes a (read only) task cursor
 protocol Paginated {


### PR DESCRIPTION
## Summary

Moves `Log` out of the `Sync` package and into `SharedPocketKit`

## Implementation Details

- [ ] Update `Package.swift` to move Sentry dependency from `Sync` to `SharedPocketKit`
- [ ] Fix ALL the build errors

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
