### PR TITLE
fix(coredata): make Item optional on SavedItem

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -72,7 +72,7 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     var components: [ArticleComponent]? {
-        item.item.article?.components
+        item.item?.article?.components
     }
 
     var textAlignment: Textile.TextAlignment {
@@ -80,19 +80,19 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     var title: String? {
-        item.item.title
+        item.item?.title
     }
 
     var authors: [ReadableAuthor]? {
-        item.item.authors?.compactMap { $0 as? Author }
+        item.item?.authors?.compactMap { $0 as? Author }
     }
 
     var domain: String? {
-        item.item.domainMetadata?.name ?? item.item.domain ?? item.host
+        item.item?.domainMetadata?.name ?? item.item?.domain ?? item.host
     }
 
     var publishDate: Date? {
-        item.item.datePublished
+        item.item?.datePublished
     }
 
     var url: URL? {
@@ -117,7 +117,7 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     func fetchDetailsIfNeeded() {
-        guard item.item.article == nil else {
+        guard item.item?.article == nil else {
             _events.send(.contentUpdated)
             return
         }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -307,7 +307,7 @@ extension HomeViewModel {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.item.shouldOpenInWebView {
+        if let item = savedItem.item, item.shouldOpenInWebView {
             selectedReadableType = .webViewSavedItem(viewModel)
         } else {
             selectedReadableType = .savedItem(viewModel)

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -8,11 +8,11 @@ import Sync
 
 public extension SavedItem {
     var textAlignment: TextAlignment {
-        TextAlignment(language: item.language)
+        TextAlignment(language: item?.language)
     }
 
     var bestURL: URL? {
-        item.bestURL ?? url
+        item?.bestURL ?? url
     }
 
     var isPending: Bool {
@@ -20,11 +20,11 @@ public extension SavedItem {
     }
 
     var shouldOpenInWebView: Bool {
-        item.shouldOpenInWebView == true
+        item?.shouldOpenInWebView == true
     }
 
     var isSyndicated: Bool {
-        item.isSyndicated == true
+        item?.isSyndicated == true
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -40,7 +40,7 @@ class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
                 return false
             }
 
-            return savedItem.item.isArticle
+            return savedItem.item?.isArticle ?? false
         }).compactMap({item in
             let v = PKTListenKusariCreate(item.albumID!, PKTListenQueueSectionType.item.rawValue, item, config)
             return v

--- a/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
@@ -28,16 +28,16 @@ extension SavedItem: PKTListenItem {
     }
 
     public var albumLanguage: String? {
-        self.item.language
+        self.item?.language
     }
 
     public var estimatedAlbumDuration: TimeInterval {
-        if let wordCount = item.wordCount?.intValue, wordCount > 0 {
+        if let wordCount = item?.wordCount?.intValue, wordCount > 0 {
             let wordsPerMinute = 155
             return Double(wordCount/wordsPerMinute * 60).rounded()
         }
 
-        if let timeToRead = item.timeToRead?.intValue, timeToRead > 0 {
+        if let timeToRead = item?.timeToRead?.intValue, timeToRead > 0 {
             return Double(timeToRead * 60)
         }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -8,23 +8,23 @@ extension SavedItem: ItemsListItem {
     }
 
     var domain: String? {
-        item.domain
+        item?.domain
     }
 
     var topImageURL: URL? {
-        item.topImageURL
+        item?.topImageURL
     }
 
     var timeToRead: Int? {
-        item.timeToRead?.intValue
+        item?.timeToRead?.intValue
     }
 
     var displayTitle: String {
-        item.title ?? item.bestURL.absoluteString
+        item?.title ?? item?.bestURL.absoluteString ?? url.absoluteString
     }
 
     var displayDomain: String? {
-        item.domainMetadata?.name ?? item.domain ?? host
+        item?.domainMetadata?.name ?? item?.domain ?? host
     }
 
     var displayDetail: String {
@@ -40,7 +40,7 @@ extension SavedItem: ItemsListItem {
     }
 
     var displayAuthors: String? {
-        let authors: [String]? = item.authors?.compactMap { ($0 as? Author)?.name }
+        let authors: [String]? = item?.authors?.compactMap { ($0 as? Author)?.name }
         return authors?.joined(separator: ", ")
     }
 
@@ -53,7 +53,7 @@ extension SavedItem: ItemsListItem {
     }
 
     var cursor: String? {
-        item.savedItem?.cursor
+        item?.savedItem?.cursor
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -631,7 +631,7 @@ extension SavedItemsListViewModel {
 
         switch listOptions.selectedSortOption {
         case .longestToRead, .shortestToRead:
-            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.item.timeToRead, ascending: (listOptions.selectedSortOption == .shortestToRead))
+            sortDescriptorTemp = NSSortDescriptor(keyPath: \SavedItem.item?.timeToRead, ascending: (listOptions.selectedSortOption == .shortestToRead))
         case .newest, .oldest:
 
             switch self.viewType {

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
@@ -20,7 +20,7 @@ extension SavedItem {
     @NSManaged public var isFavorite: Bool
     @NSManaged public var remoteID: String?
     @NSManaged public var url: URL
-    @NSManaged public var item: Item
+    @NSManaged public var item: Item?
     @NSManaged public var savedItemUpdatedNotification: SavedItemUpdatedNotification?
     @NSManaged public var tags: NSOrderedSet?
     @NSManaged public var unresolvedSavedItem: UnresolvedSavedItem?

--- a/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
+++ b/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
@@ -31,13 +31,13 @@ class CoreDataSpotlightDelegate: NSCoreDataCoreSpotlightDelegate {
         let identifier = savedItem.remoteID
         let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
         attributeSet.identifier = identifier
-        attributeSet.displayName = savedItem.item.title
-        attributeSet.publishers = (savedItem.item.authors?.array as? [Author] ?? []).compactMap { $0.name }
-        attributeSet.thumbnailURL = savedItem.item.topImageURL // TODO: Image cache url..
+        attributeSet.displayName = savedItem.item?.title
+        attributeSet.publishers = (savedItem.item?.authors?.array as? [Author] ?? []).compactMap { $0.name }
+        attributeSet.thumbnailURL = savedItem.item?.topImageURL // TODO: Image cache url..
         attributeSet.contentURL = savedItem.url
-        attributeSet.contentDescription = savedItem.item.excerpt
-        attributeSet.title = savedItem.item.title
-        attributeSet.contentCreationDate = savedItem.item.datePublished
+        attributeSet.contentDescription = savedItem.item?.excerpt
+        attributeSet.title = savedItem.item?.title
+        attributeSet.contentCreationDate = savedItem.item?.datePublished
 
         return attributeSet
     }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -354,7 +354,7 @@ extension PocketSource {
 
             space.delete(savedItem)
 
-            if item.recommendation == nil {
+            if let item = item, item.recommendation == nil {
                 space.delete(item)
             }
 

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -101,7 +101,7 @@ class SavedItemViewModelTests: XCTestCase {
         source.stubFetchDetails { _ in }
 
         let savedItem = space.buildSavedItem()
-        savedItem.item.article = nil
+        savedItem.item?.article = nil
         try space.save()
 
         let viewModel = subject(item: savedItem)

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -137,7 +137,7 @@ class SlateDetailViewModelTests: XCTestCase {
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
         let savedItem = try space.createSavedItem(item: space.buildItem())
-        let recommendation = space.buildRecommendation(item: savedItem.item)
+        let recommendation = space.buildRecommendation(item: savedItem.item!)
         let slate = try space.createSlate(recommendations: [recommendation])
         try space.save()
         let viewModel = subject(slate: space.viewObject(with: slate.objectID) as! Slate)

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -71,7 +71,7 @@ class SaveItemOperationTests: XCTestCase {
         XCTAssertEqual(performCall?.mutation.input.url, url.absoluteString)
 
         let item = try space.fetchSavedItem(byURL: url)
-        XCTAssertEqual(savedItem.item.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
+        XCTAssertEqual(savedItem.item?.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
         XCTAssertNotNil(item)
     }
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -189,7 +189,7 @@ class PocketSourceTests: XCTestCase {
         }
 
         let savedItem = try space.createSavedItem(item: space.buildItem())
-        let item = savedItem.item
+        let item = savedItem.item!
         item.recommendation = space.buildRecommendation(item: item)
 
         let remoteItemURL = item.givenURL
@@ -207,7 +207,7 @@ class PocketSourceTests: XCTestCase {
         }
 
         let savedItem = try space.createSavedItem(item: space.buildItem())
-        let item = savedItem.item
+        let item = savedItem.item!
 
         let remoteItemURL = item.givenURL
 
@@ -354,7 +354,7 @@ class PocketSourceTests: XCTestCase {
 
         let savedItem = savedItems[0]
         XCTAssertEqual(savedItem.objectID, seededSavedItem.objectID)
-        XCTAssertEqual(savedItem.item.objectID, seededItem.objectID)
+        XCTAssertEqual(savedItem.item?.objectID, seededItem.objectID)
         XCTAssertFalse(savedItem.isArchived)
     }
 
@@ -701,8 +701,8 @@ extension PocketSourceTests {
         let savedItem = source.fetchOrCreateSavedItem(with: URL(string: "http://localhost:8080/hello")!, and: itemParts)
 
         XCTAssertEqual(savedItem?.remoteID, "saved-item")
-        XCTAssertEqual(savedItem?.item.title, "item-title")
-        XCTAssertEqual(savedItem?.item.bestURL.absoluteString, "http://localhost:8080/hello")
+        XCTAssertEqual(savedItem?.item?.title, "item-title")
+        XCTAssertEqual(savedItem?.item?.bestURL.absoluteString, "http://localhost:8080/hello")
     }
 
     private func setupLocalSavesSearch(with urlString: String? = nil) throws {

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -104,33 +104,33 @@ class FetchSavesTests: XCTestCase {
         XCTAssertEqual(tags?[0].name, "tag-1")
 
         let item = savedItem.item
-        XCTAssertEqual(item.remoteID, "item-1")
-        XCTAssertEqual(item.givenURL, URL(string: "https://given.example.com/item-1")!)
-        XCTAssertEqual(item.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
-        XCTAssertEqual(item.title, "Item 1")
-        XCTAssertEqual(item.topImageURL, URL(string: "https://example.com/item-1/top-image.jpg")!)
-        XCTAssertEqual(item.domain, "example.com")
-        XCTAssertEqual(item.language, "en")
-        XCTAssertEqual(item.timeToRead, 6)
-        XCTAssertEqual(item.excerpt, "Cursus Aenean Elit")
-        XCTAssertEqual(item.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
+        XCTAssertEqual(item?.remoteID, "item-1")
+        XCTAssertEqual(item?.givenURL, URL(string: "https://given.example.com/item-1")!)
+        XCTAssertEqual(item?.resolvedURL, URL(string: "https://resolved.example.com/item-1")!)
+        XCTAssertEqual(item?.title, "Item 1")
+        XCTAssertEqual(item?.topImageURL, URL(string: "https://example.com/item-1/top-image.jpg")!)
+        XCTAssertEqual(item?.domain, "example.com")
+        XCTAssertEqual(item?.language, "en")
+        XCTAssertEqual(item?.timeToRead, 6)
+        XCTAssertEqual(item?.excerpt, "Cursus Aenean Elit")
+        XCTAssertEqual(item?.datePublished, Date(timeIntervalSinceReferenceDate: 631195261))
 
         let expected: [ArticleComponent] = Fixture.load(name: "marticle").decode()
-        XCTAssertEqual(item.article?.components, expected)
+        XCTAssertEqual(item?.article?.components, expected)
 
-        let authors = item.authors?.compactMap { $0 as? Author }
+        let authors = item?.authors?.compactMap { $0 as? Author }
         XCTAssertEqual(authors?[0].id, "author-1")
         XCTAssertEqual(authors?[0].name, "Eleanor")
         XCTAssertEqual(authors?[0].url, URL(string: "https://example.com/authors/eleanor")!)
 
-        let domain = item.domainMetadata
+        let domain = item?.domainMetadata
         XCTAssertEqual(domain?.name, "WIRED")
         XCTAssertEqual(domain?.logo, URL(string: "http://example.com/item-1/domain-logo.jpg")!)
 
-        let images = item.images?.compactMap { $0 as? Image } ?? []
+        let images = item?.images?.compactMap { $0 as? Image } ?? []
         XCTAssertEqual(images[0].source, URL(string: "http://example.com/item-1/image-1.jpg"))
 
-        XCTAssertEqual(item.syndicatedArticle?.itemID, "syndicated-article-item-id")
+        XCTAssertEqual(item?.syndicatedArticle?.itemID, "syndicated-article-item-id")
     }
 
     func test_refresh_whenFetchSucceeds_andResultContainsDuplicateItems_createsSingleItem() async throws {
@@ -157,7 +157,7 @@ class FetchSavesTests: XCTestCase {
         _ = await service.execute(syncTaskId: task.objectID)
 
         let item = try space.fetchSavedItem(byURL: URL(string: "http://example.com/item-1")!)
-        XCTAssertEqual(item?.item.title, "Updated Item 1")
+        XCTAssertEqual(item?.item?.title, "Updated Item 1")
     }
 
     func test_refresh_whenFetchFails_sendsErrorOverGivenSubject() async throws {


### PR DESCRIPTION
## Summary
Set Item back to non-optional on SavedItem since there are scenarios such as extension and offline where we can't create an Item (which is server backed)

## References 
See convo here:
https://pocket.slack.com/archives/C01UH57EJKD/p1683046168112139?thread_ts=1683042594.907889&cid=C01UH57EJKD

## Implementation Details
* Make `Item` optional on `SavedItem`
* Fix build errors for compiling project and running tests

## Test Steps
1. Save an article to Pocket via Share Extension on airplane mode
2. Navigate to Saves List
3. Validate that no crash occurs

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
