### PR TITLE
feat(color) Add new Textile button style 'Destructive' with a red col…

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/DeleteAccountView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/DeleteAccountView.swift
@@ -68,7 +68,7 @@ struct DeleteAccountView: View {
                 Button(Localization.Settings.AccountManagement.deleteAccount) {
                     viewModel.deleteAccount()
                 }
-                .buttonStyle(PocketButtonStyle(.primary))
+                .buttonStyle(PocketButtonStyle(.destructive))
                 .disabled(
                     viewModel.isPremium ?
                           !(hasCancelledPremium && understandsPermanentDeletion) :

--- a/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
+++ b/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
@@ -12,6 +12,7 @@ public struct PocketButtonStyle: ButtonStyle {
         case primary
         case secondary
         case internalInfoLink
+        case destructive
     }
 
     let variation: Variation
@@ -45,6 +46,14 @@ public struct PocketButtonStyle: ButtonStyle {
             static let pressedForegorundColor = Color(.ui.white1)
             static let buttonHeight: CGFloat = 34
             static let style = Style.header.sansSerif.p4
+        }
+
+        struct Destructive {
+            static let tintColor = Color(.ui.grey1)
+            static let backgroundColor = Color(.ui.coral1)
+            static let pressedBackgroundColor = Color(.ui.white)
+            static let foregroundColor = Color(.ui.white)
+            static let pressedForegroundColor = Color(.ui.white)
         }
     }
 
@@ -103,6 +112,15 @@ public struct PocketButtonStyle: ButtonStyle {
                     .tint(Constants.InternalInfoLink.tintColor)
                     .background( configuration.isPressed ? Constants.InternalInfoLink.pressedBackgroundColor : Constants.InternalInfoLink.backgroundColor)
                     .foregroundColor(configuration.isPressed ? Constants.InternalInfoLink.pressedForegorundColor : Constants.InternalInfoLink.foregroundColor)
+                    .cornerRadius(Constants.cornerRadius)
+            }
+            .if(variation == .destructive) { view in
+                view
+                    .font(Font(Constants.style.fontDescriptor))
+                    .frame(height: Constants.buttonHeight)
+                    .tint(Constants.Destructive.tintColor)
+                    .background( configuration.isPressed ? Constants.Destructive.pressedBackgroundColor : Constants.Destructive.backgroundColor)
+                    .foregroundColor(configuration.isPressed ? Constants.Destructive.pressedForegroundColor : Constants.Destructive.foregroundColor)
                     .cornerRadius(Constants.cornerRadius)
             }
         }

--- a/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
+++ b/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
@@ -138,6 +138,10 @@ struct PocketButton_PreviewProvider: PreviewProvider {
             .padding()
             .buttonStyle(PocketButtonStyle(.secondary))
 
+            Button("Destructive Action") {}
+                .padding()
+                .buttonStyle(PocketButtonStyle(.destructive))
+
             Button("Internal Info Link") {}
             .padding()
             .buttonStyle(PocketButtonStyle(.internalInfoLink))
@@ -156,6 +160,11 @@ struct PocketButton_PreviewProvider: PreviewProvider {
             .padding()
             .buttonStyle(PocketButtonStyle(.secondary))
 
+            Button("Destructive Action") {}
+            .disabled(true)
+            .padding()
+            .buttonStyle(PocketButtonStyle(.destructive))
+
             Button("Internal Info Link") {}
             .disabled(true)
             .padding()
@@ -172,6 +181,10 @@ struct PocketButton_PreviewProvider: PreviewProvider {
             Button("Secondary Action") {}
             .padding()
             .buttonStyle(PocketButtonStyle(.secondary))
+
+            Button("Destructive Action") {}
+            .padding()
+            .buttonStyle(PocketButtonStyle(.destructive))
 
             Button("Internal Info Link") {}
             .padding()
@@ -190,6 +203,11 @@ struct PocketButton_PreviewProvider: PreviewProvider {
             .disabled(true)
             .padding()
             .buttonStyle(PocketButtonStyle(.secondary))
+
+            Button("Destructive Action") {}
+            .disabled(true)
+            .padding()
+            .buttonStyle(PocketButtonStyle(.destructive))
 
             Button("Internal Info Link") {}
             .disabled(true)


### PR DESCRIPTION
…ouring

## Summary
Changes the Delete Account button from the hero colour to a red colour. Should be more in line with user expectations and Apple guidelines.

## References 
https://developer.apple.com/documentation/swiftui/buttonrole/destructive

## Implementation Details
Added a new button style
Applied new style to the delete account button

## Test Steps
Go to Settings > Account Management > Delete Account

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
<img width="564" alt="Screenshot 2023-04-19 at 4 26 54 PM" src="https://user-images.githubusercontent.com/8590135/233192830-2286456d-e2e8-46c9-ac08-2bd042811c2d.png">
<img width="564" alt="Screenshot 2023-04-19 at 4 27 05 PM" src="https://user-images.githubusercontent.com/8590135/233192840-7d241aeb-83e2-42de-bbb5-a602c2aa1ed6.png">
