### PR TITLE
Fix Core Data crash on search results

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -708,9 +708,11 @@ extension SavedItemsListViewModel: SavedItemsControllerDelegate {
         // Build up a snapshot for us to use
         var newSnapshot = buildSnapshot()
 
-        // Grab any ids that have changed, map them to .item and then setup our custom snapshot to reload them
+        // Grab any ids that have changed, filter them based on what newSnapshot contains, map them to .item and then setup our custom snapshot to reload them
         let idsToReload: [ItemsListCell<ItemIdentifier>] =  snapshot.reloadedItemIdentifiers.compactMap({ .item($0 as! NSManagedObjectID) })
+            .filter { newSnapshot.itemIdentifiers.contains($0) }
         let idsToReconfigure: [ItemsListCell<ItemIdentifier>] =  snapshot.reconfiguredItemIdentifiers.compactMap({ .item($0 as! NSManagedObjectID) })
+            .filter { newSnapshot.itemIdentifiers.contains($0) }
         newSnapshot.reloadItems(idsToReload)
         newSnapshot.reconfigureItems(idsToReconfigure)
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -52,7 +52,7 @@ struct ResultsView: View {
     var body: some View {
         List {
             ForEach(Array(results.enumerated()), id: \.offset) { index, item in
-                result(for: item, at: index)
+                basicRow(for: item, at: index)
                 .onTapGesture {
                     if viewModel.isOffline {
                         showingAlert = true
@@ -90,30 +90,6 @@ struct ResultsView: View {
             .tint(swipeTintColor)
         }
         .contentShape(Rectangle())
-    }
-
-    @ViewBuilder
-    private func result(for item: PocketItem, at index: Int) -> some View {
-        if #available(iOS 16, *) {
-            if let (viewModel, showInWebView) = viewModel.readableViewModel(for: item, index: index) {
-                basicRow(for: item, at: index)
-                    .contextMenu {
-                        Button("Edit", action: {
-                            viewModel.beginBulkEdit()
-                        })
-                    } preview: {
-                        if showInWebView {
-                            SFSafariView(url: viewModel.url!)
-                        } else {
-                            ReadableView(viewModel: viewModel)
-                        }
-                    }
-            } else {
-                basicRow(for: item, at: index)
-            }
-        } else {
-            basicRow(for: item, at: index)
-        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -442,9 +442,7 @@ extension SearchViewModel {
     }
 
     func swipeActionTitle(_ searchItem: PocketItem) -> String {
-        guard let savedItem = fetchSavedItem(searchItem) else { return Localization.Search.Swipe.unableToMove }
-
-        if savedItem.isArchived {
+        if searchItem.isArchived {
             return Localization.Search.Swipe.moveToSaves
         } else {
             return Localization.Search.Swipe.archive
@@ -484,37 +482,6 @@ extension SearchViewModel {
             return nil
         }
         return savedItem
-    }
-
-    func readableViewModel(for item: PocketItem, index: Int) -> (ReadableViewModel, Bool)? {
-        guard
-            let id = item.id,
-            let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
-                and: item.remoteItemParts
-            )
-        else {
-            Log.capture(message: "Saved Item not created")
-            return nil
-        }
-
-        let viewModel = SavedItemViewModel(
-            item: savedItem,
-            source: source,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            pasteboard: UIPasteboard.general,
-            user: user,
-            store: store,
-            networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults,
-            notificationCenter: notificationCenter
-        )
-
-        if savedItem.shouldOpenInWebView {
-            return (viewModel, true)
-        } else {
-            return (viewModel, false)
-        }
     }
 
     private func trackContentOpen(destination: ContentOpenEvent.Destination, item: SavedItem) {


### PR DESCRIPTION
## Summary
* Fixes a crash occurring while scrolling online search results

## Implementation Details
* Update `SavedItemsListViewModel`, ensure reloaded items are present in the snapshot
* Update `SearchViewModel`, `SearchView`: (temporarily) remove peek 'n' pop from search results

## Test Steps
* Login with a premium account
* Search something that produces a long list
* Scroll through and make sure that:
    - The UI does not freeze
    - There are no crashes

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
