### PR TITLE
fix(home): adjust padding between sections for iPad layout

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -196,7 +196,7 @@ class HomeViewControllerSectionProvider {
                 widthDimension: .fractionalWidth(1),
                 heightDimension: .absolute(
                     numberOfGroups * StyleConstants.groupHeight +
-                    (Constants.sectionSpacing * (numberOfGroups - 1))
+                    (Constants.spacing * (numberOfGroups - 1))
                 )
             ),
             subitems: groups


### PR DESCRIPTION
## Summary
Adjust padding between sections in Home tab for iPad layout

## References 
IN-1386

## Implementation Details
* Update padding to be consistent with the spacing between recent saves and editor's pick

## Test Steps
Run app and verify there is no longer inconsistent space between section

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
