### PR TITLE
Apollo - Always log error code to Sentry

### DIFF
--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -79,16 +79,20 @@ public extension ApolloClientProtocol {
         // Codes we wish to notify the user about
         let notifiableErrorCodes = [429, 500, 503]
 
-        guard let responseError = error as? ResponseCodeInterceptor.ResponseCodeError,
-              case .invalidResponseCode(let response, _) = responseError,
-              let code = response?.statusCode else {
-            Log.capture(message: "GraphQl Error - unknown response/status code.", filename: filename, line: line, column: column, funcName: funcName)
+        guard let responseError = error as? ResponseCodeInterceptor.ResponseCodeError else {
+            Log.capture(message: "GraphQl Error - unknown error.", filename: filename, line: line, column: column, funcName: funcName)
             return
         }
 
-        Log.capture(message: "GraphQl Error - status code:\(code).", filename: filename, line: line, column: column, funcName: funcName)
+        Log.capture(message: "GraphQl Error - description: \(responseError.errorDescription ?? "no description found").",
+                    filename: filename,
+                    line: line,
+                    column: column,
+                    funcName: funcName)
 
-        if notifiableErrorCodes.contains(code) {
+        if case .invalidResponseCode(let response, _) = responseError,
+           let code = response?.statusCode,
+           notifiableErrorCodes.contains(code) {
             NotificationCenter.default.post(name: .serverError, object: code)
         }
     }

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -24,9 +24,7 @@ public extension ApolloClientProtocol {
             _ = fetch(query: query, queue: queue) { result in
                 switch result {
                 case .failure(let error):
-                    if !Self.handleServerError(error) {
-                        Log.capture(error: error, filename: filename, line: line, column: column, funcName: funcName)
-                    }
+                    Self.handleServerError(error, filename: filename, line: line, column: column, funcName: funcName)
                     continuation.resume(throwing: error)
                 case .success(let data):
                     guard let errors = data.errors,
@@ -53,9 +51,7 @@ public extension ApolloClientProtocol {
             ) { result in
                 switch result {
                 case .failure(let error):
-                    if !Self.handleServerError(error) {
-                        Log.capture(error: error, filename: filename, line: line, column: column, funcName: funcName)
-                    }
+                    Self.handleServerError(error, filename: filename, line: line, column: column, funcName: funcName)
                     continuation.resume(throwing: error)
                 case .success(let data):
                     guard let errors = data.errors,
@@ -72,17 +68,28 @@ public extension ApolloClientProtocol {
         }
     }
 
-    private static func handleServerError(_ error: Error) -> Bool {
+    /// Takes a GraphQl response error and logs it to Sentry. If the error code belongs
+    /// to a specified set of errors, also posts a notification containing the status code
+    private static func handleServerError(_ error: Error,
+                                          filename: String,
+                                          line: Int,
+                                          column: Int,
+                                          funcName: String) {
 
         // Codes we wish to notify the user about
-        let serverErrorCodes = [429, 500, 503]
+        let notifiableErrorCodes = [429, 500, 503]
 
         guard let responseError = error as? ResponseCodeInterceptor.ResponseCodeError,
               case .invalidResponseCode(let response, _) = responseError,
-              let code = response?.statusCode,
-              serverErrorCodes.contains(code) else { return false }
+              let code = response?.statusCode else {
+            Log.capture(message: "GraphQl Error - unknown response/status code.", filename: filename, line: line, column: column, funcName: funcName)
+            return
+        }
 
-        NotificationCenter.default.post(name: .serverError, object: code)
-        return true
+        Log.capture(message: "GraphQl Error - status code:\(code).", filename: filename, line: line, column: column, funcName: funcName)
+
+        if notifiableErrorCodes.contains(code) {
+            NotificationCenter.default.post(name: .serverError, object: code)
+        }
     }
 }


### PR DESCRIPTION

## Summary
* This PR updates Sentry logging from Apollo operations, making sure to always send the error code to Sentry

## Implementation Details
* Update `ApolloClientProtocol+Extensions`, refactor `handleServerError()` method to always log the code to Sentry.

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
