### PR TITLE
fix(ui): add semibold weight to offline view title

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListOfflineCell.swift
@@ -5,7 +5,7 @@ import Localization
 class ItemsListOfflineCell: UICollectionViewCell {
     enum Constants {
         static let image = UIImage(asset: .looking)
-        static let text = NSAttributedString(string: Localization.noInternetConnection, style: .header.sansSerif.h2)
+        static let text = NSAttributedString(string: Localization.noInternetConnection, style: .header.sansSerif.h2.with(weight: .semibold))
         static let detailText = NSAttributedString(
             string: Localization.LooksLikeYouReOffline.tryCheckingYourMobileDataOrWifi,
             style: .header.sansSerif.p2.with { $0.with(alignment: .center).with(lineHeight: .explicit(28)) }


### PR DESCRIPTION
## Summary
Make title for Home offline state semibold to match other empty screens

## References 
IN-1392

## Implementation Details
Add semibold weight onto title 

## Test Steps
Run app in offline mode and navigate to Home 
Verify that title is now in semibold

## PR Checklist:
- N / A  Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| Dark Mode | Light Mode | 
| --- | --- |
|![Simulator Screenshot - iPhone 13 mini - 2023-05-09 at 14 11 05](https://github.com/Pocket/pocket-ios/assets/6743397/e3e65983-f419-4ec1-bc0d-4812223ae7b5) | ![Simulator Screenshot - iPhone 13 mini - 2023-05-09 at 14 11 17](https://github.com/Pocket/pocket-ios/assets/6743397/862515d3-6bdc-4597-a6c6-a2407c1c29fd) |
