### PR TITLE
fix(ui): making saves deselect and reader full screen push

### DIFF
--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -62,6 +62,18 @@ class ReadableHostViewController: UIViewController {
         }.store(in: &subscriptions)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // This view is hosted in SwitUI and it seems that hidesBottomBarWhenPushed is not resepected,
+        // but manually hiding the tab bar does
+        self.tabBarController?.tabBar.isHidden = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         lockOrientation(.allButUpsideDown)

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -22,6 +22,7 @@ struct SavesContainerViewControllerSwiftUI: UIViewControllerRepresentable {
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.barTintColor = UIColor(.ui.white1)
         navigationController.navigationBar.tintColor = UIColor(.ui.grey1)
+        navigationController.delegate = v
         return navigationController
     }
 
@@ -87,7 +88,6 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
 
         view.accessibilityIdentifier = "saves"
         select(child: viewControllers.first)
-        navigationController?.delegate = self
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

Ensure that reader full screen pushes, and that saved items deselect when returning to saves view.


https://user-images.githubusercontent.com/1010384/234144522-080b58c0-2c13-4fa2-9c77-b1794d9c4007.mp4



## References 
*[IN-1334](https://getpocket.atlassian.net/browse/IN-1334)


## Implementation Details
* `hidesBottomBarWhenPushed` did not work. Likely because the view is hosted in a UI Nav view, hosted in a SwiftUI Tab View

[IN-1334]: https://getpocket.atlassian.net/browse/IN-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ