### PR TITLE
chore(tests): fix premium tests that are failing locally

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -1703,6 +1703,219 @@
 			};
 			name = Release;
 		};
+		8A6EADDE29F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MARKETING_VERSION = 8.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug_Tests;
+		};
+		8A6EADDF29F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Pocket_iOS_Debug.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				ENABLE_BITCODE = NO;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
+				PRODUCT_NAME = Pocket;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Tests;
+		};
+		8A6EADE029F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				INFOPLIST_FILE = "Tests iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Pocket (iOS)";
+			};
+			name = Debug_Tests;
+		};
+		8A6EADE129F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				ENABLE_BITCODE = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Save to Pocket";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.SaveTo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Tests;
+		};
+		8A6EADE229F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_ENTITLEMENTS = PushNotificationServiceExtension/PushNotificationServiceExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationServiceExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationServiceExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Tests;
+		};
+		8A6EADE329F87C2900355D92 /* Debug_Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_ENTITLEMENTS = PushNotificationStoryExtension/PushNotificationStoryExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = EX3VH4YFCH;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PushNotificationStoryExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = PushNotificationStoryExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug_Tests;
+		};
 		F204A76C27E22EC50010E155 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1774,6 +1987,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				166A81D82637406C0015AA1D /* Debug */,
+				8A6EADDE29F87C2900355D92 /* Debug_Tests */,
 				653DA73029C3BBE800123847 /* Debug_AlphaNeue */,
 				166A81D92637406C0015AA1D /* Release */,
 				653DA72629C3BB0C00123847 /* Release_AlphaNeue */,
@@ -1785,6 +1999,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				166A81DB2637406C0015AA1D /* Debug */,
+				8A6EADDF29F87C2900355D92 /* Debug_Tests */,
 				653DA73129C3BBE800123847 /* Debug_AlphaNeue */,
 				166A81DC2637406C0015AA1D /* Release */,
 				653DA72729C3BB0C00123847 /* Release_AlphaNeue */,
@@ -1796,6 +2011,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				166A81E12637406C0015AA1D /* Debug */,
+				8A6EADE029F87C2900355D92 /* Debug_Tests */,
 				653DA73229C3BBE800123847 /* Debug_AlphaNeue */,
 				166A81E22637406C0015AA1D /* Release */,
 				653DA72829C3BB0C00123847 /* Release_AlphaNeue */,
@@ -1807,6 +2023,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				650FECD428BA85F300A3CB0C /* Debug */,
+				8A6EADE229F87C2900355D92 /* Debug_Tests */,
 				653DA73429C3BBE800123847 /* Debug_AlphaNeue */,
 				650FECD628BA85F300A3CB0C /* Release */,
 				653DA72A29C3BB0C00123847 /* Release_AlphaNeue */,
@@ -1818,6 +2035,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				65EC273528BA8AD50075E1DF /* Debug */,
+				8A6EADE329F87C2900355D92 /* Debug_Tests */,
 				653DA73529C3BBE800123847 /* Debug_AlphaNeue */,
 				65EC273728BA8AD50075E1DF /* Release */,
 				653DA72B29C3BB0C00123847 /* Release_AlphaNeue */,
@@ -1829,6 +2047,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F204A76C27E22EC50010E155 /* Debug */,
+				8A6EADE129F87C2900355D92 /* Debug_Tests */,
 				653DA73329C3BBE800123847 /* Debug_AlphaNeue */,
 				F204A76D27E22EC50010E155 /* Release */,
 				653DA72929C3BB0C00123847 /* Release_AlphaNeue */,

--- a/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
+++ b/Pocket.xcodeproj/xcshareddata/xcschemes/Pocket (iOS).xcscheme
@@ -121,7 +121,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Debug_Tests"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"

--- a/Tests iOS/Fixtures/recommendation-detail-4.json
+++ b/Tests iOS/Fixtures/recommendation-detail-4.json
@@ -38,8 +38,7 @@
           "__typename": "Publisher",
           "name": "Mozilla"
         }
-      }
-      "datePublished": "2021-01-01 12:01:01",
+      },
       "marticle": [
         
       ],


### PR DESCRIPTION
## Summary
Fix issue where Premium Tests were not passing locally, but was passing it Bitrise.

## References 
N/A

## Implementation Details
This is due to the `secrets` file being used that don't have the proper productIDs. To fix this, we created a new config called `Debug_Test` which is a copy of `Debug`, but uses `secrets_tests` and also changed the Scheme to use this config for Tests.

## Test Steps
Confirm the Premium Tests are now passing successfully locally. 

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

![image](https://user-images.githubusercontent.com/6743397/234406414-aee992c9-e534-48a7-9e47-ab38076f316f.png)

![image](https://user-images.githubusercontent.com/6743397/234406498-ff51ce29-62f3-4fb8-bfee-d791157ea81c.png)
