### PR TITLE
fix(retry): disabling retry on a 500

### DIFF
--- a/PocketKit/Sources/Sync/Operations/FetchArchive.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchArchive.swift
@@ -75,7 +75,7 @@ class FetchArchive: SyncOperation {
                         level: .error,
                         message: "ResponseCodeInterceptor.ResponseCodeError with Error: \(error.localizedDescription) and status code \(String(describing: response?.statusCode))"
                     )
-                    return .retry(error)
+                    return .failure(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -75,7 +75,7 @@ class FetchSaves: SyncOperation {
                         level: .error,
                         message: "ResponseCodeInterceptor.ResponseCodeError with Error: \(error.localizedDescription) and status code \(String(describing: response?.statusCode))"
                     )
-                    return .retry(error)
+                    return .failure(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Sources/Sync/Operations/FetchTags.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchTags.swift
@@ -59,7 +59,7 @@ class FetchTags: SyncOperation {
                         level: .error,
                         message: "ResponseCodeInterceptor.ResponseCodeError with Error: \(error.localizedDescription) and status code \(String(describing: response?.statusCode))"
                     )
-                    return .retry(error)
+                    return .failure(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SaveItemOperation.swift
@@ -41,7 +41,7 @@ class SaveItemOperation: SyncOperation {
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
-                    return .retry(error)
+                    return .failure(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/SavedItemMutationOperation.swift
@@ -53,7 +53,7 @@ class SavedItemMutationOperation: SyncOperation {
             case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
                 switch response?.statusCode {
                 case .some((500...)):
-                    return .retry(error)
+                    return .failure(error)
                 default:
                     return .failure(error)
                 }

--- a/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
@@ -94,8 +94,8 @@ class ItemMutationOperationTests: XCTestCase {
         let service = subject(mutation: mutation)
         let result = await service.execute(syncTaskId: task.objectID)
 
-        guard case .retry = result else {
-            XCTFail("Expected retry result but got \(result)")
+        guard case .failure = result else {
+            XCTFail("Expected failure result but got \(result)")
             return
         }
     }

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -92,7 +92,7 @@ class SaveItemOperationTests: XCTestCase {
         }
     }
 
-    func test_main_whenMutationFailsWithHTTP5XX_retries() async throws {
+    func test_main_whenMutationFailsWithHTTP5XX_does_not_retry() async throws {
         let initialError = ResponseCodeInterceptor.ResponseCodeError.withStatusCode(500)
         apollo.stubPerform(ofMutationType: SaveItemMutation.self, toReturnError: initialError)
 
@@ -100,8 +100,8 @@ class SaveItemOperationTests: XCTestCase {
         let service = subject(managedItemID: savedItem.objectID, url: savedItem.url)
         let result = await service.execute(syncTaskId: task.objectID)
 
-        guard case .retry = result else {
-            XCTFail("Expected retry result but got \(result)")
+        guard case .failure = result else {
+            XCTFail("Expected failure result but got \(result)")
             return
         }
     }

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -443,7 +443,7 @@ class FetchSavesTests: XCTestCase {
         }
     }
 
-    func test_execute_whenResponseIs5XX_retries() async {
+    func test_execute_whenResponseIs5XX_does_not_retry() async {
         let initialError = ResponseCodeInterceptor.ResponseCodeError.withStatusCode(500)
         user.stubSetStatus { _ in }
         apollo.setupTagsResponse()
@@ -452,8 +452,8 @@ class FetchSavesTests: XCTestCase {
         let service = subject()
         let result = await service.execute(syncTaskId: task.objectID)
 
-        guard case .retry = result else {
-            XCTFail("Expected retry result but got \(result)")
+        guard case .failure = result else {
+            XCTFail("Expected failure result but got \(result)")
             return
         }
     }


### PR DESCRIPTION
## Summary
* A 500 indicates an internal server error, without any backoff logic the code will try the same operation again within seconds of it failing. It is highly unlikely that an internal server error will be solved in that time. 

Until we have a backoff strategy removing the retries on 500 errors

## References 
* https://pocket.slack.com/archives/C01UH57EJKD/p1683583090774729

## Implementation Details
* Making 500 errors be a general failure.
* Pairs with https://github.com/Pocket/pocket-ios/pull/718

## Screenshots
