### PR TITLE
fix(ui): make adjustments to margins for iPad

### DIFF
--- a/PocketKit/Sources/PocketKit/Constants.swift
+++ b/PocketKit/Sources/PocketKit/Constants.swift
@@ -2,14 +2,15 @@ import Foundation
 import UIKit
 
 enum Margins: CGFloat {
-  case thin = 8
-  case normal = 16
-  case wide = 32
+    case thin = 8
+    case normal = 16
+    case iPadNormal = 20
+    case wide = 32
 }
 
 enum Width: CGFloat {
-  case normal = 145
-  case wide = 300
+    case normal = 145
+    case wide = 300
 }
 
 enum StyleConstants {

--- a/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
+++ b/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
@@ -18,3 +18,12 @@ extension UIViewController {
         PocketAppDelegate.phoneOrientationLock = orientation
     }
 }
+
+extension UITraitCollection {
+    /// Used to determine if the device should use wide layout due to it being an iPad with regular horizontal size class
+    /// - Returns: true or false if the device should use our configurations for a wide layout
+    func shouldUseWideLayout() -> Bool {
+        userInterfaceIdiom == .pad &&
+        horizontalSizeClass == .regular
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -7,13 +7,9 @@ class HomeViewControllerSectionProvider {
     struct Constants {
         static let margin: CGFloat = Margins.thin.rawValue
         static let sideMargin: CGFloat = Margins.normal.rawValue
+        static let iPadSideMargin: CGFloat = Margins.iPadNormal.rawValue
         static let spacing: CGFloat = 16
         static let sectionSpacing: CGFloat = 64
-    }
-
-    func shouldUseWideLayout(traitCollection: UITraitCollection) -> Bool {
-        traitCollection.userInterfaceIdiom == .pad &&
-        traitCollection.horizontalSizeClass == .regular
     }
 
     func loadingSection() -> NSCollectionLayoutSection {
@@ -47,9 +43,12 @@ class HomeViewControllerSectionProvider {
         )
 
         let itemWidthPercentage: CGFloat
-        if shouldUseWideLayout(traitCollection: env.traitCollection) {
+        let sideMargin: CGFloat
+        if env.traitCollection.shouldUseWideLayout() {
+            sideMargin = Constants.iPadSideMargin
             itemWidthPercentage = 2/5
         } else {
+            sideMargin = Constants.sideMargin
             itemWidthPercentage = 0.8
         }
 
@@ -83,9 +82,9 @@ class HomeViewControllerSectionProvider {
         section.boundarySupplementaryItems = [headerItem]
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Constants.margin,
-            leading: Constants.sideMargin,
+            leading: sideMargin,
             bottom: Constants.sectionSpacing,
-            trailing: Constants.sideMargin
+            trailing: sideMargin
         )
         return section
     }
@@ -104,9 +103,12 @@ class HomeViewControllerSectionProvider {
 
         let width = env.container.effectiveContentSize.width
         let heroHeight: CGFloat
-        if shouldUseWideLayout(traitCollection: env.traitCollection) {
+        let sideMargin: CGFloat
+        if env.traitCollection.shouldUseWideLayout() {
+            sideMargin = Constants.iPadSideMargin
             heroHeight = width * 0.28
         } else {
+            sideMargin = Constants.sideMargin
             heroHeight = RecommendationCell.fullHeight(viewModel: hero, availableWidth: width - (Constants.sideMargin * 2))
         }
 
@@ -127,15 +129,15 @@ class HomeViewControllerSectionProvider {
         section.boundarySupplementaryItems = [headerItem]
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Constants.margin,
-            leading: Constants.sideMargin,
+            leading: sideMargin,
             bottom: Constants.margin,
-            trailing: Constants.sideMargin
+            trailing: sideMargin
         )
         return section
     }
 
     func additionalRecommendationsSection(for slateID: NSManagedObjectID, in viewModel: HomeViewModel, env: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
-        if shouldUseWideLayout(traitCollection: env.traitCollection) {
+        if env.traitCollection.shouldUseWideLayout() {
             return recommendationCellGridSection(for: slateID, in: viewModel, env: env)
         } else {
             return carouselSection(for: slateID, in: viewModel, env: env)
@@ -206,9 +208,9 @@ class HomeViewControllerSectionProvider {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Constants.margin,
-            leading: Constants.sideMargin,
+            leading: Constants.iPadSideMargin,
             bottom: Constants.sectionSpacing,
-            trailing: Constants.sideMargin
+            trailing: Constants.iPadSideMargin
         )
 
         return section

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -201,7 +201,7 @@ extension HomeViewController {
             cell.configure(model: viewModel)
             return cell
         case .recommendationHero(let objectID):
-            if sectionProvider.shouldUseWideLayout(traitCollection: traitCollection) {
+            if traitCollection.shouldUseWideLayout() {
                 let cell: RecommendationCellHeroWide = collectionView.dequeueCell(for: indexPath)
                 guard let viewModel = model.recommendationHeroWideViewModel(for: objectID, at: indexPath) else {
                     return cell

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -182,7 +182,8 @@ private extension SlateDetailViewController {
             return NSCollectionLayoutSection(group: group)
         case .slate(let slate):
             let width = environment.container.effectiveContentSize.width
-            let margin: CGFloat = Margins.normal.rawValue
+            let margin: CGFloat = environment.traitCollection.shouldUseWideLayout() ? Margins.iPadNormal.rawValue : Margins.normal.rawValue
+
             let recommendations = slate.recommendations?.compactMap { $0 as? Recommendation } ?? []
 
             let components = recommendations.reduce((CGFloat(0), [NSCollectionLayoutItem]())) { result, recommendation in


### PR DESCRIPTION
## Summary
Modify margins on iPad so that sections below the tile Home (“Recent Saves“, “Editors' picks“ and all others below) align with the “Home“ title margin. 

## References 
IN-1387

## Implementation Details
Add new margin for iPad and move implementation for `shouldUseWideLayout` as an extension to `UITraitCollection` to be reused in multiple places. Utilize new iPad margin of `20` for Home leading and trailing side margins. Also, modified margins for Slate Detail. 

## Test Steps
1. Navigate to Home
2. Confirm that margins are now aligned and left / right margins are consistent

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| iPad - Home | iPad - Slates | 
| --- | --- |
| ![image](https://github.com/Pocket/pocket-ios/assets/6743397/dc2eec9d-1f14-498c-bdd1-a0781348b465) | ![image](https://github.com/Pocket/pocket-ios/assets/6743397/8556d8f0-a36a-4c68-b023-2050a42ef473) |
