### PR TITLE
Core Data - Add `mergeByPropertyObjectTrump` to child contexts

### DIFF
--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -133,6 +133,7 @@ public class Space {
     func makeChildBackgroundContext() -> NSManagedObjectContext {
         let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         context.parent = backgroundContext
+        context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         context.automaticallyMergesChangesFromParent = true
         return context
     }


### PR DESCRIPTION

## Summary
* This PR adds a merge policy to the child contexts to avoid erroring when an existing object gets updated


## Implementation Details
* Update `Space`, add `mergeByPropertyObjectTrump` merge policy in `makeChildBackgroundContext()`

## Test Steps
* Make sure no crashes are observed while using the app, particularly Home, Saves/archive, and tags

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

