### PR TITLE
fix(dark-mode): use correct background colors for home / saves

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -10,6 +10,7 @@ public struct MainView: View {
     public var body: some View {
         TabView(selection: $model.selectedSection) {
             HomeViewControllerSwiftUI(model: model.home)
+                .edgesIgnoringSafeArea(.all) // Allow Home to use the entire screen, including under the status bar
                 .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
                 .tabItem {
                     if model.selectedSection == .home {
@@ -23,6 +24,7 @@ public struct MainView: View {
                 .tag(MainViewModel.AppSection.home)
 
             SavesContainerViewControllerSwiftUI(model: model.saves)
+                .edgesIgnoringSafeArea(.all) // Allow Saves to use the entire screen, including under the status bar
                 .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
                 .tabItem {
                     if model.selectedSection == .saves {


### PR DESCRIPTION
## Summary

Fixes an issue where dark mode users would have the incorrect background color under the status bar.

## Test Steps

- [ ] While using dark mode, the color under the status bar should match that of Home / Saves. This includes when scrolling the list.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

### Before

![Simulator Screenshot - iPhone 14 - 2023-04-20 at 10 46 32](https://user-images.githubusercontent.com/1158092/233421383-1231fde3-4b28-4971-bc3f-aadcca484a75.png)

### After

![Simulator Screenshot - iPhone 14 - 2023-04-20 at 10 47 15](https://user-images.githubusercontent.com/1158092/233421426-134b8591-e2ac-41c0-9a0c-07c741f8a3d8.png)

