### PR TITLE
fix(SaveTo): notify app for refresh after adding tags from Save extension

### DIFF
--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -73,6 +73,14 @@ public class PocketSaveService: SaveService {
                 space.fetchOrCreateTag(byName: tag)
             }))
 
+            // Adding and sending a SavedItemUpdatedNotification will trigger the app to update
+            // its list for updated items from the share extension, since the context
+            // used within the space, here, and that within the app (used by Saves) may be different.
+            // Once the notification is posted, and these types of notifications exist within the space,
+            // the app target can appropriately update from the Save extension by listener (see PocketSource.init).
+            let notification: SavedItemUpdatedNotification = SavedItemUpdatedNotification(context: space.backgroundContext)
+            notification.savedItem = savedItem
+
             try? space.save()
 
             osNotifications.post(name: .savedItemUpdated)


### PR DESCRIPTION
## Summary

Fixes an issue where, when offline, adding tags to an item saved from the save extension would not update the UI in the app.

## References 

IN-1351

## Implementation Details

Since the save extension and app are run as different processes, the core data store itself is shared, but not references to certain contexts (e.g background context). However, the parent remains the same (the persistent container). Since we are not directly saving to the context used by the app (since it's in another process), we notify the app that a saved item has been updated. However, a necessary Core Data type was not being saved, causing a guard to fail (`PocketSource.handleSavedItemsUpdatedNotification()`). This pull request saves the correct Core Data type to the store such that once the app is notified that a saved item has been created, `PocketSource` can subsequently forward events that cause a downstream list refresh, showing the correct tags in the list.

## Test Steps

- [ ] Open the Pocket app as a logged in user, open Saves, and background the app
- [ ] When offline, save an item via Save extension to Pocket, adding tags
- [ ] Re-open the Pocket app, and the saved item should be shown (with its url as the title) as well as the correct tags

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
