### PR TITLE
ci(tests): fix unit tests after core data changes

### DIFF
--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -507,7 +507,7 @@ extension PocketSource {
                 return
             }
 
-            let fetchedTag = try? space.fetchTag(byID: remoteID)
+            let fetchedTag = try? space.fetchTag(by: oldTag.name)
             fetchedTag?.name = name
 
             do {

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -393,12 +393,14 @@ extension Space {
         }
         let createTag = Tag(context: context)
         createTag.name = name
-        createTag.remoteID = "remoteID\(name)"
         return createTag
     }
 
-    func fetchTag(byID id: String) throws -> Tag? {
-        try fetch(Requests.fetchTag(byID: id)).first
+    func fetchTag(by name: String, context: NSManagedObjectContext? = nil) throws -> Tag? {
+        let context = context ?? backgroundContext
+        let fetchRequest = Requests.fetchTag(byName: name)
+        fetchRequest.fetchLimit = 1
+        return try fetch(fetchRequest, context: context).first
     }
 
     func retrieveTags(excluding tags: [String]) throws -> [Tag] {

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -388,10 +388,13 @@ extension Space {
         let context = context ?? backgroundContext
         let fetchRequest = Requests.fetchTag(byName: name)
         fetchRequest.fetchLimit = 1
-        let fetchedTag = (try? fetch(fetchRequest, context: context).first) ?? Tag(context: context)
-        guard fetchedTag.name == nil else { return fetchedTag }
-        fetchedTag.name = name
-        return fetchedTag
+        if let fetchedTag = (try? fetch(fetchRequest, context: context).first) {
+            return fetchedTag
+        }
+        let createTag = Tag(context: context)
+        createTag.name = name
+        createTag.remoteID = "remoteID\(name)"
+        return createTag
     }
 
     func fetchTag(byID id: String) throws -> Tag? {

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -59,8 +59,8 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         userDefaults.setValue(true, forKey: AccountViewModel.ToggleAppBadgeKey)
 
-        space.buildSavedItem()
-        space.buildSavedItem(isArchived: true)
+        space.buildSavedItem(item: try space.createItem())
+        space.buildSavedItem(remoteID: "saved-item-2", url: "http://example.com/item-2", isArchived: true, item: try space.createItem(remoteID: "item-2", givenURL: URL(string: "http://example.com/item-2")))
         try space.save()
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -63,8 +63,9 @@ class RecommendationViewModelTests: XCTestCase {
 
         // not-favorited, not-archived
         do {
-            let item = space.buildItem()
-            let recommendation = space.buildRecommendation(item: item)
+            let item = space.buildItem(remoteID: "item-2", givenURL: URL(string: "https://example.com/items/item-2"))
+            let recommendation = space.buildRecommendation(remoteID: "rec-2", item: item)
+
             try space.createSavedItem(isFavorite: false, isArchived: false, item: item)
 
             let viewModel = subject(recommendation: recommendation)
@@ -76,8 +77,10 @@ class RecommendationViewModelTests: XCTestCase {
 
         // favorited, archived
         do {
-            let item = space.buildItem()
-            let recommendation = space.buildRecommendation(item: item)
+
+            let item = space.buildItem(remoteID: "item-3", givenURL: URL(string: "https://example.com/items/item-2"))
+            let recommendation = space.buildRecommendation(remoteID: "rec-3", item: item)
+
             try space.createSavedItem(isFavorite: true, isArchived: true, item: item)
 
             let viewModel = subject(recommendation: recommendation)
@@ -313,6 +316,7 @@ class RecommendationViewModelTests: XCTestCase {
         let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
         let actions = viewModel.externalActions(for: url)
+
         viewModel.invokeAction(from: actions, title: "Copy Link")
 
         XCTAssertEqual(pasteboard.url, url)

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -148,9 +148,10 @@ class SavedItemsListViewModelTests: XCTestCase {
 
     func test_selectCell_whenItemIsArticle_setsSelectedItemToReaderView() throws {
         let viewModel = subject()
-        let item = space.buildPendingSavedItem()
+        let savedItem = space.buildPendingSavedItem()
+        savedItem.item = space.buildItem()
         try space.save()
-        viewModel.selectCell(with: .item(item.objectID), sender: UIView())
+        viewModel.selectCell(with: .item(savedItem.objectID), sender: UIView())
 
         guard let selectedItem = viewModel.selectedItem else {
             XCTFail("Received nil for selectedItem")

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -136,7 +136,8 @@ class SlateDetailViewModelTests: XCTestCase {
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
-        let recommendation = space.buildRecommendation(item: space.buildItem())
+        let savedItem = try space.createSavedItem(item: space.buildItem())
+        let recommendation = space.buildRecommendation(item: savedItem.item)
         let slate = try space.createSlate(recommendations: [recommendation])
         try space.save()
         let viewModel = subject(slate: space.viewObject(with: slate.objectID) as! Slate)

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -71,6 +71,7 @@ extension Space {
         func buildPendingSavedItem() -> SavedItem {
             backgroundContext.performAndWait {
                 let savedItem: SavedItem = SavedItem(context: backgroundContext, url: URL(string: "https://mozilla.com/example")!)
+                savedItem.createdAt = Date()
                 return savedItem
             }
         }
@@ -266,7 +267,6 @@ extension Space {
             recommendation.title = title
             recommendation.excerpt = excerpt
             recommendation.imageURL = imageURL
-
             return recommendation
         }
     }

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -81,7 +81,7 @@ extension APISlateServiceTests {
                 let item = recommendation.item
                 XCTAssertNotNil(item)
                 XCTAssertEqual(item.remoteID, "item-1")
-                XCTAssertEqual(item.givenURL.absoluteString, "https://given.example.com/rec-1")
+                XCTAssertEqual(item.givenURL.absoluteString, "https://given.example.com/slate-1-rec-1")
                 XCTAssertEqual(item.resolvedURL?.absoluteString, "https://resolved.example.com/rec-1")
                 XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
                 XCTAssertEqual(item.language, "en")

--- a/PocketKit/Tests/SyncTests/Fixtures/list.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list.json
@@ -75,7 +75,14 @@
                                 "hasVideo": "HAS_VIDEOS",
                                 "syndicatedArticle": {
                                     "__typename": "SyndicatedArticle",
-                                    "itemId": "syndicated-article-item-id"
+                                    "itemId": "syndicated-article-item-id",
+                                    "title": "syndicated-article-title",
+                                    "mainImage": "https://example.com/syndicated-article-image.jpg",
+                                    "excerpt": "syndicated-article-excerpt",
+                                    "publisher": {
+                                        "__typename": "[type-name-here]",
+                                        "name": "syndicated-article-publisher"
+                                    }
                                 }
                             }
                         }

--- a/PocketKit/Tests/SyncTests/Fixtures/slates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/slates.json
@@ -21,7 +21,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-1",
-                                "givenUrl": "https://given.example.com/rec-1",
+                                "givenUrl": "https://given.example.com/slate-1-rec-1",
                                 "resolvedUrl": "https://resolved.example.com/rec-1",
                                 "title": "Slate 1, Recommendation 1",
                                 "language": "en",
@@ -60,7 +60,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-2",
-                                "givenUrl": "https://given.example.com/rec-2",
+                                "givenUrl": "https://given.example.com/slate-1-rec-2",
                                 "resolvedUrl": "https://resolved.example.com/rec-2",
                                 "title": "Slate 1, Recommendation 2",
                                 "language": "en",
@@ -101,7 +101,7 @@
                             "item": {
                                 "__typename": "[some-type-name]",
                                 "remoteID": "item-3",
-                                "givenUrl": "https://given.example.com/rec-1",
+                                "givenUrl": "https://given.example.com/slate-2-rec-1",
                                 "resolvedUrl": "https://resolved.example.com/rec-1",
                                 "title": "Slate 2, Recommendation 1",
                                 "language": "en",

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -280,7 +280,7 @@ class PocketSourceTests: XCTestCase {
         }
         savesResultsController.delegate = delegate
 
-        let item2 = try space.createSavedItem(createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(title: "Item 2"))
+        let item2 = try space.createSavedItem(remoteID: "saved-item-2", url: "http://example.com/item-2", createdAt: .init(timeIntervalSince1970: TimeInterval(0)), item: space.buildItem(remoteID: "item-2", title: "Item 2", givenURL: URL(string: "https://example.com/items/item-2")))
         try space.save()
         try savesResultsController.performFetch()
 
@@ -596,7 +596,7 @@ extension PocketSourceTests {
             let tag: Tag = Tag(context: space.backgroundContext)
             tag.remoteID = "id \(num)"
             tag.name = "tag \(num)"
-            return space.buildSavedItem(isArchived: isArchived, tags: [tag])
+            return space.buildSavedItem(remoteID: "saved-item-\(num)", url: "http://example.com/item-\(num)", isArchived: isArchived, tags: [tag])
         }
     }
 }
@@ -628,8 +628,8 @@ extension PocketSourceTests {
 
     func test_savesSearches_withFreeUser_showSearchResults_searchUrl() throws {
         user.setPremiumStatus(false)
-        let url = URL(string: "testUrl.saved")
-        try setupLocalSavesSearch(with: url)
+        let urlString = "testUrl.saved"
+        try setupLocalSavesSearch(with: urlString)
 
         let source = subject()
         let results = source.searchSaves(search: "saved")
@@ -642,8 +642,8 @@ extension PocketSourceTests {
     func test_savesSearches_withPremiumUser_showSearchResults_searchUrl() throws {
         user.setPremiumStatus(true)
 
-        let url = URL(string: "testUrl.saved")
-        try setupLocalSavesSearch(with: url)
+        let urlString = "testUrl.saved"
+        try setupLocalSavesSearch(with: urlString)
 
         let source = subject()
         let results = source.searchSaves(search: "saved")
@@ -706,12 +706,17 @@ extension PocketSourceTests {
         XCTAssertEqual(savedItem?.item.bestURL?.absoluteString, "http://localhost:8080/hello")
     }
 
-    private func setupLocalSavesSearch(with url: URL? = nil) throws {
+    private func setupLocalSavesSearch(with urlString: String? = nil) throws {
+        var url: URL?
         _ = (1...2).map {
+            if let urlString {
+                url = URL(string: urlString + "-\($0)")
+            }
             space.buildSavedItem(
                 remoteID: "saved-item-\($0)",
+                url: "http://example.com/item-\($0)",
                 createdAt: Date(timeIntervalSince1970: TimeInterval($0)),
-                item: space.buildItem(title: "saved-item-\($0)", givenURL: url)
+                item: space.buildItem(remoteID: "saved-item-\($0)", title: "saved-item-\($0)", givenURL: url, num: $0)
             )
         }
         try space.save()

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -61,11 +61,10 @@ class SpaceTests: XCTestCase {
     func testFetchTagsByID() throws {
         let space = subject()
         let tag1: Tag = Tag(context: space.backgroundContext)
-        tag1.remoteID = "id 1"
         tag1.name = "tag 1"
 
-        let fetchedTag1 = try space.fetchTag(byID: "id 1")
-        let fetchedTag2 = try space.fetchTag(byID: "id 2")
+        let fetchedTag1 = try space.fetchTag(by: "tag 1")
+        let fetchedTag2 = try space.fetchTag(by: "tag 2")
 
         XCTAssertEqual(fetchedTag1?.name, "tag 1")
         XCTAssertNil(fetchedTag2)

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -141,11 +141,12 @@ extension Space {
         givenURL: URL? = URL(string: "https://example.com/items/item-1"),
         resolvedURL: URL? = nil,
         isArticle: Bool = true,
-        syndicatedArticle: SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil,
+        num: Int? = nil
     ) -> Item {
         var url = givenURL
         if url == nil {
-            url = URL(string: "https://example.com/items/item-1")
+            url = URL(string: "https://example.com/items/item-1-\(num)")
         }
 
         return backgroundContext.performAndWait {


### PR DESCRIPTION
## Summary
Fix tests, see original PR for context
https://github.com/Pocket/pocket-ios/pull/605

## References 
N/A

## Implementation Details
* We updated SavedItem and Item to have unique properties (i.e. given_url and url and remoteID), but the items to set up these tests were using the same values for the saved Items causing errors. Setting up the items to have unique values, causes the tests pass.
* Need to create `remoteID` with tag creation in `fetchOrCreateTag` (needs to be revisited)
* Added `createdAt` when building pending saved item

## Test Steps
Make sure tests are passing.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
