### PR TITLE
feat: add peek n' pop, bulk edit fake door

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "itemlist.filter.tagged" = "Tagged";
 "itemlist.filter.favorites" = "Favorites";
 "itemlist.filter.sortFilter" = "Sort/Filter";
+"itemList.edit.banner" = "Editing your list is not available in this version of Pocket, but will be returning soon!";
 
 //List view
 "item.list.min" = "%@ min";
@@ -75,7 +76,7 @@
 "search.swipe.unableToMove" = "Unable to Move";
 "search.swipe.archive" = "Archive";
 "search.swipe.moveToSaves" = "Move to Saves";
-
+"search.edit.banner" = "Editing your search results is not available in this version of Pocket, but will be returning soon!";
 "search.empty.header" = "Search by title or URL";
 
 "search.allItems.premium.header" = "Unlock more search options";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -250,6 +250,12 @@ public enum Localization {
     /// Unfavorite
     public static let unfavorite = Localization.tr("Localizable", "itemAction.unfavorite", fallback: "Unfavorite")
   }
+  public enum ItemList {
+    public enum Edit {
+      /// Editing your list is not available in this version of Pocket, but will be returning soon!
+      public static let banner = Localization.tr("Localizable", "itemList.edit.banner", fallback: "Editing your list is not available in this version of Pocket, but will be returning soon!")
+    }
+  }
   public enum Itemlist {
     public enum Filter {
       /// All
@@ -377,6 +383,10 @@ public enum Localization {
     public enum Banner {
       /// We’re experiencing an error and can’t show you full search results. Please try again later.
       public static let errorMessage = Localization.tr("Localizable", "search.banner.errorMessage.", fallback: "We’re experiencing an error and can’t show you full search results. Please try again later.")
+    }
+    public enum Edit {
+      /// Editing your search results is not available in this version of Pocket, but will be returning soon!
+      public static let banner = Localization.tr("Localizable", "search.edit.banner", fallback: "Editing your search results is not available in this version of Pocket, but will be returning soon!")
     }
     public enum Empty {
       /// Search by title or URL

--- a/PocketKit/Sources/PocketKit/Article/ReadableView.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableView.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct ReadableView: UIViewControllerRepresentable {
+    private let viewModel: ReadableViewModel
+
+    init(viewModel: ReadableViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func makeUIViewController(context: Context) -> ReadableViewController {
+        return ReadableViewController(readable: viewModel, readerSettings: ReaderSettings(userDefaults: .standard))
+    }
+
+    func updateUIViewController(_ viewController: ReadableViewController, context: Context) {
+
+    }
+}

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -40,6 +40,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     func clearPresentedWebReaderURL()
     func unfavorite()
     func favorite()
+    func beginBulkEdit()
 }
 
 // MARK: - ReadableViewControllerDelegate

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -252,6 +252,10 @@ extension RecommendationViewModel {
         _events.send(.archive)
     }
 
+    func beginBulkEdit() {
+
+    }
+
     private func save() {
         source.save(recommendation: recommendation)
         track(identifier: .itemSave)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -5,6 +5,7 @@ import Textile
 import Analytics
 import UIKit
 import SharedPocketKit
+import Localization
 
 class SavedItemViewModel: ReadableViewModel {
     let tracker: Tracker
@@ -195,8 +196,8 @@ extension SavedItemViewModel {
     func beginBulkEdit() {
         let bannerData = BannerModifier.BannerData(
             image: .warning,
-            title: "",
-            detail: "Editing your search results is not available in this version of Pocket, but will be returning soon!"
+            title: nil,
+            detail: Localization.Search.Edit.banner
         )
 
         notificationCenter.post(name: .bannerRequested, object: bannerData)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -33,6 +33,7 @@ class SavedItemViewModel: ReadableViewModel {
     private var subscriptions: [AnyCancellable] = []
     private var store: SubscriptionStore
     private var networkPathMonitor: NetworkPathMonitor
+    private let notificationCenter: NotificationCenter
 
     init(
         item: SavedItem,
@@ -42,7 +43,8 @@ class SavedItemViewModel: ReadableViewModel {
         user: User,
         store: SubscriptionStore,
         networkPathMonitor: NetworkPathMonitor,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        notificationCenter: NotificationCenter
     ) {
         self.item = item
         self.source = source
@@ -52,6 +54,7 @@ class SavedItemViewModel: ReadableViewModel {
         self.store = store
         self.networkPathMonitor = networkPathMonitor
         self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()
@@ -187,6 +190,16 @@ extension SavedItemViewModel {
         source.archive(item: item)
         trackArchiveButtonTapped(url: item.url)
         _events.send(.archive)
+    }
+
+    func beginBulkEdit() {
+        let bannerData = BannerModifier.BannerData(
+            image: .warning,
+            title: "",
+            detail: "Editing your search results is not available in this version of Pocket, but will be returning soon!"
+        )
+
+        notificationCenter.post(name: .bannerRequested, object: bannerData)
     }
 
     private func showAddTagsView() {

--- a/PocketKit/Sources/PocketKit/BannerPresenter.swift
+++ b/PocketKit/Sources/PocketKit/BannerPresenter.swift
@@ -6,6 +6,7 @@ import Foundation
 import Textile
 import Combine
 import SwiftUI
+import SharedPocketKit
 
 class BannerPresenter: ObservableObject {
     var bannerData: BannerModifier.BannerData?
@@ -19,15 +20,18 @@ class BannerPresenter: ObservableObject {
     }
 
     func listen() {
-        notificationCenter.publisher(for: .bannerRequested).sink { [weak self] notification in
-            guard let data = notification.object as? BannerModifier.BannerData else {
-                // TODO: Log?
-                return
-            }
+        notificationCenter
+            .publisher(for: .bannerRequested)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let data = notification.object as? BannerModifier.BannerData else {
+                    Log.capture(message: "Requesting banner, but no banner data was supplied")
+                    return
+                }
 
-            self?.bannerData = data
-            self?.shouldPresentBanner = true
-        }.store(in: &subscriptions)
+                self?.bannerData = data
+                self?.shouldPresentBanner = true
+            }.store(in: &subscriptions)
 
         $shouldPresentBanner.filter({ $0 == false }).sink { [weak self] value in
             self?.bannerData = nil

--- a/PocketKit/Sources/PocketKit/BannerPresenter.swift
+++ b/PocketKit/Sources/PocketKit/BannerPresenter.swift
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Textile
+import Combine
+import SwiftUI
+
+class BannerPresenter: ObservableObject {
+    var bannerData: BannerModifier.BannerData?
+    @Published var shouldPresentBanner = false
+
+    private let notificationCenter: NotificationCenter
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(notificationCenter: NotificationCenter) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func listen() {
+        notificationCenter.publisher(for: .bannerRequested).sink { [weak self] notification in
+            guard let data = notification.object as? BannerModifier.BannerData else {
+                // TODO: Log?
+                return
+            }
+
+            self?.bannerData = data
+            self?.shouldPresentBanner = true
+        }.store(in: &subscriptions)
+
+        $shouldPresentBanner.filter({ $0 == false }).sink { [weak self] value in
+            self?.bannerData = nil
+        }.store(in: &subscriptions)
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -99,6 +99,7 @@ class HomeViewModel: NSObject {
     private let userDefaults: UserDefaults
     private let networkPathMonitor: NetworkPathMonitor
     private let homeRefreshCoordinator: RefreshCoordinator
+    private let notificationCenter: NotificationCenter
     private var subscriptions: [AnyCancellable] = []
     private var recentSavesCount: Int = 0
     private var store: SubscriptionStore
@@ -113,7 +114,8 @@ class HomeViewModel: NSObject {
         homeRefreshCoordinator: RefreshCoordinator,
         user: User,
         store: SubscriptionStore,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        notificationCenter: NotificationCenter
     ) {
         self.source = source
         self.tracker = tracker
@@ -123,6 +125,7 @@ class HomeViewModel: NSObject {
         self.user = user
         self.store = store
         self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
 
         self.snapshot = {
             return Self.loadingSnapshot()
@@ -304,7 +307,8 @@ extension HomeViewModel {
             user: user,
             store: store,
             networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
         )
 
         if let item = savedItem.item, item.shouldOpenInWebView {

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -4,6 +4,7 @@ import Localization
 
 public struct MainView: View {
     @ObservedObject var model: MainViewModel
+    @ObservedObject var bannerPresenter: BannerPresenter
 
     @State var tabBarHeightOffset: CGFloat = 0
 
@@ -57,5 +58,7 @@ public struct MainView: View {
         .background(Color(.ui.white1))
         .foregroundColor(Color(.ui.grey1))
         .tint(Color(.ui.grey1))
+        .zIndex(-1)
+        .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -30,7 +30,8 @@ class MainViewModel: ObservableObject {
                     userDefaults: Services.shared.userDefaults,
                     source: Services.shared.source,
                     tracker: Services.shared.tracker.childTracker(hosting: .saves.search),
-                    store: Services.shared.subscriptionStore
+                    store: Services.shared.subscriptionStore,
+                    notificationCenter: Services.shared.notificationCenter
                 ) { source in
                     PremiumUpgradeViewModel(
                         store: Services.shared.subscriptionStore,
@@ -73,7 +74,8 @@ class MainViewModel: ObservableObject {
                 homeRefreshCoordinator: Services.shared.homeRefreshCoordinator,
                 user: Services.shared.user,
                 store: Services.shared.subscriptionStore,
-                userDefaults: Services.shared.userDefaults
+                userDefaults: Services.shared.userDefaults,
+                notificationCenter: Services.shared.notificationCenter
             ),
             account: AccountViewModel(
                 appSession: Services.shared.appSession,

--- a/PocketKit/Sources/PocketKit/Main/RootView.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootView.swift
@@ -18,7 +18,7 @@ public struct RootView: View {
     }
 
     private func mainView(model: MainViewModel) -> MainView {
-        MainView(model: model)
+        MainView(model: model, bannerPresenter: Services.shared.bannerPresenter)
     }
 
     private func loggedOutView(model: LoggedOutViewModel) -> LoggedOutViewControllerSwiftUI {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -332,7 +332,9 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             }
         } actionProvider: { _ in
             return UIMenu(children: [
-                UIAction(title: "Edit") { _ in }
+                UIAction(title: "Edit") { [weak self] _ in
+                    self?.model.beginBulkEdit()
+                }
             ])
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -4,6 +4,7 @@ import CoreData
 import Combine
 import Kingfisher
 import Textile
+import SafariServices
 
 class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, UICollectionViewDelegate, UICollectionViewDataSourcePrefetching {
     private let model: ViewModel
@@ -315,6 +316,25 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
 
     func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         model.prefetch(itemsAt: indexPaths)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+
+        guard let item = dataSource.itemIdentifier(for: indexPath), let (viewModel, showInWebView) = model.preview(for: item) else {
+            return nil
+        }
+
+        return UIContextMenuConfiguration {
+            if showInWebView {
+                return SFSafariViewController(url: viewModel.url!)
+            } else {
+                return ReadableViewController(readable: viewModel, readerSettings: ReaderSettings(userDefaults: .standard))
+            }
+        } actionProvider: { _ in
+            return UIMenu(children: [
+                UIAction(title: "Edit") { _ in }
+            ])
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -106,6 +106,7 @@ protocol ItemsListViewModel: AnyObject {
     func fetch()
     func refresh(_ completion: (() -> Void)?)
 
+    func preview(for cell: ItemsListCell<ItemIdentifier>) -> (ReadableViewModel, Bool)?
     func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter?
     func presenter(for itemID: ItemIdentifier) -> ItemsListItemPresenter?
     func filterButton(with id: ItemsListFilter) -> TopicChipPresenter

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -113,6 +113,7 @@ protocol ItemsListViewModel: AnyObject {
     func tagModel(with name: String) -> SelectedTagChipModel
     func shouldSelectCell(with cell: ItemsListCell<ItemIdentifier>) -> Bool
     func selectCell(with: ItemsListCell<ItemIdentifier>, sender: Any?)
+    func beginBulkEdit()
 
     func filterByTagAction() -> UIAction?
     func trackOverflow(for objectID: ItemIdentifier) -> UIAction?

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -279,8 +279,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     func beginBulkEdit() {
         let bannerData = BannerModifier.BannerData(
             image: .warning,
-            title: "",
-            detail: "Editing your search results is not available in this version of Pocket, but will be returning soon!"
+            title: nil,
+            detail: Localization.ItemList.Edit.banner
         )
 
         notificationCenter.post(name: .bannerRequested, object: bannerData)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -275,6 +275,16 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         }
     }
 
+    func beginBulkEdit() {
+        let bannerData = BannerModifier.BannerData(
+            image: .warning,
+            title: "",
+            detail: "Editing your search results is not available in this version of Pocket, but will be returning soon!"
+        )
+
+        notificationCenter.post(name: .bannerRequested, object: bannerData)
+    }
+
     func filterByTagAction() -> UIAction? {
         return UIAction(title: "", handler: { [weak self] action in
             let event = SnowplowEngagement(type: .general, value: nil)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -219,7 +219,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             user: user,
             store: store,
             networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
         )
 
         if savedItem.shouldOpenInWebView {
@@ -596,7 +597,8 @@ extension SavedItemsListViewModel {
             user: user,
             store: store,
             networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
         )
 
         if savedItem.shouldOpenInWebView {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -202,6 +202,33 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         source.retryImmediately()
     }
 
+    func preview(for cell: ItemsListCell<NSManagedObjectID>) -> (ReadableViewModel, Bool)? {
+        guard case .item(let itemID) = cell else {
+            return nil
+        }
+
+        guard let savedItem = bareItem(with: itemID) else {
+            return nil
+        }
+
+        let readable = SavedItemViewModel(
+            item: savedItem,
+            source: source,
+            tracker: tracker.childTracker(hosting: .articleView.screen),
+            pasteboard: UIPasteboard.general,
+            user: user,
+            store: store,
+            networkPathMonitor: networkPathMonitor,
+            userDefaults: userDefaults
+        )
+
+        if savedItem.shouldOpenInWebView {
+            return (readable, true)
+        } else {
+            return (readable, false)
+        }
+    }
+
     func presenter(for cellID: ItemsListCell<ItemIdentifier>) -> ItemsListItemPresenter? {
         guard case .item(let objectID) = cellID else {
             return nil

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -52,17 +52,7 @@ struct ResultsView: View {
     var body: some View {
         List {
             ForEach(Array(results.enumerated()), id: \.offset) { index, item in
-                HStack {
-                    ListItem(viewModel: viewModel.itemViewModel(item, index: index))
-                    Spacer()
-                }
-                .swipeActions {
-                    Button(viewModel.swipeActionTitle(item)) {
-                        viewModel.handleSwipeAction(item, index: index)
-                    }
-                    .tint(swipeTintColor)
-                }
-                .contentShape(Rectangle())
+                result(for: item, at: index)
                 .onTapGesture {
                     if viewModel.isOffline {
                         showingAlert = true
@@ -84,6 +74,43 @@ struct ResultsView: View {
         .banner(data: viewModel.bannerData, show: $viewModel.showBanner, bottomOffset: 0)
         .alert(isPresented: $showingAlert) {
             Alert(title: Text(Localization.Search.Error.View.needsInternet), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    @ViewBuilder
+    private func basicRow(for item: PocketItem, at index: Int) -> some View {
+        HStack {
+            ListItem(viewModel: viewModel.itemViewModel(item, index: index))
+            Spacer()
+        }
+        .swipeActions {
+            Button(viewModel.swipeActionTitle(item)) {
+                viewModel.handleSwipeAction(item, index: index)
+            }
+            .tint(swipeTintColor)
+        }
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func result(for item: PocketItem, at index: Int) -> some View {
+        if #available(iOS 16, *) {
+            if let (viewModel, showInWebView) = viewModel.readableViewModel(for: item, index: index) {
+                basicRow(for: item, at: index)
+                    .contextMenu {
+                        Button("Edit", action: { })
+                    } preview: {
+                        if showInWebView {
+                            SFSafariView(url: viewModel.url!)
+                        } else {
+                            ReadableView(viewModel: viewModel)
+                        }
+                    }
+            } else {
+                basicRow(for: item, at: index)
+            }
+        } else {
+            basicRow(for: item, at: index)
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -98,7 +98,9 @@ struct ResultsView: View {
             if let (viewModel, showInWebView) = viewModel.readableViewModel(for: item, index: index) {
                 basicRow(for: item, at: index)
                     .contextMenu {
-                        Button("Edit", action: { })
+                        Button("Edit", action: {
+                            viewModel.beginBulkEdit()
+                        })
                     } preview: {
                         if showInWebView {
                             SFSafariView(url: viewModel.url!)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -41,6 +41,7 @@ class SearchViewModel: ObservableObject {
     private let userDefaults: UserDefaults
     private let source: Source
     private let premiumUpgradeViewModelFactory: PremiumUpgradeViewModelFactory
+    private let notificationCenter: NotificationCenter
 
     private var savesLocalSearch: LocalSavesSearch
     private var savesOnlineSearch: OnlineSearch
@@ -106,6 +107,7 @@ class SearchViewModel: ObservableObject {
          source: Source,
          tracker: Tracker,
          store: SubscriptionStore,
+         notificationCenter: NotificationCenter,
          premiumUpgradeViewModelFactory: @escaping PremiumUpgradeViewModelFactory) {
         self.networkPathMonitor = networkPathMonitor
         self.user = user
@@ -113,6 +115,7 @@ class SearchViewModel: ObservableObject {
         self.source = source
         self.tracker = tracker
         self.store = store
+        self.notificationCenter = notificationCenter
         self.premiumUpgradeViewModelFactory = premiumUpgradeViewModelFactory
         itemsController = source.makeSavesController()
 
@@ -230,6 +233,18 @@ class SearchViewModel: ObservableObject {
             guard !allOnlineSearch.hasFinishedResults else { return }
             allOnlineSearch.search(with: term, and: true)
         }
+    }
+
+    func beginBulkEdit() {
+        // TODO: The context of a bulk edit is within the entire list, not a single search result.
+        // Maybe there's potential for this being lifted from the row _to_ the search results list.
+        let bannerData = BannerModifier.BannerData(
+            image: .warning,
+            title: "",
+            detail: "Editing your search results is not available in this version of Pocket, but will be returning soon!"
+        )
+
+        notificationCenter.post(name: .bannerRequested, object: bannerData)
     }
 
     /// Handles submitting a search for the different scopes
@@ -406,7 +421,8 @@ extension SearchViewModel {
             user: user,
             store: store,
             networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
         )
 
         trackOpenSearchItem(url: savedItem.url, index: index)
@@ -487,7 +503,8 @@ extension SearchViewModel {
             user: user,
             store: store,
             networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            notificationCenter: notificationCenter
         )
 
         if savedItem.shouldOpenInWebView {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -467,6 +467,36 @@ extension SearchViewModel {
         return savedItem
     }
 
+    func readableViewModel(for item: PocketItem, index: Int) -> (ReadableViewModel, Bool)? {
+        guard
+            let id = item.id,
+            let savedItem = source.fetchOrCreateSavedItem(
+                with: id,
+                and: item.remoteItemParts
+            )
+        else {
+            Log.capture(message: "Saved Item not created")
+            return nil
+        }
+
+        let viewModel = SavedItemViewModel(
+            item: savedItem,
+            source: source,
+            tracker: tracker.childTracker(hosting: .articleView.screen),
+            pasteboard: UIPasteboard.general,
+            user: user,
+            store: store,
+            networkPathMonitor: networkPathMonitor,
+            userDefaults: userDefaults
+        )
+
+        if savedItem.shouldOpenInWebView {
+            return (viewModel, true)
+        } else {
+            return (viewModel, false)
+        }
+    }
+
     private func trackContentOpen(destination: ContentOpenEvent.Destination, item: SavedItem) {
         guard let url = item.bestURL else {
             return

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -41,6 +41,8 @@ struct Services {
     let lastRefresh: LastRefresh
     let featureFlagService: FeatureFlagService
     let listen: Listen
+    let bannerPresenter: BannerPresenter
+    let notificationCenter: NotificationCenter
 
     private let persistentContainer: PersistentContainer
 
@@ -49,6 +51,8 @@ struct Services {
             fatalError("UserDefaults with suite name \(Keys.shared.groupID) must exist.")
         }
         userDefaults = sharedUserDefaults
+
+        notificationCenter = .default
 
         persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupID)
 
@@ -83,21 +87,21 @@ struct Services {
         sceneTracker = SceneTracker(tracker: tracker, userDefaults: userDefaults)
 
         savesRefreshCoordinator = SavesRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source
         )
 
         archiveRefreshCoordinator = ArchiveRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source
         )
 
         tagsRefreshCoordinator = TagsRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source,
@@ -105,14 +109,14 @@ struct Services {
         )
 
         unresolvedSavesRefreshCoordinator = UnresolvedSavesRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source
         )
 
         homeRefreshCoordinator = HomeRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source,
@@ -120,14 +124,14 @@ struct Services {
         )
 
         userRefreshCoordinator = UserRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source
         )
 
         featureFlagsRefreshCoordinator = FeatureFlagsRefreshCoordinator(
-            notificationCenter: .default,
+            notificationCenter: notificationCenter,
             taskScheduler: BGTaskScheduler.shared,
             appSession: appSession,
             source: source,
@@ -178,7 +182,12 @@ struct Services {
         )
         subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService(client: v3Client), loggedIn: appSession.session != nil)
 
-        userManagementService = UserManagementService(appSession: appSession, user: user, notificationCenter: .default, source: source)
+        userManagementService = UserManagementService(
+            appSession: appSession,
+            user: user,
+            notificationCenter: notificationCenter,
+            source: source
+        )
 
         featureFlagService = FeatureFlagService(source: source, tracker: tracker)
 
@@ -189,6 +198,9 @@ struct Services {
             tracker: tracker,
             source: source
         )
+
+        bannerPresenter = BannerPresenter(notificationCenter: notificationCenter)
+        bannerPresenter.listen()
     }
 }
 

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 public extension Notification.Name {
-    public static let userLoggedIn = Notification.Name("com.mozilla.pocket.userLoggedIn")
-    public static let userLoggedOut = Notification.Name("com.mozilla.pocket.userLoggedOut")
-    public static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
+    static let userLoggedIn = Notification.Name("com.mozilla.pocket.userLoggedIn")
+    static let userLoggedOut = Notification.Name("com.mozilla.pocket.userLoggedOut")
+    static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
+    static let bannerRequested = Notification.Name("com.mozilla.pocket.bannerRequested")
 }

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -12,7 +12,7 @@ public struct BannerModifier: ViewModifier {
 
     public struct BannerData {
         var image: ImageAsset
-        var title: String
+        var title: String?
         var detail: String
         var action: BannerAction?
 
@@ -28,7 +28,7 @@ public struct BannerModifier: ViewModifier {
             }
         }
 
-        public init(image: ImageAsset, title: String, detail: String, action: BannerAction? = nil) {
+        public init(image: ImageAsset, title: String?, detail: String, action: BannerAction? = nil) {
             self.image = image
             self.title = title
             self.detail = detail
@@ -54,9 +54,11 @@ public struct BannerModifier: ViewModifier {
                             .accessibilityIdentifier("banner-image")
                             .padding(Constants.imagePadding)
                         VStack(alignment: .leading, spacing: 8) {
-                            Text(data.title)
-                                .style(Constants.titleStyle)
-                                .accessibilityIdentifier("banner-title")
+                            if let title = data.title {
+                                Text(title)
+                                    .style(Constants.titleStyle)
+                                    .accessibilityIdentifier("banner-title")
+                            }
                             Text(data.detail)
                                 .style(Constants.detailStyle)
                                 .accessibilityIdentifier("banner-detail")

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -36,7 +36,7 @@ public struct BannerModifier: ViewModifier {
         }
     }
 
-    let data: BannerData
+    let data: BannerData?
     let bottomOffset: CGFloat
 
     @Binding var show: Bool
@@ -44,7 +44,7 @@ public struct BannerModifier: ViewModifier {
     public func body(content: Content) -> some View {
         ZStack(alignment: .bottom) {
             content
-            if show {
+            if show, let data = data {
                 VStack {
                     HStack(spacing: 8) {
                         Image(asset: data.image)
@@ -99,7 +99,8 @@ public struct BannerModifier: ViewModifier {
 }
 
 extension View {
-    public func banner(data: BannerModifier.BannerData, show: Binding<Bool>, bottomOffset: CGFloat) -> some View {
+    @ViewBuilder
+    public func banner(data: BannerModifier.BannerData?, show: Binding<Bool>, bottomOffset: CGFloat) -> some View {
         self.modifier(BannerModifier(data: data, bottomOffset: bottomOffset, show: show))
     }
 }
@@ -122,12 +123,12 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-            image: .warning,
-            title: "Title",
-            detail: "Detail Message"
-        ),
-                show: .constant(true),
-                bottomOffset: 0
+                image: .warning,
+                title: "Title",
+                detail: "Detail Message"
+            ),
+            show: .constant(true),
+            bottomOffset: 0
         )
         .previewDisplayName("Warning - Light")
         .preferredColorScheme(.light)
@@ -139,12 +140,12 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-            image: .warning,
-            title: "Title",
-            detail: "Detail Message"
-        ),
-                show: .constant(true),
-                bottomOffset: 0
+                image: .warning,
+                title: "Title",
+                detail: "Detail Message"
+            ),
+            show: .constant(true),
+            bottomOffset: 0
         )
         .previewDisplayName("Warning - Dark")
         .preferredColorScheme(.dark)
@@ -156,17 +157,17 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-            image: .warning,
-            title: "Title",
-            detail: "Detail Message",
-            action: BannerModifier.BannerData.BannerAction(
-                text: "Click!",
-                style: PocketButtonStyle(.primary)
-            ) {
-            }
+                image: .warning,
+                title: "Title",
+                detail: "Detail Message",
+                action: BannerModifier.BannerData.BannerAction(
+                    text: "Click!",
+                    style: PocketButtonStyle(.primary)
+                ) {
+                }
             ),
-                show: .constant(true),
-                bottomOffset: 0
+            show: .constant(true),
+            bottomOffset: 0
         )
         .previewDisplayName("Action - Light")
         .preferredColorScheme(.light)
@@ -178,17 +179,17 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-            image: .accountDeleted,
-            title: "You’ve deleted your Pocket account",
-            detail: "What could we have done better?",
-            action: BannerModifier.BannerData.BannerAction(
-                text: "Quick survey",
-                style: PocketButtonStyle(.primary)
-            ) {
-            }
+                image: .accountDeleted,
+                title: "You’ve deleted your Pocket account",
+                detail: "What could we have done better?",
+                action: BannerModifier.BannerData.BannerAction(
+                    text: "Quick survey",
+                    style: PocketButtonStyle(.primary)
+                ) {
+                }
             ),
-                show: .constant(true),
-                bottomOffset: 0
+            show: .constant(true),
+            bottomOffset: 0
         )
         .previewDisplayName("Action - Dark")
         .preferredColorScheme(.dark)
@@ -210,17 +211,17 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-            image: .accountDeleted,
-            title: "You’ve deleted your Pocket account",
-            detail: "What could we have done better?",
-            action: BannerModifier.BannerData.BannerAction(
-                text: "Quick survey",
-                style: PocketButtonStyle(.primary)
-            ) {
-            }
+                image: .accountDeleted,
+                title: "You’ve deleted your Pocket account",
+                detail: "What could we have done better?",
+                action: BannerModifier.BannerData.BannerAction(
+                    text: "Quick survey",
+                    style: PocketButtonStyle(.primary)
+                ) {
+                }
             ),
-                show: .constant(true),
-                bottomOffset: 49
+            show: .constant(true),
+            bottomOffset: 49
         )
         .previewDisplayName("TabBar")
     }

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -23,12 +23,14 @@ class HomeViewModelTests: XCTestCase {
     var subscriptionStore: SubscriptionStore!
     var userDefaults: UserDefaults!
     var lastRefresh: UserDefaultsLastRefresh!
+    var notificationCenter: NotificationCenter!
 
     override func setUp() async throws {
         subscriptions = []
         space = .testSpace()
         source = MockSource()
         networkPathMonitor = MockNetworkPathMonitor()
+        notificationCenter = .default
 
         taskScheduler = MockBGTaskScheduler()
         userDefaults = .standard
@@ -77,7 +79,8 @@ class HomeViewModelTests: XCTestCase {
         networkPathMonitor: NetworkPathMonitor? = nil,
         homeRefreshCoordinator: RefreshCoordinator? = nil,
         user: User? = nil,
-        userDefaults: UserDefaults? = nil
+        userDefaults: UserDefaults? = nil,
+        notificationCenter: NotificationCenter? = nil
     ) -> HomeViewModel {
         return HomeViewModel(
             source: source ?? self.source,
@@ -86,7 +89,8 @@ class HomeViewModelTests: XCTestCase {
             homeRefreshCoordinator: homeRefreshCoordinator ?? self.homeRefreshCoordinator,
             user: user ?? self.user,
             store: subscriptionStore ?? self.subscriptionStore,
-            userDefaults: userDefaults ?? self.userDefaults
+            userDefaults: userDefaults ?? self.userDefaults,
+            notificationCenter: notificationCenter ?? self.notificationCenter
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -15,6 +15,7 @@ class SavedItemViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var userDefaults: UserDefaults!
+    private var notificationCenter: NotificationCenter!
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -27,6 +28,7 @@ class SavedItemViewModelTests: XCTestCase {
         networkPathMonitor = MockNetworkPathMonitor()
         subscriptionStore = MockSubscriptionStore()
         userDefaults = .standard
+        notificationCenter = .default
     }
 
     override func tearDown() async throws {
@@ -42,7 +44,8 @@ class SavedItemViewModelTests: XCTestCase {
         tracker: Tracker? = nil,
         pasteboard: UIPasteboard? = nil,
         user: User? = nil,
-        networkPathMonitor: NetworkPathMonitor? = nil
+        networkPathMonitor: NetworkPathMonitor? = nil,
+        notificationCenter: NotificationCenter? = nil
     ) -> SavedItemViewModel {
         SavedItemViewModel(
             item: item,
@@ -52,7 +55,8 @@ class SavedItemViewModelTests: XCTestCase {
             user: user ?? self.user,
             store: subscriptionStore ?? self.subscriptionStore,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
-            userDefaults: userDefaults ?? self.userDefaults
+            userDefaults: userDefaults ?? self.userDefaults,
+            notificationCenter: notificationCenter ?? self.notificationCenter
         )
     }
 

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -22,6 +22,7 @@ class SearchViewModelTests: XCTestCase {
     private var subscriptions: [AnyCancellable] = []
     private var subscriptionStore: SubscriptionStore!
     private var itemsController: MockSavedItemsController!
+    private var notificationCenter: NotificationCenter!
 
     override func setUpWithError() throws {
         networkPathMonitor = MockNetworkPathMonitor()
@@ -29,6 +30,7 @@ class SearchViewModelTests: XCTestCase {
         tracker = MockTracker()
         userDefaults = UserDefaults(suiteName: "SearchViewModelTests")
         space = .testSpace()
+        notificationCenter = .default
         searchService = MockSearchService()
         source.stubMakeSearchService { self.searchService }
 
@@ -58,9 +60,15 @@ class SearchViewModelTests: XCTestCase {
         user: User,
         userDefaults: UserDefaults? = nil,
         source: Source? = nil,
-        tracker: Tracker? = nil
+        tracker: Tracker? = nil,
+        notificationCenter: NotificationCenter? = nil
     ) async -> SearchViewModel {
-        let premiumViewModel = await PremiumUpgradeViewModel(store: subscriptionStore, tracker: MockTracker(), source: .search, networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor)
+        let premiumViewModel = await PremiumUpgradeViewModel(
+            store: subscriptionStore,
+            tracker: MockTracker(),
+            source: .search,
+            networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor
+        )
         return SearchViewModel(
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user,
@@ -68,6 +76,7 @@ class SearchViewModelTests: XCTestCase {
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             store: subscriptionStore ?? self.subscriptionStore,
+            notificationCenter: notificationCenter ?? self.notificationCenter,
             premiumUpgradeViewModelFactory: {_ in
                 premiumViewModel
             }


### PR DESCRIPTION
## Summary

Adds peek n' pop to both Saves and Search, appropriately previewing via web view or the reader. An "Edit" option is included under the preview, which will present a banner saying that editing will come in a later release.

## References 

IN-1247

## Implementation Details

The main change here is the addition of a `BannerPresenter`, which maintains the state of whether an app-wide banner should be presented, and with what data. This type listens to a `.bannerRequested` notification, which when posted, should also include the banner data to present. The pre-existing `.banner` modifier is used to show / dismiss the banner as appropriate, which is presented within `MainView`, as to maintain visibility across all views. When `Edit` is tapped both within the context of Saves and Search, the correct notification is posted with the banner data for the context in which an item was previewed. These strings have also been added to `Localizable.strings`, and regenerated with `swiftgen`.

## Test Steps

- [ ] Saves
  - [ ] Tap and hold on an item in Saves or Archive (both should act the same)
  - [ ] The item should be previewed in a web view if not available for offline viewing, otherwise the reader
  - [ ] When tapping `Edit`, the preview should dismiss, and a banner should be visible stating that editing will come later
  - [ ] When tapping the banner, it should dismiss
- [ ] Search
  - [ ] Tap and hold on an item in Search in any of the 3 scopes
  - [ ] The item should be previewed in a web view if not available for offline viewing, otherwise the reader
  - [ ] When tapping `Edit`, the preview should dismiss, and a banner should be visible stating that editing will come later
  - [ ] When tapping the banner, it should dismiss

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

![Simulator Screenshot - iPhone 14 - 2023-04-20 at 11 19 14](https://user-images.githubusercontent.com/1158092/233427286-5898d2ad-6323-4566-94bb-fc5326389423.png)


![Simulator Screenshot - iPhone 14 - 2023-04-20 at 11 19 18](https://user-images.githubusercontent.com/1158092/233427313-db5d9885-894a-444c-8d6b-c0ee5fb3870e.png)

