### PR TITLE
fix(data): fixing tests missing a piece of data

### DIFF
--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -199,6 +199,7 @@ extension Response {
         return .init(
             mock: Mock<Query>(
                 user: Mock<PocketGraphTestMocks.User>(
+                    email: "free@mozilla.com",
                     isPremium: false,
                     name: "Pocket User",
                     username: "User Name"
@@ -211,6 +212,7 @@ extension Response {
         return .init(
             mock: Mock<Query>(
                 user: Mock<PocketGraphTestMocks.User>(
+                    email: "premium@mozilla.com",
                     isPremium: true,
                     name: "Pocket User",
                     username: "User Name"


### PR DESCRIPTION
## Summary
* With https://github.com/Pocket/pocket-ios/pull/717 the mock data stopped loading.

This was a hidden error in Apollo Client complaining about missing fields from a graphql request response.

I propose we should do 1 of 2 things to mitigate in the future:
* Detect if we are in a testing environment and make this type of missing data error crash the app for tests
* Show this error to the user, and make our tests ensure that the error is not shown.