### PR TITLE
Search: fix a crash when deleting an item

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -6,7 +6,7 @@ import Foundation
 import PocketGraph
 
 struct PocketItem {
-    private let item: ItemsListItem
+    let item: ItemsListItem
     private let itemPresenter: ItemsListItemPresenter
 
     init(item: ItemsListItem) {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/LocalSavesSearch.swift
@@ -7,18 +7,13 @@ import Analytics
 
 class LocalSavesSearch {
     private let source: Source
-    private var cache: [String: [PocketItem]] = [:]
 
     init(source: Source) {
         self.source = source
     }
 
     func search(with term: String) -> [PocketItem] {
-        guard cache[term] == nil else {
-            return cache[term] ?? []
-        }
         let items = source.searchSaves(search: term)?.compactMap { PocketItem(item: $0) } ?? []
-        cache[term] = items
-        return cache[term] ?? []
+        return items
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -593,7 +593,6 @@ extension SearchViewModel: SavedItemsControllerDelegate {
         let currentObjectIDs = savedItems.map { $0.objectID }
         let snapshotIDs = snapshot.itemIdentifiers as! [NSManagedObjectID]
         let deletedIDs = currentObjectIDs.filter { snapshotIDs.contains($0) == false }
-        let updatedIDs = snapshot.reloadedItemIdentifiers
         let updatedItems = savedItems
             .filter { deletedIDs.contains($0.objectID) == false }
             .filter { outOfScope($0) }
@@ -604,31 +603,6 @@ extension SearchViewModel: SavedItemsControllerDelegate {
     /// Checks if a saved item should be moved to archive or vice versa
     private func outOfScope(_ savedItem: SavedItem) -> Bool {
         (savedItem.isArchived && selectedScope == .saves) || (!savedItem.isArchived && selectedScope == .archive)
-    }
-
-    /// Remove item from list of items in `SearchView`
-    /// - Parameters:
-    ///   - savedItem: savedItem that was changed in Core Data
-    ///   - items: list of `PocketItem` that is displayed as search results
-    private func removeItemFromView(_ savedItem: SavedItem, and items: [PocketItem], at index: Int) {
-        var items = items
-        items.remove(at: index)
-        Log.debug("Search item removed \(String(describing: savedItem.displayTitle))")
-        // Animations seen to work better when we don't wrap this around main thread
-        self.searchState = .searchResults(items)
-    }
-
-    /// Update item in list of items in `SearchView`
-    /// - Parameters:
-    ///   - savedItem: savedItem that was changed in Core Data
-    ///   - items: list of `PocketItem` that is displayed as search results
-    private func updateItemInView(_ savedItem: SavedItem, and items: [PocketItem], at index: Int) {
-        var items = items
-        items.remove(at: index)
-        items.insert(PocketItem(item: savedItem), at: index)
-        Log.debug("Search item updated \(String(describing: savedItem.displayTitle))")
-        // Animations seen to work better when we don't wrap this around main thread
-        self.searchState = .searchResults(items)
     }
 }
 

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -52,7 +52,7 @@ public enum Requests {
         var allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, unarchivedPredicate])
         if isPremium {
             let tagsPredicate = NSPredicate(format: "%@ IN tags.name", searchTerm)
-            allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, tagsPredicate])
+            allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, unarchivedPredicate, tagsPredicate])
         }
         request.predicate = allPredicate
         return request

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -48,11 +48,13 @@ public enum Requests {
         let request = SavedItem.fetchRequest()
         let urlPredicate = NSPredicate(format: "url CONTAINS %@", searchTerm)
         let titlePredicate = NSPredicate(format: "item.title CONTAINS %@", searchTerm)
+        let urlTitlePredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate])
         let unarchivedPredicate = NSPredicate(format: "isArchived = false")
-        var allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, unarchivedPredicate])
+        var allPredicate = NSCompoundPredicate(type: .and, subpredicates: [urlTitlePredicate, unarchivedPredicate])
         if isPremium {
             let tagsPredicate = NSPredicate(format: "%@ IN tags.name", searchTerm)
-            allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, unarchivedPredicate, tagsPredicate])
+            let premiumPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlTitlePredicate, tagsPredicate])
+            allPredicate = NSCompoundPredicate(type: .and, subpredicates: [premiumPredicate, unarchivedPredicate])
         }
         request.predicate = allPredicate
         return request

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -48,7 +48,8 @@ public enum Requests {
         let request = SavedItem.fetchRequest()
         let urlPredicate = NSPredicate(format: "url CONTAINS %@", searchTerm)
         let titlePredicate = NSPredicate(format: "item.title CONTAINS %@", searchTerm)
-        var allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate])
+        let unarchivedPredicate = NSPredicate(format: "isArchived = false")
+        var allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, unarchivedPredicate])
         if isPremium {
             let tagsPredicate = NSPredicate(format: "%@ IN tags.name", searchTerm)
             allPredicate = NSCompoundPredicate(type: .or, subpredicates: [urlPredicate, titlePredicate, tagsPredicate])

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -33,17 +33,13 @@ class LocalSavesSearchTests: XCTestCase {
         let sut = subject()
         var results = sut.search(with: "saved")
         XCTAssertEqual(results.count, 2)
-
-        source.stubSearchItems { _ in return [] }
-
-        results = sut.search(with: "saved")
-        XCTAssertEqual(results.count, 2)
     }
 
     private func setupLocalSavesSearch() throws {
         let savedItems = (1...2).map {
             space.buildSavedItem(
                 remoteID: "saved-item-\($0)",
+                url: "http://example.com/item-1-\($0)",
                 createdAt: Date(timeIntervalSince1970: TimeInterval($0)),
                 item: space.buildItem(title: "saved-item-\($0)")
             )

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -31,7 +31,7 @@ class LocalSavesSearchTests: XCTestCase {
     func test_search_showsResultsAndCaches() throws {
         try setupLocalSavesSearch()
         let sut = subject()
-        var results = sut.search(with: "saved")
+        let results = sut.search(with: "saved")
         XCTAssertEqual(results.count, 2)
     }
 


### PR DESCRIPTION
## Summary
*This PR
    - Fixes a crash on delete an item from local search results on `saves`
    - Fixes an issue that was causing archived items to show in the local `saves` search

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
