### PR TITLE
fix(analytics): ensure we always init the api user entity

### DIFF
--- a/PocketKit/Sources/Analytics/Events/System.swift
+++ b/PocketKit/Sources/Analytics/Events/System.swift
@@ -25,12 +25,23 @@ public struct System: Event, CustomStringConvertible {
         }
     }
 
-    public func toSelfDescribing() -> SelfDescribing {
-        let base = SelfDescribing(schema: System.schema, payload: [
-            "identifier": NSString(string: self.description),
-        ])
+    public var value: String? {
+        switch type {
+        case .userMigration(let userMigrationState):
+            return userMigrationState.id(source)
+        }
+    }
 
-        return base
+    public func toSelfDescribing() -> SelfDescribing {
+        var payload = [
+            "identifier": NSString(string: self.description),
+        ]
+
+        if let value = value {
+            payload["value"] = NSString(string: value)
+        }
+
+        return SelfDescribing(schema: System.schema, payload: payload)
     }
 }
 
@@ -55,6 +66,15 @@ extension System {
                     return "ios.\(source).migration.to8.failed"
                 }
                 return "ios.\(source).migration.to8.failedWithError"
+            }
+        }
+        
+        func value(_ source: MigrationSource) -> String? {
+            switch self {
+            case .started, .succeeded:
+                return nil
+            case UserMigrationState.failed(let error):
+                return error?.localizedDescription
             }
         }
     }

--- a/PocketKit/Sources/Analytics/Events/System.swift
+++ b/PocketKit/Sources/Analytics/Events/System.swift
@@ -28,7 +28,7 @@ public struct System: Event, CustomStringConvertible {
     public var value: String? {
         switch type {
         case .userMigration(let userMigrationState):
-            return userMigrationState.id(source)
+            return userMigrationState.value(source)
         }
     }
 
@@ -68,7 +68,7 @@ extension System {
                 return "ios.\(source).migration.to8.failedWithError"
             }
         }
-        
+
         func value(_ source: MigrationSource) -> String? {
             switch self {
             case .started, .succeeded:

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -73,9 +73,9 @@ public class RootViewModel: ObservableObject {
 
     private func setUpSession(_ session: SharedPocketKit.Session) {
         tracker.resetPersistentEntities([
-            APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey)
+            APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey),
+            UserEntity(guid: session.guid, userID: session.userIdentifier, adjustAdId: Adjust.adid())
         ])
-        tracker.addPersistentEntity(UserEntity(guid: session.guid, userID: session.userIdentifier, adjustAdId: Adjust.adid()))
         Log.setUserID(session.userIdentifier)
     }
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -132,6 +132,14 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             })
 
             if attempted {
+                // Migration ran successfully, so lets reset the entities to capture it.
+                // We do a reset in case the RootViewModel recieves a login notice first and to ensure no duplicates.
+                if let currentSession = appSession.currentSession {
+                    tracker.resetPersistentEntities([
+                        APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey),
+                        UserEntity(guid: currentSession.guid, userID: currentSession.userIdentifier, adjustAdId: Adjust.adid())
+                    ])
+                }
                 tracker.track(event: Events.Migration.MigrationTo_v8DidSucceed(source: .pocketKit))
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
                 // Legacy cleanup

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -53,6 +53,14 @@ class MainViewController: UIViewController {
             }
 
             if attempted {
+                // Migration ran successfully, so lets reset the entities to capture it.
+                // We do a reset in case something else recieves a login notice first and to ensure no duplicates.
+                if let currentSession = appSession.currentSession {
+                    tracker.resetPersistentEntities([
+                        APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey),
+                        UserEntity(guid: currentSession.guid, userID: currentSession.userIdentifier, adjustAdId: Adjust.adid())
+                    ])
+                }
                 tracker.track(event: Events.Migration.MigrationTo_v8DidSucceed(source: .saveToPocketKit))
                 Log.breadcrumb(category: "launch", level: .info, message: "Legacy user migration required; running.")
                 // Legacy cleanup

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -4,6 +4,7 @@ import Textile
 import Apollo
 import SharedPocketKit
 import Sync
+import Adjust
 
 class MainViewController: UIViewController {
     private let childViewController: UIViewController
@@ -22,6 +23,16 @@ class MainViewController: UIViewController {
         let notificationCenter = services.notificationCenter
         let child: UIViewController
         let tracker = services.tracker
+
+        // Reset and attach at least an api user entity on extension launch
+        tracker.resetPersistentEntities([
+            APIUserEntity(consumerKey: Keys.shared.pocketApiConsumerKey)
+        ])
+
+        if let currentSession = appSession.currentSession {
+            // Attach a user entity at launch if it exists
+            tracker.addPersistentEntity(UserEntity(guid: currentSession.guid, userID: currentSession.userIdentifier, adjustAdId: Adjust.adid()))
+        }
 
         SignOutOnFirstLaunch(
             appSession: appSession,

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -3,7 +3,6 @@ import SharedPocketKit
 import Sync
 import Combine
 import Analytics
-import Adjust
 
 class SavedItemViewModel {
     private let appSession: AppSession
@@ -41,15 +40,6 @@ class SavedItemViewModel {
         self.user = user
 
         guard let session = appSession.currentSession else { return }
-
-        tracker.resetPersistentEntities([
-            APIUserEntity(consumerKey: consumerKey),
-            UserEntity(
-                guid: session.guid,
-                userID: session.userIdentifier,
-                adjustAdId: Adjust.adid()
-            )
-        ])
     }
 
     func save(from context: ExtensionContext?) async {


### PR DESCRIPTION
## Summary

This ensure that we always attach the APIUser entity and if there is a session, the UserEntity to analytics at app launch. This was primarly done in RootViewModel, but RootViewModel is not loaded until after the App finish launching method and with the 7 -> 8 migration, we are now emitting analytics before the RootViewModel loads.

## References 
* https://pocket.slack.com/archives/C4DL4QSU8/p1682463311167069?thread_ts=1682447329.175119&cid=C4DL4QSU8

## Implementation Details
* I think we can do a cleaner job of analytics initing but I am not going to include that work in MVP.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
