### PR TITLE
refactor(analytics): correctly append Content entity, update SaveTo tag event identifiers

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
@@ -1,0 +1,233 @@
+//
+//  File.swift
+//  
+//
+//  Created by David Skuza on 4/24/23.
+//
+
+import Foundation
+
+public extension Events {
+    struct SaveTo {}
+}
+
+public extension Events.SaveTo {
+    struct Tags { }
+}
+
+public extension Events.SaveTo {
+    /// Fired when a user opens the Save extension, since we cannot directly interact with
+    /// the tapping of the icon from the share sheet. The Save extension is the entrypoint
+    /// for that tap, so treat the opening of the Save extension as an engagement.
+    static func saveEngagement(url: URL) -> Event {
+        return Engagement(
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "save-extension.opened"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /// Fired when a user taps on "Add Tags" from the Save extension
+    static func addTagsEngagement(url: URL) -> Event {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.opened"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+}
+
+public extension Events.SaveTo.Tags {
+    /// Fired when user taps on "Save" button in `Add Tags` screen for an item
+    static func saveTags(itemUrl: URL) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.save"
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /// Fired when a user adds tag to an input list in the `Add Tags` screen for an item
+    static func addTag(itemUrl: URL) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.addTag"
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /// Fired when user taps on a tag name and removes it from the list of input tags in `Add Tags` screen for an item
+    static func remoteInputTag(itemUrl: URL) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.removeInputTag"
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /// Fired when a user enters text in the text field in the `Add Tags` screen for an item and includes component detail of text user entered
+    static func userEntersText(itemUrl: URL, text: String) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .dialog,
+                identifier: "save-extension.addTags.userEntersText",
+                componentDetail: text
+            ),
+            extraEntities: [
+                ContentEntity(
+                    url: itemUrl
+                )
+            ]
+        )
+    }
+
+    /// Fired when a user views all of their tags in the `Add Tags` screen for an item
+    static func allTagsImpression(itemUrl: URL) -> Event {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "save-extension.addTags.allTags"
+            ),
+            extraEntities: [
+                ContentEntity(url: itemUrl)
+            ]
+        )
+    }
+
+    /// Fired when a user views filtered tags in the `Add Tags` screen for an item
+    static func filteredTagsImpression(itemUrl: URL) -> Event {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "save-extension.addTags.filteredTags"
+            ),
+            extraEntities: [
+                ContentEntity(url: itemUrl)
+            ]
+        )
+    }
+
+    /// "Go Premium" button viewed
+    static func premiumUpsellViewed() -> Event {
+        return Impression(
+            component: .button,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.upsell"
+            )
+        )
+    }
+
+    /// Fired when a user taps on a general tag from `Add Tags` screen
+    static func selectTagToAddToItem() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.selectTag"
+            )
+        )
+    }
+
+    /// Fired when a user taps on a recent tag from `Add Tags` screen
+    static func selectRecentTagToAddToItem() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.addTags.selectRecentTag"
+            )
+        )
+    }
+
+    /// Fired when a user selects on a general tag using the `Tags` screen after tapping on `Tagged` filter
+    static func selectTagToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.filterTags.selectTag"
+            )
+        )
+    }
+
+    /// Fired when a user selects `not tagged` using the `Tags` screen after tapping on `Tagged` filter
+    static func selectNotTaggedToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.filterTags.selectNotTagged"
+            )
+        )
+    }
+
+    /// Fired when a user selects on a recent tag using the `Tags` screen after tapping on `Tagged` filter
+    static func selectRecentTagToFilter() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.filterTags.selectRecentTag"
+            )
+        )
+    }
+
+    /// Fired when a user adds tag to an input list in the `Add Tags` screen for an item
+    static func renameTag() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.filterTags.tagRename"
+            )
+        )
+    }
+
+    /// Fired when a user confirms to delete tags from 'Tags' screen after tapping on `Tagged` filter
+    static func deleteTags() -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .button,
+                identifier: "save-extension.filterTags.tagsDelete"
+            )
+        )
+    }
+
+}

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -102,7 +102,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.saveTags")
             return
         }
-        tracker.track(event: Events.Tags.saveTags(itemUrl: url))
+        tracker.track(event: Events.SaveTo.Tags.saveTags(itemUrl: url))
     }
 
     func trackAddTag() {
@@ -110,7 +110,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.addTag")
             return
         }
-        tracker.track(event: Events.Tags.addTag(itemUrl: url))
+        tracker.track(event: Events.SaveTo.Tags.addTag(itemUrl: url))
     }
 
     func trackRemoveTag() {
@@ -118,7 +118,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.remoteInputTag")
             return
         }
-        tracker.track(event: Events.Tags.remoteInputTag(itemUrl: url))
+        tracker.track(event: Events.SaveTo.Tags.remoteInputTag(itemUrl: url))
     }
 
     func trackUserEnterText(with text: String) {
@@ -126,7 +126,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.saveTags")
             return
         }
-        tracker.track(event: Events.Tags.userEntersText(itemUrl: url, text: text))
+        tracker.track(event: Events.SaveTo.Tags.userEntersText(itemUrl: url, text: text))
     }
 
     func trackAllTagsImpression() {
@@ -134,7 +134,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.saveTags")
             return
         }
-        tracker.track(event: Events.Tags.allTagsImpression(itemUrl: url))
+        tracker.track(event: Events.SaveTo.Tags.allTagsImpression(itemUrl: url))
     }
 
     func trackFilteredTagsImpression() {
@@ -142,7 +142,7 @@ extension SaveToAddTagsViewModel {
             Log.capture(message: "Adding tags to an item without an associated url, not logging analytics for Tags.saveTags")
             return
         }
-        tracker.track(event: Events.Tags.filteredTagsImpression(itemUrl: url))
+        tracker.track(event: Events.SaveTo.Tags.filteredTagsImpression(itemUrl: url))
     }
 
     func trackExistingTagTapped(with tagType: TagType) {
@@ -150,9 +150,9 @@ extension SaveToAddTagsViewModel {
         case .notTagged:
             return
         case .recent:
-            tracker.track(event: Events.Tags.selectRecentTagToAddToItem())
+            tracker.track(event: Events.SaveTo.Tags.selectRecentTagToAddToItem())
         case .tag:
-            tracker.track(event: Events.Tags.selectTagToAddToItem())
+            tracker.track(event: Events.SaveTo.Tags.selectTagToAddToItem())
         }
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -24,7 +24,14 @@ class SavedItemViewModel {
 
     let dismissAttributedText = NSAttributedString(string: "Tap to Dismiss", style: .dismiss)
 
-    init(appSession: AppSession, saveService: SaveService, dismissTimer: Timer.TimerPublisher, tracker: Tracker, consumerKey: String, userDefaults: UserDefaults, user: User) {
+    init(appSession: AppSession,
+         saveService: SaveService,
+         dismissTimer: Timer.TimerPublisher,
+         tracker: Tracker,
+         consumerKey: String,
+         userDefaults: UserDefaults,
+         user: User
+    ) {
         self.appSession = appSession
         self.saveService = saveService
         self.dismissTimer = dismissTimer
@@ -36,10 +43,13 @@ class SavedItemViewModel {
         guard let session = appSession.currentSession else { return }
 
         tracker.resetPersistentEntities([
-            APIUserEntity(consumerKey: consumerKey)
+            APIUserEntity(consumerKey: consumerKey),
+            UserEntity(
+                guid: session.guid,
+                userID: session.userIdentifier,
+                adjustAdId: Adjust.adid()
+            )
         ])
-
-        tracker.addPersistentEntity(UserEntity(guid: session.guid, userID: session.userIdentifier, adjustAdId: Adjust.adid()))
     }
 
     func save(from context: ExtensionContext?) async {
@@ -56,9 +66,7 @@ class SavedItemViewModel {
                 break
             }
 
-            // TODO: Add this to all track calls not the global call.
-            tracker.addPersistentEntity(ContentEntity(url: url))
-            track(context: .saveExtension.saveDialog)
+            tracker.track(event: Events.SaveTo.saveEngagement(url: url))
 
             let result = saveService.save(url: url)
             switch result {
@@ -78,6 +86,10 @@ class SavedItemViewModel {
     }
 
     func showAddTagsView(from context: ExtensionContext?) {
+        if let url = savedItem?.url {
+            tracker.track(event: Events.SaveTo.addTagsEngagement(url: url))
+        }
+
         presentedAddTags = SaveToAddTagsViewModel(
             item: savedItem,
             tracker: tracker,
@@ -93,7 +105,6 @@ class SavedItemViewModel {
                 self?.addTags(tags: tags, from: context)
             }
         )
-        track(context: .saveExtension.addTagsButton)
     }
 
     func addTags(tags: [String], from context: ExtensionContext?) {
@@ -102,8 +113,6 @@ class SavedItemViewModel {
         if case let .taggedItem(savedItem) = result {
             self.savedItem = savedItem
             infoViewModel = .taggedItem
-
-            track(context: .saveExtension.addTagsDone)
         }
         finish(context: context)
     }
@@ -178,11 +187,6 @@ extension SavedItemViewModel {
             return URL(string: string)
         }
         return nil
-    }
-
-    private func track(context: UIContext) {
-        let event = SnowplowEngagement(type: .general, value: nil)
-        tracker.track(event: event, [context])
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes an issue where a `Content` entity would be attached to all analytic events from the Save extension, e.g migration, unnecessarily.

Updates the event identifiers used for all tag-related events tracked within the Save extension.

## References 

https://getpocket.atlassian.net/browse/IN-1356

## Implementation Details

- Updated the Analytics spreadsheet after discussing updated identifiers for the scope of the Save extension
- Updated tag-event-related identifiers when used within the Save extension
- Removed the use of a persisted Content entity, instead appending the Content entity as necessary

## Test Steps

- [ ] When using the Save extension, a migration event should not include a Content entity
- [ ] When using the Save extension, opening the extension should create an engagement event with a content entity
- [ ] When using the Save extension, tapping "Add Tags" should create an engagement event with a content entity
- [ ] When using the Save extension and adding tags, all events should be updated to use the new identifiers

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
