### PR TITLE
refactor(analytics): update content open identifiers

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Reader.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Reader.swift
@@ -80,4 +80,14 @@ public extension Events.Reader {
             )
         )
     }
+
+    static func openExternalLink(url: URL) -> ContentOpen {
+        return ContentOpen(
+            contentEntity: ContentEntity(url: url),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "reader.external-link"
+            )
+        )
+    }
 }

--- a/PocketKit/Sources/Analytics/AppEvents/Reader.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Reader.swift
@@ -76,7 +76,7 @@ public extension Events.Reader {
             contentEntity: ContentEntity(url: url),
             uiEntity: UiEntity(
                 .button,
-                identifier: "reader.view_original"
+                identifier: "reader.view-original"
             )
         )
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Saves.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Saves.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public extension Events {
+    struct Saves { }
+}
+
+public extension Events.Saves {
+    /// Returns a ContentOpen event for a url that was opened within Saves
+    /// - Parameters:
+    ///     - destination: Internal, or external, based on whether the content was opened in the reader or web view, respectively
+    ///     - trigger: What triggered the content open; defaults to '.click'
+    ///     - url: The url of the content that was opened
+    static func contentOpen(
+        destination: ContentOpen.Destination,
+        trigger: ContentOpen.Trigger = .click,
+        url: URL
+    ) -> ContentOpen {
+        return ContentOpen(
+            destination: destination,
+            trigger: trigger,
+            contentEntity: ContentEntity(url: url),
+            uiEntity: UiEntity(.card, identifier: "saves.card.open")
+        )
+    }
+}

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -32,7 +32,16 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var premiumURL: URL? { get }
 
     func delete()
+    /// Opens an item presented in the reader in a web view instead
+    /// - Parameters:
+    ///     - url: The URL of the item to open in a web view
+    /// - Note: A typical callee of this function will be the handler for when the Safari icon in the navigation bar is tapped
     func openInWebView(url: URL?)
+    /// Opens a link that was tapped within an item opened in the reader
+    /// - Parameters:
+    ///     - url: The URL of the link that was tapped within the reader
+    /// - Note: A typical callee of this function will be the handler for when a link in the reader is tapped,
+    /// or when a link is long-pressed, and "Open" is selected beneath the preview
     func openExternalLink(url: URL)
     func archive()
     func moveFromArchiveToSaves(completion: (Bool) -> Void)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -32,7 +32,8 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var premiumURL: URL? { get }
 
     func delete()
-    func openExternally(url: URL?)
+    func openInWebView(url: URL?)
+    func openExternalLink(url: URL)
     func archive()
     func moveFromArchiveToSaves(completion: (Bool) -> Void)
     func fetchDetailsIfNeeded()
@@ -47,7 +48,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
 
 extension ReadableViewModel {
     func readableViewController(_ controller: ReadableViewController, openURL url: URL) {
-        openExternally(url: url)
+        openExternalLink(url: url)
     }
 
     func readableViewController(_ controller: ReadableViewController, shareWithAdditionalText text: String?) {
@@ -64,7 +65,7 @@ extension ReadableViewModel {
     }
 
     func showWebReader() {
-        openExternally(url: url)
+        openInWebView(url: url)
     }
 
     func share(additionalText: String? = nil) {
@@ -181,5 +182,9 @@ extension ReadableViewModel {
             return
         }
         tracker.track(event: Events.Reader.openInWebView(url: url))
+    }
+
+    func trackExternalLinkOpen(url: URL) {
+        tracker.track(event: Events.Reader.openExternalLink(url: url))
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -119,7 +119,7 @@ class RecommendationViewModel: ReadableViewModel {
     func externalActions(for url: URL) -> [ItemAction] {
         [
             .save { [weak self] _ in self?.saveExternalURL(url) },
-            .open { [weak self] _ in self?.openExternally(url: url) },
+            .open { [weak self] _ in self?.openExternalLink(url: url) },
             .copyLink { [weak self] _ in self?.copyExternalURL(url) },
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
@@ -223,11 +223,18 @@ extension RecommendationViewModel {
         track(identifier: .itemUnfavorite)
     }
 
-    func openExternally(url: URL?) {
+    func openInWebView(url: URL?) {
         let updatedURL = pocketPremiumURL(url, user: user)
         presentedWebReaderURL = updatedURL
 
         trackWebViewOpen()
+    }
+
+    func openExternalLink(url: URL) {
+        let updatedURL = pocketPremiumURL(url, user: user)
+        presentedWebReaderURL = updatedURL
+
+        trackExternalLinkOpen(url: url)
     }
 
     func moveFromArchiveToSaves(completion: (Bool) -> Void) {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -131,7 +131,7 @@ class SavedItemViewModel: ReadableViewModel {
     func externalActions(for url: URL) -> [ItemAction] {
         [
             .save { [weak self] _ in self?.saveExternalURL(url) },
-            .open { [weak self] _ in self?.openExternalURL(url) },
+            .open { [weak self] _ in self?.openExternalLink(url: url) },
             .copyLink { [weak self] _ in self?.copyExternalURL(url) },
             .share { [weak self] _ in self?.shareExternalURL(url) }
         ]
@@ -180,11 +180,18 @@ extension SavedItemViewModel {
         completion(true)
     }
 
-    func openExternally(url: URL?) {
+    func openInWebView(url: URL?) {
         let updatedURL = pocketPremiumURL(url, user: user)
         presentedWebReaderURL = updatedURL
 
         trackWebViewOpen()
+    }
+
+    func openExternalLink(url: URL) {
+        let updatedURL = pocketPremiumURL(url, user: user)
+        presentedWebReaderURL = updatedURL
+
+        trackExternalLinkOpen(url: url)
     }
 
     func archive() {
@@ -230,10 +237,6 @@ extension SavedItemViewModel {
     private func shareExternalURL(_ url: URL) {
         // This view model is used within the context of a view that is presented within the reader
         sharedActivity = PocketItemActivity.fromReader(url: url)
-    }
-
-    private func openExternalURL(_ url: URL) {
-        presentedWebReaderURL = url
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -529,17 +529,12 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         tracker.track(event: event, contexts)
     }
 
-    private func trackContentOpen(destination: ContentOpenEvent.Destination, item: SavedItem) {
+    private func trackContentOpen(destination: ContentOpen.Destination, item: SavedItem) {
         guard let url = item.bestURL else {
             return
         }
 
-        let contexts: [Context] = [
-            ContentContext(url: url)
-        ]
-
-        let event = ContentOpenEvent(destination: destination, trigger: .click)
-        tracker.track(event: event, contexts)
+        tracker.track(event: Events.Saves.contentOpen(destination: destination, url: url))
     }
 
     private func trackButton(item: SavedItem, identifier: UIContext.Identifier) {

--- a/Tests iOS/MyList/SavesTests.swift
+++ b/Tests iOS/MyList/SavesTests.swift
@@ -10,6 +10,7 @@ import NIO
 class SavesTests: XCTestCase {
     var server: Application!
     var app: PocketAppElement!
+    var snowplowMicro = SnowplowMicro()
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -75,8 +76,10 @@ class SavesTests: XCTestCase {
         try server.start()
     }
 
-    override func tearDownWithError() throws {
+    @MainActor
+    override func tearDown() async throws {
         try server.stop()
+        await snowplowMicro.assertBaselineSnowplowExpectation()
         app.terminate()
     }
 
@@ -116,7 +119,7 @@ class SavesTests: XCTestCase {
         app.saves.itemView(matching: "Item 3").wait()
     }
 
-    func test_tappingItem_displaysNativeReaderView() {
+    func test_tappingItem_displaysNativeReaderView() async {
         app.launch().tabBar.savesButton.wait().tap()
 
         app
@@ -162,6 +165,10 @@ class SavesTests: XCTestCase {
                 return
             }
         }
+
+        let contentOpenEvent = await snowplowMicro.getFirstEvent(with: "saves.card.open")
+        contentOpenEvent!.getUIContext()!.assertHas(type: "card")
+        contentOpenEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     func test_webReader_displaysWebContent() {
@@ -293,19 +300,32 @@ class SavesTests: XCTestCase {
 // MARK: - Web View
 
 extension SavesTests {
-    func test_list_showsWebViewWhenItemIsImage() {
-        test_list_showsWebView(at: 0)
+    func test_list_showsWebViewWhenItemIsImage() async {
+        await test_list_showsWebView(at: 0)
+
+        let contentOpenEvent = await snowplowMicro.getFirstEvent(with: "saves.card.open")
+        contentOpenEvent!.getUIContext()!.assertHas(type: "card")
+        contentOpenEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/item-1")
     }
 
-    func test_list_showsWebViewWhenItemIsVideo() {
-        test_list_showsWebView(at: 1)
+    func test_list_showsWebViewWhenItemIsVideo() async {
+        await test_list_showsWebView(at: 1)
+
+        let contentOpenEvent = await snowplowMicro.getFirstEvent(with: "saves.card.open")
+        contentOpenEvent!.getUIContext()!.assertHas(type: "card")
+        contentOpenEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/item-2")
     }
 
-    func test_list_showsWebViewWhenItemIsNotAnArticle() {
-        test_list_showsWebView(at: 2)
+    func test_list_showsWebViewWhenItemIsNotAnArticle() async {
+        await test_list_showsWebView(at: 2)
+
+        let contentOpenEvent = await snowplowMicro.getFirstEvent(with: "saves.card.open")
+        contentOpenEvent!.getUIContext()!.assertHas(type: "card")
+        contentOpenEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/item-3")
     }
 
-    func test_list_showsWebView(at index: Int) {
+    @MainActor
+    func test_list_showsWebView(at index: Int) async {
         server.routes.post("/graphql") { request, _ -> Response in
             let apiRequest = ClientAPIRequest(request)
 
@@ -370,8 +390,8 @@ extension SavesTests {
             .wait()
     }
 
-    func test_webview_validateCustomItemActions_whenNavigateToAnotherPage() {
-        test_list_showsWebView(at: 0)
+    func test_webview_validateCustomItemActions_whenNavigateToAnotherPage() async {
+        await test_list_showsWebView(at: 0)
 
         app
             .webReaderView

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -170,7 +170,7 @@ class ReaderTests: XCTestCase {
         tapSafariButton()
         validateSafariOpens()
 
-        let engagementEvent = await snowplowMicro.getFirstEvent(with: "reader.view_original")
+        let engagementEvent = await snowplowMicro.getFirstEvent(with: "reader.view-original")
         engagementEvent!.getUIContext()!.assertHas(type: "button")
         engagementEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }


### PR DESCRIPTION
## Summary

Updates ContentOpen event identifiers when:
1. Opening an item from the user's list
2. Opening an item in web view from the reader
3. Opening a link by tapping on a link in the reader

## References 

IN-1343

## Test Steps

Looking at the above summary, when testing step:
1. The identifier should be `saves.card.open`
2. The identifier should be `reader.view-original`
3. The identifier should be `reader.view-external`

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
