### PR TITLE
Core Data: remove uniqueness requirement from `Item.remoteID`

### DIFF
--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -50,9 +50,6 @@
             <uniquenessConstraint>
                 <constraint value="givenURL"/>
             </uniquenessConstraint>
-            <uniquenessConstraint>
-                <constraint value="remoteID"/>
-            </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
     <entity name="PersistentSyncTask" representedClassName="PersistentSyncTask" syncable="YES">

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -58,7 +58,7 @@ extension SavedItem {
                 Log.capture(message: "Item parts not a valid url")
                 return
             }
-            let itemToUpdate = (try? space.fetchItem(byRemoteID: itemParts.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemParts.remoteID)
+            let itemToUpdate = (try? space.fetchItem(byURL: itemUrl, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemParts.remoteID)
             itemToUpdate.update(remote: itemParts, with: space)
             item = itemToUpdate
         } else if let pendingParts = remote.item.asPendingItem?.fragments.pendingItemParts {
@@ -67,7 +67,7 @@ extension SavedItem {
                 Log.capture(message: "Pending item parts not a valid url")
                 return
             }
-            let itemToUpdate = (try? space.fetchItem(byRemoteID: pendingParts.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: pendingParts.remoteID)
+            let itemToUpdate = (try? space.fetchItem(byURL: itemUrl, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: pendingParts.remoteID)
             itemToUpdate.update(remote: pendingParts, with: space)
             item = itemToUpdate
         }
@@ -120,7 +120,7 @@ extension SavedItem {
                 Log.capture(message: "Item parts not a valid url")
                 return
             }
-            let itemToUpdate = (try? space.fetchItem(byRemoteID: itemSummary.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemSummary.remoteID)
+            let itemToUpdate = (try? space.fetchItem(byURL: itemUrl, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: itemSummary.remoteID)
             itemToUpdate.update(from: itemSummary, with: space)
             item = itemToUpdate
         } else if let pendingParts = summary.item.asPendingItem?.fragments.pendingItemParts {
@@ -129,7 +129,7 @@ extension SavedItem {
                 Log.capture(message: "Pending item parts not a valid url")
                 return
             }
-            let itemToUpdate = (try? space.fetchItem(byRemoteID: pendingParts.remoteID, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: pendingParts.remoteID)
+            let itemToUpdate = (try? space.fetchItem(byURL: itemUrl, context: context)) ?? Item(context: context, givenURL: itemUrl, remoteID: pendingParts.remoteID)
             itemToUpdate.update(remote: pendingParts, with: space)
             item = itemToUpdate
         }

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -62,7 +62,7 @@ extension Recommendation {
             image = Image(src: imageSrc, context: context)
         }
 
-        let recommendationItem = (try? space.fetchItem(byRemoteID: remote.item.remoteID, context: context)) ?? Item(context: context, givenURL: url, remoteID: remoteID)
+        let recommendationItem = (try? space.fetchItem(byURL: url, context: context)) ?? Item(context: context, givenURL: url, remoteID: remoteID)
         recommendationItem.update(from: remote.item.fragments.itemSummary, with: space)
         item = recommendationItem
     }

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -159,12 +159,8 @@ extension Space {
         return try fetch(Requests.fetchItems())
     }
 
-    func fetchItem(byRemoteID id: String, context: NSManagedObjectContext? = nil) throws -> Item? {
-        return try fetch(Requests.fetchItem(byRemoteID: id), context: context).first
-    }
-
-    func fetchItem(byURL url: URL) throws -> Item? {
-        return try fetch(Requests.fetchItem(byURL: url)).first
+    func fetchItem(byURL url: URL, context: NSManagedObjectContext? = nil) throws -> Item? {
+        return try fetch(Requests.fetchItem(byURL: url), context: context).first
     }
 
     func deleteUnsavedItems() throws {

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -185,7 +185,7 @@ extension APISlateServiceTests {
 
         // fetchSlateLineup "cleans" all unsaved items before fetching,
         // so we have to fake a saved item for the item to update
-        let item = space.buildItem(title: "Item 1 Seed")
+        let item = space.buildItem(title: "Item 1 Seed", givenURL: URL(string: "https://given.example.com/slate-1-rec-1")!)
         space.buildSavedItem(item: item)
         try self.space.save()
 

--- a/PocketKit/Tests/SyncTests/Fixtures/save-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/save-item.json
@@ -13,7 +13,7 @@
       "item": {
         "__typename": "Item",
         "remoteID": "item-1",
-        "givenUrl": "https://given.example.com/item-1",
+        "givenUrl": "http://example.com/add-me-to-your-list",
         "resolvedUrl": "https://resolved.example.com/item-1",
         "title": "Item 1",
         "topImageUrl": "https://example.com/item-1/top-image.jpg",

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -192,12 +192,12 @@ class PocketSourceTests: XCTestCase {
         let item = savedItem.item
         item.recommendation = space.buildRecommendation(item: item)
 
-        let remoteItemID = item.remoteID
+        let remoteItemURL = item.givenURL
 
         let source = subject()
         source.delete(item: savedItem)
 
-        let fetchedItem = try space.fetchItem(byRemoteID: remoteItemID)
+        let fetchedItem = try space.fetchItem(byURL: remoteItemURL)
         XCTAssertNotNil(fetchedItem)
     }
 
@@ -209,12 +209,12 @@ class PocketSourceTests: XCTestCase {
         let savedItem = try space.createSavedItem(item: space.buildItem())
         let item = savedItem.item
 
-        let remoteItemID = item.remoteID
+        let remoteItemURL = item.givenURL
 
         let source = subject()
         source.delete(item: savedItem)
 
-        let fetchedItem = try space.fetchItem(byRemoteID: remoteItemID)
+        let fetchedItem = try space.fetchItem(byURL: remoteItemURL)
         XCTAssertNil(fetchedItem)
     }
 


### PR DESCRIPTION
## Summary
* Remove uniqueness from `remoteID` in `Item`

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* No crashes allowed! Also, pls delete the older version

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
