### PR TITLE
feat(flags): updating feature flags to always attach

### DIFF
--- a/PocketKit/Sources/Analytics/Tracker/LinkedTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/LinkedTracker.swift
@@ -32,4 +32,8 @@ class LinkedTracker: Tracker {
     func resetPersistentEntities(_ entities: [Entity]) {
         parent.resetPersistentEntities(entities)
     }
+
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        parent.resetPersistentFeatureEntities(entities)
+    }
 }

--- a/PocketKit/Sources/Analytics/Tracker/NoopTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/NoopTracker.swift
@@ -24,4 +24,8 @@ public struct NoopTracker: Tracker {
     public func resetPersistentEntities(_ entities: [Entity]) {
         fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
     }
+
+    public func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        fatalError("\(Self.self) cannot be used. Please set your environment's tracker to a valid tracker.")
+    }
 }

--- a/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
@@ -10,6 +10,7 @@ public class PocketSnowplowTracker: SnowplowTracker {
     private let tracker: TrackerController
 
     private var persistentEntities: [Entity] = []
+    private var persistentFeatureEntities: [FeatureFlagEntity] = []
 
     public init() {
         let endpoint = ProcessInfo.processInfo.environment["SNOWPLOW_ENDPOINT"] ?? "getpocket.com"
@@ -57,6 +58,10 @@ public class PocketSnowplowTracker: SnowplowTracker {
             return self.persistentEntities.map({ $0.toSelfDescribingJson() })
         }))
 
+        _ = tracker.globalContexts?.add(tag: "persistent-feature-entities", contextGenerator: GlobalContext(generator: {  event in
+            return self.persistentFeatureEntities.map({ $0.toSelfDescribingJson() })
+        }))
+
         if CommandLine.arguments.contains("disableSnowplow") {
             tracker.pause()
         }
@@ -68,6 +73,10 @@ public class PocketSnowplowTracker: SnowplowTracker {
 
     public func resetPersistentEntities(_ entities: [Entity]) {
         persistentEntities = entities
+    }
+
+    public func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        persistentFeatureEntities = entities
     }
 
     public func track(event: SelfDescribing) {

--- a/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketTracker.swift
@@ -43,6 +43,10 @@ public class PocketTracker: Tracker {
     public func resetPersistentEntities(_ entities: [Entity]) {
         snowplow.resetPersistentEntities(entities)
     }
+
+    public func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        snowplow.resetPersistentFeatureEntities(entities)
+    }
 }
 
 extension PocketTracker {

--- a/PocketKit/Sources/Analytics/Tracker/SnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/SnowplowTracker.swift
@@ -8,4 +8,5 @@ public protocol SnowplowTracker {
     func track(event: SelfDescribing)
     func addPersistentEntity(_ entity: Entity)
     func resetPersistentEntities(_ entities: [Entity])
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity])
 }

--- a/PocketKit/Sources/Analytics/Tracker/Tracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/Tracker.swift
@@ -12,6 +12,7 @@ public protocol Tracker {
     @available(*, deprecated, message: "No need to longer use a child tracker")
     func childTracker(with contexts: [Context]) -> Tracker
     func resetPersistentEntities(_ entities: [Entity])
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity])
 }
 
 public extension Tracker {

--- a/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
@@ -36,6 +36,9 @@ protocol RefreshCoordinator: AnyObject {
     /// - Parameter completion: The callback to execute upon finishing data loading
     /// - Parameter isForced: Whether or not a user manaully triggered the refreshing
     func refresh(isForced: Bool, _ completion: @escaping () -> Void)
+
+    /// Implemented by any coordinator to implement any logout cleanup logic
+    func didLogout()
 }
 
 /// An Abstract extension  that can be used to implement background refreshing and implement some default logic like observing to login/logout and foregorund notifications.
@@ -108,6 +111,12 @@ extension RefreshCoordinator {
     private func tearDownSession() {
         subscriptions = []
         taskScheduler.cancel(taskID)
+        didLogout()
+    }
+
+    /// Implemented by any coordinator to implement any logout cleanup logic
+    func didLogout() {
+        // No-op, but any implementing coordinator can implement.
     }
 
     /// Submit the request to be scheduled anytime after the given interval

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -135,7 +135,8 @@ struct Services {
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source,
-            lastRefresh: lastRefresh
+            lastRefresh: lastRefresh,
+            tracker: tracker
         )
 
         refreshCoordinators = [

--- a/PocketKit/Sources/PocketKit/SwiftUIPreviewSupport/PreviewTypes.swift
+++ b/PocketKit/Sources/PocketKit/SwiftUIPreviewSupport/PreviewTypes.swift
@@ -20,5 +20,6 @@ class PreviewTracker: Tracker {
     func track<T>(event: T, _ contexts: [Analytics.Context]?) where T: Analytics.OldEvent {}
     func addPersistentEntity(_ entity: Analytics.Entity) {}
     func resetPersistentEntities(_ entities: [Analytics.Entity]) {}
+    func resetPersistentFeatureEntities(_ entities: [Analytics.FeatureFlagEntity]) {}
     func track(event: Event, filename: String, line: Int, column: Int, funcName: String) {}
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -592,8 +592,9 @@ extension PocketSource {
 
 extension PocketSource {
 
-    public func fetchAllFeatureFlags() async throws {
+    public func fetchAllFeatureFlags() async throws -> [FeatureFlag] {
         try await featureFlagService.fetchFeatureFlags()
+        return try space.fetchFeatureFlags(in: space.backgroundContext)
     }
 
     public func fetchFeatureFlag(by name: String) -> FeatureFlag? {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -105,7 +105,7 @@ public protocol Source {
 
     // MARK: -
 
-    func fetchAllFeatureFlags() async throws
+    func fetchAllFeatureFlags() async throws -> [FeatureFlag]
 
     func fetchFeatureFlag(by name: String) -> FeatureFlag?
 

--- a/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
+++ b/PocketKit/Tests/AnalyticsTests/Support/Mocks.swift
@@ -22,6 +22,7 @@ class MockTracker: Analytics.Tracker {
     private(set) var trackCalls = Calls<TrackCall>()
     private(set) var addPersistentCalls = Calls<AddPersistentCall>()
     private(set) var clearPersistentContextsCalls = Calls<[Entity]>()
+    private(set) var clearPersistentFeatureContextsCalls = Calls<[FeatureFlagEntity]>()
 
     func addPersistentEntity(_ entity: Analytics.Entity) {
         addPersistentCalls.add(AddPersistentCall(entity: entity))
@@ -37,6 +38,10 @@ class MockTracker: Analytics.Tracker {
 
     func resetPersistentEntities(_ entities: [Analytics.Entity]) {
         clearPersistentContextsCalls.add(entities)
+    }
+
+    func resetPersistentFeatureEntities(_ entities: [Analytics.FeatureFlagEntity]) {
+        clearPersistentFeatureContextsCalls.add(entities)
     }
 
     func childTracker(with contexts: [Context]) -> Analytics.Tracker {
@@ -55,6 +60,7 @@ class MockSnowplow: Analytics.SnowplowTracker {
 
     private(set) var trackCalls = Calls<TrackCall>()
     private(set) var clearPersistentContextsCalls = Calls<[Entity]>()
+    private(set) var clearPersistentFeatureContextsCalls = Calls<[FeatureFlagEntity]>()
     private(set) var addPersistentCalls = Calls<AddPersistentCall>()
 
     func track(event: SelfDescribing) {
@@ -67,6 +73,10 @@ class MockSnowplow: Analytics.SnowplowTracker {
 
     func resetPersistentEntities(_ entities: [Entity]) {
         clearPersistentContextsCalls.add(entities)
+    }
+
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        clearPersistentFeatureContextsCalls.add(entities)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1371,7 +1371,7 @@ extension MockSource {
 // MARK: - fetchAllFeatureFlags
 extension MockSource {
     private static let fetchAllFeatureFlags = "fetchAllFeatureFlags"
-    typealias FetchAllFeatureFlagsImpl = () -> Void
+    typealias FetchAllFeatureFlagsImpl = () -> [FeatureFlag]
 
     struct FetchAllFeatureFlagsCall {
     }
@@ -1380,7 +1380,7 @@ extension MockSource {
         implementations[Self.fetchAllFeatureFlags] = impl
     }
 
-    func fetchAllFeatureFlags() async throws {
+    func fetchAllFeatureFlags() async throws -> [FeatureFlag] {
         guard let impl = implementations[Self.fetchAllFeatureFlags] as? FetchAllFeatureFlagsImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
@@ -1389,7 +1389,7 @@ extension MockSource {
             FetchAllFeatureFlagsCall()
         ]
 
-        impl()
+        return impl()
     }
 
     func fetchAllFeatureFlagsCall(at index: Int) -> FetchAllFeatureFlagsCall? {

--- a/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockTracker.swift
@@ -14,6 +14,7 @@ class MockTracker: Tracker {
     }
 
     private var persistentContexts: [Entity] = []
+    private var persistentFeatureContexts: [FeatureFlagEntity] = []
 
     private(set) var oldTrackCalls = Calls<OldTrackCall>()
     private(set) var trackCalls = Calls<TrackCall>()
@@ -23,6 +24,10 @@ class MockTracker: Tracker {
 
     func resetPersistentEntities(_ entities: [Entity]) {
         persistentContexts = []
+    }
+
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        persistentFeatureContexts = []
     }
 
     func track<T: OldEvent>(event: T, _ contexts: [Context]?) {

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockTracker.swift
@@ -14,6 +14,7 @@ class MockTracker: Tracker {
     }
 
     private var persistentContexts: [Entity] = []
+    private var persistentFeatureContexts: [FeatureFlagEntity] = []
 
     private(set) var oldTrackCalls = Calls<OldTrackCall>()
     private(set) var trackCalls = Calls<TrackCall>()
@@ -23,6 +24,10 @@ class MockTracker: Tracker {
 
     func resetPersistentEntities(_ entities: [Entity]) {
         persistentContexts = []
+    }
+
+    func resetPersistentFeatureEntities(_ entities: [FeatureFlagEntity]) {
+        persistentFeatureContexts = []
     }
 
     func track<T: OldEvent>(event: T, _ contexts: [Context]?) {


### PR DESCRIPTION
## Summary

After a recent nimbus integration meeting, we realized it would be useful and best practice to always attach any feature flag entity we may be assigned to our analytics events similar to APIUser and User. 

## Implementation Details
* I added a method that gets called in the refresh coordinators to have a log out call back so we can clear the feature entities on logout.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
