### PR TITLE
test(sync) Add tests to run fetchSaves and fetchArchive at the same t…

### DIFF
--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -10,6 +10,7 @@ import SharedPocketKit
 class MockOperationFactory: SyncOperationFactory {
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
+    private var lock: DispatchQueue = DispatchQueue(label: "")
 }
 
 // MARK: - fetchSaves
@@ -44,15 +45,17 @@ extension MockOperationFactory {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        calls["fetchSaves"] = (calls["fetchSaves"] ?? []) + [
-            FetchSavesCall(
-                apollo: apollo,
-                space: space,
-                events: events,
-                initialDownloadState: initialDownloadState,
-                lastRefresh: lastRefresh
-            )
-        ]
+        lock.sync {
+            calls["fetchSaves"] = (calls["fetchSaves"] ?? []) + [
+                FetchSavesCall(
+                    apollo: apollo,
+                    space: space,
+                    events: events,
+                    initialDownloadState: initialDownloadState,
+                    lastRefresh: lastRefresh
+                )
+            ]
+        }
 
         return impl(apollo, space, events, initialDownloadState)
     }
@@ -98,15 +101,17 @@ extension MockOperationFactory {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
-        calls["fetchArchive"] = (calls["fetchArchive"] ?? []) + [
-            FetchArchiveCall(
-                apollo: apollo,
-                space: space,
-                events: events,
-                initialDownloadState: initialDownloadState,
-                lastRefresh: lastRefresh
-            )
-        ]
+        lock.sync {
+            calls["fetchArchive"] = (calls["fetchArchive"] ?? []) + [
+                FetchArchiveCall(
+                    apollo: apollo,
+                    space: space,
+                    events: events,
+                    initialDownloadState: initialDownloadState,
+                    lastRefresh: lastRefresh
+                )
+            ]
+        }
 
         return impl(apollo, space, events, initialDownloadState)
     }


### PR DESCRIPTION
…ime on 2 threads. Fix crash in mockOperationFactory

## Summary
When in the background the app may try to fetch saves and archive at the same time, from 2 different threads with can cause a crash.
@bassrock guided me through adding childContexts for those operations which fixes the crash.

## References 
https://pocket.sentry.io/issues/4156754439/events/9e85fa2a05f34a739fbd45c63a5ced53/
https://pocket.sentry.io/issues/4156756592/events/83a8ff1dddad4e4e8805329aa7049c80/

## Implementation Details
Added a childContext in the PocketSource enqueue function to avoid collisions between threads.
Also, to fix a crash in MockOperationFactory, we wrapped the fetchArchiveCall assignment in a DispatchQueue .sync

## Test Steps
The crash happens in the background, so testing seems nigh-impossible.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
