### PR TITLE
Settings - Add user email to the top section header

### DIFF
--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetUserDataQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetUserDataQuery.graphql.swift
@@ -14,6 +14,7 @@ public class GetUserDataQuery: GraphQLQuery {
           isPremium
           username
           name
+          email
         }
       }
       """#
@@ -46,6 +47,7 @@ public class GetUserDataQuery: GraphQLQuery {
         .field("isPremium", Bool?.self),
         .field("username", String?.self),
         .field("name", String?.self),
+        .field("email", String?.self),
       ] }
 
       /// The user's premium status
@@ -54,6 +56,8 @@ public class GetUserDataQuery: GraphQLQuery {
       public var username: String? { __data["username"] }
       /// The users first name and last name combined
       public var name: String? { __data["name"] }
+      /// Email address associated with the account.
+      public var email: String? { __data["email"] }
     }
   }
 }

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/user.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/user.graphql
@@ -8,5 +8,6 @@ query GetUserData {
     isPremium
     username
     name
+    email
   }
 }

--- a/PocketKit/Sources/PocketGraphTestMocks/User+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/User+Mock.graphql.swift
@@ -10,6 +10,7 @@ public class User: MockObject {
   public typealias MockValueCollectionType = Array<Mock<User>>
 
   public struct MockFields {
+    @Field<String>("email") public var email
     @Field<Bool>("isPremium") public var isPremium
     @Field<String>("name") public var name
     @available(*, deprecated, message: "Use saveById instead")
@@ -23,6 +24,7 @@ public class User: MockObject {
 
 public extension Mock where O == User {
   convenience init(
+    email: String? = nil,
     isPremium: Bool? = nil,
     name: String? = nil,
     savedItemById: Mock<SavedItem>? = nil,
@@ -32,6 +34,7 @@ public extension Mock where O == User {
     username: String? = nil
   ) {
     self.init()
+    self.email = email
     self.isPremium = isPremium
     self.name = name
     self.savedItemById = savedItemById

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -50,6 +50,10 @@ class AccountViewModel: ObservableObject {
     var isOffline: Bool {
         return networkPathMonitor.currentNetworkPath.status == .unsatisfied
     }
+    // TODO: replace with the actual email
+    var userEmail: String {
+        user.displayName
+    }
 
     init(appSession: AppSession,
          user: User,

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -50,9 +50,9 @@ class AccountViewModel: ObservableObject {
     var isOffline: Bool {
         return networkPathMonitor.currentNetworkPath.status == .unsatisfied
     }
-    // TODO: replace with the actual email
+
     var userEmail: String {
-        user.displayName
+        user.email
     }
 
     init(appSession: AppSession,

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -101,16 +101,25 @@ struct SettingsForm: View {
 // These methods should be removed once we support iOS 16+
 extension SettingsForm {
     /// Handles top section separator on different versions of iOS
-    @ViewBuilder
     private func topSectionWithLeadingDivider() -> some View {
         topSection()
             .alignmentGuide(.listRowSeparatorLeading) { _ in
                 return 0
             }
     }
+
+    private func header() -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(Localization.yourAccount)
+                .style(.settings.header)
+            Text(model.userEmail)
+                .style(.credits)
+        }
+        .padding(.bottom, 16)
+    }
     /// Provides the standard top section view
     private func topSection() -> some View {
-        Section(header: Text(Localization.yourAccount).style(.settings.header)) {
+        Section(header: header()) {
             if model.isPremium {
                 makePremiumSubscriptionRow()
                     .accessibilityIdentifier("premium-subscription-button")

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -11,10 +11,12 @@ public protocol User {
     var status: Status { get }
     var userName: String { get }
     var displayName: String { get }
+    var email: String { get }
     var statusPublisher: Published<Status>.Publisher { get }
     func setPremiumStatus(_ isPremium: Bool)
     func setUserName(_ userName: String)
     func setDisplayName(_ displayName: String)
+    func setEmail(_ email: String)
     func clear()
 }
 
@@ -24,6 +26,8 @@ public class PocketUser: User, ObservableObject {
     public var userName: String
     @AppStorage
     public var displayName: String
+    @AppStorage
+    public private(set) var email: String
     public var statusPublisher: Published<Status>.Publisher { $status }
     @AppStorage
     private var storedStatus: Status
@@ -31,11 +35,13 @@ public class PocketUser: User, ObservableObject {
     private static let userStatusKey = UserDefaults.Key.userStatus
     private static let userNameKey = UserDefaults.Key.userName
     private static let displayNameKey = UserDefaults.Key.displayName
+    private static let emailKey = UserDefaults.Key.userEmail
 
-    public init(status: Status = .unknown, userDefaults: UserDefaults, userName: String = "", displayName: String = "") {
+    public init(status: Status = .unknown, userDefaults: UserDefaults, userName: String = "", displayName: String = "", email: String = "") {
         _storedStatus = AppStorage(wrappedValue: status, Self.userStatusKey, store: userDefaults)
         _userName = AppStorage(wrappedValue: userName, Self.userNameKey, store: userDefaults)
         _displayName = AppStorage(wrappedValue: displayName, Self.displayNameKey, store: userDefaults)
+        _email = AppStorage(wrappedValue: email, Self.emailKey)
         publishStatus()
     }
 
@@ -52,10 +58,15 @@ public class PocketUser: User, ObservableObject {
         self.displayName = displayName
     }
 
+    public func setEmail(_ email: String) {
+        self.email = email
+    }
+
     public func clear() {
         setStatus(.unknown)
         setUserName("")
         setDisplayName("")
+        setEmail("")
     }
 }
 

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -28,6 +28,7 @@ public extension UserDefaults {
         case userStatus = "User.statusKey"
         case userName = "User.nameKey"
         case displayName = "User.displayNameKey"
+        case userEmail = "User.email"
         case userId = "User.userId"
         case startingAppSection = "MainViewModel.StartingAppSection"
 

--- a/PocketKit/Sources/Sync/User/UserService.swift
+++ b/PocketKit/Sources/Sync/User/UserService.swift
@@ -39,5 +39,6 @@ class APIUserService: UserService {
         user.setPremiumStatus(remoteIsPremium)
         user.setUserName(remote.username ?? "")
         user.setDisplayName(remote.name ?? "")
+        user.setEmail(remote.email ?? "")
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
@@ -7,8 +7,9 @@ class MockUser: User {
 
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
-    internal var userName: String = ""
-    internal var displayName: String = ""
+    var userName: String = ""
+    var displayName: String = ""
+    var email: String = ""
 
     init(status: Status = .unknown) {
         self.status = status
@@ -76,11 +77,10 @@ extension MockUser {
 
 // MARK: - User Name
 extension MockUser {
+    typealias SetParameterImpl = (String) -> Void
     private static let setUserName = "setUserName"
-    typealias SetUserNameImpl = (String) -> Void
-
     private static let setDisplayName = "setDisplayName"
-    typealias SetDisplayNameImpl = (String) -> Void
+    private static let setEmail = "setEmail"
 
     struct SetUserName {
         let userName: String
@@ -90,12 +90,20 @@ extension MockUser {
         let displayName: String
     }
 
-    func stubSetUserName(impl: @escaping SetUserNameImpl) {
+    struct SetEmail {
+        let email: String
+    }
+
+    func stubSetUserName(impl: @escaping SetParameterImpl) {
         implementations[Self.setUserName] = impl
     }
 
-    func stubSetDisplayName(impl: @escaping SetDisplayNameImpl) {
+    func stubSetDisplayName(impl: @escaping SetParameterImpl) {
         implementations[Self.setDisplayName] = impl
+    }
+
+    func stumSetEmail(impl: @escaping SetParameterImpl) {
+        implementations[Self.setEmail] = impl
     }
 
     func stubStandardUserName() {
@@ -107,7 +115,7 @@ extension MockUser {
     }
 
     func setUserName(_ userName: String) {
-        guard let impl = implementations[Self.setUserName] as? SetUserNameImpl else {
+        guard let impl = implementations[Self.setUserName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
@@ -117,12 +125,22 @@ extension MockUser {
     }
 
     func setDisplayName(_ displayName: String) {
-        guard let impl = implementations[Self.setDisplayName] as? SetDisplayNameImpl else {
+        guard let impl = implementations[Self.setDisplayName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
         calls[Self.setDisplayName] = (calls[Self.setDisplayName] ?? [] + [SetDisplayName(displayName: displayName)])
 
         impl(displayName)
+    }
+
+    func setEmail(_ email: String) {
+        guard let impl = implementations[Self.setEmail] as? SetParameterImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.setEmail] = (calls[Self.setEmail] ?? [] + [SetEmail(email: email)])
+
+        impl(email)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockUser.swift
@@ -11,8 +11,9 @@ class MockUser: User {
 
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
-    internal var userName: String = ""
-    internal var displayName: String = ""
+    var userName: String = ""
+    var displayName: String = ""
+    var email: String = ""
 
     init(status: Status = .unknown) {
         self.status = status
@@ -80,11 +81,10 @@ extension MockUser {
 
 // MARK: - User Name
 extension MockUser {
+    typealias SetParameterImpl = (String) -> Void
     private static let setUserName = "setUserName"
-    typealias SetUserNameImpl = (String) -> Void
-
     private static let setDisplayName = "setDisplayName"
-    typealias SetDisplayNameImpl = (String) -> Void
+    private static let setEmail = "setEmail"
 
     struct SetUserName {
         let userName: String
@@ -94,12 +94,20 @@ extension MockUser {
         let displayName: String
     }
 
-    func stubSetUserName(impl: @escaping SetUserNameImpl) {
+    struct SetEmail {
+        let email: String
+    }
+
+    func stubSetUserName(impl: @escaping SetParameterImpl) {
         implementations[Self.setUserName] = impl
     }
 
-    func stubSetDisplayName(impl: @escaping SetDisplayNameImpl) {
+    func stubSetDisplayName(impl: @escaping SetParameterImpl) {
         implementations[Self.setDisplayName] = impl
+    }
+
+    func stubSetEmail(impl: @escaping SetParameterImpl) {
+        implementations[Self.setEmail] = impl
     }
 
     func stubStandardUserName() {
@@ -111,7 +119,7 @@ extension MockUser {
     }
 
     func setUserName(_ userName: String) {
-        guard let impl = implementations[Self.setUserName] as? SetUserNameImpl else {
+        guard let impl = implementations[Self.setUserName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
@@ -121,12 +129,22 @@ extension MockUser {
     }
 
     func setDisplayName(_ displayName: String) {
-        guard let impl = implementations[Self.setDisplayName] as? SetDisplayNameImpl else {
+        guard let impl = implementations[Self.setDisplayName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
         calls[Self.setDisplayName] = (calls[Self.setDisplayName] ?? [] + [SetDisplayName(displayName: displayName)])
 
         impl(displayName)
+    }
+
+    func setEmail(_ email: String) {
+        guard let impl = implementations[Self.setEmail] as? SetParameterImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.setEmail] = (calls[Self.setEmail] ?? [] + [SetEmail(email: email)])
+
+        impl(email)
     }
 }

--- a/PocketKit/Tests/SyncTests/Fixtures/user.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/user.json
@@ -4,7 +4,8 @@
       "__typename": "[type-name-here]",
       "isPremium": true,
       "username": "User Name",
-      "name": "Pocket User"
+      "name": "Pocket User",
+      "email": "pocket@mozilla.com"
     }
   }
 }

--- a/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
@@ -30,6 +30,7 @@ class FetchUserTests: XCTestCase {
         user.stubSetStatus { _ in }
         user.stubSetUserName { _ in }
         user.stubSetDisplayName { _ in }
+        user.stubSetEmail { _ in }
         apollo.setupUserSyncResponse()
         let service = subject()
         try await service.fetchUser()

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -2,12 +2,17 @@ import SharedPocketKit
 import Combine
 
 class MockUser: User {
-    @Published public private(set) var status: Status = .unknown
+    @Published public private(set) var status: Status
     public var statusPublisher: Published<Status>.Publisher { $status }
     private var implementations: [String: Any] = [:]
     private var calls: [String: [Any]] = [:]
-    internal var userName: String = ""
-    internal var displayName: String = ""
+    var userName: String = ""
+    var displayName: String = ""
+    var email: String = ""
+
+    init(status: Status = .unknown) {
+        self.status = status
+    }
 }
 
 // MARK: - Set Status
@@ -77,11 +82,10 @@ extension MockUser {
 
 // MARK: - User Name
 extension MockUser {
+    typealias SetParameterImpl = (String) -> Void
     private static let setUserName = "setUserName"
-    typealias SetUserNameImpl = (String) -> Void
-
     private static let setDisplayName = "setDisplayName"
-    typealias SetDisplayNameImpl = (String) -> Void
+    private static let setEmail = "setEmail"
 
     struct SetUserName {
         let userName: String
@@ -91,12 +95,20 @@ extension MockUser {
         let displayName: String
     }
 
-    func stubSetUserName(impl: @escaping SetUserNameImpl) {
+    struct SetEmail {
+        let email: String
+    }
+
+    func stubSetUserName(impl: @escaping SetParameterImpl) {
         implementations[Self.setUserName] = impl
     }
 
-    func stubSetDisplayName(impl: @escaping SetDisplayNameImpl) {
+    func stubSetDisplayName(impl: @escaping SetParameterImpl) {
         implementations[Self.setDisplayName] = impl
+    }
+
+    func stubSetEmail(impl: @escaping SetParameterImpl) {
+        implementations[Self.setEmail] = impl
     }
 
     func stubStandardUserName() {
@@ -108,7 +120,7 @@ extension MockUser {
     }
 
     func setUserName(_ userName: String) {
-        guard let impl = implementations[Self.setUserName] as? SetUserNameImpl else {
+        guard let impl = implementations[Self.setUserName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
@@ -118,12 +130,22 @@ extension MockUser {
     }
 
     func setDisplayName(_ displayName: String) {
-        guard let impl = implementations[Self.setDisplayName] as? SetDisplayNameImpl else {
+        guard let impl = implementations[Self.setDisplayName] as? SetParameterImpl else {
             fatalError("\(Self.self)#\(#function) has not been stubbed")
         }
 
         calls[Self.setDisplayName] = (calls[Self.setDisplayName] ?? [] + [SetDisplayName(displayName: displayName)])
 
         impl(displayName)
+    }
+
+    func setEmail(_ email: String) {
+        guard let impl = implementations[Self.setEmail] as? SetParameterImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.setEmail] = (calls[Self.setEmail] ?? [] + [SetEmail(email: email)])
+
+        impl(email)
     }
 }


### PR DESCRIPTION
## Summary
* This PR adds the user email to the top section header in the Settings screen, right below the section title ("Your Account")

## References 
* see branch name

## Implementation Details
* Update graphql query for `User`, request `email`
* Update `User`, `PocketUser`, add `email` property
* Update `AccountViewModel`, add `userEmail` property
* Update `SettingsView`, add user email to the top section header, styled as the footer

## Test Steps
* Checkout this branch and build/run
* go to Settings
* Make sure the email of the account you used is displayed below the "Your Account" title (see screenshot)

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

<p align=center>
<img height="500" src="https://user-images.githubusercontent.com/34376330/236945313-a0e044f0-307c-4c04-925f-4d44ee408c59.png">

</p>
