### PR TITLE
feat(HTTPError) Add detection for a 429 error, meaning we are being t…

### DIFF
--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -5,4 +5,5 @@ public extension Notification.Name {
     static let userLoggedOut = Notification.Name("com.mozilla.pocket.userLoggedOut")
     static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
     static let bannerRequested = Notification.Name("com.mozilla.pocket.bannerRequested")
+    static let serverThrottleDetected = Notification.Name("com.mozilla.pocket.throttleDetected")
 }


### PR DESCRIPTION
…hrottled

## Summary
Add a check to each fetch request looking for a HTTP 429 error code
Add a notification name for serverthrottle.

Next we need to notify the mainView that this has happened so we can pop a toast message to notify the user.

## References 
https://getpocket.atlassian.net/browse/IN-1212
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
https://pocket.slack.com/archives/C03QVL4SU/p1683135486799189

## Test Steps
Unknown...

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

