### PR TITLE
fix(item): ensuring that an item always exists, using PendingItem

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/ItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/ItemParts.graphql.swift
@@ -795,7 +795,7 @@ public struct ItemParts: PocketGraph.SelectionSet, Fragment {
     public var mainImage: String? { __data["mainImage"] }
     /// Title of syndicated article
     public var title: String { __data["title"] }
-    /// Excerpt
+    /// Excerpt 
     public var excerpt: String? { __data["excerpt"] }
     /// The manually set publisher information for this article
     public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }

--- a/PocketKit/Sources/PocketGraph/Fragments/PendingItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/PendingItemParts.graphql.swift
@@ -7,7 +7,8 @@ public struct PendingItemParts: PocketGraph.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """
     fragment PendingItemParts on PendingItem {
       __typename
-      url
+      remoteID: itemId
+      givenUrl: url
       status
     }
     """ }
@@ -18,20 +19,26 @@ public struct PendingItemParts: PocketGraph.SelectionSet, Fragment {
   public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.PendingItem }
   public static var __selections: [ApolloAPI.Selection] { [
     .field("__typename", String.self),
-    .field("url", PocketGraph.Url.self),
+    .field("itemId", alias: "remoteID", String.self),
+    .field("url", alias: "givenUrl", PocketGraph.Url.self),
     .field("status", GraphQLEnum<PocketGraph.PendingItemStatus>?.self),
   ] }
 
-  public var url: PocketGraph.Url { __data["url"] }
+  /// URL of the item that the user gave for the SavedItem
+  /// that is pending processing by parser
+  public var remoteID: String { __data["remoteID"] }
+  public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
   public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
   public init(
-    url: PocketGraph.Url,
+    remoteID: String,
+    givenUrl: PocketGraph.Url,
     status: GraphQLEnum<PocketGraph.PendingItemStatus>? = nil
   ) {
     self.init(_dataDict: DataDict(data: [
       "__typename": PocketGraph.Objects.PendingItem.typename,
-      "url": url,
+      "remoteID": remoteID,
+      "givenUrl": givenUrl,
       "status": status,
       "__fulfilled": Set([
         ObjectIdentifier(Self.self)

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemParts.graphql.swift
@@ -796,7 +796,7 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
         public var mainImage: String? { __data["mainImage"] }
         /// Title of syndicated article
         public var title: String { __data["title"] }
-        /// Excerpt
+        /// Excerpt 
         public var excerpt: String? { __data["excerpt"] }
         /// The manually set publisher information for this article
         public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -844,7 +844,10 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
         .fragment(PendingItemParts.self),
       ] }
 
-      public var url: PocketGraph.Url { __data["url"] }
+      /// URL of the item that the user gave for the SavedItem
+      /// that is pending processing by parser
+      public var remoteID: String { __data["remoteID"] }
+      public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
       public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
       public struct Fragments: FragmentContainer {
@@ -855,12 +858,14 @@ public struct SavedItemParts: PocketGraph.SelectionSet, Fragment {
       }
 
       public init(
-        url: PocketGraph.Url,
+        remoteID: String,
+        givenUrl: PocketGraph.Url,
         status: GraphQLEnum<PocketGraph.PendingItemStatus>? = nil
       ) {
         self.init(_dataDict: DataDict(data: [
           "__typename": PocketGraph.Objects.PendingItem.typename,
-          "url": url,
+          "remoteID": remoteID,
+          "givenUrl": givenUrl,
           "status": status,
           "__fulfilled": Set([
             ObjectIdentifier(Self.self),

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
@@ -21,6 +21,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
       item {
         __typename
         ...ItemSummary
+        ...PendingItemParts
       }
     }
     """ }
@@ -141,9 +142,11 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
       .inlineFragment(AsItem.self),
+      .inlineFragment(AsPendingItem.self),
     ] }
 
     public var asItem: AsItem? { _asInlineFragment() }
+    public var asPendingItem: AsPendingItem? { _asInlineFragment() }
 
     public init(
       __typename: String
@@ -348,6 +351,51 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
             ])
           ]))
         }
+      }
+    }
+
+    /// Item.AsPendingItem
+    ///
+    /// Parent Type: `PendingItem`
+    public struct AsPendingItem: PocketGraph.InlineFragment {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public typealias RootEntityType = SavedItemSummary.Item
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.PendingItem }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .fragment(PendingItemParts.self),
+      ] }
+
+      /// URL of the item that the user gave for the SavedItem
+      /// that is pending processing by parser
+      public var remoteID: String { __data["remoteID"] }
+      public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
+      public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
+
+      public struct Fragments: FragmentContainer {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public var pendingItemParts: PendingItemParts { _toFragment() }
+      }
+
+      public init(
+        remoteID: String,
+        givenUrl: PocketGraph.Url,
+        status: GraphQLEnum<PocketGraph.PendingItemStatus>? = nil
+      ) {
+        self.init(_dataDict: DataDict(data: [
+          "__typename": PocketGraph.Objects.PendingItem.typename,
+          "remoteID": remoteID,
+          "givenUrl": givenUrl,
+          "status": status,
+          "__fulfilled": Set([
+            ObjectIdentifier(Self.self),
+            ObjectIdentifier(SavedItemSummary.Item.self),
+            ObjectIdentifier(PendingItemParts.self)
+          ])
+        ]))
       }
     }
   }

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
@@ -316,7 +316,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
         public var mainImage: String? { __data["mainImage"] }
         /// Title of syndicated article
         public var title: String { __data["title"] }
-        /// Excerpt
+        /// Excerpt 
         public var excerpt: String? { __data["excerpt"] }
         /// The manually set publisher information for this article
         public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }

--- a/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SlateParts.graphql.swift
@@ -273,7 +273,7 @@ public struct SlateParts: PocketGraph.SelectionSet, Fragment {
         public var mainImage: String? { __data["mainImage"] }
         /// Title of syndicated article
         public var title: String { __data["title"] }
-        /// Excerpt
+        /// Excerpt 
         public var excerpt: String? { __data["excerpt"] }
         /// The manually set publisher information for this article
         public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/ReplaceSavedItemTagsMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/ReplaceSavedItemTagsMutation.graphql.swift
@@ -513,7 +513,7 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
             public var mainImage: String? { __data["mainImage"] }
             /// Title of syndicated article
             public var title: String { __data["title"] }
-            /// Excerpt
+            /// Excerpt 
             public var excerpt: String? { __data["excerpt"] }
             /// The manually set publisher information for this article
             public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -541,7 +541,10 @@ public class ReplaceSavedItemTagsMutation: GraphQLMutation {
             SavedItemParts.Item.AsPendingItem.self
           ] }
 
-          public var url: PocketGraph.Url { __data["url"] }
+          /// URL of the item that the user gave for the SavedItem
+          /// that is pending processing by parser
+          public var remoteID: String { __data["remoteID"] }
+          public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
           public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
           public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/SaveItemMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/SaveItemMutation.graphql.swift
@@ -508,7 +508,7 @@ public class SaveItemMutation: GraphQLMutation {
             public var mainImage: String? { __data["mainImage"] }
             /// Title of syndicated article
             public var title: String { __data["title"] }
-            /// Excerpt
+            /// Excerpt 
             public var excerpt: String? { __data["excerpt"] }
             /// The manually set publisher information for this article
             public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -536,7 +536,10 @@ public class SaveItemMutation: GraphQLMutation {
             SavedItemParts.Item.AsPendingItem.self
           ] }
 
-          public var url: PocketGraph.Url { __data["url"] }
+          /// URL of the item that the user gave for the SavedItem
+          /// that is pending processing by parser
+          public var remoteID: String { __data["remoteID"] }
+          public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
           public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
           public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/UpdateSavedItemRemoveTagsMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/UpdateSavedItemRemoveTagsMutation.graphql.swift
@@ -511,7 +511,7 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
             public var mainImage: String? { __data["mainImage"] }
             /// Title of syndicated article
             public var title: String { __data["title"] }
-            /// Excerpt
+            /// Excerpt 
             public var excerpt: String? { __data["excerpt"] }
             /// The manually set publisher information for this article
             public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -539,7 +539,10 @@ public class UpdateSavedItemRemoveTagsMutation: GraphQLMutation {
             SavedItemParts.Item.AsPendingItem.self
           ] }
 
-          public var url: PocketGraph.Url { __data["url"] }
+          /// URL of the item that the user gave for the SavedItem
+          /// that is pending processing by parser
+          public var remoteID: String { __data["remoteID"] }
+          public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
           public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
           public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
@@ -317,7 +317,7 @@ public class FetchArchiveQuery: GraphQLQuery {
                   public var mainImage: String? { __data["mainImage"] }
                   /// Title of syndicated article
                   public var title: String { __data["title"] }
-                  /// Excerpt
+                  /// Excerpt 
                   public var excerpt: String? { __data["excerpt"] }
                   /// The manually set publisher information for this article
                   public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
@@ -31,7 +31,7 @@ public class FetchArchiveQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [SavedItemSummary.self, TagParts.self, ItemSummary.self, DomainMetadataParts.self, SyndicatedArticleParts.self]
+      fragments: [SavedItemSummary.self, TagParts.self, ItemSummary.self, DomainMetadataParts.self, SyndicatedArticleParts.self, PendingItemParts.self]
     ))
 
   public var pagination: GraphQLNullable<PaginationInput>
@@ -218,6 +218,7 @@ public class FetchArchiveQuery: GraphQLQuery {
               public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.ItemResult }
 
               public var asItem: AsItem? { _asInlineFragment() }
+              public var asPendingItem: AsPendingItem? { _asInlineFragment() }
 
               /// User.SavedItems.Edge.Node.Item.AsItem
               ///
@@ -328,6 +329,34 @@ public class FetchArchiveQuery: GraphQLQuery {
 
                     public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
                   }
+                }
+              }
+
+              /// User.SavedItems.Edge.Node.Item.AsPendingItem
+              ///
+              /// Parent Type: `PendingItem`
+              public struct AsPendingItem: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+                public let __data: DataDict
+                public init(_dataDict: DataDict) { __data = _dataDict }
+
+                public typealias RootEntityType = User.SavedItems.Edge.Node.Item
+                public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.PendingItem }
+                public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+                  PendingItemParts.self,
+                  SavedItemSummary.Item.AsPendingItem.self
+                ] }
+
+                /// URL of the item that the user gave for the SavedItem
+                /// that is pending processing by parser
+                public var remoteID: String { __data["remoteID"] }
+                public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
+                public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
+
+                public struct Fragments: FragmentContainer {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public var pendingItemParts: PendingItemParts { _toFragment() }
                 }
               }
             }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchSavesQuery.graphql.swift
@@ -611,7 +611,7 @@ public class FetchSavesQuery: GraphQLQuery {
                   public var mainImage: String? { __data["mainImage"] }
                   /// Title of syndicated article
                   public var title: String { __data["title"] }
-                  /// Excerpt
+                  /// Excerpt 
                   public var excerpt: String? { __data["excerpt"] }
                   /// The manually set publisher information for this article
                   public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -639,7 +639,10 @@ public class FetchSavesQuery: GraphQLQuery {
                   SavedItemParts.Item.AsPendingItem.self
                 ] }
 
-                public var url: PocketGraph.Url { __data["url"] }
+                /// URL of the item that the user gave for the SavedItem
+                /// that is pending processing by parser
+                public var remoteID: String { __data["remoteID"] }
+                public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
                 public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
                 public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/ItemByIDQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/ItemByIDQuery.graphql.swift
@@ -433,7 +433,7 @@ public class ItemByIDQuery: GraphQLQuery {
         public var mainImage: String? { __data["mainImage"] }
         /// Title of syndicated article
         public var title: String { __data["title"] }
-        /// Excerpt
+        /// Excerpt 
         public var excerpt: String? { __data["excerpt"] }
         /// The manually set publisher information for this article
         public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/SavedItemByIDQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/SavedItemByIDQuery.graphql.swift
@@ -527,7 +527,7 @@ public class SavedItemByIDQuery: GraphQLQuery {
               public var mainImage: String? { __data["mainImage"] }
               /// Title of syndicated article
               public var title: String { __data["title"] }
-              /// Excerpt
+              /// Excerpt 
               public var excerpt: String? { __data["excerpt"] }
               /// The manually set publisher information for this article
               public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -555,7 +555,10 @@ public class SavedItemByIDQuery: GraphQLQuery {
               SavedItemParts.Item.AsPendingItem.self
             ] }
 
-            public var url: PocketGraph.Url { __data["url"] }
+            /// URL of the item that the user gave for the SavedItem
+            /// that is pending processing by parser
+            public var remoteID: String { __data["remoteID"] }
+            public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
             public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
             public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/SearchSavedItemsQuery.graphql.swift
@@ -626,7 +626,7 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                     public var mainImage: String? { __data["mainImage"] }
                     /// Title of syndicated article
                     public var title: String { __data["title"] }
-                    /// Excerpt
+                    /// Excerpt 
                     public var excerpt: String? { __data["excerpt"] }
                     /// The manually set publisher information for this article
                     public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
@@ -654,7 +654,10 @@ public class SearchSavedItemsQuery: GraphQLQuery {
                     SavedItemParts.Item.AsPendingItem.self
                   ] }
 
-                  public var url: PocketGraph.Url { __data["url"] }
+                  /// URL of the item that the user gave for the SavedItem
+                  /// that is pending processing by parser
+                  public var remoteID: String { __data["remoteID"] }
+                  public var givenUrl: PocketGraph.Url { __data["givenUrl"] }
                   public var status: GraphQLEnum<PocketGraph.PendingItemStatus>? { __data["status"] }
 
                   public struct Fragments: FragmentContainer {

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/archive.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/archive.graphql
@@ -38,6 +38,7 @@ fragment SavedItemSummary on SavedItem {
   }
   item {
     ...ItemSummary
+    ...PendingItemParts
   }
 }
 

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/itemFragments.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/itemFragments.graphql
@@ -64,7 +64,8 @@ fragment SyndicatedArticleParts on SyndicatedArticle {
 }
 
 fragment PendingItemParts on PendingItem {
-  url
+  remoteID: itemId
+  givenUrl: url
   status
 }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -85,7 +85,7 @@ extension Item {
         remoteID = remote.remoteID
 
         guard let url = URL(string: remote.givenUrl) else {
-            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Item \(remoteID) because \(givenURL) is not valid url")
+            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Pending Item \(remoteID) because \(givenURL) is not valid url")
             return
         }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -81,6 +81,17 @@ extension Item {
         }
     }
 
+    func update(remote: PendingItemParts, with space: Space) {
+        remoteID = remote.remoteID
+
+        guard let url = URL(string: remote.givenUrl) else {
+            Log.breadcrumb(category: "sync", level: .warning, message: "Skipping updating of Item \(remoteID) because \(givenURL) is not valid url")
+            return
+        }
+
+        givenURL = url
+    }
+
     func update(from summary: ItemSummary, with space: Space) {
         remoteID = summary.remoteID
 

--- a/PocketKit/Sources/Sync/Space/DerivedSpace.swift
+++ b/PocketKit/Sources/Sync/Space/DerivedSpace.swift
@@ -115,7 +115,7 @@ extension DerivedSpace: ArchivedItemSpace {
             context.performAndWait {
                 let item = (try? space.fetchSavedItem(byRemoteID: node.remoteID, context: context)) ?? SavedItem(context: context, url: url, remoteID: node.remoteID)
                 item.update(from: node.fragments.savedItemSummary, with: space)
-
+                item.cursor = edge.cursor
                 if item.deletedAt != nil {
                     space.delete(item)
                 }


### PR DESCRIPTION
## Summary

Item is not null in the Graph, but only if you adhere to it's interface and check for Pending Item. 

This updates the code to create an item from pending item.

In the future I think we will want to update some field names to be more clear, and drop things we don't need (we dont need givenURL and resolvedURL from the graph on Item).

## Test Steps
* Save something that the parser can not reach on the internet (like a local ip url)
* Without this change the app will crash if you scroll to the item in your list
* With this change the app will not crash and fallback to showing URL instead of a fancy title in the list, and treat the item as non article.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
