### PR TITLE
Article - Fix a crash when attempting to load a video with an invalid URL

### DIFF
--- a/PocketKit/Sources/Sync/Article/ArticleComponent.swift
+++ b/PocketKit/Sources/Sync/Article/ArticleComponent.swift
@@ -1,4 +1,3 @@
-import Foundation
 import PocketGraph
 import SharedPocketKit
 

--- a/PocketKit/Sources/Sync/Article/ArticleComponent.swift
+++ b/PocketKit/Sources/Sync/Article/ArticleComponent.swift
@@ -1,4 +1,6 @@
+import Foundation
 import PocketGraph
+import SharedPocketKit
 
 public typealias Markdown = String
 
@@ -151,8 +153,8 @@ extension ArticleComponent {
         self = .codeBlock(CodeBlockComponent(marticle))
     }
 
-    init(_ marticle: VideoParts) {
-        self = .video(VideoComponent(marticle))
+    init(_ videoParts: VideoParts) throws {
+        self = .video(try VideoComponent(videoParts))
     }
 
     init(_ marticle: MarticleBulletedListParts) {
@@ -198,9 +200,13 @@ extension ArticleComponent {
             return
         }
 
-        if let parts = marticle.asVideo {
-            self.init(parts.fragments.videoParts)
-            return
+        if let videoParts = marticle.asVideo?.fragments.videoParts {
+            do {
+                try self.init(videoParts)
+                return
+            } catch {
+                Log.capture(message: "Invalid source URL for video: \(error)")
+            }
         }
 
         if let parts = marticle.asMarticleBulletedList {

--- a/PocketKit/Sources/Sync/Article/VideoComponent.swift
+++ b/PocketKit/Sources/Sync/Article/VideoComponent.swift
@@ -1,6 +1,10 @@
 import Foundation
 import PocketGraph
 
+public enum VideoComponentError: Error {
+    case invalidURL
+}
+
 public struct VideoComponent: Codable, Equatable, Hashable {
     public let id: Int
     public let type: VideoType
@@ -35,15 +39,21 @@ public extension VideoComponent {
 }
 
 extension VideoComponent {
-    init(_ marticle: VideoParts) {
+    /// Convenience initalizer using a `VideoParts` instance.
+    /// Throws an error if the parts does not contain a valid `URL`
+    /// - Parameter marticle: the `VideoParts` instance
+    init(_ videoParts: VideoParts) throws {
+        guard let url = URL(string: videoParts.src) else {
+            throw VideoComponentError.invalidURL
+        }
         self.init(
-            id: marticle.videoID,
-            type: VideoType(rawValue: marticle.type.rawValue) ?? .unknown,
-            source: URL(string: marticle.src)!,
-            vid: marticle.vid,
-            width: marticle.width.flatMap(UInt.init),
-            height: marticle.height.flatMap(UInt.init),
-            length: marticle.length.flatMap(UInt.init)
+            id: videoParts.videoID,
+            type: VideoType(rawValue: videoParts.type.rawValue) ?? .unknown,
+            source: url,
+            vid: videoParts.vid,
+            width: videoParts.width.flatMap(UInt.init),
+            height: videoParts.height.flatMap(UInt.init),
+            length: videoParts.length.flatMap(UInt.init)
         )
     }
 }


### PR DESCRIPTION
## Summary
* This PR fixes a crash occurring when trying to create a `VideoComponent` instance with an invalid url
* 
## References 
* See branch name

## Implementation Details
* Update `VideoComponent`, make the convenience initializer throw an error if the url from `VideoParts` is invalid
* Update `ArticleComponent`, handle the errors described in the previous bullet

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
