### PR TITLE
fix(tabBar): brining back the tab bar appearance

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -10,54 +10,51 @@ public struct MainView: View {
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {
-            HomeViewControllerSwiftUI(model: model.home)
-                .edgesIgnoringSafeArea(.all) // Allow Home to use the entire screen, including under the status bar
+                HomeViewControllerSwiftUI(model: model.home)
+                    .edgesIgnoringSafeArea(.all) // Allow Home to use the entire screen, including under the status bar
+                    .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
+                    .tabItem {
+                        if model.selectedSection == .home {
+                            Image(asset: .tabHomeSelected)
+                        } else {
+                            Image(asset: .tabHomeDeselected)
+                        }
+                        Text(Localization.home)
+                    }
+                    .accessibilityIdentifier("home-tab-bar-button")
+                    .tag(MainViewModel.AppSection.home)
+
+                SavesContainerViewControllerSwiftUI(model: model.saves)
+                    .edgesIgnoringSafeArea(.all) // Allow Saves to use the entire screen, including under the status bar
+                    .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
+                    .tabItem {
+                        if model.selectedSection == .saves {
+                            Image(asset: .tabSavesSelected)
+                        } else {
+                            Image(asset: .tabSavesDeselected)
+                        }
+                        Text(Localization.saves)
+                    }
+                    .accessibilityIdentifier("saves-tab-bar-button")
+                    .tag(MainViewModel.AppSection.saves)
+
+                NavigationView {
+                    SettingsView(model: model.account)
+                }
+                .navigationViewStyle(.stack)
+                .background(Color(.ui.white1))
                 .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
                 .tabItem {
-                    if model.selectedSection == .home {
-                        Image(asset: .tabHomeSelected)
+                    if model.selectedSection == .account {
+                        Image(asset: .tabSettingsSelected)
                     } else {
-                        Image(asset: .tabHomeDeselected)
+                        Image(asset: .tabSettingsDeselected)
                     }
-                    Text(Localization.home)
+                    Text(Localization.settings)
                 }
-                .accessibilityIdentifier("home-tab-bar-button")
-                .tag(MainViewModel.AppSection.home)
-
-            SavesContainerViewControllerSwiftUI(model: model.saves)
-                .edgesIgnoringSafeArea(.all) // Allow Saves to use the entire screen, including under the status bar
-                .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
-                .tabItem {
-                    if model.selectedSection == .saves {
-                        Image(asset: .tabSavesSelected)
-                    } else {
-                        Image(asset: .tabSavesDeselected)
-                    }
-                    Text(Localization.saves)
-                }
-                .accessibilityIdentifier("saves-tab-bar-button")
-                .tag(MainViewModel.AppSection.saves)
-
-            NavigationView {
-                SettingsView(model: model.account)
-            }
-            .navigationViewStyle(.stack)
-            .background(Color(.ui.white1))
-            .tabBarHeightOffset { offset in tabBarHeightOffset = offset }
-            .tabItem {
-                if model.selectedSection == .account {
-                    Image(asset: .tabSettingsSelected)
-                } else {
-                    Image(asset: .tabSettingsDeselected)
-                }
-                Text(Localization.settings)
-            }
-            .accessibilityIdentifier("account-tab-bar-button")
-            .tag(MainViewModel.AppSection.account)
+                .accessibilityIdentifier("account-tab-bar-button")
+                .tag(MainViewModel.AppSection.account)
         }
-        .background(Color(.ui.white1))
-        .foregroundColor(Color(.ui.grey1))
-        .tint(Color(.ui.grey1))
         .zIndex(-1)
         .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
     }

--- a/PocketKit/Sources/PocketKit/Main/RootView.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootView.swift
@@ -5,6 +5,36 @@ public struct RootView: View {
 
     public init(model: RootViewModel) {
         self.model = model
+        self.setupTabBarAppearance()
+    }
+
+    /// Sets up the tab bar appearance following some of https://stackoverflow.com/questions/56969309/change-tabbed-view-bar-color-swiftui
+    private func setupTabBarAppearance() {
+        let tabBarAppeareance = UITabBarAppearance()
+        tabBarAppeareance.configureWithOpaqueBackground()
+
+        tabBarAppeareance.shadowColor = UIColor(.ui.grey1) // For line separator of the tab bar
+        tabBarAppeareance.backgroundColor = UIColor(.ui.white1)
+        tabBarAppeareance.backgroundEffect = nil
+        tabBarAppeareance.selectionIndicatorTintColor = UIColor(.ui.grey1)
+
+        tabBarAppeareance.stackedLayoutAppearance = tabItemAppearance
+        tabBarAppeareance.compactInlineLayoutAppearance = tabItemAppearance
+        tabBarAppeareance.inlineLayoutAppearance = tabItemAppearance
+
+        // Use this appearance when scrolling behind the TabView:
+        UITabBar.appearance().standardAppearance = tabBarAppeareance
+        // Use this appearance when scrolled all the way up:
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppeareance
+    }
+
+    private var tabItemAppearance: UITabBarItemAppearance {
+       let tabItemAppeareance =  UITabBarItemAppearance()
+       tabItemAppeareance.selected.iconColor = UIColor(.ui.grey1)
+       tabItemAppeareance.selected.titleTextAttributes[.foregroundColor] = UIColor(.ui.grey1)
+       tabItemAppeareance.normal.iconColor = UIColor(.ui.grey1)
+       tabItemAppeareance.normal.titleTextAttributes[.foregroundColor] = UIColor(.ui.grey1)
+       return tabItemAppeareance
     }
 
     public var body: some View {


### PR DESCRIPTION
## Summary
* Bring back the tab bar appearance that we lost with the coordinators https://github.com/Pocket/pocket-ios/pull/473/files#diff-bf02518d373044a10a8e8299a3d13ce19bc283ed4baa898598e6feeb681b25f2L51-L63
<img src="https://user-images.githubusercontent.com/1010384/234150803-4cfbcf13-8b88-4c59-bc5e-26e549d058a2.png" height=600>