### PR TITLE
fix(search): add proper url to fetch and create savedItem

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -50,8 +50,12 @@ struct PocketItem {
         item.remoteItemParts
     }
 
-    var url: URL? {
+    var bestURL: URL? {
         item.bestURL
+    }
+
+    var savedItemURL: URL? {
+        item.savedItemURL
     }
 
     var cursor: String? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItemViewModel.swift
@@ -109,7 +109,7 @@ class PocketItemViewModel: ObservableObject {
     }
 
     private func _share() {
-        if let url = item.url {
+        if let url = item.savedItemURL {
             tracker.track(event: Events.Search.shareItem(itemUrl: url, positionInList: index, scope: scope))
         } else {
             Log.capture(message: "Selected search item without an associated url, not logging analytics for shareItem")
@@ -149,7 +149,7 @@ class PocketItemViewModel: ObservableObject {
     /// Fetch a SavedItem or create one in order to use actions related to source
     private func fetchSavedItem() -> SavedItem? {
         guard
-            let url = item.url,
+            let url = item.savedItemURL,
             let savedItem = source.fetchOrCreateSavedItem(
                 with: url,
                 and: item.remoteItemParts

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/ItemsListItem.swift
@@ -17,6 +17,7 @@ protocol ItemsListItem {
     var host: String? { get }
     var tagNames: [String]? { get }
     var remoteItemParts: SavedItemParts? { get }
+    var savedItemURL: URL? { get }
     var cursor: String? { get }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -55,6 +55,10 @@ extension SavedItem: ItemsListItem {
     var cursor: String? {
         item?.savedItem?.cursor
     }
+
+    var savedItemURL: URL? {
+        url
+    }
 }
 
 extension DomainMetadata: ItemsListItemDomainMetadata {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
@@ -26,7 +26,7 @@ struct ListItem: View {
                 ActionButton(viewModel.favoriteAction(), selected: viewModel.isFavorite)
                 ActionButton(viewModel.shareAction())
                     .sheet(isPresented: $viewModel.presentShareSheet) {
-                        ShareSheetView(activity: PocketItemActivity.fromSaves(url: viewModel.item.url))
+                        ShareSheetView(activity: PocketItemActivity.fromSaves(url: viewModel.item.bestURL))
                             .presentationDetents([.medium])
                     }
                 // Instead of using existing code of overflow, we created a new SwiftUI view

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
@@ -89,6 +89,10 @@ extension SearchSavedItem: ItemsListItem {
     var tagNames: [String]? {
         remoteItem.tags?.compactMap { $0.name }.sorted()
     }
+
+    var savedItemURL: URL? {
+        URL(string: remoteItem.url)
+    }
 }
 
 extension SavedItemParts.Item.AsItem.DomainMetadata: ItemsListItemDomainMetadata { }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -64,7 +64,7 @@ struct ResultsView: View {
                     if triggerNextPage {
                         viewModel.loadMoreSearchResults(with: item, at: index)
                     }
-                    viewModel.trackViewResults(url: item.url, index: index)
+                    viewModel.trackViewResults(url: item.savedItemURL, index: index)
                 }
             }
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -411,7 +411,7 @@ extension SearchViewModel: SearchResultActionDelegate {
 
     func select(_ searchItem: PocketItem, index: Int) {
         guard
-            let url = searchItem.url,
+            let url = searchItem.savedItemURL,
             let savedItem = source.fetchOrCreateSavedItem(
                 with: url,
                 and: searchItem.remoteItemParts
@@ -501,7 +501,7 @@ extension SearchViewModel: SearchResultActionDelegate {
 
     func fetchSavedItem(_ searchItem: PocketItem) -> SavedItem? {
         guard
-            let url = searchItem.url,
+            let url = searchItem.savedItemURL,
             let savedItem = source.fetchOrCreateSavedItem(
                 with: url,
                 and: searchItem.remoteItemParts

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -40,6 +40,7 @@ struct MockItemsListItem: ItemsListItem {
     let host: String?
     let tagNames: [String]?
     let cursor: String?
+    let savedItemURL: URL?
 
     static func build(
         id: String? = nil,
@@ -54,7 +55,8 @@ struct MockItemsListItem: ItemsListItem {
         isPending: Bool = false,
         host: String? = nil,
         tagNames: [String]? = nil,
-        cursor: String? = nil
+        cursor: String? = nil,
+        savedItemURL: URL? = nil
     ) -> MockItemsListItem {
         MockItemsListItem(
             id: id,
@@ -69,7 +71,8 @@ struct MockItemsListItem: ItemsListItem {
             isPending: isPending,
             host: host,
             tagNames: tagNames,
-            cursor: cursor
+            cursor: cursor,
+            savedItemURL: savedItemURL
         )
     }
 }


### PR DESCRIPTION
## Summary
Add proper url input parameter for `fetchOrCreateSavedItem` so that it takes the right `url` and fetches the right item in core data.

Previously, we were searching on `bestURL` and we were unable to find the item so we created a new one. However, updated this so that we are fetching the item instead of creating a new one. 

## References 
IN-1430

## Implementation Details
Instead of using the `bestURL`, we created another field `savedItemURL` to get the proper url to be fetched from core data. Added test to make sure that the url we pass in is the savedItem URL and should match the remoteParts.

## Test Steps
1. Navigate to Search
2. Search for Items in Both Online + Local Search
3. Confirm if Search Actions are now working

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
