### PR TITLE
Premium: remove expired subscription log from Sentry

### DIFF
--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -174,7 +174,7 @@ private extension PocketSubscriptionStore {
             // if the subscription is expired, revert to free
             state = .unsubscribed
             user.setPremiumStatus(false)
-            Log.capture(message: "Subscription was expired")
+            Log.debug("Subscription was expired")
             return
         }
 


### PR DESCRIPTION
## Summary
* Remove a Subscription expired info log from Sentry

## Implementation Details
* Update `PocketSubscriptionStore`, remove the aforementioned log.

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
