### PR TITLE
fix(tasks): address errors associated with throwing tasks

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -111,8 +111,12 @@ class RecommendationViewModel: ReadableViewModel {
         }
 
         Task {
-            try await source.fetchDetails(for: recommendation)
-            _events.send(.contentUpdated)
+            do {
+                try await source.fetchDetails(for: recommendation)
+                _events.send(.contentUpdated)
+            } catch {
+                Log.capture(message: "Failed to fetch details for recommendation: \(error)")
+            }
         }
     }
 

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -57,7 +57,7 @@ extension AuthorizationClientTests {
         }
     }
 
-    func test_logIn_startsOnlyOneSession() throws {
+    func test_logIn_startsOnlyOneSession() async {
         mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
 
         let expectSessionStart = expectation(description: "expected session start")
@@ -69,14 +69,24 @@ extension AuthorizationClientTests {
         }
 
         Task {
-            _ = try await self.client.logIn(from: self)
+            do {
+                _ = try await self.client.logIn(from: self)
+            } catch {
+                XCTFail("Should not have thrown an error \(error)")
+            }
         }
 
         Task {
-            _ = try await self.client.logIn(from: self)
+            do {
+                _ = try await self.client.logIn(from: self)
+                XCTFail("Expected to throw error, but didn't")
+            } catch {
+                XCTAssertTrue(error is AuthorizationClient.Error)
+                XCTAssertEqual(error as? AuthorizationClient.Error, .alreadyAuthenticating)
+            }
         }
 
-        wait(for: [expectSessionStart], timeout: 10)
+        await fulfillment(of: [expectSessionStart], timeout: 10)
     }
 }
 
@@ -111,7 +121,8 @@ extension AuthorizationClientTests {
         }
     }
 
-    func test_signUp_startsOnlyOneSession() throws {
+    @MainActor
+    func test_signUp_startsOnlyOneSession() async {
         mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
 
         let expectSessionStart = expectation(description: "expected session start")
@@ -123,14 +134,25 @@ extension AuthorizationClientTests {
         }
 
         Task {
-            _ = try await self.client.signUp(from: self)
+            do {
+                _ = try await self.client.signUp(from: self)
+            } catch {
+                XCTFail("Should not have thrown an error \(error)")
+            }
+
         }
 
         Task {
-            _ = try await self.client.signUp(from: self)
+            do {
+                _ = try await self.client.signUp(from: self)
+                XCTFail("Expected to throw error, but didn't")
+            } catch {
+                XCTAssertTrue(error is AuthorizationClient.Error)
+                XCTAssertEqual(error as? AuthorizationClient.Error, .alreadyAuthenticating)
+            }
         }
 
-        wait(for: [expectSessionStart], timeout: 10)
+        await fulfillment(of: [expectSessionStart], timeout: 10)
     }
 }
 


### PR DESCRIPTION
## Summary
Address errors associated with throwing tasks that were being triggered in Bitrise.

```
/Users/[REDACTED]/git/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift:129:9: Unhandled Throwing Task Violation: Errors thrown inside this task are not handled, which may be unexpected. Handle errors inside the task, or use `try await` to access the Tasks value and handle errors. See this forum thread for more details: https://forums.swift.org/t/task-initializer-with-throwing-closure-swallows-error/56066 (unhandled_throwing_task)

/Users/[REDACTED]/git/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift:113:9: Unhandled Throwing Task Violation: Errors thrown inside this task are not handled, which may be unexpected. Handle errors inside the task, or use `try await` to access the Tasks value and handle errors. See this forum thread for more details: https://forums.swift.org/t/task-initializer-with-throwing-closure-swallows-error/56066 (unhandled_throwing_task)
```

## References 
N/A

## Implementation Details
Handle throwing tasks properly

## Test Steps
Verify that app builds and bitrise succeeds.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
