### PR TITLE
refactor(iap): start subscription store later in app launch

### DIFF
--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -22,6 +22,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     private let tracker: Tracker
     private let sessionBackupUtility: SessionBackupUtility
     private let consumerKey: String
+    private let subscriptionStore: SubscriptionStore
 
     let notificationService: PushNotificationService
 
@@ -38,6 +39,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.brazeService = services.braze
         self.tracker = services.tracker
         self.sessionBackupUtility = services.sessionBackupUtility
+        self.subscriptionStore = services.subscriptionStore
 
         self.notificationService = services.notificationService
         self.consumerKey = Keys.shared.pocketApiConsumerKey
@@ -102,6 +104,13 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         // The session backup utility can be started after user migration since
         // the session can possibly already be backed up, i.e if used for user migration
         sessionBackupUtility.start()
+
+        if appSession.currentSession != nil {
+            // If the user is not logged in, we can start the subscription
+            // in preparation for in-app purchases. Otherwise, the store
+            // listens for log in / out events to appropriately start / stop.
+            subscriptionStore.start()
+        }
 
         return true
     }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -25,15 +25,11 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
 
     private let subscriptionMap: [String: PremiumSubscriptionType]
 
-    init(user: User, receiptService: ReceiptService, loggedIn: Bool, subscriptionMap: [String: PremiumSubscriptionType]? = nil) {
+    init(user: User, receiptService: ReceiptService, subscriptionMap: [String: PremiumSubscriptionType]? = nil) {
         self.user = user
         self.receiptService = receiptService
         self.subscriptionMap = subscriptionMap ?? [Keys.shared.pocketPremiumMonthly: .monthly, Keys.shared.pocketPremiumAnnual: .annual]
         makeUserSessionListener()
-        guard loggedIn else {
-            return
-        }
-        start()
     }
 
     deinit {
@@ -60,10 +56,7 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
         try await AppStore.sync()
         await fetchActiveSubscription()
     }
-}
 
-// MARK: private methods
-private extension PocketSubscriptionStore {
     /// Start the transaction listener, fetch purchaseable subscriptions,
     /// and look for purchased subscriptions on the App Store
     func start() {
@@ -81,7 +74,10 @@ private extension PocketSubscriptionStore {
             await self.fetchActiveSubscription()
         }
     }
+}
 
+// MARK: private methods
+private extension PocketSubscriptionStore {
     /// Reset user status and cancel the transaction listener
     func stop() {
         state = .unsubscribed

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/SubscriptionStore.swift
@@ -37,4 +37,5 @@ public protocol SubscriptionStore {
     func requestSubscriptions() async throws
     func purchase(_ subscription: PremiumSubscription) async
     func restoreSubscription() async throws
+    func start()
 }

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -181,7 +181,7 @@ struct Services {
             userDefaults: userDefaults,
             badgeProvider: UIApplication.shared
         )
-        subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService(client: v3Client), loggedIn: appSession.session != nil)
+        subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService(client: v3Client))
 
         userManagementService = UserManagementService(
             appSession: appSession,

--- a/PocketKit/Tests/PocketKitTests/Support/MockSubscriptionStore.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSubscriptionStore.swift
@@ -13,4 +13,5 @@ class MockSubscriptionStore: SubscriptionStore {
     var statePublisher: Published<PurchaseState>.Publisher { $state }
     func requestSubscriptions() async throws {}
     func purchase(_ subscription: PocketKit.PremiumSubscription) async {}
+    func start() { }
 }


### PR DESCRIPTION
## Summary

Defer starting the subscription store until later in the app launch cycle, if necessary. This aids in fixing an issue where a user may be prompted to log in with their Apple ID (by the system) on app launch.

## Implementation Details

There was a possible race condition where the subscription store would start itself because it was incorrectly started on the first launch of an app (after install). Previously, the subscription store would start itself on initialization based on if a user was logged in or not. This would be based on the current session (within the keychain). However, this store is initialized within `Services`, which is initialized before `didFinishLaunching` is called. Remember that on a first install, it's possible that a user's session will still exist within the keychain, since the keychain does not get cleared on uninstall. Then, during `didFinishLaunching`, we clear out a session from the keychain if it is the first time an app is launched. This means that if `AppSession.currentSession` is accessed at any point before `didFinishLaunching` is called, the session may still exist, since we have yet to log the user out. Since this would then start the subscription store, App Store details would be requested prematurely, potentially displaying a system login prompt.

By deferring starting the subscription store until the end of `didFinishLaunching` we are guaranteed to have the session in the correct state, to then determine whether we should start the store on launch, or if it should be later handled after login.

## Test Steps

- [ ] Log into the Pocket 8 app
- [ ] Uninstall the Pocket 8 app while logged in
- [ ] Reinstall the Pocket 8 app
- [ ] You should not receive a system login prompt (and, if a developer, a breakpoint on `SubscriptionStore.start()` should not be hit)

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
