### PR TITLE
fix(saved-item): ensuring saved item only is pulled by url

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -145,9 +145,9 @@ class PocketItemViewModel: ObservableObject {
     /// Fetch a SavedItem or create one in order to use actions related to source
     private func fetchSavedItem() -> SavedItem? {
         guard
-            let id = item.id,
+            let url = item.url,
             let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
+                with: url,
                 and: item.remoteItemParts
             )
         else {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -406,9 +406,9 @@ extension SearchViewModel {
 
     func select(_ searchItem: PocketItem, index: Int) {
         guard
-            let id = searchItem.id,
+            let url = searchItem.url,
             let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
+                with: url,
                 and: searchItem.remoteItemParts
             )
         else {
@@ -472,9 +472,9 @@ extension SearchViewModel {
 
     func fetchSavedItem(_ searchItem: PocketItem) -> SavedItem? {
         guard
-            let id = searchItem.id,
+            let url = searchItem.url,
             let savedItem = source.fetchOrCreateSavedItem(
-                with: id,
+                with: url,
                 and: searchItem.remoteItemParts
             )
         else {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -880,21 +880,21 @@ extension PocketSource {
         try? space.fetchSavedItems(bySearchTerm: search, userPremium: user.status == .premium)
     }
 
-    public func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
-        let savedItem = (try? space.fetchSavedItem(byRemoteID: remoteID))
+    public func fetchOrCreateSavedItem(with url: URL, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
+        let savedItem = (try? space.fetchSavedItem(byURL: url))
 
         if let remoteParts {
             savedItem?.update(from: remoteParts, with: space)
         }
 
-        guard savedItem == nil, let remoteParts, let url = URL(string: remoteParts.url) else {
+        guard savedItem == nil, let remoteParts else {
             Log.breadcrumb(category: "sync", level: .debug, message: "SavedItem found and don't need to create one")
             // save the space with the updated item data
             try? space.save()
             return savedItem
         }
 
-        let remoteSavedItem = SavedItem(context: space.backgroundContext, url: url, remoteID: remoteID)
+        let remoteSavedItem = SavedItem(context: space.backgroundContext, url: url, remoteID: remoteParts.remoteID)
         remoteSavedItem.update(from: remoteParts, with: space)
         try? space.save()
 

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -37,20 +37,6 @@ public enum Requests {
         return request
     }
 
-    public static func fetchSavedItem(byRemoteID remoteID: String) -> NSFetchRequest<SavedItem> {
-        let request = SavedItem.fetchRequest()
-        request.predicate = NSPredicate(format: "remoteID = %@", remoteID)
-        request.fetchLimit = 1
-        return request
-    }
-
-    public static func fetchSavedItem(byRemoteItemID remoteItemID: String) -> NSFetchRequest<SavedItem> {
-        let request = SavedItem.fetchRequest()
-        request.predicate = NSPredicate(format: "item.remoteID = %@", remoteItemID)
-        request.fetchLimit = 1
-        return request
-    }
-
     public static func fetchSavedItem(byURL url: URL) -> NSFetchRequest<SavedItem> {
         let request = SavedItem.fetchRequest()
         request.predicate = NSPredicate(format: "url.absoluteString = %@", url.absoluteString)
@@ -133,13 +119,6 @@ public enum Requests {
 
     public static func fetchItems() -> NSFetchRequest<Item> {
         Item.fetchRequest()
-    }
-
-    public static func fetchItem(byRemoteID id: String) -> NSFetchRequest<Item> {
-        let request = self.fetchItems()
-        request.predicate = NSPredicate(format: "remoteID = %@", id)
-        request.fetchLimit = 1
-        return request
     }
 
     public static func fetchSyndicatedArticles() -> NSFetchRequest<SyndicatedArticle> {

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -84,7 +84,7 @@ public protocol Source {
 
     func searchSaves(search: String) -> [SavedItem]?
 
-    func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem?
+    func fetchOrCreateSavedItem(with url: URL, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem?
 
     /// Get the count of unread saves
     /// - Returns: Int of unread saves

--- a/PocketKit/Sources/Sync/Space/DerivedSpace.swift
+++ b/PocketKit/Sources/Sync/Space/DerivedSpace.swift
@@ -88,7 +88,7 @@ extension DerivedSpace: SavedItemSpace {
             logItemUpdated(itemID: node.remoteID)
 
             context.performAndWait {
-                let item = (try? space.fetchSavedItem(byRemoteID: node.remoteID, context: context)) ?? SavedItem(context: context, url: url, remoteID: node.remoteID)
+                let item = (try? space.fetchSavedItem(byURL: url, context: context)) ?? SavedItem(context: context, url: url, remoteID: node.remoteID)
                 item.update(from: edge, with: space)
 
                 if item.deletedAt != nil {
@@ -113,7 +113,7 @@ extension DerivedSpace: ArchivedItemSpace {
             logItemUpdated(itemID: node.remoteID)
 
             context.performAndWait {
-                let item = (try? space.fetchSavedItem(byRemoteID: node.remoteID, context: context)) ?? SavedItem(context: context, url: url, remoteID: node.remoteID)
+                let item = (try? space.fetchSavedItem(byURL: url, context: context)) ?? SavedItem(context: context, url: url, remoteID: node.remoteID)
                 item.update(from: node.fragments.savedItemSummary, with: space)
                 item.cursor = edge.cursor
                 if item.deletedAt != nil {

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -208,12 +208,8 @@ extension Space {
 
 // MARK: SavedItem
 extension Space {
-    func fetchSavedItem(byRemoteID remoteID: String, context: NSManagedObjectContext? = nil) throws -> SavedItem? {
-        return try fetch(Requests.fetchSavedItem(byRemoteID: remoteID), context: context).first
-    }
-
-    func fetchSavedItem(byRemoteItemID remoteItemID: String) throws -> SavedItem? {
-        return try fetch(Requests.fetchSavedItem(byRemoteItemID: remoteItemID)).first
+    func fetchSavedItem(byURL url: URL, context: NSManagedObjectContext? = nil) throws -> SavedItem? {
+        return try fetch(Requests.fetchSavedItem(byURL: url), context: context).first
     }
 
     func fetchSavedItem(byURL url: URL) throws -> SavedItem? {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1209,23 +1209,23 @@ extension MockSource {
 // MARK: - Fetch SavedItem by Remote ID
 extension MockSource {
     private static let fetchSavedItem = "fetchSavedItem"
-    typealias FetchSavedItemImpl = (String) -> SavedItem?
+    typealias FetchSavedItemImpl = (URL) -> SavedItem?
 
     struct FetchSavedItemCall {
-        let remoteID: String
+        let url: URL
     }
 
     func stubFetchSavedItem(impl: @escaping FetchSavedItemImpl) {
         implementations[Self.fetchSavedItem] = impl
     }
 
-    func fetchOrCreateSavedItem(with remoteID: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
+    func fetchOrCreateSavedItem(with url: URL, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem? {
         guard let impl = implementations[Self.fetchSavedItem] as? FetchSavedItemImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        calls[Self.fetchSavedItem] = (calls[Self.fetchSavedItem] ?? []) + [FetchSavedItemCall(remoteID: remoteID)]
-        return impl(remoteID)
+        calls[Self.fetchSavedItem] = (calls[Self.fetchSavedItem] ?? []) + [FetchSavedItemCall(url: url)]
+        return impl(url)
     }
 
     func fetchSavedItemCall(at index: Int) -> FetchSavedItemCall? {

--- a/PocketKit/Tests/SyncTests/Fixtures/save-item.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/save-item.json
@@ -3,7 +3,7 @@
     "upsertSavedItem": {
       "__typename": "[type-name-here]",
       "remoteID": "saved-item-1",
-      "url": "https://example.com/item-1",
+      "url": "http://example.com/add-me-to-your-list",
       "_createdAt": 0,
       "_deletedAt": null,
       "archivedAt": null,

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -70,7 +70,7 @@ class SaveItemOperationTests: XCTestCase {
         XCTAssertNotNil(performCall)
         XCTAssertEqual(performCall?.mutation.input.url, url.absoluteString)
 
-        let item = try space.fetchSavedItem(byRemoteID: "saved-item-1")
+        let item = try space.fetchSavedItem(byURL: url)
         XCTAssertEqual(savedItem.item.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
         XCTAssertNotNil(item)
     }

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -109,7 +109,7 @@ class PocketSaveServiceTests: XCTestCase {
             return MockCancellable()
         }
 
-        let url = URL(string: "https://example.com/a-new-item")!
+        let url = URL(string: "http://example.com/add-me-to-your-list")!
         let service = subject()
         _ = service.save(url: url)
 
@@ -122,7 +122,7 @@ class PocketSaveServiceTests: XCTestCase {
 
         do {
             wait(for: [performMutationCompleted], timeout: 10)
-            let savedItem = try space.fetchSavedItem(byRemoteID: "saved-item-1")
+            let savedItem = try space.fetchSavedItem(byURL: url)
             XCTAssertNotNil(savedItem?.item)
         }
     }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -166,7 +166,7 @@ class PocketSourceTests: XCTestCase {
     }
 
     func test_delete_removesItemFromLocalStorage_andExecutesDeleteMutation() throws {
-        let item = try space.createSavedItem(remoteID: "delete-me")
+        let item = try space.createSavedItem(remoteID: "delete-me", url: "https://mozilla.com/delete")
         let expectationToRunOperation = expectation(description: "Run operation")
         operations.stubItemMutationOperation { (_, _, _: DeleteItemMutation) in
             TestSyncOperation {
@@ -177,7 +177,7 @@ class PocketSourceTests: XCTestCase {
         let source = subject()
         source.delete(item: item)
 
-        let fetchedItem = try space.fetchSavedItem(byRemoteID: "delete-me")
+        let fetchedItem = try space.fetchSavedItem(byURL: URL(string: "https://mozilla.com/delete")!)
         XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.hasChanges)
         wait(for: [expectationToRunOperation], timeout: 10)
@@ -237,7 +237,7 @@ class PocketSourceTests: XCTestCase {
     }
 
     func test_unarchive_executesSaveItemMutation_andUpdatesCreatedAtField() throws {
-        let item = try space.createSavedItem(remoteID: "unarchive-me")
+        let item = try space.createSavedItem(remoteID: "unarchive-me", url: "https://mozilla.com/unarchive")
         item.isArchived = true
 
         let expectationToRunOperation = expectation(description: "Run operation")
@@ -250,8 +250,6 @@ class PocketSourceTests: XCTestCase {
         let source = subject()
         source.unarchive(item: item)
 
-        let fetchedItem = try space.fetchSavedItem(byRemoteID: "archive-me")
-        XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.isArchived)
         XCTAssertNotNil(item.createdAt)
         wait(for: [expectationToRunOperation], timeout: 10)
@@ -699,7 +697,7 @@ extension PocketSourceTests {
         )
 
         let source = subject()
-        let savedItem = source.fetchOrCreateSavedItem(with: "saved-item", and: itemParts)
+        let savedItem = source.fetchOrCreateSavedItem(with: URL(string: "http://localhost:8080/hello")!, and: itemParts)
 
         XCTAssertEqual(savedItem?.remoteID, "saved-item")
         XCTAssertEqual(savedItem?.item.title, "item-title")

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -149,13 +149,14 @@ class FetchSavesTests: XCTestCase {
         apollo.setupFetchSavesSyncResponse(listFixtureName: "updated-item")
         try space.createSavedItem(
             remoteID: "saved-item-1",
+            url: "http://example.com/item-1",
             item: space.buildItem(title: "Item 1")
         )
 
         let service = subject()
         _ = await service.execute(syncTaskId: task.objectID)
 
-        let item = try space.fetchSavedItem(byRemoteID: "saved-item-1")
+        let item = try space.fetchSavedItem(byURL: URL(string: "http://example.com/item-1")!)
         XCTAssertEqual(item?.item.title, "Updated Item 1")
     }
 


### PR DESCRIPTION
## Summary

Followup to https://github.com/Pocket/pocket-ios/pull/663 to ensure savedItem is always fetched by URL.

## Implementation Details
* Removed all by remoteID methods so we arent tempted to use it.

## Test Steps
* Ask @nzeltzer  if you can use her list that has an item with a non-unique url 🤣 

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
