### PR TITLE
feat(session): write session data to encrypted store on log in / out

### DIFF
--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -127,7 +127,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
         } catch LegacyUserMigrationError.emptyData {
-            Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration has no data to decrypt, likely due to a fresh install of Pocket 8")
+            Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration has no data to decrypt, likely due to a fresh install of Pocket 8; skipping.")
             // Since there's no initial data, we don't have anything to migrate, and we can skip
             // any further attempts at running this migration. This is not a true "error" in the sense that
             // it breaks migration; it's a special case to be handled if data was created (on fresh install).

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -132,6 +132,12 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             // any further attempts at running this migration. This is not a true "error" in the sense that
             // it breaks migration; it's a special case to be handled if data was created (on fresh install).
             legacyUserMigration.forceSkip()
+        } catch LegacyUserMigrationError.noSession {
+            // If a user was logged out in Pocket 7, and then launches Pocket 8, there is no session to migrate.
+            // Previously, this would trigger a `failedDeserialization`, which is correct, but not within the context
+            // of a valid user case. If there was nothing to migrate, we can skip any further attempts.
+            Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration has no session to migration; skipping.")
+            legacyUserMigration.forceSkip()
         } catch LegacyUserMigrationError.missingStore {
             tracker.track(event: Events.Migration.MigrationTo_v8DidFail(with: LegacyUserMigrationError.missingStore, source: .pocketKit))
             Log.breadcrumb(category: "launch", level: .info, message: "No previous store for user migration; skipped.")

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -43,6 +43,7 @@ struct Services {
     let listen: Listen
     let bannerPresenter: BannerPresenter
     let notificationCenter: NotificationCenter
+    let sessionBackupUtility: SessionBackupUtility
 
     private let persistentContainer: PersistentContainer
 
@@ -201,6 +202,12 @@ struct Services {
 
         bannerPresenter = BannerPresenter(notificationCenter: notificationCenter)
         bannerPresenter.listen()
+
+        sessionBackupUtility = SessionBackupUtility(
+            userDefaults: userDefaults,
+            store: PocketEncryptedStore(),
+            notificationCenter: notificationCenter
+        )
     }
 }
 

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -49,7 +49,7 @@ class MainViewController: UIViewController {
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration not required; skipped.")
             }
         } catch LegacyUserMigrationError.emptyData {
-            Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration has no data to decrypt, likely due to a fresh install of Pocket 8")
+            Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration has no data to decrypt, likely due to a fresh install of Pocket 8; skipping.")
             // Since there's no initial data, we don't have anything to migrate, and we can skip
             // any further attempts at running this migration. This is not a true "error" in the sense that
             // it breaks migration; it's a special case to be handled if data was created (on fresh install).

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -37,8 +37,10 @@ class MainViewController: UIViewController {
         )
 
         do {
-            tracker.track(event: Events.Migration.MigrationTo_v8DidBegin(source: .saveToPocketKit))
-            let attempted = try legacyUserMigration.attemptMigration { }
+            let attempted = try legacyUserMigration.attemptMigration {
+                tracker.track(event: Events.Migration.MigrationTo_v8DidBegin(source: .saveToPocketKit))
+            }
+
             if attempted {
                 tracker.track(event: Events.Migration.MigrationTo_v8DidSucceed(source: .saveToPocketKit))
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -12,6 +12,7 @@ struct Services {
     let user: User
     let tracker: Tracker
     let userDefaults: UserDefaults
+    let notificationCenter: NotificationCenter
 
     private let persistentContainer: PersistentContainer
 
@@ -22,6 +23,8 @@ struct Services {
             fatalError("UserDefaults with suite name \(Keys.shared.groupdId) must exist.")
         }
         userDefaults = sharedUserDefaults
+
+        notificationCenter = .default
 
         persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupdId)
 

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
@@ -3,22 +3,36 @@ import RNCryptor
 
 public protocol LegacyEncryptedStore {
     func decryptStore(securedBy password: String) throws -> Data?
+    func encrypt(store: Data, securedBy password: String) throws
 }
 
 public class PocketEncryptedStore: LegacyEncryptedStore {
+    /// Returns the URL of the legacy encrypted store.
+    /// If this file does not exist, it will create it.
     private lazy var storeURL: URL? = {
         let groupID = "group.com.ideashower.ReadItLaterPro"
         let directory = "data"
         let filename = "PKTSharedKeyStore.json"
 
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupID) else {
+            Log.breadcrumb(category: "store", level: .info, message: "Could not find container URL for \(groupID)")
             return nil
         }
 
         let filepath = url.appendingPathComponent(directory).appendingPathComponent("PKTSharedKeyStore").appendingPathExtension("json")
 
-        guard FileManager.default.fileExists(atPath: filepath.path) else {
-            return nil
+        if FileManager.default.fileExists(atPath: filepath.path) == false {
+            do {
+                try FileManager.default.createDirectory(at: filepath.deletingLastPathComponent().absoluteURL, withIntermediateDirectories: false)
+            } catch {
+                Log.capture(error: error)
+                return nil
+            }
+
+            if FileManager.default.createFile(atPath: filepath.path(), contents: Data()) == false {
+                Log.capture(message: "Could not create PKTSharedKeyStore file")
+                return nil
+            }
         }
 
         return filepath
@@ -26,12 +40,30 @@ public class PocketEncryptedStore: LegacyEncryptedStore {
 
     public init() { }
 
+    /// Reads the data of `storeURL`, decrypting it using `password`
     public func decryptStore(securedBy password: String) throws -> Data? {
         guard let storeURL = storeURL else {
             throw LegacyUserMigrationError.missingStore
         }
 
         let data = try Data(contentsOf: storeURL)
+        if data.isEmpty {
+            // Do not attempt to decrypt empty data, as decryption will fail due
+            // to a missing RNCryptor header. This file will be empty if created within Pocket 8,
+            // and if empty, should not attempt to be decrypted. Empty data is different
+            // than missing data, which is another error that can be thrown during the decryption phase.
+            throw LegacyUserMigrationError.emptyData
+        }
         return try RNCryptor.decrypt(data: data, withPassword: password)
+    }
+
+    /// Writes `store` to `storeURL`, encrypting it using `password`
+    public func encrypt(store: Data, securedBy password: String) throws {
+        guard let storeURL = storeURL else {
+            return
+        }
+
+        let encrypted = RNCryptor.encrypt(data: store, withPassword: password)
+        try encrypted.write(to: storeURL)
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/Session/SessionBackupUtility.swift
+++ b/PocketKit/Sources/SharedPocketKit/Session/SessionBackupUtility.swift
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Combine
+import RNCryptor
+
+/**
+ A utility class that can back up a `SharedPocketKit.Session` to an encrypted legacy Pocket store.
+ This is done by adding / modifying existing key/value pairs in the store.
+ - Note: The utility of this class is that we will want to force-run the legacy migration
+ after transferring orgs, and a Pocket 8-only user won't have a pre-existing (required) store.
+ By backing up a session, we can create this store (or update a pre-existing one) as necessary.
+ */
+public class SessionBackupUtility {
+    /// The decryption key used in conjunction with `store`.
+    private let password: String
+
+    private let userDefaults: UserDefaults
+    private let store: LegacyEncryptedStore
+    private let notificationCenter: NotificationCenter
+
+    private let notificationQueue = DispatchQueue(label: "SessionBackupUtility", qos: .utility)
+    private var subscriptions: Set<AnyCancellable> = []
+
+    public init(userDefaults: UserDefaults, store: LegacyEncryptedStore, notificationCenter: NotificationCenter) {
+        self.userDefaults = userDefaults
+        self.store = store
+        self.notificationCenter = notificationCenter
+
+        // Return an existing decryption key, else create + store a new one, and return that
+        if let existing = userDefaults.string(forKey: LegacyUserMigration.decryptionKey) {
+            self.password = existing
+        } else {
+            // Generate a password the same way as the legacy app
+            let password = RNCryptor.randomData(ofLength: 32).base64EncodedString()
+            userDefaults.set(password, forKey: LegacyUserMigration.decryptionKey)
+            self.password = password
+        }
+    }
+
+    public func start() {
+        // Utilize NotificationCenter to save a user session on-disk after a user has logged in
+        notificationCenter.publisher(for: .userLoggedIn)
+            .receive(on: notificationQueue)
+            .sink { [weak self] notification in
+                guard let self = self, let session = notification.object as? Session else {
+                    return
+                }
+
+                do {
+                    try self.save(session: session)
+                    Log.breadcrumb(category: "session", level: .info, message: "Successfully backed up logged in session.")
+                } catch {
+                    Log.capture(error: error)
+                }
+            }.store(in: &subscriptions)
+
+        // Utilize NotificationCenter to reset a user session on-disk after a user has logged out
+        notificationCenter.publisher(for: .userLoggedOut)
+            .receive(on: notificationQueue)
+            .sink { [weak self] notification in
+                guard let self = self else {
+                    return
+                }
+
+                do {
+                    try self.save(session: nil)
+                    Log.breadcrumb(category: "session", level: .info, message: "Successfully backed up logged out session.")
+                } catch {
+                    Log.capture(error: error)
+                }
+            }.store(in: &subscriptions)
+    }
+
+    /// Saves a `SharedPocketKit.Session` to `store`, adding / modifying existing key/value pairs
+    ///  within the store to contain the requested Session data.
+    private func save(session: Session?) throws {
+        let data: Data
+        do {
+            // `decryptStore` will throw if the on-disk store was
+            // empty, or if something went wrong. We want to continue saving
+            // the session, though, so we will default to empty data and continue.
+            // This assumes that if the file already existed (via Pocket 7), that this won't throw,
+            // and will only throw if the file was empty (i.e empty when created by Pocket 8).
+            data = try store.decryptStore(securedBy: password) ?? Data()
+        } catch {
+            // TODO: Something better?
+            Log.breadcrumb(category: "session", level: .info, message: "Failed decrypting store: \(error); creating empty data")
+            data = Data()
+        }
+
+        let initial: [String: Any]
+
+        if data.isEmpty { // data will be empty if the store has been created in Pocket 8
+            initial = [:]
+        } else { // data will not be empty if previously created, either in Pocket 7 or 8
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return
+            }
+            initial = json
+        }
+
+        let updated = update(initial, with: session)
+
+        do {
+            let serialized = try JSONSerialization.data(withJSONObject: updated)
+            try store.encrypt(store: serialized, securedBy: password)
+        } catch {
+            Log.capture(error: error)
+        }
+    }
+
+    private func update(_ json: [String: Any], with session: Session?) -> [String: Any] {
+        var json = json // We want to mutate a copy, rather than the original
+        if let session = session {
+            json["guid"] = session.guid
+            json["accessToken"] = session.accessToken
+            json["uid"] = session.userIdentifier // uid == userIdentifier in the legacy store
+            json["version"] = Bundle.main.infoDictionary?["CFBundleShortVersionString"]
+        } else {
+            json.removeValue(forKey: "guid")
+            json.removeValue(forKey: "accessToken")
+            json.removeValue(forKey: "uid")
+        }
+
+        return json
+    }
+}

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -34,6 +34,7 @@ public extension UserDefaults {
         var isRemovable: Bool {
             switch self {
             case .hasAppBeenLaunchedPreviously: return false // This must remain in-tact for the "SignOutOnFirstLaunch" to be run exactly one time per app install
+            case .legacyUserMigration: return false // We want to maintain the state of whether the migration has already been run
             default: return true
             }
         }

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -2,40 +2,6 @@ import XCTest
 @testable import SharedPocketKit
 
 // swiftlint:disable force_try
-class BlankKeychain: Keychain {
-    func add(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
-        .zero
-    }
-
-    func update(query: CFDictionary, attributes: CFDictionary) -> OSStatus {
-        .zero
-    }
-
-    func delete(query: CFDictionary) -> OSStatus {
-        .zero
-    }
-
-    func copyMatching(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
-        .zero
-    }
-}
-
-class MockEncryptedStore: LegacyEncryptedStore {
-    typealias Impl = (String) throws -> Data?
-    private var impl: Impl?
-
-    func stubDecryptStore(_ impl: @escaping Impl) {
-        self.impl = impl
-    }
-
-    func decryptStore(securedBy password: String) throws -> Data? {
-        guard let impl = impl else {
-            fatalError("decryptedStore must be stubbed before use")
-        }
-
-        return try impl(password)
-    }
-}
 
 private enum MockError: Error {
     case someError

--- a/PocketKit/Tests/SharedPocketKitTests/SessionBackupUtilityTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/SessionBackupUtilityTests.swift
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import SharedPocketKit
+
+// swiftlint:disable force_try
+class SessionBackupUtilityTests: XCTestCase {
+    var userDefaults: UserDefaults!
+    var store: MockEncryptedStore!
+    var notificationCenter: NotificationCenter!
+
+    override func setUp() {
+        userDefaults = UserDefaults(suiteName: "SessionBackupUtilityTests")!
+        userDefaults.removePersistentDomain(forName: "SessionBackupUtilityTests")
+
+        store = MockEncryptedStore()
+        notificationCenter = .default
+    }
+
+    func test_password_ifNil_createdNewPassword() {
+        store.stubEncrypt { _, _ in }
+        store.stubDecryptStore { _ in return nil }
+
+        func createUtility() -> SessionBackupUtility {
+            return SessionBackupUtility(
+                userDefaults: userDefaults,
+                store: store,
+                notificationCenter: notificationCenter
+            )
+        }
+
+        // Passwords are fetched or created on init, but the utility itself is unnecessary
+        _ = createUtility()
+
+        let password = userDefaults.string(forKey: LegacyUserMigration.decryptionKey)
+        XCTAssertNotNil(password)
+    }
+
+    func test_password_persistsAcrossUtilities() {
+        userDefaults.set("password", forKey: LegacyUserMigration.decryptionKey)
+
+        store.stubEncrypt { _, _ in }
+        store.stubDecryptStore { _ in return nil }
+
+        func createUtility() -> SessionBackupUtility {
+            return SessionBackupUtility(
+                userDefaults: userDefaults,
+                store: store,
+                notificationCenter: notificationCenter
+            )
+        }
+
+        // Passwords are fetched or created on init, but the utility itself is unnecessary
+        _ = createUtility()
+        let firstPassword = userDefaults.string(forKey: LegacyUserMigration.decryptionKey)
+        XCTAssertEqual(firstPassword!, "password")
+
+        // Passwords are fetched or created on init, but the utility itself is unnecessary
+        _ = createUtility()
+        let secondPassword = userDefaults.string(forKey: LegacyUserMigration.decryptionKey)
+        XCTAssertEqual(secondPassword!, "password")
+    }
+
+    func test_userLoggedIn_withNoExistingData_savesSessionData() {
+        let session = Session(guid: "test-guid", accessToken: "test-accessToken", userIdentifier: "test-uid")
+
+        store.stubDecryptStore { _ in
+            return Data()
+        }
+
+        let encryptExpectation = expectation(description: "expected encrypt to be called")
+        store.stubEncrypt { data, _ in
+            defer { encryptExpectation.fulfill() }
+
+            let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+            XCTAssertEqual(json["guid"] as! String, session.guid)
+            XCTAssertEqual(json["accessToken"] as! String, session.accessToken)
+            XCTAssertEqual(json["uid"] as! String, session.userIdentifier)
+        }
+
+        let utility = SessionBackupUtility(
+            userDefaults: userDefaults,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+        utility.start()
+
+        notificationCenter.post(name: .userLoggedIn, object: session)
+
+        wait(for: [encryptExpectation], timeout: 1)
+    }
+
+    func test_userLoggedIn_withExistingData_overwritesSessionData() {
+        let session = Session(guid: "test-guid", accessToken: "test-accessToken", userIdentifier: "test-uid")
+
+        let store = MockEncryptedStore()
+
+        store.stubDecryptStore { _ in
+            let data: [String: Any] = ["guid": "guid", "accessToken": "accessToken", "uid": "uid"]
+            let json = try! JSONSerialization.data(withJSONObject: data)
+            return json
+        }
+
+        let encryptExpectation = expectation(description: "expected encrypt to be called")
+        store.stubEncrypt { data, _ in
+            defer { encryptExpectation.fulfill() }
+
+            let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+            XCTAssertEqual(json["guid"] as! String, session.guid)
+            XCTAssertEqual(json["accessToken"] as! String, session.accessToken)
+            XCTAssertEqual(json["uid"] as! String, session.userIdentifier)
+        }
+
+        let utility = SessionBackupUtility(
+            userDefaults: userDefaults,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+        utility.start()
+
+        notificationCenter.post(name: .userLoggedIn, object: session)
+
+        wait(for: [encryptExpectation], timeout: 1)
+    }
+
+    func test_userLoggedOut_withExistingData_removesSessionData() {
+        let session = Session(guid: "test-guid", accessToken: "test-accessToken", userIdentifier: "test-uid")
+
+        store.stubDecryptStore { _ in
+            let data: [String: Any] = ["guid": "guid", "accessToken": "accessToken", "uid": "uid"]
+            let json = try! JSONSerialization.data(withJSONObject: data)
+            return json
+        }
+
+        let encryptExpectation = expectation(description: "expected encrypt to be called")
+        store.stubEncrypt { data, _ in
+            defer { encryptExpectation.fulfill() }
+
+            let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+            XCTAssertNil(json["guid"])
+            XCTAssertNil(json["accessToken"])
+            XCTAssertNil(json["uid"])
+        }
+
+        let utility = SessionBackupUtility(
+            userDefaults: userDefaults,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+        utility.start()
+
+        notificationCenter.post(name: .userLoggedOut, object: session)
+
+        wait(for: [encryptExpectation], timeout: 1)
+    }
+}
+// swiftlint:enable force_try

--- a/PocketKit/Tests/SharedPocketKitTests/Support/BlankKeychain.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/Support/BlankKeychain.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import SharedPocketKit
+
+class BlankKeychain: Keychain {
+    func add(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        .zero
+    }
+
+    func update(query: CFDictionary, attributes: CFDictionary) -> OSStatus {
+        .zero
+    }
+
+    func delete(query: CFDictionary) -> OSStatus {
+        .zero
+    }
+
+    func copyMatching(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        .zero
+    }
+}

--- a/PocketKit/Tests/SharedPocketKitTests/Support/MockEncryptedStore.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/Support/MockEncryptedStore.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import SharedPocketKit
+
+class MockEncryptedStore: LegacyEncryptedStore {
+    private var implementations: [String: Any] = [:]
+
+    private static let decrypt = "decrypt"
+    typealias DecryptImpl = (String) throws -> Data?
+
+    func stubDecryptStore(_ impl: @escaping DecryptImpl) {
+        implementations[Self.decrypt] = impl
+    }
+
+    func decryptStore(securedBy password: String) throws -> Data? {
+        guard let impl = implementations[Self.decrypt] as? DecryptImpl else {
+            fatalError("decryptedStore must be stubbed before use")
+        }
+
+        return try impl(password)
+    }
+}
+
+extension MockEncryptedStore {
+    private static let encrypt = "encrypt"
+    typealias EncryptImpl = (Data, String) throws -> Void
+
+    func stubEncrypt(_ impl: @escaping EncryptImpl) {
+        implementations[Self.encrypt] = impl
+    }
+
+    func encrypt(store: Data, securedBy password: String) throws {
+        guard let impl = implementations[Self.encrypt] as? EncryptImpl else {
+            fatalError("encrypt must be stubbed before use")
+        }
+
+        try impl(store, password)
+    }
+}


### PR DESCRIPTION
## Summary

- On user log in / out, the session is saved to an encrypted store, which can later be reused by the legacy migration. This is required for re-authenticating a user after org transfer, where we can force re-run the legacy user migration for re-authentication.

- Fixes an issue where analytic events and migration errors were being captured for scenarios that were not true "errors", but special cases that had to be handled.

## References 

IN-1182

## Implementation Details

In order to save session data to a file, `SessionBackupUtility` was used. This listens to both `.userLoggedIn` and `.userLoggedOut` notifications, and appropriately adding / updating the required keys within an encrypted store. Upon requesting file access, this store will be created on-disk if it did not previously exist. Otherwise, this file will be updated as required.

The basic steps for the utility are:
1. Create the store file as necessary
2. Upon session update, decrypt the store
3. Update the required keys (`uid`, `guid`, and `accessToken`) by either inserting, updating, or removing the keys depending on if a user logged in or logged out
4. Encrypt the store, and write to disk

In order to update migrations being incorrectly tracked and logged, two additional cases can be thrown - `noData` (which can possibly happen when Pocket 8 is launched for the first time), and `noSession` (which can happen when a user is logged out). Both of these paths would previously cause an analytic event to be tracked, as well as an error logged, however, these are both valid cases that require custom handling, rather than be treated as other errors.

Additionally, we bail out early of running a migration if we have discovered it has been run, via `UserDefaults`. This helps minimize the number of errors reported, since version comparison is done by first decrypting the store, which is unnecessary if already run.

## Test Steps

This pull request, due to encryption / decryption, is best tested locally with a debugger. 

### Pocket 7 -> 8

- Pocket 7 Logged Out User
  - After updating to Pocket 8, and logging in, the store should contain session data mimicking that contained within the keychain
  - No analytic event should be tracked for failing to decrypt the store due to a missing session.
- Pocket 7 Logged In User
  - After updating to Pocket 8, the user should still be logged in. No store changes are necessary.
  - After signing out within Pocket 8, the store should be updated to remove the session data (no keys will exist)
  - Analytic event should be tracked for the migration succeeding
  
### Pocket 8
- Initially Pocket 8 Logged Out User
  - The store should be created on-disk, but should not contain any session data (empty or otherwise)
- Newly Signed In User
  - The store should be updated with the session data that is within the keychain
- On Sign Out
  - The store should be updated by removing the session data (no keys will exist) 

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
