### PR TITLE
fix(ui): dark mode buttons + color

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -133,7 +133,7 @@
 "settings.premium.settings.questionOrFeedback" = "Questions or feedback?";
 "settings.premium.settings.pocketPremiumFAQ" = "Pocket Premium FAQ";
 // this refers to an action to open an email
-"settings.premium.settings.contactPocketSupport" = "Contact pocket support";
+"settings.premium.settings.contactPocketSupport" = "Contact Pocket support";
 
 //Sorting Options
 "sortingOption.sortBy" = "Sort by";

--- a/PocketKit/Sources/PocketKit/Article/ArticleComponentUnavailableView.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleComponentUnavailableView.swift
@@ -14,7 +14,7 @@ class ArticleComponentUnavailableView: UIView {
 
     private lazy var button: UIButton = {
         var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = UIColor(.ui.teal2)
+        config.baseBackgroundColor = UIColor(.ui.teal2).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
         config.attributedTitle = AttributedString(
             NSAttributedString(
                 string: Localization.openInWebView,

--- a/PocketKit/Sources/PocketKit/Style/ActionsPrimaryButtonStyle.swift
+++ b/PocketKit/Sources/PocketKit/Style/ActionsPrimaryButtonStyle.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ActionsPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .background(configuration.isPressed ? Color(.ui.teal1) : Color(.ui.teal2))
+            .background(configuration.isPressed ? Color(UIColor(.ui.teal1).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))) : Color(UIColor(.ui.teal2).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))))
             .cornerRadius(13)
     }
 }

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/teal2.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/teal2.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD2",
-          "green" : "0xD5",
-          "red" : "0x95"
+          "blue" : "0xDE",
+          "green" : "0xE2",
+          "red" : "0x9A"
         }
       },
       "idiom" : "universal"

--- a/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
+++ b/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
@@ -18,14 +18,14 @@ public struct PocketButtonStyle: ButtonStyle {
     let variation: Variation
 
     private struct Constants {
-        static let cornerRadius: CGFloat = 4
+        static let cornerRadius: CGFloat = 13
         static let buttonHeight: CGFloat = 52
         static let style = Style.header.sansSerif.h6
 
         struct Primary {
             static let tintColor = Color(.ui.grey1)
-            static let backgroundColor = Color(.ui.teal2)
-            static let pressedBackgroundColor = Color(.ui.teal1)
+            static let backgroundColor = Color(UIColor(.ui.teal2).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)))
+            static let pressedBackgroundColor = Color(UIColor(.ui.teal1).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)))
             static let foregroundColor = Color(.ui.white)
             static let pressedForegroundColor = Color(.ui.white)
         }


### PR DESCRIPTION
## Summary
Button color should be the same as light mode and `teal2` color in dark mode should be adjusted.

## References 
IN-1393

## Implementation Details
As part of this work: 
* Updated `teal2` dark mode to use `#9AE2DE`
* Added corner radius of `13` to buttons
* Change dark mode buttons to use light mode colors
* Small fix on capitalizing Pocket in Strings

## Test Steps
Verify that dark mode buttons are now same color as light mode buttons

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| iPad  | iPhone |
| ------------- | ------------- |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-04 at 11 33 25](https://user-images.githubusercontent.com/6743397/236256661-57d122b2-2a1c-415d-bc8e-c8a7a6a9dd3b.png) | ![Simulator Screenshot - iPhone 13 mini - 2023-05-04 at 11 35 24](https://user-images.githubusercontent.com/6743397/236257158-17b0ad6c-4314-4396-bd9d-1c35bd4059d3.png)  |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-04 at 11 47 41](https://user-images.githubusercontent.com/6743397/236260374-acb48bde-b65e-416e-8a1a-52c49ac0521d.png)| ![Simulator Screenshot - iPhone 13 mini - 2023-05-04 at 11 44 56](https://user-images.githubusercontent.com/6743397/236259530-8efebb24-828d-4069-a4b8-3acc98960a39.png) |