### PR TITLE
feat(article): open article in web view if it has no article components

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -112,8 +112,8 @@ class RecommendationViewModel: ReadableViewModel {
 
         Task {
             do {
-                try await source.fetchDetails(for: recommendation)
-                checkForArticleData()
+                let remoteHasArticle = try await source.fetchDetails(for: recommendation)
+                checkForArticleData(with: remoteHasArticle)
             } catch {
                 Log.capture(message: "Failed to fetch details for RecommendationViewModel: \(error)")
             }
@@ -121,9 +121,9 @@ class RecommendationViewModel: ReadableViewModel {
     }
 
     /// Check to see if item has article components to display in reader view, else display in web view
-    /// - Parameter item: item that the user wants to open
-    private func checkForArticleData() {
-        if recommendation.item.hasArticleComponents {
+    /// - Parameter remoteHasArticle: condition if the remote in `fetchDetails` has article data
+    private func checkForArticleData(with remoteHasArticle: Bool) {
+        if recommendation.item.hasArticleComponents || remoteHasArticle {
             _events.send(.contentUpdated)
         } else {
             showWebReader()

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -113,10 +113,20 @@ class RecommendationViewModel: ReadableViewModel {
         Task {
             do {
                 try await source.fetchDetails(for: recommendation)
-                _events.send(.contentUpdated)
+                checkForArticleData()
             } catch {
-                Log.capture(message: "Failed to fetch details for recommendation: \(error)")
+                Log.capture(message: "Failed to fetch details for RecommendationViewModel: \(error)")
             }
+        }
+    }
+
+    /// Check to see if item has article components to display in reader view, else display in web view
+    /// - Parameter item: item that the user wants to open
+    private func checkForArticleData() {
+        if recommendation.item.hasArticleComponents {
+            _events.send(.contentUpdated)
+        } else {
+            showWebReader()
         }
     }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -113,7 +113,7 @@ class RecommendationViewModel: ReadableViewModel {
         Task {
             do {
                 let remoteHasArticle = try await source.fetchDetails(for: recommendation)
-                checkForArticleData(with: remoteHasArticle)
+                displayArticle(with: remoteHasArticle)
             } catch {
                 Log.capture(message: "Failed to fetch details for RecommendationViewModel: \(error)")
             }
@@ -122,7 +122,7 @@ class RecommendationViewModel: ReadableViewModel {
 
     /// Check to see if item has article components to display in reader view, else display in web view
     /// - Parameter remoteHasArticle: condition if the remote in `fetchDetails` has article data
-    private func checkForArticleData(with remoteHasArticle: Bool) {
+    private func displayArticle(with remoteHasArticle: Bool) {
         if recommendation.item.hasArticleComponents || remoteHasArticle {
             _events.send(.contentUpdated)
         } else {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -123,8 +123,22 @@ class SavedItemViewModel: ReadableViewModel {
         }
 
         Task {
-            try? await self.source.fetchDetails(for: self.item)
+            do {
+                try await self.source.fetchDetails(for: self.item)
+                checkForArticleData()
+            } catch {
+                Log.capture(message: "Failed to fetch details for SavedItemViewModel: \(error)")
+            }
+        }
+    }
+
+    /// Check to see if item has article components to display in reader view, else display in web view
+    /// - Parameter item: item that the user wants to open
+    private func checkForArticleData() {
+        if let itemDetails = item.item, itemDetails.hasArticleComponents {
             _events.send(.contentUpdated)
+        } else {
+            showWebReader()
         }
     }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -124,8 +124,8 @@ class SavedItemViewModel: ReadableViewModel {
 
         Task {
             do {
-                try await self.source.fetchDetails(for: self.item)
-                checkForArticleData()
+                let remoteHasArticle = try await self.source.fetchDetails(for: self.item)
+                checkForArticleData(with: remoteHasArticle)
             } catch {
                 Log.capture(message: "Failed to fetch details for SavedItemViewModel: \(error)")
             }
@@ -133,9 +133,9 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     /// Check to see if item has article components to display in reader view, else display in web view
-    /// - Parameter item: item that the user wants to open
-    private func checkForArticleData() {
-        if let itemDetails = item.item, itemDetails.hasArticleComponents {
+    /// - Parameter remoteHasArticle: condition if the remote in `fetchDetails` has article data
+    private func checkForArticleData(with remoteHasArticle: Bool) {
+        if let itemDetails = item.item, itemDetails.hasArticleComponents || remoteHasArticle {
             _events.send(.contentUpdated)
         } else {
             showWebReader()

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -125,7 +125,7 @@ class SavedItemViewModel: ReadableViewModel {
         Task {
             do {
                 let remoteHasArticle = try await self.source.fetchDetails(for: self.item)
-                checkForArticleData(with: remoteHasArticle)
+                displayArticle(with: remoteHasArticle)
             } catch {
                 Log.capture(message: "Failed to fetch details for SavedItemViewModel: \(error)")
             }
@@ -134,7 +134,7 @@ class SavedItemViewModel: ReadableViewModel {
 
     /// Check to see if item has article components to display in reader view, else display in web view
     /// - Parameter remoteHasArticle: condition if the remote in `fetchDetails` has article data
-    private func checkForArticleData(with remoteHasArticle: Bool) {
+    private func displayArticle(with remoteHasArticle: Bool) {
         if let itemDetails = item.item, itemDetails.hasArticleComponents || remoteHasArticle {
             _events.send(.contentUpdated)
         } else {

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -67,7 +67,6 @@ public extension Item {
     }
 
     var hasArticleComponents: Bool {
-        guard let article else { return false }
-        return !article.components.isEmpty
+        article?.components.isEmpty == false
     }
 }

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -65,4 +65,9 @@ public extension Item {
     var isImage: Bool {
         hasImage == .isImage
     }
+
+    var hasArticleComponents: Bool {
+        guard let article else { return false }
+        return !article.components.isEmpty
+    }
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -547,7 +547,7 @@ extension PocketSource {
     }
 
     public func fetchDetails(for savedItem: SavedItem) async throws -> Bool {
-        Log.breadcrumb(category: "sync", level: .debug, message: "Fetching detals for item with id \(String(describing: savedItem.remoteID))")
+        Log.breadcrumb(category: "sync", level: .debug, message: "Fetching details for item with id \(String(describing: savedItem.remoteID))")
 
         guard let remoteID = savedItem.remoteID else {
             return false
@@ -567,8 +567,7 @@ extension PocketSource {
             savedItem.update(from: remoteSavedItem.fragments.savedItemParts, with: space)
             try space.save()
 
-            guard let article = remoteSavedItem.item.asItem?.marticle else { return false }
-            return !article.isEmpty
+            return remoteSavedItem.item.asItem?.marticle?.isEmpty == false
         }
     }
 
@@ -630,8 +629,7 @@ extension PocketSource {
             backgroundItem.update(remote: remoteItem, with: space)
             try space.save()
 
-            guard let article = remoteItem.marticle else { return false }
-            return !article.isEmpty
+            return remoteItem.marticle?.isEmpty == false
         }
     }
 }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -74,9 +74,9 @@ public protocol Source {
 
     func delete(images: [Image])
 
-    func fetchDetails(for savedItem: SavedItem) async throws
+    func fetchDetails(for savedItem: SavedItem) async throws -> Bool
 
-    func fetchDetails(for recommendation: Recommendation) async throws
+    func fetchDetails(for recommendation: Recommendation) async throws -> Bool
 
     func save(url: URL)
 

--- a/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+@testable import PocketKit
+@testable import Sync
+
+class ItemExtensionsTests: XCTestCase {
+    var space: Space!
+
+    override func setUp() {
+        space = .testSpace()
+    }
+
+    override func tearDownWithError() throws {
+        try space.clear()
+    }
+
+    func test_shouldOpenInWebView_andIsNotArticle_returnsTrue() throws {
+        let savedItem: SavedItem = try space.createSavedItem()
+        savedItem.item?.isArticle = false
+
+        XCTAssertEqual(savedItem.shouldOpenInWebView, true)
+    }
+
+    func test_shouldOpenInWebView_andIsArticle_returnsFalse() throws {
+        let savedItem: SavedItem = try space.createSavedItem()
+        savedItem.item?.isArticle = true
+
+        XCTAssertEqual(savedItem.shouldOpenInWebView, false)
+    }
+
+    func test_shouldOpenInWebView_withArticleComponents_returnsTrue() throws {
+        let savedItem: SavedItem = try space.createSavedItem()
+        savedItem.item?.article = .some(Article(components: [.text(TextComponent(content: "This article has components"))]))
+
+        XCTAssertEqual(savedItem.item?.hasArticleComponents, true)
+    }
+
+    func test_hasArticleComponents_withEmptyArticleComponents_returnsFalse() throws {
+        let savedItem: SavedItem = try space.createSavedItem()
+        savedItem.item?.article = .some(Article(components: []))
+
+        XCTAssertEqual(savedItem.item?.hasArticleComponents, false)
+    }
+
+    func test_hasArticleComponents_withNilArticleComponents_returnsFalse() throws {
+        let savedItem: SavedItem = try space.createSavedItem()
+        savedItem.item?.article = nil
+
+        XCTAssertEqual(savedItem.item?.hasArticleComponents, false)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -344,6 +344,7 @@ class RecommendationViewModelTests: XCTestCase {
         )
         source.stubFetchDetailsForRecommendation { rec in
             rec.item.article = .some(Article(components: [.text(TextComponent(content: "This article has components"))]))
+            return true
         }
 
         let viewModel = subject(recommendation: recommendation)
@@ -367,6 +368,7 @@ class RecommendationViewModelTests: XCTestCase {
         )
         source.stubFetchDetailsForRecommendation { rec in
             rec.item.article = nil
+            return false
         }
 
         let viewModel = subject(recommendation: recommendation)
@@ -390,6 +392,7 @@ class RecommendationViewModelTests: XCTestCase {
 
         source.stubFetchDetailsForRecommendation { rec in
             XCTFail("Should not fetch details when article content is already available")
+            return false
         }
 
         let viewModel = subject(recommendation: recommendation)

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -343,7 +343,7 @@ class RecommendationViewModelTests: XCTestCase {
             item: space.buildItem()
         )
         source.stubFetchDetailsForRecommendation { rec in
-            rec.item.article = .some(Article(components: []))
+            rec.item.article = .some(Article(components: [.text(TextComponent(content: "This article has components"))]))
         }
 
         let viewModel = subject(recommendation: recommendation)
@@ -359,6 +359,28 @@ class RecommendationViewModelTests: XCTestCase {
         viewModel.fetchDetailsIfNeeded()
         wait(for: [receivedEvent], timeout: 10)
         XCTAssertNotNil(recommendation.item.article)
+    }
+
+    func test_fetchDetailsIfNeeded_whenMarticleIsNilAfterFetching_returnsWebView() {
+        let recommendation = space.buildRecommendation(
+            item: space.buildItem()
+        )
+        source.stubFetchDetailsForRecommendation { rec in
+            rec.item.article = nil
+        }
+
+        let viewModel = subject(recommendation: recommendation)
+        let receivedEvent = expectation(description: "receivedEvent")
+        receivedEvent.isInverted = true
+        viewModel.events.sink { event in
+            receivedEvent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.fetchDetailsIfNeeded()
+        wait(for: [receivedEvent], timeout: 10)
+
+        XCTAssertFalse(recommendation.item.hasArticleComponents)
+        XCTAssertNil(recommendation.item.article)
     }
 
     func test_fetchDetailsIfNeeded_whenMarticleIsPresent_immediatelySendsContentUpdatedEvent() {

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -98,11 +98,13 @@ class SavedItemViewModelTests: XCTestCase {
     }
 
     func test_fetchDetailsIfNeeded_whenItemDetailsAreNotAvailable_fetchesItemDetails_andSendsEvent() throws {
-        source.stubFetchDetails { _ in }
-
         let savedItem = space.buildSavedItem()
         savedItem.item?.article = nil
         try space.save()
+
+        source.stubFetchDetails { _ in
+            savedItem.item?.article = .some(Article(components: [.text(TextComponent(content: "This article has components"))]))
+        }
 
         let viewModel = subject(item: savedItem)
 
@@ -122,6 +124,33 @@ class SavedItemViewModelTests: XCTestCase {
         let call = source.fetchDetailsCall(at: 0)
         XCTAssertNotNil(call)
         XCTAssertEqual(call?.savedItem, savedItem)
+    }
+
+    func test_fetchDetailsIfNeeded_whenItemDetailsAreNotAvailable_afterFetching_doesNotSendEvent() throws {
+        let savedItem = space.buildSavedItem()
+        savedItem.item?.article = nil
+        try space.save()
+
+        source.stubFetchDetails { _ in
+            savedItem.item?.article = nil
+        }
+
+        let viewModel = subject(item: savedItem)
+
+        let eventSent = expectation(description: "eventSent")
+        eventSent.isInverted = true
+        viewModel.events.sink { event in
+            eventSent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.fetchDetailsIfNeeded()
+        wait(for: [eventSent], timeout: 10)
+
+        let call = source.fetchDetailsCall(at: 0)
+        XCTAssertNotNil(call)
+        XCTAssertEqual(call?.savedItem, savedItem)
+        XCTAssertEqual(savedItem.item?.hasArticleComponents, false)
+        XCTAssertEqual(savedItem.item?.article, nil)
     }
 
     func test_fetchDetailsIfNeeded_whenItemDetailsAreAlreadyAvailable_immediatelySendsContentUpdatedEvent() {

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -104,6 +104,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         source.stubFetchDetails { _ in
             savedItem.item?.article = .some(Article(components: [.text(TextComponent(content: "This article has components"))]))
+            return true
         }
 
         let viewModel = subject(item: savedItem)
@@ -133,6 +134,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         source.stubFetchDetails { _ in
             savedItem.item?.article = nil
+            return false
         }
 
         let viewModel = subject(item: savedItem)
@@ -156,6 +158,7 @@ class SavedItemViewModelTests: XCTestCase {
     func test_fetchDetailsIfNeeded_whenItemDetailsAreAlreadyAvailable_immediatelySendsContentUpdatedEvent() {
         source.stubFetchDetails { _ in
             XCTFail("Expected no calls to fetch details, but lo, it has been called.")
+            return false
         }
 
         let savedItem = space.buildSavedItem(

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1020,7 +1020,7 @@ extension MockSource {
 // MARK: - Fetch details
 extension MockSource {
     static let fetchDetails = "fetchDetails"
-    typealias FetchDetailsImpl = (SavedItem) async throws -> Void
+    typealias FetchDetailsImpl = (SavedItem) async throws -> Bool
 
     struct FetchDetailsCall {
         let savedItem: SavedItem
@@ -1030,7 +1030,7 @@ extension MockSource {
         implementations[Self.fetchDetails] = impl
     }
 
-    func fetchDetails(for savedItem: SavedItem) async throws {
+    func fetchDetails(for savedItem: SavedItem) async throws -> Bool {
         guard let impl = implementations[Self.fetchDetails] as? FetchDetailsImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
@@ -1119,7 +1119,7 @@ extension MockSource {
 // MARK: - Fetch Details for Recommendation
 extension MockSource {
     static let fetchDetailsForRecommendation = "fetchDetailsForRecommendation"
-    typealias FetchDetailsForRecommendationImpl = (Recommendation) async throws -> Void
+    typealias FetchDetailsForRecommendationImpl = (Recommendation) async throws -> Bool
 
     struct FetchDetailsForRecommendationCall {
         let recommendation: Recommendation
@@ -1129,7 +1129,7 @@ extension MockSource {
         implementations[Self.fetchDetailsForRecommendation] = impl
     }
 
-    func fetchDetails(for recommendation: Recommendation) async throws {
+    func fetchDetails(for recommendation: Recommendation) async throws -> Bool {
         guard let impl = implementations[Self.fetchDetailsForRecommendation] as? FetchDetailsForRecommendationImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }

--- a/Tests iOS/Fixtures/archive-item-detail.json
+++ b/Tests iOS/Fixtures/archive-item-detail.json
@@ -40,7 +40,6 @@
                     "isArticle": true,
                     "hasImage": "HAS_IMAGES",
                     "hasVideo": "HAS_VIDEOS",
-                    "marticle": [],
                     "syndicatedArticle": null
                 }
             }

--- a/Tests iOS/Fixtures/recommendation-detail-4.json
+++ b/Tests iOS/Fixtures/recommendation-detail-4.json
@@ -39,9 +39,7 @@
           "name": "Mozilla"
         }
       },
-      "marticle": [
-        
-      ],
+      "marticle": #MARTICLE#
     }
   }
 }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -282,7 +282,9 @@ extension Response {
     static func fixture(named fixtureName: String) -> Response {
         Response {
             Status.ok
-            Fixture.data(name: fixtureName)
+            Fixture.load(name: fixtureName)
+                .replacing("MARTICLE", withFixtureNamed: "marticle")
+                .data
         }
     }
 


### PR DESCRIPTION
## Summary
Update our logic to consider only showing articles that have article components in reader view. If an article does not have marticle data associated with it, then we show the web view.

## References 
IN-1497

## Implementation Details
Created new boolean property `hasArticleComponents` to determine if an article is not nil or its components are not empty. Added a check for `checkForArticleData` to show item in web view if the article's components are missing. Also, had to modify the `PocketSource` methods `fetchDetails` to return a Bool. This allows us to also check if the remote has article data when it has not been updated locally. 

Note: Although I don't love this, it seems to work. Happy to hear alternatives.

## Test Steps
Currently, no known article to test with, but verified with unit / UI tests. If you have an article in which isArticle is true, but there are no marticle data associated, then perform the following steps.

1. Navigate to the article
2. Tap on the article to open and verify that it opens in web view
3. Verify that this works for syndicated articles, saves and archive articles

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
