### PR TITLE
fix(search): adjust ui refinements for search dark mode

### DIFF
--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -482,8 +482,8 @@ public enum Localization {
     }
     public enum Premium {
       public enum Settings {
-        /// Contact pocket support
-        public static let contactPocketSupport = Localization.tr("Localizable", "settings.premium.settings.contactPocketSupport", fallback: "Contact pocket support")
+        /// Contact Pocket support
+        public static let contactPocketSupport = Localization.tr("Localizable", "settings.premium.settings.contactPocketSupport", fallback: "Contact Pocket support")
         /// Date purchased
         public static let datePurchased = Localization.tr("Localizable", "settings.premium.settings.datePurchased", fallback: "Date purchased")
         /// Manage your subscription

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -88,7 +88,7 @@ struct EmptyStateView<Content: View>: View {
 }
 
 private extension Style {
-    static let main: Self = .header.sansSerif.h2.with(weight: .bold).with { $0.with(alignment: .center).with(lineSpacing: 6) }
+    static let main: Self = .header.sansSerif.h2.with(weight: .semibold).with { $0.with(alignment: .center).with(lineSpacing: 6) }
     static let detail: Self = .header.sansSerif.p2.with { $0.with(alignment: .center).with(lineSpacing: 6) }
     static let buttonLabel: Self = .header.sansSerif.h7.with(color: .ui.white)
 }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -146,6 +146,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
     // MARK: Search
     private func setupSearch() {
         let searchViewController = UIHostingController(rootView: SearchView(viewModel: searchViewModel))
+        searchViewController.view.backgroundColor = UIColor(.ui.white1)
         navigationItem.searchController = UISearchController(searchResultsController: searchViewController)
         navigationItem.searchController?.searchBar.delegate = self
         navigationItem.searchController?.searchBar.autocapitalizationType = .none

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -22,6 +22,7 @@ struct SearchView: View {
                 ResultsView(viewModel: viewModel, results: results)
             case .loading:
                 SkeletonView()
+                    .background(Color(.ui.white1))
             default:
                 EmptyView()
             }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -22,7 +22,6 @@ struct SearchView: View {
                 ResultsView(viewModel: viewModel, results: results)
             case .loading:
                 SkeletonView()
-                    .background(Color(.ui.white1))
             default:
                 EmptyView()
             }
@@ -68,6 +67,7 @@ struct ResultsView: View {
                     viewModel.trackViewResults(url: item.savedItemURL, index: index)
                 }
             }
+            .listRowBackground(Color.clear)
         }
         .zIndex(-1)
         .listStyle(.plain)
@@ -169,7 +169,7 @@ struct RecentSearchView: View {
                     .onTapGesture {
                         viewModel.searchText = recentSearch
                     }
-                }
+                }.listRowBackground(Color.clear)
             }
         }
         .listStyle(.plain)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
@@ -25,10 +25,12 @@ struct SkeletonView: View {
                         Image(asset: .itemSkeletonThumbnail)
                         Image(asset: .itemSkeletonActions)
                     }
-                }.foregroundColor(Color(.ui.skeletonCellImageBackground))
+                }
+                .foregroundColor(Color(.ui.skeletonCellImageBackground))
             }
         }
         .listStyle(.plain)
         .accessibilityIdentifier("skeleton-view")
+        .background(Color(.ui.white1))
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SkeletonView.swift
@@ -25,12 +25,11 @@ struct SkeletonView: View {
                         Image(asset: .itemSkeletonThumbnail)
                         Image(asset: .itemSkeletonActions)
                     }
-                }
-                .foregroundColor(Color(.ui.skeletonCellImageBackground))
+                }.foregroundColor(Color(.ui.skeletonCellImageBackground))
             }
+            .listRowBackground(Color.clear)
         }
         .listStyle(.plain)
         .accessibilityIdentifier("skeleton-view")
-        .background(Color(.ui.white1))
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -15,7 +15,7 @@ class SavedItemViewController: UIViewController {
 
     private let addTagsButton: UIButton = {
         var configuration: UIButton.Configuration = .filled()
-        configuration.background.backgroundColor = UIColor(.ui.teal2)
+        configuration.background.backgroundColor = UIColor(.ui.teal2).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
         configuration.background.cornerRadius = 13
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 13, leading: 0, bottom: 13, trailing: 0)
         configuration.attributedTitle = AttributedString(NSAttributedString(string: "Add Tags", style: .buttonText))


### PR DESCRIPTION
## Summary
Fix Search Section in Dark Mode
* Titles of empty states on search should be semibold (currently, it seems it is in bold)
* In dark mode the background is not matching the rest of the app

## References 
IN-1257

## Implementation Details
Added some UI adjustments in terms of color in dark mode and font weight.

## Test Steps
Verify the following:
* Search dark mode background should match the rest of the app
* Change empty states title from bold to semibold
* Fix Button color in dark Mode for Add Tags (snuck it in :) )

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| iPhone  | iPhone |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 13 mini - 2023-05-05 at 12 53 00](https://user-images.githubusercontent.com/6743397/236519325-582954c7-4196-4975-8cbb-47c8e61a27e4.png) | ![Simulator Screenshot - iPhone 13 mini - 2023-05-05 at 12 53 08](https://user-images.githubusercontent.com/6743397/236519346-2a41b613-ee05-40fe-bc7b-4aee18fcf4a5.png) |
