### PR TITLE
feat(list): disallow selection of archived or pending items

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
@@ -40,7 +40,7 @@ class ItemsListItemPresenter {
     private let item: ItemsListItem
     private let isDisabled: Bool
 
-    init(item: ItemsListItem, isDisabled: Bool) {
+    init(item: ItemsListItem, isDisabled: Bool = false) {
         self.item = item
         self.isDisabled = isDisabled
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListItemPresenter.swift
@@ -38,17 +38,19 @@ private extension Style {
 
 class ItemsListItemPresenter {
     private let item: ItemsListItem
+    private let isDisabled: Bool
 
-    init(item: ItemsListItem) {
+    init(item: ItemsListItem, isDisabled: Bool) {
         self.item = item
+        self.isDisabled = isDisabled
     }
 
     var attributedTitle: NSAttributedString {
-        NSAttributedString(string: title, style: item.isPending ? .pendingTitle : .title)
+        NSAttributedString(string: title, style: isDisabled ? .pendingTitle : .title)
     }
 
     var attributedDetail: NSAttributedString {
-        NSAttributedString(string: detail, style: item.isPending ? .pendingDetail : .detail)
+        NSAttributedString(string: detail, style: isDisabled ? .pendingDetail : .detail)
     }
 
     var attributedTags: [NSAttributedString]? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewController.swift
@@ -336,6 +336,10 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
         switch event {
         case .selectionCleared:
             deselectAll()
+        case .networkStatusUpdated:
+            let reloads = collectionView.indexPathsForVisibleItems
+                .compactMap { dataSource.itemIdentifier(for: $0) }
+            model.reloadSnapshot(for: reloads)
         }
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/ItemsListViewModel.swift
@@ -92,6 +92,7 @@ enum ItemsListFilter: String, Hashable, CaseIterable {
 
 enum ItemsListEvent<ItemIdentifier: Hashable> {
     case selectionCleared
+    case networkStatusUpdated
 }
 
 protocol ItemsListViewModel: AnyObject {
@@ -126,4 +127,6 @@ protocol ItemsListViewModel: AnyObject {
 
     func willDisplay(_ cell: ItemsListCell<ItemIdentifier>)
     func prefetch(itemsAt: [IndexPath])
+
+    func reloadSnapshot(for identifiers: [ItemsListCell<ItemIdentifier>])
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/PocketItem.swift
@@ -11,7 +11,9 @@ struct PocketItem {
 
     init(item: ItemsListItem) {
         self.item = item
-        self.itemPresenter = ItemsListItemPresenter(item: item)
+        // `PocketItem` is used within the scope of search, so we can simply use isPending
+        // since archive is only available online, anyways, so there's no additional logic needed
+        self.itemPresenter = ItemsListItemPresenter(item: item, isDisabled: item.isPending)
     }
 
     var id: String? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -839,15 +839,11 @@ extension SavedItemsListViewModel {
 
 extension SavedItemsListViewModel {
     static func isItemDisabled(_ item: SavedItem, networkStatus: NWPath.Status) -> Bool {
-        if networkStatus == .unsatisfied {
-            if item.isArchived {
-                return !(item.item?.hasArticleComponents ?? false)
-            } else {
-                return item.isPending
-            }
+        guard networkStatus == .unsatisfied, item.isArchived else {
+            return item.isPending
         }
 
-        return item.isPending
+        return !(item.item?.hasArticleComponents ?? false)
     }
 
     func reloadSnapshot(for identifiers: [ItemsListCell<ItemIdentifier>]) {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItemsListViewModel.swift
@@ -6,6 +6,7 @@ import UIKit
 import Localization
 import SharedPocketKit
 import Textile
+import Network
 
 public enum SavesViewType {
     case saves
@@ -153,6 +154,11 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             }
             .store(in: &subscriptions)
 
+        networkPathMonitor.updateHandler = { [weak self] status in
+            guard let self = self else { return }
+            _events.send(.networkStatusUpdated)
+        }
+        networkPathMonitor.start(queue: DispatchQueue.global(qos: .utility))
     }
 
     func fetch() {
@@ -260,7 +266,10 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     }
 
     func presenter(for itemID: ItemIdentifier) -> ItemsListItemPresenter? {
-        bareItem(with: itemID).flatMap(ItemsListItemPresenter.init)
+        return bareItem(with: itemID)
+            .flatMap { ($0, Self.isItemDisabled($0, networkStatus: networkPathMonitor.currentNetworkPath.status)) }
+            .map { ItemsListItemPresenter(item: $0.0, isDisabled: $0.1) }
+        ?? nil
     }
 
     func filterButton(with filter: ItemsListFilter) -> TopicChipPresenter {
@@ -280,7 +289,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         case .filterButton:
             return true
         case .item(let objectID):
-            return !(bareItem(with: objectID)?.isPending ?? true)
+            guard let item = bareItem(with: objectID) else { return false }
+            return !Self.isItemDisabled(item, networkStatus: networkPathMonitor.currentNetworkPath.status)
         case .offline, .emptyState, .placeholder, .tag:
             return false
         }
@@ -824,5 +834,26 @@ extension SavedItemsListViewModel {
 
     func clearSelectedItem() {
         selectedItem = nil
+    }
+}
+
+extension SavedItemsListViewModel {
+    static func isItemDisabled(_ item: SavedItem, networkStatus: NWPath.Status) -> Bool {
+        if networkStatus == .unsatisfied {
+            if item.isArchived {
+                return !(item.item?.hasArticleComponents ?? false)
+            } else {
+                return item.isPending
+            }
+        }
+
+        return item.isPending
+    }
+
+    func reloadSnapshot(for identifiers: [ItemsListCell<ItemIdentifier>]) {
+        guard identifiers.isEmpty == false else { return }
+        var snapshot = _snapshot
+        snapshot.reloadItems(identifiers)
+        _snapshot = snapshot
     }
 }

--- a/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
@@ -8,21 +8,21 @@ class ItemsListItemPresenterTests: XCTestCase { }
 extension ItemsListItemPresenterTests {
     func test_attributedTitle_withItemTitle_usesTitle() {
         let item = MockItemsListItem.build(title: "Test Title")
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTitle.string, "Test Title")
     }
 
     func test_attributedTitle_noItemTitle_usesBestURL() {
         let item = MockItemsListItem.build(bestURL: URL(string: "https://getpocket.com")!)
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTitle.string, "https://getpocket.com")
     }
 
     func test_attributedTitle_whenItemIsNotPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(title: "Pocket")
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         let style = presenter.attributedTitle.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey1))
@@ -38,42 +38,42 @@ extension ItemsListItemPresenterTests {
 
     func test_attributedTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: [])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, nil)
     }
 
     func test_attributedTags_returnsOneLabel() {
         let item = MockItemsListItem.build(tagNames: ["tag 1"])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, ["tag 1"])
     }
 
     func test_attributedTags_returnsMaxTwoLabels() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2", "tag 3"])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, ["tag 1", "tag 2"])
     }
 
     func test_attributedTagCount_withNoAdditionalTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: [])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, nil)
     }
 
     func test_attributedTagCount_withOnlyTwoAdditionalTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2"])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, nil)
     }
 
     func test_attributedTagCount_withAdditionalTags_returnsProperCount() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2", "tag 3", "tag 4", "tag 5"])
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, "+3")
     }
@@ -85,28 +85,28 @@ extension ItemsListItemPresenterTests {
         let item = MockItemsListItem.build(
             domainMetadata: MockItemsListItemDomainMetadata(name: "Pocket Domain")
         )
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedDetail.string, "Pocket Domain")
     }
 
     func test_attributedDetail_noDomainMetatada_usesDomain() {
         let item = MockItemsListItem.build(domain: "getpocket.com")
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
     }
 
     func test_attributedDetail_noDomainMetadataOrName_usesHost() {
         let item = MockItemsListItem.build(host: "getpocket.com")
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
     }
 
     func test_attributedDetail_whenItemIsNotPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(domain: "Pocket")
-        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
+        let presenter = ItemsListItemPresenter(item: item)
 
         let style = presenter.attributedDetail.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey4))

--- a/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
@@ -8,21 +8,21 @@ class ItemsListItemPresenterTests: XCTestCase { }
 extension ItemsListItemPresenterTests {
     func test_attributedTitle_withItemTitle_usesTitle() {
         let item = MockItemsListItem.build(title: "Test Title")
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTitle.string, "Test Title")
     }
 
     func test_attributedTitle_noItemTitle_usesBestURL() {
         let item = MockItemsListItem.build(bestURL: URL(string: "https://getpocket.com")!)
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTitle.string, "https://getpocket.com")
     }
 
     func test_attributedTitle_whenItemIsNotPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(title: "Pocket")
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         let style = presenter.attributedTitle.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey1))
@@ -30,7 +30,7 @@ extension ItemsListItemPresenterTests {
 
     func test_attributedTitle_whenItemIsPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(title: "Pocket", isPending: true)
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: true)
 
         let style = presenter.attributedTitle.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey5))
@@ -38,42 +38,42 @@ extension ItemsListItemPresenterTests {
 
     func test_attributedTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: [])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, nil)
     }
 
     func test_attributedTags_returnsOneLabel() {
         let item = MockItemsListItem.build(tagNames: ["tag 1"])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, ["tag 1"])
     }
 
     func test_attributedTags_returnsMaxTwoLabels() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2", "tag 3"])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTags?.compactMap { $0.string }, ["tag 1", "tag 2"])
     }
 
     func test_attributedTagCount_withNoAdditionalTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: [])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, nil)
     }
 
     func test_attributedTagCount_withOnlyTwoAdditionalTags_returnsNil() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2"])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, nil)
     }
 
     func test_attributedTagCount_withAdditionalTags_returnsProperCount() {
         let item = MockItemsListItem.build(tagNames: ["tag 1", "tag 2", "tag 3", "tag 4", "tag 5"])
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedTagCount?.string, "+3")
     }
@@ -85,28 +85,28 @@ extension ItemsListItemPresenterTests {
         let item = MockItemsListItem.build(
             domainMetadata: MockItemsListItemDomainMetadata(name: "Pocket Domain")
         )
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedDetail.string, "Pocket Domain")
     }
 
     func test_attributedDetail_noDomainMetatada_usesDomain() {
         let item = MockItemsListItem.build(domain: "getpocket.com")
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
     }
 
     func test_attributedDetail_noDomainMetadataOrName_usesHost() {
         let item = MockItemsListItem.build(host: "getpocket.com")
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         XCTAssertEqual(presenter.attributedDetail.string, "getpocket.com")
     }
 
     func test_attributedDetail_whenItemIsNotPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(domain: "Pocket")
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: false)
 
         let style = presenter.attributedDetail.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey4))
@@ -114,7 +114,7 @@ extension ItemsListItemPresenterTests {
 
     func test_attributedDetail_whenItemIsPending_usesCorrectStyle() {
         let item = MockItemsListItem.build(domain: "Pocket", isPending: true)
-        let presenter = ItemsListItemPresenter(item: item)
+        let presenter = ItemsListItemPresenter(item: item, isDisabled: true)
 
         let style = presenter.attributedDetail.attributes(at: 0, effectiveRange: nil)[.style] as! Style
         XCTAssertEqual(UIColor(style.colorAsset), UIColor(.ui.grey5))


### PR DESCRIPTION
Disallows the selection of archived items that contain no offline data, or are pending. Additionally, automatically reloads the current Saves list when the network status changes to show the latest state of the items.

## References 

IN-1308

## Implementation Details

Adds a helper function, `isItemDisabled`, that returns true if:
- the user is offline, and an archived item has no article data
- the user is offline, and an item is pending
- the user is online, and an item is pending

This is then used to initialize item presenters appropriately for the required state by adding a `isDisabled` argument. This is because determining whether or not an item is disabled required use of network monitoring, which is outside the scope of a `SavedItem`.

Additionally, a network monitor is used to determine when to reload the Saves list as to show the most up-to-date status of items. On monitor change, we send an updated snapshot, reloading the item identifiers representing the visible cells (as to not reload the whole list). This will update the item(s) to their correct coloring.

## Test Steps

- [ ] Save an item that will have no article components (e.g a google search). Archive the item.
- [ ] Enter airplane mode, and view your archive. The saved item should be greyed out, and tapping it should do nothing.
- [ ] Leave airplane mode, and view your archive. The saved item should not be greyed out, and tapping it should open in web view.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
