### PR TITLE
feat(progress): adding in a progress bar for initial downloading

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -217,32 +217,50 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         super.viewDidLoad()
         view.backgroundColor = UIColor(.ui.white1)
         model.fetch()
-        view.addSubview(progressView)
-        progressView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            progressView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            progressView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            progressView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            progressView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale)
-        ])
+
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
     }
 
+    /// Whether or not we should show the progress bar.
+    /// We specifically add or remove it instead of hide/show it because our tests will not execute actions on the list when the progress bar is there, but hidden.
+    /// - Parameter shouldShow: Whether or not to show the progress barå
+    func shouldShowProgressBar(shouldShow: Bool) {
+        if shouldShow {
+            guard !self.view.subviews.contains(progressView) else {
+                // Progress bar is already in the view, so return
+                return
+            }
+            view.addSubview(progressView)
+            progressView.isHidden = false
+            progressView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                progressView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                progressView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                progressView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                progressView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale)
+            ])
+        } else {
+            progressView.isHidden = true
+            progressView.removeFromSuperview()
+        }
+    }
+
     func updateProgressBar(downloadState: InitialDownloadState) {
         switch downloadState {
         case .unknown:
-            progressView.isHidden = true
+            shouldShowProgressBar(shouldShow: false)
         case .started:
-            progressView.isHidden = false
             progressView.setProgress(0, animated: true)
+            shouldShowProgressBar(shouldShow: true)
         case .paginating(totalCount: _, currentPercentProgress: let progess):
             progressView.setProgress(progess, animated: true)
+            shouldShowProgressBar(shouldShow: true)
         case .completed:
             progressView.setProgress(100, animated: true)
-            progressView.isHidden = true
+            shouldShowProgressBar(shouldShow: false)
         }
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -102,6 +102,7 @@ protocol ItemsListViewModel: AnyObject {
     var selectionItem: SelectionItem { get }
     var emptyState: EmptyStateViewModel? { get }
     var snapshot: Published<Snapshot>.Publisher { get }
+    var initialDownloadState: Published<InitialDownloadState>.Publisher { get }
 
     func fetch()
     func refresh(_ completion: (() -> Void)?)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -46,6 +46,9 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     @Published
     var presentedListenViewModel: ListenViewModel?
 
+    @Published private var _initialDownloadState: InitialDownloadState
+    var initialDownloadState: Published<InitialDownloadState>.Publisher { $_initialDownloadState }
+
     private let listOptions: ListOptions
 
     var emptyState: EmptyStateViewModel? {
@@ -101,13 +104,30 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         switch self.viewType {
         case .saves:
             self.itemsController = source.makeSavesController()
+            self._initialDownloadState = source.initialSavesDownloadState.value
         case .archive:
             self.itemsController = source.makeArchiveController()
+            self._initialDownloadState = source.initialArchiveDownloadState.value
         }
 
         self.notificationCenter = notificationCenter
 
         super.init()
+
+        switch self.viewType {
+        case .saves:
+            source.initialSavesDownloadState.receive(on: DispatchQueue.global(qos: .userInteractive))
+                .sink { [weak self] initialDownloadState in
+                    self?._initialDownloadState = initialDownloadState
+                }
+                .store(in: &subscriptions)
+        case .archive:
+            source.initialArchiveDownloadState.receive(on: DispatchQueue.global(qos: .userInteractive))
+                .sink { [weak self] initialDownloadState in
+                    self?._initialDownloadState = initialDownloadState
+                }
+                .store(in: &subscriptions)
+        }
 
         itemsController.delegate = self
 
@@ -132,6 +152,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
                 self?.handle(syncEvent: event)
             }
             .store(in: &subscriptions)
+
     }
 
     func fetch() {
@@ -456,15 +477,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         snapshot.reloadItems(filters)
         let itemCellIDs: [ItemsListCell<ItemIdentifier>]
 
-        var stateValue: InitialDownloadState
-        switch self.viewType {
-        case .saves:
-            stateValue = source.initialSavesDownloadState.value
-        case .archive:
-            stateValue = source.initialArchiveDownloadState.value
-        }
-
-        switch stateValue {
+        switch self._initialDownloadState {
         case .unknown, .completed:
             itemCellIDs = itemsController
                 .fetchedObjects?
@@ -479,7 +492,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             } else {
                 itemCellIDs = (0..<4).map { .placeholder($0) }
             }
-        case .paginating(let totalCount):
+        case .paginating(let totalCount, _):
             itemCellIDs = (0..<totalCount).compactMap { index in
                 guard let fetchedObjects = itemsController.fetchedObjects,
                       fetchedObjects.count > index else {

--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -88,22 +88,25 @@ class FetchArchive: SyncOperation {
     }
 
     private func fetchArchive(firstSync: Bool) async throws {
-        var pagination = PaginationSpec(maxItems: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize)
+        var pagination = PaginationSpec(maxRemainingItemsAllowedToDownload: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize)
         if let cursor = safeSpace.currentCursor {
-            pagination = PaginationSpec(maxItems: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize, cursor: cursor)
+            pagination = PaginationSpec(maxRemainingItemsAllowedToDownload: SyncConstants.Archive.firstLoadMaxCount, pageSize: SyncConstants.Archive.initalPageSize, cursor: cursor)
         }
 
         var pageNumber = 1
+        var totalToDownload = SyncConstants.Archive.firstLoadMaxCount
         repeat {
-            Log.breadcrumb(category: "sync.archive", level: .debug, message: "Loading page \(pageNumber)")
             let result = try await fetchPage(pagination)
 
             if let totalCount = result.data?.user?.savedItems?.totalCount,
                firstSync {
-                let totalDownloadingCount = Float(min(totalCount, pagination.maxItems))
-                let totalPages = Float(totalDownloadingCount/Float(pagination.pageSize))
-                let progress = (Float(pageNumber) / totalPages)
-                initialDownloadState.send(.paginating(totalCount: Int(totalDownloadingCount), currentPercentProgress: progress))
+                if pageNumber == 1 {
+                    totalToDownload = min(totalCount, totalToDownload)
+                }
+                let totalReaminingToDownload = min(totalToDownload, pagination.maxRemainingItemsAllowedToDownload)
+                let progress = Float(totalToDownload - totalReaminingToDownload) / Float(totalToDownload)
+                Log.breadcrumb(category: "sync.archive", level: .debug, message: "Download Progress: \(progress) - Remaining Downloading: \(totalReaminingToDownload)")
+                initialDownloadState.send(.paginating(totalCount: totalReaminingToDownload, currentPercentProgress: progress))
             }
             try updateLocalStorage(result: result)
             pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Archive.pageSize)
@@ -145,21 +148,21 @@ class FetchArchive: SyncOperation {
     struct PaginationSpec {
         let cursor: String?
         let shouldFetchNextPage: Bool
-        let maxItems: Int
+        let maxRemainingItemsAllowedToDownload: Int
         let pageSize: Int
 
-        init(maxItems: Int, pageSize: Int) {
-            self.init(cursor: nil, shouldFetchNextPage: false, maxItems: maxItems, pageSize: pageSize)
+        init(maxRemainingItemsAllowedToDownload: Int, pageSize: Int) {
+            self.init(cursor: nil, shouldFetchNextPage: false, maxRemainingItemsAllowedToDownload: maxRemainingItemsAllowedToDownload, pageSize: pageSize)
         }
 
-        init(maxItems: Int, pageSize: Int, cursor: String) {
-            self.init(cursor: cursor, shouldFetchNextPage: false, maxItems: maxItems, pageSize: pageSize)
+        init(maxRemainingItemsAllowedToDownload: Int, pageSize: Int, cursor: String) {
+            self.init(cursor: cursor, shouldFetchNextPage: false, maxRemainingItemsAllowedToDownload: maxRemainingItemsAllowedToDownload, pageSize: pageSize)
         }
 
-        private init(cursor: String?, shouldFetchNextPage: Bool, maxItems: Int, pageSize: Int) {
+        private init(cursor: String?, shouldFetchNextPage: Bool, maxRemainingItemsAllowedToDownload: Int, pageSize: Int) {
             self.cursor = cursor
             self.shouldFetchNextPage = shouldFetchNextPage
-            self.maxItems = maxItems
+            self.maxRemainingItemsAllowedToDownload = maxRemainingItemsAllowedToDownload
             self.pageSize = pageSize
         }
 
@@ -167,13 +170,13 @@ class FetchArchive: SyncOperation {
             guard let savedItems = result.data?.user?.savedItems,
                   let itemCount = savedItems.edges?.count,
                   let endCursor = savedItems.pageInfo.endCursor else {
-                      return PaginationSpec(cursor: nil, shouldFetchNextPage: false, maxItems: maxItems, pageSize: pageSize)
+                      return PaginationSpec(cursor: nil, shouldFetchNextPage: false, maxRemainingItemsAllowedToDownload: maxRemainingItemsAllowedToDownload, pageSize: pageSize)
                   }
 
             return PaginationSpec(
                 cursor: endCursor,
-                shouldFetchNextPage: savedItems.pageInfo.hasNextPage && itemCount < maxItems,
-                maxItems: maxItems - itemCount,
+                shouldFetchNextPage: savedItems.pageInfo.hasNextPage && itemCount < maxRemainingItemsAllowedToDownload,
+                maxRemainingItemsAllowedToDownload: min((maxRemainingItemsAllowedToDownload - itemCount), savedItems.totalCount),
                 pageSize: pageSize
             )
         }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -5,7 +5,7 @@ import Foundation
 public enum InitialDownloadState {
     case unknown
     case started
-    case paginating(totalCount: Int)
+    case paginating(totalCount: Int, currentPercentProgress: Float)
     case completed
 }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -391,7 +391,7 @@ class SavedItemsListViewModelTests: XCTestCase {
             )
         }.store(in: &subscriptions)
 
-        source.initialSavesDownloadState.send(.paginating(totalCount: 2))
+        source.initialSavesDownloadState.send(.paginating(totalCount: 2, currentPercentProgress: 0))
         try? itemsController.performFetch()
 
         wait(for: [receivedSnapshot], timeout: 10)

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -400,7 +400,7 @@ class FetchSavesTests: XCTestCase {
             switch state {
             case .unknown, .started:
                 break
-            case .paginating(let totalCount):
+            case .paginating(let totalCount, _):
                 XCTAssertEqual(2, totalCount)
                 receivedFirstPageEvent.fulfill()
             case .completed:


### PR DESCRIPTION
## Summary

Adds a progress bar while downloading your saves/archives to make clear to the user we are still doing work. 

## Implementation Details
* I changed our breadcrumbs to be more helpful on download.

## Test Steps
* Log in fresh. See progress bar and breadcrumbs

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
https://user-images.githubusercontent.com/1010384/235556980-493444c6-4e8a-4bc3-8d49-cc54a41031d9.mp4


