### PR TITLE
fix(analytics): add content entity to upsell call

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Tags.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Tags.swift
@@ -114,14 +114,17 @@ public extension Events.Tags {
     }
 
     /// "Go Premium" button viewed
-    static func premiumUpsellViewed() -> Event {
+    static func premiumUpsellViewed(itemURL: URL) -> Event {
         return Impression(
             component: .button,
             requirement: .viewable,
             uiEntity: UiEntity(
                 .button,
                 identifier: "global-nav.addTags.upsell"
-            )
+            ),
+            extraEntities: [
+                ContentEntity(url: itemURL)
+            ]
         )
     }
 

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
@@ -5,6 +5,7 @@ import Localization
 struct PremiumUpsellView: View {
     @ObservedObject
     var viewModel: PremiumUpsellViewModel
+    let itemURL: URL
 
     @State var dismissReason: DismissReason = .swipe
     var body: some View {
@@ -31,7 +32,7 @@ struct PremiumUpsellView: View {
                         PremiumUpgradeView(dismissReason: self.$dismissReason, viewModel: viewModel.makePremiumUpgradeViewModel())
                     }
                     .task {
-                        viewModel.trackPremiumUpsellViewed()
+                        viewModel.trackPremiumUpsellViewed(with: itemURL)
                     }
                     .accessibilityIdentifier("get-pocket-premium-button")
             }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/ViewModel/PremiumUpsellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/ViewModel/PremiumUpsellViewModel.swift
@@ -7,6 +7,7 @@ import SharedPocketKit
 import Sync
 import Combine
 import Analytics
+import Foundation
 
 class PremiumUpsellViewModel: ObservableObject {
     private let premiumUpgradeViewModelFactory: PremiumUpgradeViewModelFactory
@@ -58,7 +59,7 @@ extension PremiumUpsellViewModel {
         }
     }
 
-    func trackPremiumUpsellViewed() {
-        tracker.track(event: Events.Tags.premiumUpsellViewed())
+    func trackPremiumUpsellViewed(with itemURL: URL) {
+        tracker.track(event: Events.Tags.premiumUpsellViewed(itemURL: itemURL))
     }
 }

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -72,7 +72,7 @@ class PocketAddTagsViewModel: AddTagsViewModel {
             PremiumUpgradeViewModel(store: store, tracker: tracker, source: .tags, networkPathMonitor: networkPathMonitor)
         })
 
-        self.premiumUpsellView = PremiumUpsellView(viewModel: premiumUpsellViewModel)
+        self.premiumUpsellView = PremiumUpsellView(viewModel: premiumUpsellViewModel, itemURL: item.url)
 
         tags = itemTagNames
         allOtherTags()


### PR DESCRIPTION
## Summary
Add missing content entity to Add Tags Premium Upsell Analytics Call

## References 
IN-1371

## Implementation Details
Added the Content Entity to the Premium Upsell Impression Call
![image](https://user-images.githubusercontent.com/6743397/235512608-d2ec8f7e-de92-4484-acd8-6399a7a584eb.png)

## Test Steps
Verify that `global-nav.addTags.upsell` is triggered and has an associated url

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
