### PR TITLE
fix(listen): ensuring that Saves or Archive show if not in the playlist flag

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -666,16 +666,17 @@ extension SavedItemsListViewModel {
             // If the user selected a filter, and the user is not in the Listen tags playlist feature flag
             // Remove any filters and sorts they selected and re-fetch data before showing listen.
             if !selectedFilters.isEmpty && !featureFlags.isAssigned(flag: .listenTagsPlaylists) {
-                if let tag = self.presentedTagsFilter?.selectedTag {
-                    switch tag {
-                    case .recent(let tagName), .tag(let tagName):
-                        title = tagName
-                    case .notTagged: break
-                    }
-                }
                 selectedFilters.removeAll()
+                presentedTagsFilter = nil
                 applySorting()
                 fetch()
+            }
+            if let tag = self.presentedTagsFilter?.selectedTag {
+                switch tag {
+                case .recent(let tagName), .tag(let tagName):
+                    title = tagName
+                case .notTagged: break
+                }
             }
             presentedListenViewModel = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects, title: title)
             selectedFilters.remove(.listen)


### PR DESCRIPTION
## Summary
The logic was in the wrong place to set the title name for Listen playlists when enabled.