### PR TITLE
feat(braze): send begin migration event in save extension

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -60,7 +60,8 @@ let package = Package(
                 "Textile",
                 "Sync",
                 "Analytics",
-                .product(name: "Adjust", package: "ios_sdk")
+                .product(name: "Adjust", package: "ios_sdk"),
+                .product(name: "BrazeKit", package: "braze-swift-sdk")
             ]
         ),
         .testTarget(

--- a/PocketKit/Sources/SaveToPocketKit/Keys.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Keys.swift
@@ -9,7 +9,9 @@ struct Keys {
 
     let pocketApiConsumerKey: String
     let sentryDSN: String
-    let groupdId: String
+    let groupID: String
+    let brazeAPIEndpoint: String
+    let brazeAPIKey: String
 
     private init() {
         guard let info = Bundle.main.infoDictionary else {
@@ -32,8 +34,18 @@ struct Keys {
             fatalError("Unable to extract GroupId from main bundle")
         }
 
+        guard let brazeAPIEndpoint = info["BrazeAPIEndpoint"] as? String else {
+            fatalError("Unable to extract BrazeAPIEndpoint from main bundle")
+        }
+
+        guard let brazeAPIKey = info["BrazeAPIKey"] as? String else {
+            fatalError("Unable to extract BrazeAPIKey from main bundle")
+        }
+
         self.pocketApiConsumerKey = UIDevice.current.userInterfaceIdiom == .pad ? pocketApiConsumerKeyPad : pocketApiConsumerKey
         self.sentryDSN = sentryDSN
-        self.groupdId = groupID
+        self.groupID = groupID
+        self.brazeAPIEndpoint = brazeAPIEndpoint
+        self.brazeAPIKey = brazeAPIKey
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -23,6 +23,7 @@ class MainViewController: UIViewController {
         let notificationCenter = services.notificationCenter
         let child: UIViewController
         let tracker = services.tracker
+        let braze = services.braze
 
         // Reset and attach at least an api user entity on extension launch
         tracker.resetPersistentEntities([
@@ -44,12 +45,13 @@ class MainViewController: UIViewController {
             userDefaults: userDefaults,
             encryptedStore: encryptedStore,
             appSession: appSession,
-            groupID: Keys.shared.groupdId
+            groupID: Keys.shared.groupID
         )
 
         do {
             let attempted = try legacyUserMigration.attemptMigration {
                 tracker.track(event: Events.Migration.MigrationTo_v8DidBegin(source: .saveToPocketKit))
+                braze.signedInUserDidBeginMigration()
             }
 
             if attempted {

--- a/PocketKit/Sources/SaveToPocketKit/SaveToBraze.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToBraze.swift
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BrazeKit
+import SharedPocketKit
+import Sync
+
+/**
+ Class that is managing our Braze SDK implementation for the Save extension
+ */
+class SaveToBraze: NSObject {
+    /// Our Braze SDK Object
+    let braze: Braze
+
+    init(apiKey: String, endpoint: String, groupdID: String) {
+        // Init Braze with our information.
+        let configuration = Braze.Configuration(
+            apiKey: apiKey,
+            endpoint: endpoint
+        )
+
+        // Enable logging of general SDK information (e.g. user changes, etc.)
+        configuration.logger.level = .info
+        configuration.push.appGroup = groupdID
+        braze = Braze(configuration: configuration)
+
+        super.init()
+    }
+
+    // MARK: Migration Events
+
+    func signedInUserDidBeginMigration() {
+        braze.logCustomEvent(name: "SIGNED_IN_USER_UPGRADE_DID_START")
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -13,22 +13,23 @@ struct Services {
     let tracker: Tracker
     let userDefaults: UserDefaults
     let notificationCenter: NotificationCenter
+    let braze: SaveToBraze
 
     private let persistentContainer: PersistentContainer
 
     private init() {
         Log.start(dsn: Keys.shared.sentryDSN)
 
-        guard let sharedUserDefaults = UserDefaults(suiteName: Keys.shared.groupdId) else {
-            fatalError("UserDefaults with suite name \(Keys.shared.groupdId) must exist.")
+        guard let sharedUserDefaults = UserDefaults(suiteName: Keys.shared.groupID) else {
+            fatalError("UserDefaults with suite name \(Keys.shared.groupID) must exist.")
         }
         userDefaults = sharedUserDefaults
 
         notificationCenter = .default
 
-        persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupdId)
+        persistentContainer = .init(storage: .shared, groupID: Keys.shared.groupID)
 
-        appSession = AppSession(groupID: Keys.shared.groupdId)
+        appSession = AppSession(groupID: Keys.shared.groupID)
 
         user = PocketUser(userDefaults: userDefaults)
 
@@ -40,6 +41,12 @@ struct Services {
             sessionProvider: appSession,
             consumerKey: Keys.shared.pocketApiConsumerKey,
             expiringActivityPerformer: ProcessInfo.processInfo
+        )
+
+        braze = SaveToBraze(
+            apiKey: Keys.shared.brazeAPIKey,
+            endpoint: Keys.shared.brazeAPIEndpoint,
+            groupdID: Keys.shared.groupID
         )
     }
 }

--- a/SaveToPocket/Info.plist
+++ b/SaveToPocket/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BrazeAPIEndpoint</key>
+	<string>$(BRAZE_API_ENDPOINT)</string>
+	<key>BrazeAPIKey</key>
+	<string>$(BRAZE_API_KEY)</string>
 	<key>GroupId</key>
 	<string>$(GROUP_ID)</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
## Summary

Sends a `SIGNED_IN_USER_UPGRADE_DID_START` event to Braze when a migration attempt begins in the save extension.

## References 

IN-1299

## Implementation Details

1. Update `SaveToPocketKit.Keys' to fetch Braze API key and endpoint from the main bundle
2. Create a very basic class that interfaces with Braze whose only capability (currently) is to send the `SIGNED_IN_USER_UPGRADE_DID_START` event
3. When a migration is attempted in the save extension, send the event

## Test Steps

- [ ] Install Pocket 7, and log in. Install Pocket 8 over your previous install, but do not open it. Open some app, and share a URL with Pocket using the save extension. The migration event should then be visible in Braze.

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
