### PR TITLE
fix(ci): add missing test support dependency

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -127,6 +127,7 @@ let package = Package(
             name: "PocketGraphTestMocks",
             dependencies: [
                 .product(name: "ApolloAPI", package: "apollo-ios"),
+                .product(name: "ApolloTestSupport", package: "apollo-ios"),
                 "PocketGraph"
             ]
         ),


### PR DESCRIPTION
## Summary

Adds missing `ApolloTestSupport` package dependency that would cause build errors when attempting to run UI tests.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
