### PR TITLE
Home - Fix a crash when loading remote lineup

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -291,7 +291,7 @@ extension HomeViewModel {
             return
         }
 
-        tracker.track(event: Events.Home.SlateArticleContentOpen(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.remoteID))
+        tracker.track(event: Events.Home.SlateArticleContentOpen(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID))
     }
 
     private func select(savedItem: SavedItem, at indexPath: IndexPath) {
@@ -525,7 +525,7 @@ extension HomeViewModel {
             return
         }
 
-        tracker.track(event: Events.Home.SlateArticleShare(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.remoteID))
+        tracker.track(event: Events.Home.SlateArticleShare(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID))
     }
 
     private func share(_ savedItem: SavedItem, at indexPath: IndexPath, with sender: Any?) {
@@ -546,7 +546,7 @@ extension HomeViewModel {
             return
         }
 
-        tracker.track(event: Events.Home.SlateArticleSave(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.remoteID))
+        tracker.track(event: Events.Home.SlateArticleSave(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID))
     }
 
     private func archive(_ recommendation: Recommendation, at indexPath: IndexPath) {
@@ -560,7 +560,7 @@ extension HomeViewModel {
             return
         }
 
-        tracker.track(event: Events.Home.SlateArticleArchive(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.remoteID))
+        tracker.track(event: Events.Home.SlateArticleArchive(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID))
     }
 
     private func archive(_ savedItem: SavedItem, at indexPath: IndexPath) {
@@ -598,7 +598,7 @@ extension HomeViewModel {
                 return
             }
 
-            tracker.track(event: Events.Home.SlateArticleImpression(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.remoteID))
+            tracker.track(event: Events.Home.SlateArticleImpression(url: item.givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID))
         }
     }
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataClass.swift
@@ -24,10 +24,12 @@ public class Recommendation: NSManagedObject {
 
     public init(
         context: NSManagedObjectContext,
-        remoteID: String
+        remoteID: String,
+        analyticsID: String
     ) {
         let entity = NSEntityDescription.entity(forEntityName: "Recommendation", in: context)!
         super.init(entity: entity, insertInto: context)
         self.remoteID = remoteID
+        self.analyticsID = analyticsID
     }
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
+
 import Foundation
 import CoreData
 
 extension Recommendation {
-    @nonobjc
-    public class func fetchRequest() -> NSFetchRequest<Recommendation> {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Recommendation> {
         return NSFetchRequest<Recommendation>(entityName: "Recommendation")
     }
 
@@ -15,6 +16,7 @@ extension Recommendation {
     @NSManaged public var imageURL: URL?
     @NSManaged public var remoteID: String
     @NSManaged public var title: String?
+    @NSManaged public var analyticsID: String
     @NSManaged public var item: Item
     @NSManaged public var slate: Slate?
     @NSManaged public var image: Image?

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -61,6 +61,7 @@
         <attribute name="syncTaskContainer" attributeType="Transformable" valueTransformerName="SyncTaskTransformer" customClassName="SyncTaskContainer"/>
     </entity>
     <entity name="Recommendation" representedClassName="Recommendation" syncable="YES">
+        <attribute name="analyticsID" attributeType="String"/>
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="remoteID" attributeType="String"/>

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -31,13 +31,14 @@ extension Slate {
             // concatenate recommendation ID with slate ID to ensure that a unique recommendation entity exists even if an actual recommendation is
             // present in more than one slate
             let remoteID = remote.id + remoteSlate.id
-            guard let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID, context: context) ?? Recommendation(context: context, remoteID: remoteID) else {
+            let analyticsID = remote.id
+            guard let recommendation = try? space.fetchRecommendation(byRemoteID: remoteID, context: context) ?? Recommendation(context: context, remoteID: remoteID, analyticsID: analyticsID) else {
                 return nil
             }
             recommendation.update(from: remote, in: space, context: context)
             recommendation.sortIndex = NSNumber(value: i)
             recommendation.slate = self
-            recommendation.analyticsID = remote.id
+            recommendation.analyticsID = analyticsID
             i = i + 1
             return recommendation
         })

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -259,14 +259,16 @@ extension Space {
         item: Item,
         imageURL: URL? = nil,
         title: String? = nil,
-        excerpt: String?  = nil
+        excerpt: String?  = nil,
+        analyticsID: String = ""
     ) -> Recommendation {
         backgroundContext.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID, analyticsID: analyticsID)
             recommendation.item = item
             recommendation.title = title
             recommendation.excerpt = excerpt
             recommendation.imageURL = imageURL
+            recommendation.analyticsID = analyticsID
             return recommendation
         }
     }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -222,7 +222,7 @@ extension Space {
         item: Item
     ) -> Recommendation {
         backgroundContext.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID, analyticsID: "")
             recommendation.item = item
 
             return recommendation

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -76,7 +76,7 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[0]
-                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-1")
+                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-1slate-1")
 
                 let item = recommendation.item
                 XCTAssertNotNil(item)
@@ -102,7 +102,7 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[1]
-                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-2")
+                XCTAssertEqual(recommendation.remoteID, "slate-1-rec-2slate-1")
                 XCTAssertNotNil(recommendation.item)
             }
         }
@@ -120,7 +120,7 @@ extension APISlateServiceTests {
 
             do {
                 let recommendation = recommendations[0]
-                XCTAssertEqual(recommendation.remoteID, "slate-2-rec-1")
+                XCTAssertEqual(recommendation.remoteID, "slate-2-rec-1slate-2")
             }
         }
     }

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -269,7 +269,7 @@ extension Space {
         item: Item
     ) -> Recommendation {
         backgroundContext.performAndWait {
-            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID)
+            let recommendation: Recommendation = Recommendation(context: backgroundContext, remoteID: remoteID, analyticsID: "")
             recommendation.item = item
 
             return recommendation


### PR DESCRIPTION
## Summary
* This PR improves the recommendations fetching logic to prevent a crash

## Implementation Details
* Update `Recommendation`, add `analyticsID` property
* Update `SlateLineup+RemoteMapping`, concatenate recommendation id and slate id, and use it as a `Recommendation` unique ID, to account for recommendations that could be present in more than one slate
* Update `HomeViewModel`, use the newly added `analyticsID` field to identify a recommendation in analytics tracks

>**Note**
This PR changes the data model, it is recommended to delete previous builds before installing and testing this one

## Test Steps
* Build/run this branch
* Refresh Home repeatedly
* Make sure there are no crashes

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
