### PR TITLE
fix(listen): filtering out savedItems that have no itemIds

### DIFF
--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -24,6 +24,10 @@ class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
         }
 
         let allItems: [PKTKusari<PKTListenItem>] = savedItems?.compactMap { $0 }.filter({savedItem in
+            if savedItem.remoteID == nil {
+                return false
+            }
+
             if savedItem.estimatedAlbumDuration <= 60 {
                 return false
             }
@@ -36,7 +40,7 @@ class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
                 return false
             }
 
-            return savedItem.item.isArticle ?? false
+            return savedItem.item.isArticle
         }).compactMap({item in
             let v = PKTListenKusariCreate(item.albumID!, PKTListenQueueSectionType.item.rawValue, item, config)
             return v


### PR DESCRIPTION
## Summary

We have a few listen crashes because remoteID is nil for some SavedItems which can occur before a users changes are pushed to the server, and get remoteIDs.

Fix is to filter out unprocessed items.