### PR TITLE
ci(swiftlint): updated rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,16 +81,22 @@ opt_in_rules: # some rules are only opt-in
   - multiline_arguments
   - opening_brace
   - optional_enum_case_matching
-  - overridden_super_call:
-      excluded:
-        - PocketKit/Tests
-        - Tests iOS/
+#  - overridden_super_call:
+#      excluded:
+#        - PocketKit/Tests
+#        - Tests iOS/
   - return_arrow_whitespace
   - unused_import
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
   - yoda_condition
+
+file_header:
+  required_pattern: |
+                    \/\/ This Source Code Form is subject to the terms of the Mozilla Public
+                    \/\/ License, v. 2.0. If a copy of the MPL was not distributed with this
+                    \/\/ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,7 +30,6 @@ disabled_rules: # rule identifiers to exclude from running
   - nsobject_prefer_isequal
   - private_unit_test
   - reduce_boolean
-  - redundant_string_enum_value
   - self_in_property_initialization
   - shorthand_operator
   - todo
@@ -49,7 +48,6 @@ opt_in_rules: # some rules are only opt-in
   # These rules were originally opted into. Disabling for now to get
   # Swiftlint up and running.
   # - statement_position
-  # - file_header
   # - deployment_target
   # - discouraged_optional_collection
   # - prohibited_interface_builder
@@ -77,6 +75,7 @@ opt_in_rules: # some rules are only opt-in
   - explicit_init
   - duplicate_imports
   - duplicate_enum_cases
+  - file_header
   - last_where
   - multiline_arguments_brackets
   - multiline_arguments

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,10 @@ disabled_rules: # rule identifiers to exclude from running
   - weak_delegate
   - xctfail_message
 
+analyzer_rules:
+  - capture_variable
+  - unused_import
+
 opt_in_rules: # some rules are only opt-in
   # These rules were originally opted into. Disabling for now to get
   # Swiftlint up and running.
@@ -60,7 +64,6 @@ opt_in_rules: # some rules are only opt-in
   - anyobject_protocol
   - array_init
   - attributes
-  - capture_variable
   - closing_brace
   - closure_spacing
   - contains_over_filter_count
@@ -81,22 +84,12 @@ opt_in_rules: # some rules are only opt-in
   - multiline_arguments
   - opening_brace
   - optional_enum_case_matching
-#  - overridden_super_call:
-#      excluded:
-#        - PocketKit/Tests
-#        - Tests iOS/
+  - overridden_super_call
   - return_arrow_whitespace
-  - unused_import
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
   - yoda_condition
-
-file_header:
-  required_pattern: |
-                    \/\/ This Source Code Form is subject to the terms of the Mozilla Public
-                    \/\/ License, v. 2.0. If a copy of the MPL was not distributed with this
-                    \/\/ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build
@@ -109,3 +102,12 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - PocketKit/Sources/Localization/Strings.swift
 # reporter: "json" # reporter type (xcode, json, csv, checkstyle)
 reporter: 'xcode' # reporter type (xcode, json, csv, checkstyle)
+
+#file_header:
+#  required_pattern: |
+#                    \/\/ This Source Code Form is subject to the terms of the Mozilla Public
+#                    \/\/ License, v. 2.0. If a copy of the MPL was not distributed with this
+#                    \/\/ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+overridden_super_call:
+  excluded: ["PocketKit/Tests/*", "Tests iOS/*"]

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,10 +44,6 @@ disabled_rules: # rule identifiers to exclude from running
   - weak_delegate
   - xctfail_message
 
-analyzer_rules:
-  - capture_variable
-  - unused_import
-
 opt_in_rules: # some rules are only opt-in
   # These rules were originally opted into. Disabling for now to get
   # Swiftlint up and running.
@@ -91,6 +87,16 @@ opt_in_rules: # some rules are only opt-in
   - vertical_whitespace_opening_braces
   - yoda_condition
 
+file_header:
+  required_string: |
+                    // This Source Code Form is subject to the terms of the Mozilla Public
+                    // License, v. 2.0. If a copy of the MPL was not distributed with this
+                    // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+analyzer_rules: # Rules run by `swiftlint analyze`
+  - capture_variable
+  - unused_import
+
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - build
   - .build
@@ -102,12 +108,3 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - PocketKit/Sources/Localization/Strings.swift
 # reporter: "json" # reporter type (xcode, json, csv, checkstyle)
 reporter: 'xcode' # reporter type (xcode, json, csv, checkstyle)
-
-#file_header:
-#  required_pattern: |
-#                    \/\/ This Source Code Form is subject to the terms of the Mozilla Public
-#                    \/\/ License, v. 2.0. If a copy of the MPL was not distributed with this
-#                    \/\/ file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-overridden_super_call:
-  excluded: ["PocketKit/Tests/*", "Tests iOS/*"]

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Danger
 import DangerSwiftCoverage
 import Foundation

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PackageDescription
 
 let package = Package(

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PackageDescription
 
 let package = Package(

--- a/PocketKit/Sources/Analytics/AppEvents/ExpandedSlate.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/ExpandedSlate.swift
@@ -8,7 +8,6 @@ public extension Events {
 }
 
 public extension Events.ExpandedSlate {
-
     /**
      Fired when a user views a slate in detail
      */

--- a/PocketKit/Sources/Analytics/AppEvents/Listen.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Listen.swift
@@ -14,7 +14,6 @@ public extension Events {
 }
 
 public extension Events.Listen {
-
     /// Fired when an Item is impressed in the listen view
     /// - Parameters:
     ///   - url: URL of the item

--- a/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by David Skuza on 4/24/23.
-//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
 

--- a/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
@@ -253,5 +253,4 @@ public extension Events.SaveTo.Tags {
             )
         )
     }
-
 }

--- a/PocketKit/Sources/Analytics/OldEvent/OldEvent.swift
+++ b/PocketKit/Sources/Analytics/OldEvent/OldEvent.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.s
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 public protocol OldEvent: Encodable {
     static var schema: String { get }

--- a/PocketKit/Sources/Analytics/TrackableView.swift
+++ b/PocketKit/Sources/Analytics/TrackableView.swift
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.s
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
 

--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import UIKit

--- a/PocketKit/Sources/PocketKit/Article/ActivityItemSource.swift
+++ b/PocketKit/Sources/PocketKit/Article/ActivityItemSource.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 ///

--- a/PocketKit/Sources/PocketKit/Article/ArticleComponentUnavailableView.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleComponentUnavailableView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 // An object that conforms to this protocol is commonly capable of responding to

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleMetadataCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleMetadataCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class ArticleMetadataCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {

--- a/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class BlockquoteComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {

--- a/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class CodeBlockComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {

--- a/PocketKit/Sources/PocketKit/Article/Cells/DIviderComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/DIviderComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class DividerComponentCell: UICollectionViewCell {

--- a/PocketKit/Sources/PocketKit/Article/Cells/EmptyCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/EmptyCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class EmptyCell: UICollectionViewCell {

--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Kingfisher
 

--- a/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {

--- a/PocketKit/Sources/PocketKit/Article/Cells/ReaderSkeletonCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ReaderSkeletonCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class ReaderSkeletonCell: UICollectionViewCell {

--- a/PocketKit/Sources/PocketKit/Article/Cells/UnsupportedComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/UnsupportedComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/Article/Cells/VimeoComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/VimeoComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import WebKit
 import Combine

--- a/PocketKit/Sources/PocketKit/Article/Cells/YouTubeVideoComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/YouTubeVideoComponentCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import YouTubePlayerKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/Presenters/ArticleComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/ArticleComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 protocol ArticleComponentPresenter {

--- a/PocketKit/Sources/PocketKit/Article/Presenters/BlockquoteComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/BlockquoteComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/Presenters/CodeBlockPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/CodeBlockPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/Presenters/DividerComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/DividerComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/ImageComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/ImageComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 import Kingfisher

--- a/PocketKit/Sources/PocketKit/Article/Presenters/ListComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/ListComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/Presenters/MarkdownComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/MarkdownComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import UIKit

--- a/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import UIKit
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/YouTubeVideoComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/YouTubeVideoComponentPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import YouTubePlayerKit
 import Combine

--- a/PocketKit/Sources/PocketKit/Article/ReadableView.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableView.swift
@@ -16,6 +16,5 @@ struct ReadableView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ viewController: ReadableViewController, context: Context) {
-
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAuthor.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableAuthor.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 protocol ReadableAuthor {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 enum ReadableEvent {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Sync
 import Foundation

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Sync
 import Foundation

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -278,7 +278,6 @@ extension RecommendationViewModel {
     }
 
     func beginBulkEdit() {
-
     }
 
     private func save() {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Combine
 import Foundation

--- a/PocketKit/Sources/PocketKit/Constants.swift
+++ b/PocketKit/Sources/PocketKit/Constants.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import UIKit
 

--- a/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
+++ b/PocketKit/Sources/PocketKit/Extensions/UIViewControllerExtension.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension UIViewController {

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -64,7 +64,6 @@ class FeatureFlagService: FeatureFlagServiceProtocol {
         }
         tracker.track(event: Events.FeatureFlag.FeatureFlagFelt(name: flag.rawValue, variant: variant))
     }
-
 }
 
 /// Describes the current feature flags that iOS cares about

--- a/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCarouselItemCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Kingfisher
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeCollectionViewSectionProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import CoreData

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellHeroWideViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellHeroWideViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import Combine

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import Combine

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Combine
 import UIKit

--- a/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import UIKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/RecommendationButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import UIKit
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Kingfisher
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCellHeroWide.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCellHeroWide.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Kingfisher
 

--- a/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationSaveButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SectionHeaderView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Analytics

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import UIKit

--- a/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/TopicChipCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 

--- a/PocketKit/Sources/PocketKit/Home/TopicChipPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Home/TopicChipPresenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/ImageManager.swift
+++ b/PocketKit/Sources/PocketKit/ImageManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Kingfisher
 import Sync

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Combine
 import Analytics

--- a/PocketKit/Sources/PocketKit/ItemAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemAction.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import UIKit

--- a/PocketKit/Sources/PocketKit/ItemContextualAction.swift
+++ b/PocketKit/Sources/PocketKit/ItemContextualAction.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import UIKit

--- a/PocketKit/Sources/PocketKit/Listen/Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/Listen.swift
@@ -104,7 +104,6 @@ class Listen: NSObject {
 }
 
 extension Listen: PKTListenServiceDelegate {
-
     static let skippedActions = [
         "listen_opened",
         "listen_closed"

--- a/PocketKit/Sources/PocketKit/LoggedOut/AuthenticationSession.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/AuthenticationSession.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import AuthenticationServices
 
 protocol AuthenticationSession {

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutCoordinator.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Combine
 import AuthenticationServices

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutOfflineView.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutOfflineView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import SwiftUI

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Combine
 import AuthenticationServices

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Network
 import Sync

--- a/PocketKit/Sources/PocketKit/Main/RootView.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootView.swift
@@ -32,7 +32,6 @@ public struct RootView: View {
         UINavigationBar.appearance().compactAppearance = navBar
         UINavigationBar.appearance().scrollEdgeAppearance = navBar2
         UINavigationBar.appearance().compactScrollEdgeAppearance = navBar2
-
     }
 
     /// Sets up the tab bar appearance following some of https://stackoverflow.com/questions/56969309/change-tabbed-view-bar-color-swiftui

--- a/PocketKit/Sources/PocketKit/Main/RootView.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 public struct RootView: View {

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Analytics
 import Sync

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/ArchiveEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/ArchiveEmptyStateViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SwiftUI
 import Textile

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/FavoritesEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/FavoritesEmptyStateViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/SFSafariView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/SFSafariView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import SafariServices
 

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/SavesEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/SavesEmptyStateViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/GetPremiumEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/GetPremiumEmptyState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/NoResultsEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/NoResultsEmptyState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/OfflineEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/OfflineEmptyState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import SharedPocketKit

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/RecentSearchEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/RecentSearchEmptyState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/SearchEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/SearchEmptyState.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/TagsEmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/TagsEmptyStateViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ActivityViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ActivityViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 struct ShareSheetView: UIViewControllerRepresentable {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ActionButton.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ActionButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemDetails.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemDetails.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 struct ItemDetails: View {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemTags.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/ItemTags.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 struct ItemTags: View {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/OverflowMenu.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/TagComponent.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Components/TagComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 struct TagComponent: View {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem+Constants.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem+Constants.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 extension ListItem {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/ListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import Kingfisher

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Style+ListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Style+ListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 import SwiftUI
 import UIKit

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/ActionButtonStyles.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/ActionButtonStyles.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 private let constants = ListItem.Constants.actionButton

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/TagStyles.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/Styles/TagStyles.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 private let constants = ListItem.Constants.tags

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemSkeletonCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemSkeletonCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Kingfisher
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListOfflineCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListOfflineCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import CoreData

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -63,7 +63,6 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(.ui.white1)
-
         model.fetch()
     }
 
@@ -398,7 +397,6 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
     }
 
     func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-
         guard let item = dataSource.itemIdentifier(for: indexPath), let (viewModel, showInWebView) = model.preview(for: item) else {
             return nil
         }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import UIKit
 import Sync

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/ItemsListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Foundation
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -505,7 +505,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         case .started:
             // If you background the app, and reopen the Fetch operations can override the sent staus,
             // so instead we will first make sure we have no objects before switching to placeholders.
-            if let fetchedObjects = itemsController.fetchedObjects, fetchedObjects.count > 0 {
+            if let fetchedObjects = itemsController.fetchedObjects, !fetchedObjects.isEmpty {
                 itemCellIDs = (0..<fetchedObjects.count).compactMap { index in
                     .item(fetchedObjects[index].objectID)
                 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -48,8 +48,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
 
     @Published var presentedSortFilterViewModel: SortMenuViewModel?
 
-    @Published
-    var presentedListenViewModel: ListenViewModel?
+    @Published var presentedListenViewModel: ListenViewModel?
 
     @Published private var _initialDownloadState: InitialDownloadState
     var initialDownloadState: Published<InitialDownloadState>.Publisher { $_initialDownloadState }
@@ -487,7 +486,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
 
         var cases = ItemsListFilter.allCases
         if !self.featureFlags.isAssigned(flag: .listen) {
-            cases.removeAll(where: {$0 == .listen})
+            cases.removeAll(where: { $0 == .listen })
         }
         snapshot.appendItems(
             cases.map { ItemsListCell<ItemIdentifier>.filterButton($0) },

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 import Sync
 import Analytics

--- a/PocketKit/Sources/PocketKit/MyList/ReaderActionsWebActivity/ReaderActionsWebActivity.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ReaderActionsWebActivity/ReaderActionsWebActivity.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import SwiftUI
 import Sync

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Sync
 import UIKit

--- a/PocketKit/Sources/PocketKit/MyList/SavesTitleView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesTitleView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 import Sync

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -42,7 +42,8 @@ struct ResultsView: View {
         static let maxReadableWidth: CGFloat = 700
     }
 
-    @Environment(\.horizontalSizeClass) var sizeClass
+    @Environment(\.horizontalSizeClass)
+    var sizeClass
     @ObservedObject var viewModel: SearchViewModel
     @State private var showingAlert = false
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -85,14 +85,16 @@ class SearchViewModel: ObservableObject {
     var bannerData: BannerModifier.BannerData {
         let offlineView = BannerModifier.BannerData(image: .looking, title: Localization.Search.limitedResults, detail: Localization.Search.offlineMessage)
         let errorView = BannerModifier.BannerData(
-            image: .warning, title: Localization.Search.limitedResults,
+            image: .warning,
+            title: Localization.Search.limitedResults,
             detail: Localization.Search.Banner.errorMessage,
             action: BannerModifier.BannerData.BannerAction(
                 text: Localization.General.Error.sendReport,
                 style: PocketButtonStyle(.primary, .small)
             ) {
                 self.isPresentingReportIssue.toggle()
-            })
+            }
+        )
         return isOffline ? offlineView : errorView
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/Style+Search.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/Style+Search.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 
 extension Style {

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Localization
 

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/SortMenuViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Analytics

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Sync
 import Combine

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/ListOptions.swift
@@ -41,8 +41,7 @@ class ListOptions: ObservableObject {
 }
 
 class SavedListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage
-    var selectedSortOption: SortOption
+    @AppStorage var selectedSortOption: SortOption
 
     private var cancellable: AnyCancellable?
     private let _publisher: PassthroughSubject<Void, Never>
@@ -61,8 +60,7 @@ class SavedListOptions: ObservableObject, ListOptionsHolder {
 }
 
 class ArchiveListOptions: ObservableObject, ListOptionsHolder {
-    @AppStorage
-    var selectedSortOption: SortOption
+    @AppStorage var selectedSortOption: SortOption
 
     private var cancellable: AnyCancellable?
     private let _publisher: PassthroughSubject<Void, Never>

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuHeaderView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuHeaderView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class SortMenuHeaderView: UITableViewHeaderFooterView {

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuViewCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuViewCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 class SortMenuViewCell: UITableViewCell {

--- a/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SortFilterMenu/View/SortMenuViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Lottie
 import Combine

--- a/PocketKit/Sources/PocketKit/NSAttributedString+size.swift
+++ b/PocketKit/Sources/PocketKit/NSAttributedString+size.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreGraphics
 

--- a/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
+++ b/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension NSCollectionLayoutSection {

--- a/PocketKit/Sources/PocketKit/NSLayoutConstraint+withPriority.swift
+++ b/PocketKit/Sources/PocketKit/NSLayoutConstraint+withPriority.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension NSLayoutConstraint {

--- a/PocketKit/Sources/PocketKit/Notifications/InstantSync.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/InstantSync.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import SharedPocketKit

--- a/PocketKit/Sources/PocketKit/Notifications/PocketAppDelegate+PocketNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketAppDelegate+PocketNotificationService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import UIKit
 import Sync

--- a/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import BrazeUI
 import BrazeKit

--- a/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
@@ -28,7 +28,6 @@ typealias BrazeProtocol = BrazeSDKProtocol & PushNotificationProtocol
  Class that is managing our Braze SDK implementation
  */
 class PocketBraze: NSObject {
-
     /// Our Braze SDK Object
     let braze: Braze
 

--- a/PocketKit/Sources/PocketKit/Notifications/PushNotificationService.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PushNotificationService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import BrazeKit
 import BrazeUI

--- a/PocketKit/Sources/PocketKit/OnDismissHostingController.swift
+++ b/PocketKit/Sources/PocketKit/OnDismissHostingController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 class OnDismissHostingController<T: View>: UIHostingController<T> {

--- a/PocketKit/Sources/PocketKit/Pasteboard.swift
+++ b/PocketKit/Sources/PocketKit/Pasteboard.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 protocol Pasteboard: AnyObject {

--- a/PocketKit/Sources/PocketKit/PocketAlert.swift
+++ b/PocketKit/Sources/PocketKit/PocketAlert.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Localization
 

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -49,25 +49,29 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        Log.start(dsn: Keys.shared.sentryDSN, tracesSampler: { context in
-            guard self.featureFlags.isAssigned(flag: .traceSampling),
-                  // Get the sentry traces sample value from the feature flag
-                  let sample = self.featureFlags.getPayload(flag: .traceSampling)?.numberValue else {
-                // Traces sampler is disabled or not set, so returning a 0
-                return 0.0
+        Log.start(
+            dsn: Keys.shared.sentryDSN,
+            tracesSampler: { context in
+                guard self.featureFlags.isAssigned(flag: .traceSampling),
+                      // Get the sentry traces sample value from the feature flag
+                      let sample = self.featureFlags.getPayload(flag: .traceSampling)?.numberValue else {
+                    // Traces sampler is disabled or not set, so returning a 0
+                    return 0.0
+                }
+                return sample
+            },
+            profilesSampler: { context in
+                // NOTE: This is relative to the TracesSampler. IE. if tracesSampler responds with 100%, profilesSampler will be called 100% of the time,
+                // if traces responds with 50%, profileSamples will be called 50% of the time.
+                guard self.featureFlags.isAssigned(flag: .profileSampling),
+                      // Get the sentry profile sample value from the feature flag
+                      let sample = self.featureFlags.getPayload(flag: .profileSampling)?.numberValue else {
+                    // Profiles sampler is disabled or not set, so returning a 0
+                    return 0.0
+                }
+                return sample
             }
-            return sample
-        }, profilesSampler: { context in
-            // NOTE: This is relative to the TracesSampler. IE. if tracesSampler responds with 100%, profilesSampler will be called 100% of the time,
-            // if traces responds with 50%, profileSamples will be called 50% of the time.
-            guard self.featureFlags.isAssigned(flag: .profileSampling),
-                  // Get the sentry profile sample value from the feature flag
-                  let sample = self.featureFlags.getPayload(flag: .profileSampling)?.numberValue else {
-                // Profiles sampler is disabled or not set, so returning a 0
-                return 0.0
-            }
-            return sample
-        })
+        )
 
         if CommandLine.arguments.contains("clearKeychain") {
             appSession.currentSession = nil
@@ -114,7 +118,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             tracker.addPersistentEntity(UserEntity(guid: currentSession.guid, userID: currentSession.userIdentifier, adjustAdId: Adjust.adid()))
         }
 
-        self.refreshCoordinators.forEach({$0.initialize()})
+        self.refreshCoordinators.forEach({ $0.initialize() })
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.source.restore()
         }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/ReceiptService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import StoreKit
 import Sync

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeSuccessScreen.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeSuccessScreen.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import Localization

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeSuccessScreen.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeSuccessScreen.swift
@@ -7,8 +7,10 @@ import Textile
 import Localization
 
 struct PremiumUpgradeSuccessView: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.colorScheme)
+    var colorScheme
 
     var body: some View {
         VStack(spacing: Constants.verticalPadding) {

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SharedPocketKit
 import SwiftUI
 import Textile

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpgradeView.swift
@@ -9,7 +9,8 @@ import Localization
 
 struct PremiumUpgradeView: View {
     @Binding var dismissReason: DismissReason
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
     @StateObject var viewModel: PremiumUpgradeViewModel
 
     var body: some View {

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import SharedPocketKit
 import Localization

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/View/PremiumUpsellView.swift
@@ -7,8 +7,7 @@ import SharedPocketKit
 import Localization
 
 struct PremiumUpsellView: View {
-    @ObservedObject
-    var viewModel: PremiumUpsellViewModel
+    @ObservedObject var viewModel: PremiumUpsellViewModel
     let itemURL: URL
 
     @State var dismissReason: DismissReason = .swipe

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettings.swift
@@ -7,11 +7,9 @@ import Textile
 import SwiftUI
 
 class ReaderSettings: StylerModifier, ObservableObject {
-    @AppStorage
-    var fontSizeAdjustment: Int
+    @AppStorage var fontSizeAdjustment: Int
 
-    @AppStorage
-    var fontFamily: FontDescriptor.Family
+    @AppStorage var fontFamily: FontDescriptor.Family
 
     var currentStyling: FontStyling {
         if fontFamily == .graphik {

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -13,7 +13,8 @@ struct ReaderSettingsView: View {
         static let allowedFontFamilies: [FontDescriptor.Family] = [.graphik, .blanco]
     }
 
-    @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.presentationMode)
+    private var presentationMode
 
     @ObservedObject private var settings: ReaderSettings
 

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 class ReaderSettingsViewController: OnDismissHostingController<ReaderSettingsView> {

--- a/PocketKit/Sources/PocketKit/Recommendation/Recommendation+Extenstions.swift
+++ b/PocketKit/Sources/PocketKit/Recommendation/Recommendation+Extenstions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 

--- a/PocketKit/Sources/PocketKit/Refresh/BGTaskSchedulerProtocol.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/BGTaskSchedulerProtocol.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import BackgroundTasks
 
 protocol BGTaskProtocol: AnyObject {

--- a/PocketKit/Sources/PocketKit/Refresh/FeatureFlagsRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/FeatureFlagsRefreshCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 
 /// Refresh coordinator to handle the refreshing of feature flags
 class FeatureFlagsRefreshCoordinator: RefreshCoordinator {
-
     let taskID: String = "com.mozilla.pocket.refresh.featureFlags"
 
     let refreshInterval: TimeInterval? = 60 * 60 * 48 // once every 48 hours.

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -9,7 +9,6 @@ import Sync
 import SharedPocketKit
 
 class HomeRefreshCoordinator: RefreshCoordinator {
-
     let taskID: String = "com.mozilla.pocket.refresh.home"
 
     let refreshInterval: TimeInterval? = 12 * 60 * 60

--- a/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 
 /// Refresh coordinator to handle the refreshing of a Users Save data
 class SavesRefreshCoordinator: RefreshCoordinator {
-
     let taskID: String = "com.mozilla.pocket.refresh.saves"
 
     let refreshInterval: TimeInterval? = 60 * 60

--- a/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
@@ -13,7 +13,6 @@ import Combine
 ///     However this is ok because tags are always associated with a Saved/Archived Item
 ///     and we will get any new tags via the updatedSince filter when we load Archive and Save data.
 class TagsRefreshCoordinator: RefreshCoordinator {
-
     // Return nil, which informs the protocol we never want to background refresh tags
     let refreshInterval: TimeInterval? = nil
 

--- a/PocketKit/Sources/PocketKit/Refresh/UIApplication+BackgroundTaskManager.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UIApplication+BackgroundTaskManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 

--- a/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 
 /// Refresh coordinator to handle the refreshing of all unresolved saves
 class UnresolvedSavesRefreshCoordinator: RefreshCoordinator {
-
     let taskID: String = "com.mozilla.pocket.refresh.unresolved"
 
     let refreshInterval: TimeInterval? = 60 * 60

--- a/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
@@ -9,7 +9,6 @@ import Combine
 
 /// Refresh coordinator to handle the refreshing of user data
 class UserRefreshCoordinator: RefreshCoordinator {
-
     let taskID: String = "com.mozilla.pocket.refresh.user"
 
     let refreshInterval: TimeInterval? = 60 * 60 * 24 // once every 24 hours.

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Analytics
 import Sync

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -26,7 +26,8 @@ struct ReportRecommendationView: View {
         selectedReason == nil ? "submit-report-disabled" : "submit-report"
     }
 
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
 
     @State private var selectedReason: ReportEntity.Reason?
 

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Sync
 import Analytics

--- a/PocketKit/Sources/PocketKit/Router.swift
+++ b/PocketKit/Sources/PocketKit/Router.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Network
 import Sync

--- a/PocketKit/Sources/PocketKit/SceneTracker.swift
+++ b/PocketKit/Sources/PocketKit/SceneTracker.swift
@@ -19,11 +19,9 @@ class SceneTracker {
 
     private var subscriptions: Set<AnyCancellable> = []
 
-    @AppStorage
-    private var dateLastOpened: Date?
+    @AppStorage private var dateLastOpened: Date?
 
-    @AppStorage
-    private var dateLastBackgrounded: Date?
+    @AppStorage private var dateLastBackgrounded: Date?
 
     init(tracker: Tracker, userDefaults: UserDefaults, notificationCenter: NotificationCenter = .default) {
         self.tracker = tracker

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Analytics
 import Combine
 import SharedPocketKit

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -45,8 +45,7 @@ class AccountViewModel: ObservableObject {
     @Published var isPresentingHooray = false
     @Published var isPresentingDebugMenu = false
 
-    @AppStorage
-    public var appBadgeToggle: Bool
+    @AppStorage public var appBadgeToggle: Bool
 
     private var userStatusListener: AnyCancellable?
 

--- a/PocketKit/Sources/PocketKit/Settings/Components/PremiumStatusRow.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/PremiumStatusRow.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowButton.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowLink.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowLink.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowToggle.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Components/SettingsRowToggle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 

--- a/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
@@ -9,7 +9,8 @@ import StoreKit
 import Localization
 
 struct PremiumStatusView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
     @StateObject var viewModel: PremiumStatusViewModel
     @State var result: Result<MFMailComposeResult, Error>?
     @State private var presentManageSubscriptions = false

--- a/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Textile
 import MessageUI

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SharedPocketKit
 import SwiftUI
 import Textile

--- a/PocketKit/Sources/PocketKit/Settings/Style+Settings.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Style+Settings.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 
 extension Style {

--- a/PocketKit/Sources/PocketKit/Style+ReaderSettings.swift
+++ b/PocketKit/Sources/PocketKit/Style+ReaderSettings.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 
 extension Style {

--- a/PocketKit/Sources/PocketKit/Tags/MailView.swift
+++ b/PocketKit/Sources/PocketKit/Tags/MailView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import AVFoundation
 import Foundation
 import MessageUI

--- a/PocketKit/Sources/PocketKit/Tags/MailView.swift
+++ b/PocketKit/Sources/PocketKit/Tags/MailView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import UIKit
 
 struct MailView: UIViewControllerRepresentable {
-    @Environment(\.presentationMode) var presentation
+    @Environment(\.presentationMode)
+    var presentation
     @Binding var result: Result<MFMailComposeResult, Error>?
     var recipients = [String]()
     var messageBody = ""

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import SwiftUI
 import Sync

--- a/PocketKit/Sources/PocketKit/Tags/SelectedTagChipCell.swift
+++ b/PocketKit/Sources/PocketKit/Tags/SelectedTagChipCell.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Sync
 import Textile

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterView.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterView.swift
@@ -10,7 +10,8 @@ import Sync
 struct TagsFilterView: View {
     @ObservedObject var viewModel: TagsFilterViewModel
 
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
 
     @State var didTap = false
     @State private var selectedItems = Set<TagType>()
@@ -72,7 +73,8 @@ struct TagsFilterView: View {
 }
 
 struct EditModeView: View {
-    @Environment(\.editMode) var editMode
+    @Environment(\.editMode)
+    var editMode
     @Binding var isEditing: Bool
     @ObservedObject var viewModel: TagsFilterViewModel
 

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import Sync
 import Analytics

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -10,7 +10,6 @@ import Textile
 import SharedPocketKit
 
 class TagsFilterViewModel: ObservableObject {
-
     /// Grab the latest tags from the database on each ask for them to ensure we are up to date
     private var fetchedTags: [Tag] {
         self.source.fetchAllTags() ?? []

--- a/PocketKit/Sources/PocketKit/UIActivityController+PocketKit.swift
+++ b/PocketKit/Sources/PocketKit/UIActivityController+PocketKit.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 /// Helper class to always show a share sheet via a modal

--- a/PocketKit/Sources/PocketKit/UIAlertController+PocketKit.swift
+++ b/PocketKit/Sources/PocketKit/UIAlertController+PocketKit.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension UIAlertController {

--- a/PocketKit/Sources/PocketKit/UICollectionView+registration.swift
+++ b/PocketKit/Sources/PocketKit/UICollectionView+registration.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension UICollectionView {

--- a/PocketKit/Sources/PocketKit/UITableView+Registration.swift
+++ b/PocketKit/Sources/PocketKit/UITableView+Registration.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension UITableView {

--- a/PocketKit/Sources/PocketKit/View+DidAppear.swift
+++ b/PocketKit/Sources/PocketKit/View+DidAppear.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 // Solves a problem where swiftui calls onAppear on disappear.
 // https://developer.apple.com/forums/thread/655338?page=3
 

--- a/PocketKit/Sources/PocketKit/imageCacheURL.swift
+++ b/PocketKit/Sources/PocketKit/imageCacheURL.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 private let imageCacheFilters = "/fit-in/\(Int(UIScreen.main.nativeBounds.width))x\(Int(UIScreen.main.nativeBounds.height))/filters:format(jpeg):quality(60):no_upscale():strip_exif()"

--- a/PocketKit/Sources/SaveToPocketKit/AppSession+Sync.swift
+++ b/PocketKit/Sources/SaveToPocketKit/AppSession+Sync.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SharedPocketKit
 import Sync
 

--- a/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
+++ b/PocketKit/Sources/SaveToPocketKit/ExtensionContext.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 protocol ExtensionContext {

--- a/PocketKit/Sources/SaveToPocketKit/InfoView.swift
+++ b/PocketKit/Sources/SaveToPocketKit/InfoView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Textile
 

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Combine
 

--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import SharedPocketKit
 import Combine

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Analytics
 import Textile

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import SwiftUI
 import Sync

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Combine
 import Textile

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SharedPocketKit
 import Sync

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 import SharedPocketKit

--- a/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Style+Extensions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Textile
 
 extension Style {

--- a/PocketKit/Sources/SharedPocketKit/DeviceUtilities.swift
+++ b/PocketKit/Sources/SharedPocketKit/DeviceUtilities.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import UIKit
 

--- a/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
+++ b/PocketKit/Sources/SharedPocketKit/KeychainStorage.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Combine
 

--- a/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
+++ b/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public protocol LastRefresh {

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyEncryptedStore.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import RNCryptor
 

--- a/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
+++ b/PocketKit/Sources/SharedPocketKit/Migrations/LegacyUserMigration.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public enum LegacyUserMigrationError: LoggableError {

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public extension Notification.Name {

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public enum SearchScope: String, CaseIterable, Codable {
     case saves = "Saves"
     case archive = "Archive"

--- a/PocketKit/Sources/SharedPocketKit/Session/AppSession.swift
+++ b/PocketKit/Sources/SharedPocketKit/Session/AppSession.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public class AppSession {

--- a/PocketKit/Sources/SharedPocketKit/Session/Session.swift
+++ b/PocketKit/Sources/SharedPocketKit/Session/Session.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public struct Session: Codable, Equatable {

--- a/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public class SignOutOnFirstLaunch {

--- a/PocketKit/Sources/SharedPocketKit/String+Number.swift
+++ b/PocketKit/Sources/SharedPocketKit/String+Number.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public extension String {

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import UIKit
 import Combine

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
@@ -10,7 +10,8 @@ import Textile
 public struct AddTagsView<ViewModel>: View where ViewModel: AddTagsViewModel {
     @ObservedObject var viewModel: ViewModel
 
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
 
     @FocusState private var isTextFieldFocused: Bool
 

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
@@ -59,7 +59,7 @@ public extension AddTagsViewModel {
     private func addTag(with tagName: String) {
         guard !tags.contains(tagName) else { return }
         tags.append(tagName)
-        if let index = otherTags.firstIndex(where: { $0.name == tagName}) {
+        if let index = otherTags.firstIndex(where: { $0.name == tagName }) {
             otherTags.remove(at: index)
         }
         if otherTags.isEmpty {

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -26,15 +26,11 @@ public protocol User {
 
 public class PocketUser: User, ObservableObject {
     @Published public private(set) var status: Status = .unknown
-    @AppStorage
-    public var userName: String
-    @AppStorage
-    public var displayName: String
-    @AppStorage
-    public private(set) var email: String
+    @AppStorage public var userName: String
+    @AppStorage public var displayName: String
+    @AppStorage public private(set) var email: String
     public var statusPublisher: Published<Status>.Publisher { $status }
-    @AppStorage
-    private var storedStatus: Status
+    @AppStorage private var storedStatus: Status
 
     private static let userStatusKey = UserDefaults.Key.userStatus
     private static let userNameKey = UserDefaults.Key.userName

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import SwiftUI
 

--- a/PocketKit/Sources/SharedPocketKit/User.swift
+++ b/PocketKit/Sources/SharedPocketKit/User.swift
@@ -2,9 +2,9 @@ import Combine
 import SwiftUI
 
 public enum Status: String {
-    case premium = "premium"
-    case free = "free"
-    case unknown = "unknown"
+    case premium
+    case free
+    case unknown
 }
 
 public protocol User {

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -75,7 +75,6 @@ public extension ApolloClientProtocol {
                                           line: Int,
                                           column: Int,
                                           funcName: String) {
-
         // Codes we wish to notify the user about
         let notifiableErrorCodes = [429, 500, 503]
 
@@ -84,11 +83,13 @@ public extension ApolloClientProtocol {
             return
         }
 
-        Log.capture(message: "GraphQl Error - description: \(responseError.errorDescription ?? "no description found").",
-                    filename: filename,
-                    line: line,
-                    column: column,
-                    funcName: funcName)
+        Log.capture(
+            message: "GraphQl Error - description: \(responseError.errorDescription ?? "no description found").",
+            filename: filename,
+            line: line,
+            column: column,
+            funcName: funcName
+        )
 
         if case .invalidResponseCode(let response, _) = responseError,
            let code = response?.statusCode,

--- a/PocketKit/Sources/Sync/Article/Article.swift
+++ b/PocketKit/Sources/Sync/Article/Article.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public class Article: NSObject, Codable {

--- a/PocketKit/Sources/Sync/Article/ArticleComponent.swift
+++ b/PocketKit/Sources/Sync/Article/ArticleComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 import SharedPocketKit
 

--- a/PocketKit/Sources/Sync/Article/BlockquoteComponent.swift
+++ b/PocketKit/Sources/Sync/Article/BlockquoteComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct BlockquoteComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/BulletedListComponent.swift
+++ b/PocketKit/Sources/Sync/Article/BulletedListComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct BulletedListComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/CodeBlockComponent.swift
+++ b/PocketKit/Sources/Sync/Article/CodeBlockComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct CodeBlockComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/DividerComponent.swift
+++ b/PocketKit/Sources/Sync/Article/DividerComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct DividerComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/HeadingComponent.swift
+++ b/PocketKit/Sources/Sync/Article/HeadingComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct HeadingComponent: MarkdownComponent, Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/ImageComponent.swift
+++ b/PocketKit/Sources/Sync/Article/ImageComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/Article/MarkdownComponent.swift
+++ b/PocketKit/Sources/Sync/Article/MarkdownComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public protocol MarkdownComponent {
     var content: Markdown { get }
 }

--- a/PocketKit/Sources/Sync/Article/NumberedListComponent.swift
+++ b/PocketKit/Sources/Sync/Article/NumberedListComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct NumberedListComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/TableComponent.swift
+++ b/PocketKit/Sources/Sync/Article/TableComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct TableComponent: Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/TextComponent.swift
+++ b/PocketKit/Sources/Sync/Article/TextComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import PocketGraph
 
 public struct TextComponent: MarkdownComponent, Codable, Equatable, Hashable {

--- a/PocketKit/Sources/Sync/Article/UnsupportedComponent.swift
+++ b/PocketKit/Sources/Sync/Article/UnsupportedComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public struct UnsupportedComponent: Equatable, Hashable {
     public let type: String?
 }

--- a/PocketKit/Sources/Sync/Article/VideoComponent.swift
+++ b/PocketKit/Sources/Sync/Article/VideoComponent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/BackgroundTaskManager.swift
+++ b/PocketKit/Sources/Sync/BackgroundTaskManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public protocol BackgroundTaskManager {
     func beginTask(withName name: String?, expirationHandler: (() -> Void)?) -> Int
     func endTask(_ identifier: Int)

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(Author)
 public class Author: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Author+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension Author {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Author> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<Author> {
         return NSFetchRequest<Author>(entityName: "Author")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(DomainMetadata)
 public class DomainMetadata: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/DomainMetadata+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension DomainMetadata {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<DomainMetadata> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<DomainMetadata> {
         return NSFetchRequest<DomainMetadata>(entityName: "DomainMetadata")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(FeatureFlag)
 public class FeatureFlag: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/FeatureFlag+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension FeatureFlag {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<FeatureFlag> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<FeatureFlag> {
         return NSFetchRequest<FeatureFlag>(entityName: "FeatureFlag")
     }
     @NSManaged public var assigned: Bool

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(Image)
 public class Image: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Image+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension Image {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Image> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<Image> {
         return NSFetchRequest<Image>(entityName: "Image")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(PersistentSyncTask)
 public class PersistentSyncTask: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/PersistentSyncTask+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension PersistentSyncTask {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<PersistentSyncTask> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<PersistentSyncTask> {
         return NSFetchRequest<PersistentSyncTask>(entityName: "PersistentSyncTask")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -7,8 +7,8 @@ import Foundation
 import CoreData
 
 extension Recommendation {
-
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Recommendation> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<Recommendation> {
         return NSFetchRequest<Recommendation>(entityName: "Recommendation")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(SavedItemUpdatedNotification)
 public class SavedItemUpdatedNotification: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItemUpdatedNotification+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension SavedItemUpdatedNotification {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<SavedItemUpdatedNotification> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<SavedItemUpdatedNotification> {
         return NSFetchRequest<SavedItemUpdatedNotification>(entityName: "SavedItemUpdatedNotification")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(SyndicatedArticle)
 public class SyndicatedArticle: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SyndicatedArticle+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension SyndicatedArticle {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<SyndicatedArticle> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<SyndicatedArticle> {
         return NSFetchRequest<SyndicatedArticle>(entityName: "SyndicatedArticle")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(Tag)
 public class Tag: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Tag+CoreDataProperties.swift
@@ -7,19 +7,18 @@ import Foundation
 import CoreData
 
 extension Tag {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Tag> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<Tag> {
         return NSFetchRequest<Tag>(entityName: "Tag")
     }
 
     @NSManaged public var name: String
     @NSManaged public var remoteID: String?
     @NSManaged public var savedItems: NSOrderedSet?
-
 }
 
 // MARK: Generated accessors for savedItems
 extension Tag {
-
     @objc(insertObject:inSavedItemsAtIndex:)
     @NSManaged public func insertIntoSavedItems(_ value: SavedItem, at idx: Int)
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataClass.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataClass.swift
@@ -8,5 +8,4 @@ import CoreData
 
 @objc(UnresolvedSavedItem)
 public class UnresolvedSavedItem: NSManagedObject {
-
 }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/UnresolvedSavedItem+CoreDataProperties.swift
@@ -7,7 +7,8 @@ import Foundation
 import CoreData
 
 extension UnresolvedSavedItem {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<UnresolvedSavedItem> {
+    @nonobjc
+    public class func fetchRequest() -> NSFetchRequest<UnresolvedSavedItem> {
         return NSFetchRequest<UnresolvedSavedItem>(entityName: "UnresolvedSavedItem")
     }
 

--- a/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
+++ b/PocketKit/Sources/Sync/CoreDataSpotlightDelegate.swift
@@ -41,5 +41,4 @@ class CoreDataSpotlightDelegate: NSCoreDataCoreSpotlightDelegate {
 
         return attributeSet
     }
-
 }

--- a/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
+++ b/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 extension DateFormatter {

--- a/PocketKit/Sources/Sync/ExpiringActivityPerformer.swift
+++ b/PocketKit/Sources/Sync/ExpiringActivityPerformer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public protocol ExpiringActivityPerformer {

--- a/PocketKit/Sources/Sync/FeatureFlags/FeatureFlagLoadingService.swift
+++ b/PocketKit/Sources/Sync/FeatureFlags/FeatureFlagLoadingService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import Foundation
 import CoreData

--- a/PocketKit/Sources/Sync/FeatureFlags/FeatureFlagLoadingService.swift
+++ b/PocketKit/Sources/Sync/FeatureFlags/FeatureFlagLoadingService.swift
@@ -33,7 +33,6 @@ class APIFeatureFlagService: FeatureFlagLoadingService {
 
     /// Fetches the latest feature flags from the server
     func fetchFeatureFlags() async {
-
         let context =  UnleashContext(appName: "pocket-ios", userId: appSession.currentSession?.userIdentifier ?? .none, sessionId: appSession.currentSession?.guid ?? .none)
 
         let query = FeatureFlagsQuery(context: context)

--- a/PocketKit/Sources/Sync/ImagesController.swift
+++ b/PocketKit/Sources/Sync/ImagesController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreData
 

--- a/PocketKit/Sources/Sync/Item+extensions.swift
+++ b/PocketKit/Sources/Sync/Item+extensions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 extension Item {

--- a/PocketKit/Sources/Sync/ItemImageness.swift
+++ b/PocketKit/Sources/Sync/ItemImageness.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/ItemVideoness.swift
+++ b/PocketKit/Sources/Sync/ItemVideoness.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/NetworkPathMonitor.swift
+++ b/PocketKit/Sources/Sync/NetworkPathMonitor.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Network
 
 public protocol NetworkPath {

--- a/PocketKit/Sources/Sync/OEmbedService.swift
+++ b/PocketKit/Sources/Sync/OEmbedService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public class OEmbedService {

--- a/PocketKit/Sources/Sync/OSNotificationCenter.swift
+++ b/PocketKit/Sources/Sync/OSNotificationCenter.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreFoundation
 

--- a/PocketKit/Sources/Sync/Operations/FetchSaves.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchSaves.swift
@@ -10,7 +10,6 @@ import SharedPocketKit
 import CoreData
 
 class FetchSaves: SyncOperation {
-
     private let apollo: ApolloClientProtocol
     private let space: Space
     private let events: SyncEvents

--- a/PocketKit/Sources/Sync/Operations/FetchTags.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchTags.swift
@@ -13,7 +13,6 @@ import CoreData
 /// After initial login, requesting saves/archives via the updatedSince filter will pull in all new/changed tags associated with any save.
 /// We can not filter on tags updatedSince explicitly because in the server database, tags are not a real entity at the moment and need database modeling changes to support this.
 class FetchTags: SyncOperation {
-
     private let apollo: ApolloClientProtocol
     private let space: Space
     private let events: SyncEvents

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import UIKit
 import Foundation

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import Combine

--- a/PocketKit/Sources/Sync/Operations/SyncTask.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncTask.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 enum SyncTask: Codable {

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import PocketGraph

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -596,7 +596,6 @@ extension PocketSource {
 // MARK: - Feature Flags
 
 extension PocketSource {
-
     public func fetchAllFeatureFlags() async throws {
         try await featureFlagService.fetchFeatureFlags()
     }

--- a/PocketKit/Sources/Sync/RemoteMapping/Author+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Author+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/RemoteMapping/DomainMetadata+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/DomainMetadata+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/RemoteMapping/FeatureFlag+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/FeatureFlag+RemoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/RemoteMapping/FeatureFlag+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/FeatureFlag+RemoteMapping.swift
@@ -6,7 +6,6 @@ import CoreData
 import PocketGraph
 
 extension FeatureFlag {
-
     func update(from remote: RemoteFeatureFlagAssignment) {
         name = remote.name
         assigned = remote.assigned

--- a/PocketKit/Sources/Sync/RemoteMapping/Image+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Image+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreData
 import Apollo

--- a/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SavedItem+RemoteMapping.swift
@@ -129,6 +129,5 @@ extension SavedItem {
             itemToUpdate.update(remote: pendingParts, with: space)
             item = itemToUpdate
         }
-
     }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreData
 import PocketGraph

--- a/PocketKit/Sources/Sync/RemoteMapping/Tag+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Tag+RemoteMapping.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 import PocketGraph
 

--- a/PocketKit/Sources/Sync/SaveService.swift
+++ b/PocketKit/Sources/Sync/SaveService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public enum SaveServiceStatus {

--- a/PocketKit/Sources/Sync/SavedItemsController.swift
+++ b/PocketKit/Sources/Sync/SavedItemsController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreData
 import UIKit

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import Foundation
 import PocketGraph

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -112,5 +112,4 @@ public protocol Source {
     func fetchAllFeatureFlags() async throws
 
     func fetchFeatureFlag(by name: String) -> FeatureFlag?
-
 }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Combine
 import CoreData
 import Foundation

--- a/PocketKit/Sources/Sync/Space/DerivedSpace.swift
+++ b/PocketKit/Sources/Sync/Space/DerivedSpace.swift
@@ -40,7 +40,6 @@ struct DerivedSpace {
         var fetchedTask: PersistentSyncTask?
         context.performAndWait {
             fetchedTask = context.object(with: taskID) as? PersistentSyncTask
-
         }
         guard let task = fetchedTask else {
             return nil

--- a/PocketKit/Sources/Sync/SyncEvent.swift
+++ b/PocketKit/Sources/Sync/SyncEvent.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public enum SyncEvent {
     case error(Error)
     case loadedArchivePage

--- a/PocketKit/Sources/Sync/User/UserService.swift
+++ b/PocketKit/Sources/Sync/User/UserService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import SharedPocketKit
 import Foundation

--- a/PocketKit/Sources/Sync/V3/V3Client.swift
+++ b/PocketKit/Sources/Sync/V3/V3Client.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SharedPocketKit
 

--- a/PocketKit/Sources/Sync/V3/V3ClientProtocol.swift
+++ b/PocketKit/Sources/Sync/V3/V3ClientProtocol.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 /**

--- a/PocketKit/Sources/Sync/V3/V3RequestTypes.swift
+++ b/PocketKit/Sources/Sync/V3/V3RequestTypes.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 protocol V3Request: Encodable {
     var accessToken: String { get }
 

--- a/PocketKit/Sources/Sync/V3/V3ResponseTypes.swift
+++ b/PocketKit/Sources/Sync/V3/V3ResponseTypes.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 protocol BasicV3Response {

--- a/PocketKit/Sources/Sync/VIDExtractor.swift
+++ b/PocketKit/Sources/Sync/VIDExtractor.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public struct VIDExtractor {

--- a/PocketKit/Sources/Textile/Animations/EndOfFeedAnimationView.swift
+++ b/PocketKit/Sources/Textile/Animations/EndOfFeedAnimationView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Lottie
 

--- a/PocketKit/Sources/Textile/Animations/PocketAnimation.swift
+++ b/PocketKit/Sources/Textile/Animations/PocketAnimation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 import Lottie

--- a/PocketKit/Sources/Textile/FontStyling/BlancoOSFStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/BlancoOSFStyling.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public struct BlancoOSFStyling: FontStyling {
     public let h1: Style
     public let h2: Style

--- a/PocketKit/Sources/Textile/FontStyling/FontStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/FontStyling.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public protocol FontStyling {
     var h1: Style { get }
     var h2: Style { get }

--- a/PocketKit/Sources/Textile/FontStyling/GraphikLCGStyling.swift
+++ b/PocketKit/Sources/Textile/FontStyling/GraphikLCGStyling.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public struct GraphikLCGStyling: FontStyling {
     public let h1: Style
     public let h2: Style

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Down
 

--- a/PocketKit/Sources/Textile/Style/ActionsPrimaryButtonStyle.swift
+++ b/PocketKit/Sources/Textile/Style/ActionsPrimaryButtonStyle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 public struct ActionsPrimaryButtonStyle: ButtonStyle {

--- a/PocketKit/Sources/Textile/Style/Images/ImageAsset.swift
+++ b/PocketKit/Sources/Textile/Style/Images/ImageAsset.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public struct ImageAsset {
     let name: String
 

--- a/PocketKit/Sources/Textile/Style/Images/UIImagePadding.swift
+++ b/PocketKit/Sources/Textile/Style/Images/UIImagePadding.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 public extension UIImage {

--- a/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/ParagraphStyle.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreGraphics
 
 public enum LineBreakMode {

--- a/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
+++ b/PocketKit/Sources/Textile/Style/Paragraph/TextAlignment.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 public enum TextAlignment {

--- a/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
+++ b/PocketKit/Sources/Textile/Style/PocketButtonStyle.swift
@@ -149,7 +149,6 @@ public struct PocketButtonStyle: ButtonStyle {
                 }
             }
             }
-
     }
 }
 

--- a/PocketKit/Sources/Textile/StylerModifier.swift
+++ b/PocketKit/Sources/Textile/StylerModifier.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 public protocol StylerModifier {
     var fontSizeAdjustment: Int { get }
     var fontFamily: FontDescriptor.Family { get }

--- a/PocketKit/Sources/Textile/Tags/Components/InputTagsView.swift
+++ b/PocketKit/Sources/Textile/Tags/Components/InputTagsView.swift
@@ -10,8 +10,7 @@ public struct InputTagsView: View {
     let upsellView: AnyView
     let geometry: GeometryProxy
 
-    @Namespace
-    var animation
+    @Namespace var animation
 
     enum Constants {
         static let tagsHorizontalSpacing: CGFloat = 6
@@ -113,7 +112,8 @@ struct InputTagsView_PreviewProvider: PreviewProvider {
                 tags: ["tag 0", "tag 1", "tag 2", "tag 3", "tag 4", "tag 5", "tag 6", "this is going to be a long tag"],
                 removeTag: tagAction,
                 upsellView: AnyView(EmptyView()),
-                geometry: reader)
+                geometry: reader
+            )
         }
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Light")
@@ -124,7 +124,8 @@ struct InputTagsView_PreviewProvider: PreviewProvider {
                 tags: ["tag 0", "tag 1", "tag 2", "tag 3", "tag 4", "tag 5", "tag 6", "this is going to be a long tag"],
                 removeTag: tagAction,
                 upsellView: AnyView(EmptyView()),
-                geometry: reader)
+                geometry: reader
+            )
         }
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Dark")

--- a/PocketKit/Sources/Textile/Tags/Components/TagsSectionView.swift
+++ b/PocketKit/Sources/Textile/Tags/Components/TagsSectionView.swift
@@ -62,6 +62,5 @@ struct TagsSectionView_Previews: PreviewProvider {
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Dark")
         .preferredColorScheme(.dark)
-
     }
 }

--- a/PocketKit/Sources/Textile/Tags/EditBottomBar.swift
+++ b/PocketKit/Sources/Textile/Tags/EditBottomBar.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import Localization
 

--- a/PocketKit/Sources/Textile/Tags/EditBottomBar.swift
+++ b/PocketKit/Sources/Textile/Tags/EditBottomBar.swift
@@ -53,7 +53,7 @@ public struct EditBottomBar: ViewModifier {
                     } message: {
                         Text(Localization.Tags.DeleteTag.message)
                     }
-                    .disabled(selectedItems.count == 0)
+                    .disabled(selectedItems.isEmpty)
                     .accessibilityIdentifier("delete-button")
                 }
                 .padding()

--- a/PocketKit/Sources/Textile/TextileStyler.swift
+++ b/PocketKit/Sources/Textile/TextileStyler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 import Down
 

--- a/PocketKit/Sources/Textile/Views/ActivitySheet.swift
+++ b/PocketKit/Sources/Textile/Views/ActivitySheet.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import UIKit
 

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 import UIKit
 

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -207,7 +207,8 @@ struct BannerModifier_PreviewProvider: PreviewProvider {
         }
         .banner(
             data: BannerModifier.BannerData(
-                image: .warning, title: "Limited search results",
+                image: .warning,
+                title: "Limited search results",
                 detail: "We're experiencing an error and can't show you full search results. Please try again later.",
                 action: BannerModifier.BannerData.BannerAction(
                     text: "Send a report",

--- a/PocketKit/Sources/Textile/Views/DividerView.swift
+++ b/PocketKit/Sources/Textile/Views/DividerView.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 public class DividerView: UICollectionReusableView {

--- a/PocketKit/Sources/Textile/Views/Haptics/Haptics.swift
+++ b/PocketKit/Sources/Textile/Views/Haptics/Haptics.swift
@@ -14,7 +14,6 @@ enum HapticFeedbackType {
 /// Singleton used to provide Haptics to buttons and elements in UIKit
 /// Inspired by https://stackoverflow.com/questions/56748539/how-to-create-haptic-feedback-for-a-button-in-swiftui
 public class Haptics {
-
     static let shared = Haptics()
 
     private init() { }
@@ -43,7 +42,6 @@ public class Haptics {
 
 /// Saves/Archive View Haptics
 extension Haptics {
-
     /// Saves/Archive selector changed
     public static func savesSelectorChanged() {
         Haptics.shared.haptic(.play(.rigid))

--- a/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
+++ b/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
@@ -22,7 +22,8 @@ public struct ReportIssueView: View {
         self.submitIssue = submitIssue
     }
 
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
     @State private var name = ""
     @State private var email: String
     @State private var reportComment = ""

--- a/PocketKit/Sources/Textile/Views/SFIcon/SFIcon.swift
+++ b/PocketKit/Sources/Textile/Views/SFIcon/SFIcon.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SwiftUI
 
 public struct SFIcon: View {

--- a/PocketKit/Sources/Textile/Views/SFIcon/SFIconModel.swift
+++ b/PocketKit/Sources/Textile/Views/SFIcon/SFIconModel.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SwiftUI
 

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import CoreData
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -22,6 +22,7 @@ final class AppBadgeTrackerTests: XCTestCase {
     private var badgeProvider: MockBadgeProvider!
 
     override func setUp() {
+        super.setUp()
         space = .testSpace()
         source = MockSource()
         source.viewContext = space.viewContext
@@ -42,6 +43,7 @@ final class AppBadgeTrackerTests: XCTestCase {
         userDefaults.removeObject(forKey: AccountViewModel.ToggleAppBadgeKey)
         try space.clear()
         try space.save()
+        try super.tearDownWithError()
     }
 
     func test_on_savedItemsUpdated_noSubscriberCalled() throws {

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -139,7 +139,6 @@ extension AuthorizationClientTests {
             } catch {
                 XCTFail("Should not have thrown an error \(error)")
             }
-
         }
 
         Task {

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -11,6 +11,7 @@ class AuthorizationClientTests: XCTestCase {
     var mockAuthenticationSession: MockAuthenticationSession!
 
     override func setUp() {
+        super.setUp()
         mockAuthenticationSession = MockAuthenticationSession()
         client = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token") { (_, _, completion) in
             self.mockAuthenticationSession.completionHandler = completion

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -801,9 +801,9 @@ class HomeViewModelTests: XCTestCase {
 
     func test_numberOfCarouselItemsForSlate_returnsAccurateCount() throws {
         let slates = [
-            space.buildSlate(recommendations: (0...1).map { space.buildRecommendation(remoteID: "recommendation1-\($0)", item: space.buildItem(remoteID: "item1-\($0)", givenURL: URL(string: "https://example.com/items/item1-\($0)")))}),
-            space.buildSlate(recommendations: (0...2).map { space.buildRecommendation(remoteID: "recommendation2-\($0)", item: space.buildItem(remoteID: "item2-\($0)", givenURL: URL(string: "https://example.com/items/item2-\($0)")))}),
-            space.buildSlate(recommendations: (0...3).map { space.buildRecommendation(remoteID: "recommendation3-\($0)", item: space.buildItem(remoteID: "item3-\($0)", givenURL: URL(string: "https://example.com/items/item3-\($0)")))})
+            space.buildSlate(recommendations: (0...1).map { space.buildRecommendation(remoteID: "recommendation1-\($0)", item: space.buildItem(remoteID: "item1-\($0)", givenURL: URL(string: "https://example.com/items/item1-\($0)"))) }),
+            space.buildSlate(recommendations: (0...2).map { space.buildRecommendation(remoteID: "recommendation2-\($0)", item: space.buildItem(remoteID: "item2-\($0)", givenURL: URL(string: "https://example.com/items/item2-\($0)"))) }),
+            space.buildSlate(recommendations: (0...3).map { space.buildRecommendation(remoteID: "recommendation3-\($0)", item: space.buildItem(remoteID: "item3-\($0)", givenURL: URL(string: "https://example.com/items/item3-\($0)"))) })
         ]
 
         try space.createSlateLineup(

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -29,8 +29,8 @@ class HomeViewModelTests: XCTestCase {
     var lastRefresh: UserDefaultsLastRefresh!
     var notificationCenter: NotificationCenter!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         subscriptions = []
         space = .testSpace()
         source = MockSource()

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -29,7 +29,8 @@ class HomeViewModelTests: XCTestCase {
     var lastRefresh: UserDefaultsLastRefresh!
     var notificationCenter: NotificationCenter!
 
-    override func setUp() async throws {
+    override func setUp() {
+        super.setUp()
         subscriptions = []
         space = .testSpace()
         source = MockSource()
@@ -75,6 +76,7 @@ class HomeViewModelTests: XCTestCase {
         subscriptions = []
         try space.clear()
         subscriptionStore = nil
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Analytics

--- a/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 @testable import Sync

--- a/PocketKit/Tests/PocketKitTests/ImageManagerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageManagerTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import Kingfisher
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
@@ -11,11 +11,13 @@ class ItemExtensionsTests: XCTestCase {
     var space: Space!
 
     override func setUp() {
+        super.setUp()
         space = .testSpace()
     }
 
     override func tearDownWithError() throws {
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func test_shouldOpenInWebView_andIsNotArticle_returnsTrue() throws {

--- a/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemsListItemPresenterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import Textile
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -21,6 +21,7 @@ class LoggedOutViewModelTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable>!
 
     override func setUp() {
+        super.setUp()
         authorizationClient = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token") { (_, _, completion) in
             self.mockAuthenticationSession.completionHandler = completion
             return self.mockAuthenticationSession
@@ -44,6 +45,7 @@ class LoggedOutViewModelTests: XCTestCase {
 
     override func tearDown() {
         subscriptions = []
+        super.tearDown()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import PocketKit
 import Combine

--- a/PocketKit/Tests/PocketKitTests/Notifications/InstantSyncTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/InstantSyncTests.swift
@@ -19,6 +19,7 @@ final class InstantSyncTests: XCTestCase {
     private var subject: InstantSync!
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         appSession = AppSession(keychain: MockKeychain(), groupID: "test")
         session = SharedPocketKit.Session(guid: "test-guid", accessToken: "test-access-token", userIdentifier: "test-id")

--- a/PocketKit/Tests/PocketKitTests/Notifications/InstantSyncTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/InstantSyncTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import PocketKit
 import Combine

--- a/PocketKit/Tests/PocketKitTests/Notifications/NotificationRelayTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/NotificationRelayTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import PocketKit
 

--- a/PocketKit/Tests/PocketKitTests/Notifications/NotificationRelayTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/NotificationRelayTests.swift
@@ -6,7 +6,6 @@ import XCTest
 @testable import PocketKit
 
 final class NotificationRelayTests: XCTestCase {
-
     func test_expected_bannerRequest_for_serverError() {
         let retainedRelayInstance = NotificationRelay(NotificationCenter.default)
 

--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -20,6 +20,7 @@ final class PushNotificationServiceTests: XCTestCase {
     private var subject: PushNotificationService!
 
     override func setUp() {
+        super.setUp()
         subscriptions = []
         source = MockSource()
         appSession = AppSession(keychain: MockKeychain(), groupID: "group.com.ideashower.ReadItLaterPro")

--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import PocketKit
 import Combine

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Analytics

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -22,6 +22,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         space = .testSpace()
@@ -38,6 +39,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         try space.clear()
         networkPathMonitor = nil
         subscriptionStore = nil
+        try await super.tearDown()
     }
 
     private func subject(

--- a/PocketKit/Tests/PocketKitTests/PocketURLsTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketURLsTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import SharedPocketKit
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 @testable import Sync

--- a/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Recomendation/RecomendationExtensionTests.swift
@@ -13,6 +13,7 @@ class RecomendationExtensionTests: XCTestCase {
     private var allowedCharset: CharacterSet!
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         space = .testSpace()
         allowedCharset = NSCharacterSet.urlHostAllowed
@@ -22,6 +23,7 @@ class RecomendationExtensionTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try space.clear()
+        try super.tearDownWithError()
     }
 
     // MARK: - Tests

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -81,7 +81,6 @@ class RecommendationViewModelTests: XCTestCase {
 
         // favorited, archived
         do {
-
             let item = space.buildItem(remoteID: "item-3", givenURL: URL(string: "https://example.com/items/item-2"))
             let recommendation = space.buildRecommendation(remoteID: "rec-3", item: item)
 

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Analytics
 import Combine

--- a/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendationViewModelTests.swift
@@ -21,6 +21,7 @@ class RecommendationViewModelTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable> = []
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         pasteboard = MockPasteboard()
@@ -34,6 +35,7 @@ class RecommendationViewModelTests: XCTestCase {
     override func tearDownWithError() throws {
         subscriptions = []
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -18,7 +18,8 @@ class HomeRefreshCoordinatorTests: XCTestCase {
     private var taskScheduler: MockBGTaskScheduler!
     private var userDefaults: UserDefaults!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         notificationCenter = NotificationCenter()
         userDefaults = UserDefaults()
         lastRefresh = UserDefaultsLastRefresh(defaults: userDefaults)

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Sync
 import Combine

--- a/PocketKit/Tests/PocketKitTests/Refresh/SavesRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/SavesRefreshCoordinatorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import BackgroundTasks
 

--- a/PocketKit/Tests/PocketKitTests/Refresh/SavesRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/SavesRefreshCoordinatorTests.swift
@@ -16,6 +16,7 @@ class SavesRefreshCoordinatorTests: XCTestCase {
     var appSession: AppSession!
 
     override func setUp() {
+        super.setUp()
         notificationCenter = NotificationCenter()
         taskScheduler = MockBGTaskScheduler()
         source = MockSource()

--- a/PocketKit/Tests/PocketKitTests/RouterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RouterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 @testable import Sync

--- a/PocketKit/Tests/PocketKitTests/RouterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RouterTests.swift
@@ -12,12 +12,14 @@ class RouterTests: XCTestCase {
     private var source: MockSource!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         source = MockSource()
         space = .testSpace()
     }
 
     override func tearDownWithError() throws {
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(source: Source? = nil) -> Router {

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -24,6 +24,7 @@ class SavedItemViewModelTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable> = []
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         pasteboard = MockPasteboard()
@@ -35,11 +36,12 @@ class SavedItemViewModelTests: XCTestCase {
         notificationCenter = .default
     }
 
-    override func tearDown() async throws {
+    override func tearDownWithError() throws {
         subscriptions = []
         try space.clear()
         networkPathMonitor = nil
         subscriptionStore = nil
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Analytics
 import Combine

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -29,6 +29,7 @@ class SavedItemsListViewModelTests: XCTestCase {
     var featureFlags: MockFeatureFlagService!
 
     override func setUp() {
+        try super.setUp()
         source = MockSource()
         tracker = MockTracker()
         featureFlags = MockFeatureFlagService()
@@ -80,6 +81,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         try space.save()
         networkPathMonitor = nil
         subscriptionStore = nil
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SavedItemsListViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import CoreData
 import Analytics

--- a/PocketKit/Tests/PocketKitTests/SceneTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SceneTrackerTests.swift
@@ -13,6 +13,7 @@ class SceneTrackerTests: XCTestCase {
     var sceneTracker: SceneTracker!
 
     override func setUp() {
+        super.setUp()
         userDefaults = UserDefaults()
         notificationCenter = NotificationCenter()
         tracker = MockTracker()
@@ -26,6 +27,7 @@ class SceneTrackerTests: XCTestCase {
     override func tearDown() {
         userDefaults.removeObject(forKey: SceneTracker.dateLastOpenedKey)
         userDefaults.removeObject(forKey: SceneTracker.dateLastBackgroundedKey)
+        super.tearDown()
     }
 
     // MARK: - AppOpen

--- a/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/OnlineSearchTests.swift
@@ -14,15 +14,17 @@ class OnlineSearchTests: XCTestCase {
     private var source: MockSource!
     private var searchService: MockSearchService!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         source = MockSource()
         searchService = MockSearchService()
         source.stubMakeSearchService { self.searchService }
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         source = nil
         searchService = nil
+        super.tearDown()
     }
 
     func subject(source: Source? = nil, scope: SearchScope? = nil) -> OnlineSearch {

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Analytics
 import SharedPocketKit

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
@@ -19,7 +19,8 @@ class PocketItemViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         userDefaults = UserDefaults(suiteName: "PocketItemViewModelTests")
@@ -36,6 +37,7 @@ class PocketItemViewModelTests: XCTestCase {
         try space.clear()
         networkPathMonitor = nil
         subscriptionStore = nil
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SavesLocalSearchTests.swift
@@ -14,7 +14,8 @@ class LocalSavesSearchTests: XCTestCase {
     private var user: MockUser!
     private var space: Space!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         source = MockSource()
         user = MockUser()
         space = .testSpace()
@@ -22,6 +23,7 @@ class LocalSavesSearchTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(source: Source? = nil) -> LocalSavesSearch {

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -25,6 +25,7 @@ class SearchViewModelTests: XCTestCase {
     private var notificationCenter: NotificationCenter!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         networkPathMonitor = MockNetworkPathMonitor()
         source = MockSource()
         tracker = MockTracker()
@@ -53,6 +54,7 @@ class SearchViewModelTests: XCTestCase {
         subscriptions = []
         subscriptionStore = nil
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/Settings/PremiumStatus/PremiumStatusViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Settings/PremiumStatus/PremiumStatusViewModelTests.swift
@@ -11,12 +11,14 @@ import XCTest
 class PremiumStatusViewModelTests: XCTestCase {
     var service: MockSubscriptionInfoService!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         service = MockSubscriptionInfoService()
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         service = nil
+        super.tearDown()
     }
     @MainActor
     func test_getInfoCalled() async {

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Analytics

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -21,6 +21,7 @@ class SlateDetailViewModelTests: XCTestCase {
     var userDefaults: UserDefaults!
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         space = .testSpace()
@@ -38,6 +39,7 @@ class SlateDetailViewModelTests: XCTestCase {
     override func tearDownWithError() throws {
         subscriptions = []
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
@@ -16,6 +16,7 @@ class SortMenuViewModelTests: XCTestCase {
     private var subscriptions: [AnyCancellable] = []
 
     override func setUp() {
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         listOptions = .saved(userDefaults: .standard)
@@ -24,6 +25,7 @@ class SortMenuViewModelTests: XCTestCase {
 
     override func tearDown() {
         subscriptions = []
+        super.tearDown()
     }
 
     private func subject(

--- a/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SortMenuViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Analytics
 import Combine

--- a/PocketKit/Tests/PocketKitTests/Support/FakeError.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/FakeError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 enum FakeError: Error {
     case error
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockAuthenticationSession.swift
@@ -1,5 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import PocketKit
 import AuthenticationServices
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class MockAuthenticationSession: AuthenticationSession {
     private var implementations: [String: Any] = [:]

--- a/PocketKit/Tests/PocketKitTests/Support/MockBGTaskScheduler.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockBGTaskScheduler.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import BackgroundTasks
 @testable import PocketKit
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockFeatureFlagService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockFeatureFlagService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SharedPocketKit
 import UIKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockImageDownloader.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockImageDownloader.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Kingfisher
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockImagesController.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockImagesController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 class MockImagesController: ImagesController {

--- a/PocketKit/Tests/PocketKitTests/Support/MockInstantSync.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockInstantSync.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SharedPocketKit
 import UIKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Localization
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockNetworkPathMonitor.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockNetworkPathMonitor.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Network
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockPasteboard.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPasteboard.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import PocketKit
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
@@ -45,6 +45,5 @@ extension MockPocketBraze {
     }
 
     func signedInUserDidBeginMigration() {
-
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Daniel Brooks on 9/23/22.
-//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
 import UserNotifications

--- a/PocketKit/Tests/PocketKitTests/Support/MockPushNotificationProtocol.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPushNotificationProtocol.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import SharedPocketKit
 @testable import PocketKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockSavedItemsController.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSavedItemsController.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Foundation
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Combine
 import SharedPocketKit

--- a/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSearchService.swift
@@ -8,8 +8,7 @@ import SharedPocketKit
 import PocketGraph
 
 class MockSearchService: SearchService {
-    @Published
-    var _results: [SearchSavedItem]? = []
+    @Published var _results: [SearchSavedItem]? = []
     var results: Published<[SearchSavedItem]?>.Publisher { $_results }
 
     public var hasFinishedResults: Bool = false

--- a/PocketKit/Tests/PocketKitTests/Support/MockSessionProvider.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSessionProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 class MockSessionProvider: SessionProvider {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,7 +8,6 @@ import CoreData
 import Combine
 
 class MockSource: Source {
-
     var _events: SyncEvents = SyncEvents()
     var events: AnyPublisher<SyncEvent, Never> {
         _events.eraseToAnyPublisher()

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Foundation
 import CoreData

--- a/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockUser.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SharedPocketKit
 import Combine
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockUserManagementService.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockUserManagementService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import PocketKit
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockV3Client.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockV3Client.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 extension PersistentContainer {

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import Sync
 

--- a/PocketKit/Tests/PocketKitTests/Support/UIAlertAction+invoke.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/UIAlertAction+invoke.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import UIKit
 
 extension UIAlertAction {

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -19,6 +19,7 @@ class TagsFilterViewModelTests: XCTestCase {
     private var user: MockUser!
 
     override func setUp() {
+        super.setUp()
         space = .testSpace()
         source = MockSource()
         tracker = MockTracker()
@@ -32,6 +33,7 @@ class TagsFilterViewModelTests: XCTestCase {
         source = nil
         subscriptions = []
         try space.clear()
+        try await super.tearDown()
     }
 
     private func subject(

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Textile

--- a/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import SaveToPocketKit
 

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -25,15 +25,17 @@ class SaveToAddTagsViewModelTests: XCTestCase {
     }
 
     override func setUp() {
+        super.setUp()
         tracker = MockTracker()
         user = MockUser()
         userDefaults = UserDefaults(suiteName: "SaveToAddTagsViewModelTests")
         space = .testSpace()
     }
 
-    override func tearDown() async throws {
+    override func tearDownWithError() throws {
         UserDefaults.standard.removePersistentDomain(forName: "SaveToAddTagsViewModelTests")
         try space.clear()
+        try super.tearDownWithError()
     }
 
     private func subject(

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Analytics

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Analytics
 import SharedPocketKit

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -40,6 +40,7 @@ class SavedItemViewModelTests: XCTestCase {
     }
 
     override func setUp() {
+        super.setUp()
         self.continueAfterFailure = false
 
         appSession = AppSession(keychain: MockKeychain(), groupID: "group.com.ideashower.ReadItLaterPro")
@@ -55,9 +56,10 @@ class SavedItemViewModelTests: XCTestCase {
         saveService.stubSave { _ in .newItem(savedItem) }
     }
 
-    override func tearDown() async throws {
+    override func tearDownWithError() throws {
         UserDefaults.standard.removePersistentDomain(forName: "SavedItemViewModelTests")
         try space.clear()
+        try super.tearDownWithError()
     }
 }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockExtensionContext.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import SaveToPocketKit
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockSaveService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Sync
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 extension PersistentContainer {

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/Space+factories.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import Sync
 

--- a/PocketKit/Tests/SharedPocketKitTests/KeychainStorageTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/KeychainStorageTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import SharedPocketKit
 

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import RNCryptor
 @testable import SharedPocketKit

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -36,6 +36,7 @@ class LegacyUserMigrationTests: XCTestCase {
     }
 
     override func setUp() {
+        super.setUp()
         groupID = "group.com.mozilla.test"
         userDefaults = UserDefaults(suiteName: "LegacyUserMigrationTests")
         encryptedStore = MockEncryptedStore()
@@ -45,6 +46,7 @@ class LegacyUserMigrationTests: XCTestCase {
 
     override func tearDown() {
         UserDefaults.standard.removePersistentDomain(forName: "LegacyUserMigrationTests")
+        super.tearDown()
     }
 }
 

--- a/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import SharedPocketKit
 

--- a/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/PocketUserTests.swift
@@ -8,12 +8,14 @@ import XCTest
 class PocketUserTests: XCTestCase {
     private var userDefaults: UserDefaults!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         userDefaults = UserDefaults(suiteName: "PocketUserTests")
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         userDefaults.resetKeys()
+        super.tearDown()
     }
 
     func subject(

--- a/PocketKit/Tests/SharedPocketKitTests/RecentTagProviderTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/RecentTagProviderTests.swift
@@ -8,13 +8,15 @@ import XCTest
 class RecentTagProviderTests: XCTestCase {
     private var userDefaults: UserDefaults!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         userDefaults = UserDefaults(suiteName: "PocketUserTests")
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         // Is this better than removing the suite?
         userDefaults.resetKeys()
+        super.tearDown()
     }
 
     func subject(

--- a/PocketKit/Tests/SharedPocketKitTests/SessionBackupUtilityTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/SessionBackupUtilityTests.swift
@@ -12,6 +12,7 @@ class SessionBackupUtilityTests: XCTestCase {
     var notificationCenter: NotificationCenter!
 
     override func setUp() {
+        super.setUp()
         userDefaults = UserDefaults(suiteName: "SessionBackupUtilityTests")!
         userDefaults.removePersistentDomain(forName: "SessionBackupUtilityTests")
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -14,6 +14,7 @@ class APISlateServiceTests: XCTestCase {
     var space: Space!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         apollo = MockApolloClient()

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import Apollo

--- a/PocketKit/Tests/SyncTests/ArticleComponents/ArticleTests.swift
+++ b/PocketKit/Tests/SyncTests/ArticleComponents/ArticleTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import PocketGraph
 import ApolloAPI

--- a/PocketKit/Tests/SyncTests/MockExpiringActivityPerformer.swift
+++ b/PocketKit/Tests/SyncTests/MockExpiringActivityPerformer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 class MockExpiringActivityPerformer: ExpiringActivityPerformer {

--- a/PocketKit/Tests/SyncTests/OEmbedServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/OEmbedServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 @testable import Sync

--- a/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
+++ b/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
@@ -11,6 +11,7 @@ class OSNotificationCenterTests: XCTestCase {
     var cfCenter: CFNotificationCenter!
 
     override func setUp() {
+        super.setUp()
         cfCenter = CFNotificationCenterGetDarwinNotifyCenter()
     }
 

--- a/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
+++ b/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Foundation
 

--- a/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
@@ -19,6 +19,7 @@ class ItemMutationOperationTests: XCTestCase {
     var task: PersistentSyncTask!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         apollo = MockApolloClient()
         space = .testSpace()
         queue = OperationQueue()
@@ -31,6 +32,7 @@ class ItemMutationOperationTests: XCTestCase {
     override func tearDownWithError() throws {
         subscriptions = []
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject<Mutation: GraphQLMutation>(

--- a/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/ItemMutationOperationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import ApolloAPI

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -15,6 +15,7 @@ class RetriableOperationTests: XCTestCase {
     var task: PersistentSyncTask!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         retrySignal = .init()
         backgroundTaskManager = MockBackgroundTaskManager()
         space = .testSpace()

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import CoreData
 import Combine

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import PocketGraph

--- a/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/SaveItemOperationTests.swift
@@ -19,6 +19,7 @@ class SaveItemOperationTests: XCTestCase {
     var task: PersistentSyncTask!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         apollo = MockApolloClient()
         space = .testSpace()
         queue = OperationQueue()
@@ -31,6 +32,7 @@ class SaveItemOperationTests: XCTestCase {
     override func tearDownWithError() throws {
         subscriptions = []
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import PocketGraph

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -14,7 +14,8 @@ class PocketSaveServiceTests: XCTestCase {
     private var space: Space!
     private var osNotificationCenter: OSNotificationCenter!
 
-    override func setUp() async throws {
+    override func setUp() {
+        super.setUp()
         backgroundActivityPerformer = MockExpiringActivityPerformer()
         client = MockApolloClient()
         space = .testSpace()
@@ -24,6 +25,7 @@ class PocketSaveServiceTests: XCTestCase {
     override func tearDownWithError() throws {
         try space.clear()
         osNotificationCenter.removeAllObservers()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import PocketGraph
 @testable import Sync

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+restoringOperations.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import PocketGraph
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -713,7 +713,6 @@ extension PocketSourceTests {
     }
 
     func test_fetchOrCreateSavedItem_retrievesItem() throws {
-
         let itemParts = SavedItemParts(
             url: "http://localhost:8080/hello",
             remoteID: "saved-item",

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -27,7 +27,8 @@ class PocketSourceTests: XCTestCase {
     var userService: MockUserService!
     var featureFlagService: MockFeatureFlagService!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         space = .testSpace()
         user = MockUser()
         user.stubStandardSetStatus()
@@ -54,6 +55,7 @@ class PocketSourceTests: XCTestCase {
         try space.clear()
         subscriptions = []
         osNotificationCenter.removeAllObservers()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 @testable import Sync

--- a/PocketKit/Tests/SyncTests/SpaceTests.swift
+++ b/PocketKit/Tests/SyncTests/SpaceTests.swift
@@ -12,12 +12,14 @@ class SpaceTests: XCTestCase {
     var backgroundContext: NSManagedObjectContext!
 
     override func setUp() {
+        super.setUp()
         viewContext = PersistentContainer.testContainer.viewContext
         backgroundContext = PersistentContainer.testContainer.newBackgroundContext()
     }
 
     override func tearDownWithError() throws {
         try Space.testSpace().clear()
+        try super.tearDownWithError()
     }
 
     func subject() -> Space {

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -24,6 +24,7 @@ class FetchSavesTests: XCTestCase {
     var task: PersistentSyncTask!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         apollo = MockApolloClient()
         user = MockUser()
         events = PassthroughSubject()
@@ -39,6 +40,7 @@ class FetchSavesTests: XCTestCase {
     override func tearDownWithError() throws {
         cancellables = []
         try space.clear()
+        try super.tearDownWithError()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Combine
 import CoreData

--- a/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import CoreData
 import Apollo

--- a/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchUserDataTests.swift
@@ -15,7 +15,8 @@ class FetchUserTests: XCTestCase {
     var apollo: MockApolloClient!
     var user: MockUser!
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         apollo = MockApolloClient()
         user = MockUser()
     }

--- a/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockApolloClient+stubs.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import ApolloAPI

--- a/PocketKit/Tests/SyncTests/Support/MockBackgroundTaskManager.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockBackgroundTaskManager.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 import Foundation
 

--- a/PocketKit/Tests/SyncTests/Support/MockFeatureFlagService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockFeatureFlagService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 class MockFeatureFlagService: FeatureFlagLoadingService {

--- a/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
@@ -5,7 +5,6 @@
 @testable import SharedPocketKit
 
 class MockLastRefresh: LastRefresh {
-
     // MARK: - lastRefresh saves
     typealias GetLastRefreshSavesImpl = () -> Double?
     private var getLastRefreshSavesImpl: GetLastRefreshSavesImpl?

--- a/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import SharedPocketKit
 
 class MockLastRefresh: LastRefresh {

--- a/PocketKit/Tests/SyncTests/Support/MockNetworkPathMonitor.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockNetworkPathMonitor.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 import Network
 

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Apollo
 import ApolloAPI

--- a/PocketKit/Tests/SyncTests/Support/MockSessionProvider.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockSessionProvider.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Sync
 
 class MockSessionProvider: SessionProvider {

--- a/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 class MockSlateService: SlateService {

--- a/PocketKit/Tests/SyncTests/Support/MockUser.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUser.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import SharedPocketKit
 import Combine
 

--- a/PocketKit/Tests/SyncTests/Support/MockUserService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockUserService.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 
 class MockUserService: UserService {

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import CoreData
 
 @testable import Sync

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Apollo
 import PocketGraph

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -14,12 +14,14 @@ class PocketSearchServiceTests: XCTestCase {
     var apollo: MockApolloClient!
     var cancellables: [AnyCancellable] = []
 
-    override func setUpWithError() throws {
+    override func setUp() {
+        super.setUp()
         apollo = MockApolloClient()
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         cancellables = []
+        super.tearDown()
     }
 
     func subject(

--- a/PocketKit/Tests/SyncTests/Support/ResponseCodeError+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/ResponseCodeError+factories.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Apollo
 import Foundation
 

--- a/PocketKit/Tests/SyncTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/SyncTests/Support/Space+factories.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/Support/TestError.swift
+++ b/PocketKit/Tests/SyncTests/Support/TestError.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 enum TestError: Error {
     case anError
 }

--- a/PocketKit/Tests/SyncTests/Support/TestSavedItemsControllerDelegate.swift
+++ b/PocketKit/Tests/SyncTests/Support/TestSavedItemsControllerDelegate.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 import CoreData
 import Sync

--- a/PocketKit/Tests/SyncTests/Support/TestSyncOperation.swift
+++ b/PocketKit/Tests/SyncTests/Support/TestSyncOperation.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @testable import Sync
 import CoreData
 

--- a/PocketKit/Tests/SyncTests/Support/removeWhitespace.swift
+++ b/PocketKit/Tests/SyncTests/Support/removeWhitespace.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 func removeWhitespace(_ data: Data?) -> String? {

--- a/PocketKit/Tests/SyncTests/V3/V3ClientTests.swift
+++ b/PocketKit/Tests/SyncTests/V3/V3ClientTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import Sync
 

--- a/PocketKit/Tests/SyncTests/V3/V3ClientTests.swift
+++ b/PocketKit/Tests/SyncTests/V3/V3ClientTests.swift
@@ -17,6 +17,7 @@ final class V3ClientTests: XCTestCase {
     var session: MockSession!
 
     override func setUp() {
+        try super.setUp()
         urlSession = MockURLSession()
         session = MockSession()
         sessionProvider = MockSessionProvider(session: session)

--- a/PocketKit/Tests/SyncTests/VIDExtracorTests.swift
+++ b/PocketKit/Tests/SyncTests/VIDExtracorTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 @testable import Sync
 

--- a/Sources/DangerDependencies/Fake.swift
+++ b/Sources/DangerDependencies/Fake.swift
@@ -1,1 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 // An empty file to allow the DangerDependencies target to build via SPM

--- a/Tests iOS/AddTagsItemTests.swift
+++ b/Tests iOS/AddTagsItemTests.swift
@@ -11,6 +11,7 @@ class AddTagsItemTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -31,6 +32,7 @@ class AddTagsItemTests: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertNoBadEvents()
+        try await super.tearDown()
     }
 
     @MainActor

--- a/Tests iOS/ArchiveAnItemTests.swift
+++ b/Tests iOS/ArchiveAnItemTests.swift
@@ -10,6 +10,7 @@ class ArchiveAnItemTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -22,6 +23,7 @@ class ArchiveAnItemTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_archivingAnItemFromList_removesItFromList_andSyncsWithServer() {

--- a/Tests iOS/DeleteAnItemTests.swift
+++ b/Tests iOS/DeleteAnItemTests.swift
@@ -10,6 +10,7 @@ class DeleteAnItemTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -22,6 +23,7 @@ class DeleteAnItemTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_deletingAnItemFromList_removesItFromList_andSyncsWithServer() {

--- a/Tests iOS/EditTagsTests.swift
+++ b/Tests iOS/EditTagsTests.swift
@@ -11,6 +11,7 @@ class EditTagsTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
         let uiApp = XCUIApplication()
         app = PocketAppElement(app: uiApp)
@@ -30,6 +31,7 @@ class EditTagsTests: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     @MainActor

--- a/Tests iOS/ErrorTests.swift
+++ b/Tests iOS/ErrorTests.swift
@@ -12,6 +12,7 @@ class ErrorTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -37,6 +38,7 @@ class ErrorTests: XCTestCase {
         app.terminate()
         try server.stop()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     func test_serverError_banner_for_throttled_user() {

--- a/Tests iOS/FavoriteAnItemTests.swift
+++ b/Tests iOS/FavoriteAnItemTests.swift
@@ -12,6 +12,7 @@ class FavoriteAnItemTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -32,6 +33,7 @@ class FavoriteAnItemTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_favoritingAndUnfavoritingAnItemFromList_showsFavoritedIcon_andSyncsWithServer() {

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -12,6 +12,7 @@ class HomeTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -37,6 +38,7 @@ class HomeTests: XCTestCase {
         app.terminate()
         try server.stop()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     @MainActor

--- a/Tests iOS/HomeWebViewTests.swift
+++ b/Tests iOS/HomeWebViewTests.swift
@@ -11,6 +11,7 @@ class HomeWebViewTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -58,6 +59,7 @@ class HomeWebViewTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_home_showsWebViewWhenItemIsImage() {

--- a/Tests iOS/MyList/ArchiveFiltersTests.swift
+++ b/Tests iOS/MyList/ArchiveFiltersTests.swift
@@ -13,6 +13,7 @@ class ArchiveFiltersTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -33,6 +34,7 @@ class ArchiveFiltersTests: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     func test_archiveView_tappingFavoritesPill_togglesDisplayingFavoritedArchivedContent() {

--- a/Tests iOS/MyList/ArchiveTests.swift
+++ b/Tests iOS/MyList/ArchiveTests.swift
@@ -10,6 +10,8 @@ class ArchiveTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
+
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -26,6 +28,7 @@ class ArchiveTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_archiveView_displaysArchivedContent() {

--- a/Tests iOS/MyList/CoreSpotlightTests.swift
+++ b/Tests iOS/MyList/CoreSpotlightTests.swift
@@ -12,6 +12,7 @@ class CoreSpotlightTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -29,6 +30,7 @@ class CoreSpotlightTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_openingCoreSpotlightItem_OpensToDetail() {

--- a/Tests iOS/MyList/CoreSpotlightTests.swift
+++ b/Tests iOS/MyList/CoreSpotlightTests.swift
@@ -38,5 +38,4 @@ class CoreSpotlightTests: XCTestCase {
         app.saves.itemView(at: 0).wait()
         app.terminate()
     }
-
 }

--- a/Tests iOS/MyList/EmptyStateTests.swift
+++ b/Tests iOS/MyList/EmptyStateTests.swift
@@ -10,6 +10,7 @@ class EmptyStateTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -27,6 +28,7 @@ class EmptyStateTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func testSavesAndArchive_showsEmptyStateView() {

--- a/Tests iOS/MyList/ListenTests.swift
+++ b/Tests iOS/MyList/ListenTests.swift
@@ -15,6 +15,7 @@ class ListenTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -35,6 +36,7 @@ class ListenTests: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertNoBadEvents()
+        try await super.tearDown()
     }
 
     func test_listen_shows_whenInFlag() {

--- a/Tests iOS/MyList/SavesFiltersTests.swift
+++ b/Tests iOS/MyList/SavesFiltersTests.swift
@@ -13,6 +13,7 @@ class SavesFiltersTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -30,9 +31,10 @@ class SavesFiltersTests: XCTestCase {
 
     @MainActor
     override func tearDown() async throws {
-       try server.stop()
-       app.terminate()
-       await snowplowMicro.assertBaselineSnowplowExpectation()
+        try server.stop()
+        app.terminate()
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     func test_savesView_tappingFavoritesPill_showsOnlyFavoritedItems() {

--- a/Tests iOS/MyList/SavesTests.swift
+++ b/Tests iOS/MyList/SavesTests.swift
@@ -13,6 +13,7 @@ class SavesTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -81,6 +82,7 @@ class SavesTests: XCTestCase {
         try server.stop()
         await snowplowMicro.assertBaselineSnowplowExpectation()
         app.terminate()
+        try await super.tearDown()
     }
 
     func test_savingAnItemFromShareExtension_addsItemToList() {

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -12,6 +12,7 @@ class SearchTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -27,9 +28,10 @@ class SearchTests: XCTestCase {
 
     @MainActor
     override func tearDown() async throws {
-       try server.stop()
-       app.terminate()
-       await snowplowMicro.assertBaselineSnowplowExpectation()
+        try server.stop()
+        app.terminate()
+        await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     // MARK: - Saves: Search

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -14,6 +14,7 @@ class PremiumTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
         storeSession = try SKTestSession(configurationFileNamed: "Test_Subscriptions")
         storeSession.resetToDefaultState()
@@ -32,6 +33,7 @@ class PremiumTests: XCTestCase {
         storeSession.resetToDefaultState()
         storeSession = nil
         app.terminate()
+        try super.tearDownWithError()
     }
 
     /// Test that tapping "Go Premium" in Settings presents the Premium Upgrade view

--- a/Tests iOS/PremiumTests.swift
+++ b/Tests iOS/PremiumTests.swift
@@ -35,21 +35,24 @@ class PremiumTests: XCTestCase {
     }
 
     /// Test that tapping "Go Premium" in Settings presents the Premium Upgrade view
-    @MainActor func test_tapSettingsUpsellShowsUpgradeView() async {
+    @MainActor
+    func test_tapSettingsUpsellShowsUpgradeView() async {
         configureFreeUser()
         app.launch()
         await loadPremiumUpgradeViewFromSettings()
         await snowplowMicro.assertBaselineSnowplowExpectation()
     }
 
-    @MainActor func test_tapSearchPremiumUpsellShowsUpgradeView() async {
+    @MainActor
+    func test_tapSearchPremiumUpsellShowsUpgradeView() async {
         configureFreeUser()
         app.launch()
         await loadPremiumUpgradeViewFromSearch()
     }
 
     /// Test that Premium Upgrade view dismisses when tapping the dismiss button
-    @MainActor func test_tapDismissDismissPremiumView() async {
+    @MainActor
+    func test_tapDismissDismissPremiumView() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -64,7 +67,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Test that monthly button tapped triggers the right event
-    @MainActor func test_monthlyButtonTapped() async {
+    @MainActor
+    func test_monthlyButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -78,7 +82,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Test that annual button tapped triggers the right event
-    @MainActor func test_annualButtonTapped() async {
+    @MainActor
+    func test_annualButtonTapped() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -92,7 +97,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Test that purchase monthly subscription succeeds
-    @MainActor func test_purchaseMonthlySubscriptionSuccess() async {
+    @MainActor
+    func test_purchaseMonthlySubscriptionSuccess() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -108,7 +114,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Test that purchase annual subscription succeeds
-    @MainActor func test_purchaseAnnualSubscriptionSuccess() async {
+    @MainActor
+    func test_purchaseAnnualSubscriptionSuccess() async {
         // Given
         configureFreeUser()
         app.launch()
@@ -124,7 +131,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Set user to free
-    @MainActor private func configureFreeUser() {
+    @MainActor
+    private func configureFreeUser() {
         server.routes.post("/graphql") { request, _ -> Response in
             let apiRequest = ClientAPIRequest(request)
             if apiRequest.isForSavesContent {
@@ -135,7 +143,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Load premium upgrade view from Settings
-    @MainActor private func loadPremiumUpgradeViewFromSettings() async {
+    @MainActor
+    private func loadPremiumUpgradeViewFromSettings() async {
         app.tabBar.settingsButton.wait().tap()
         XCTAssertTrue(app.settingsView.exists)
 
@@ -155,7 +164,8 @@ class PremiumTests: XCTestCase {
     }
 
     /// Load premium upgrade view from Saves > Search > All Items
-    @MainActor private func loadPremiumUpgradeViewFromSearch() async {
+    @MainActor
+    private func loadPremiumUpgradeViewFromSearch() async {
         app.tabBar.savesButton.wait().tap()
         app.saves.element.swipeDown()
         app.navigationBar.searchFields["Search"].wait().tap()

--- a/Tests iOS/PullToRefreshTests.swift
+++ b/Tests iOS/PullToRefreshTests.swift
@@ -10,6 +10,7 @@ class PullToRefreshTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -22,6 +23,7 @@ class PullToRefreshTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_saves_pullToRefresh_fetchesNewContent() {

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -11,6 +11,7 @@ class ReaderTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -45,6 +46,7 @@ class ReaderTests: XCTestCase {
         app.terminate()
         await snowplowMicro.assertBaselineSnowplowExpectation()
         try server.stop()
+        try await super.tearDown()
     }
 
     func test_tappingSaves_dismissesReader_andShowsSaves() {

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -11,14 +11,12 @@ class ReportARecommendationTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
-        await snowplowMicro.resetSnowplowEvents()
-    }
-
-    override func setUpWithError() throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
         app = PocketAppElement(app: uiApp)
+        await snowplowMicro.resetSnowplowEvents()
 
         server = Application()
 
@@ -29,11 +27,13 @@ class ReportARecommendationTests: XCTestCase {
         try server.start()
 
         app.launch()
+        try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     @MainActor

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Sails
 

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -25,9 +25,6 @@ class ReportARecommendationTests: XCTestCase {
         }
 
         try server.start()
-
-        app.launch()
-        try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
@@ -38,6 +35,7 @@ class ReportARecommendationTests: XCTestCase {
 
     @MainActor
     func test_reportingARecommendationfromHero_asBrokenMeta_sendsEvent() async {
+        app.launch()
         app.homeView
             .recommendationCell("Slate 1, Recommendation 1")
             .overflowButton.wait().tap()
@@ -62,6 +60,7 @@ class ReportARecommendationTests: XCTestCase {
 
     @MainActor
     func test_reportingARecommendationFromCarousel_asBrokenMeta_sendsEvent() async {
+        app.launch()
         let coordinateToScroll = app.homeView
             .recommendationCell("Slate 1, Recommendation 1")
             .element.coordinate(
@@ -99,6 +98,7 @@ class ReportARecommendationTests: XCTestCase {
 
     @MainActor
     func test_reportingARecommendation_fromReader_showsReportView() async {
+        app.launch()
         app.homeView
             .recommendationCell("Slate 1, Recommendation 1")
             .wait()

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -10,6 +10,7 @@ class SaveToPocketTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         self.continueAfterFailure = false
 
         server = Application()
@@ -35,6 +36,7 @@ class SaveToPocketTests: XCTestCase {
         app.terminate()
         let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
         reminders.terminate()
+        try super.tearDownWithError()
     }
 
     func test_whenLoggedOut_userTapsLogIn_opensApp() {

--- a/Tests iOS/SaveToPocketTests.swift
+++ b/Tests iOS/SaveToPocketTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 import Sails
 

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -187,8 +187,8 @@ class SettingsTest: XCTestCase {
         XCTAssertTrue(app.deleteConfirmationView.deleteAccountButton.isEnabled)
     }
 
-    @MainActor
     /// Helper to load and assert the basics of the delete confirmation view
+    @MainActor
     func loadDeleteConfirmationView() async {
         await tapSettings()
         await tap_AccountManagement()

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -12,6 +12,7 @@ class SettingsTest: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         app = PocketAppElement(app: XCUIApplication())
@@ -26,6 +27,7 @@ class SettingsTest: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     @MainActor

--- a/Tests iOS/ShareAnItemTests.swift
+++ b/Tests iOS/ShareAnItemTests.swift
@@ -10,6 +10,7 @@ class ShareAnItemTests: XCTestCase {
     var app: PocketAppElement!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
 
         let uiApp = XCUIApplication()
@@ -29,6 +30,7 @@ class ShareAnItemTests: XCTestCase {
     override func tearDownWithError() throws {
         try server.stop()
         app.terminate()
+        try super.tearDownWithError()
     }
 
     func test_sharingAnItemFromList_presentsShareSheet() {

--- a/Tests iOS/SignOutTests.swift
+++ b/Tests iOS/SignOutTests.swift
@@ -11,6 +11,7 @@ class SignOutTests: XCTestCase {
     var snowplowMicro = SnowplowMicro()
 
     override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
 
         app = PocketAppElement(app: XCUIApplication())
@@ -28,6 +29,7 @@ class SignOutTests: XCTestCase {
         try server.stop()
         app.terminate()
         await snowplowMicro.assertBaselineSnowplowExpectation()
+        try await super.tearDown()
     }
 
     @MainActor

--- a/Tests iOS/Support/Elements/ItemRowElement.swift
+++ b/Tests iOS/Support/Elements/ItemRowElement.swift
@@ -15,8 +15,6 @@ struct ItemRowElement: PocketUIElement {
         element
             .staticTexts
             .matching(NSPredicate(format: "label CONTAINS %@", string))
-            // Ignoring the next empty count because of https://github.com/realm/SwiftLint/issues/2012
-            // swiftlint:disable:next empty_count
             .firstMatch
             .wait()
             .exists

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -188,7 +188,6 @@ struct PocketAppElement {
 /// Listen
 /// Hacky helper extenstion until we add accessibility identifier helpers to Listen
 extension PocketAppElement {
-
     var listenPlay: XCUIElement {
         app.buttons["Play"]
     }
@@ -197,5 +196,4 @@ extension PocketAppElement {
     var listenList: XCUIElement {
         app.collectionViews.element(boundBy: 0)
     }
-
 }

--- a/Tests iOS/Support/Elements/ReportViewElement.swift
+++ b/Tests iOS/Support/Elements/ReportViewElement.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 struct ReportViewElement: PocketUIElement {

--- a/Tests iOS/Support/Elements/SlateDetailElement.swift
+++ b/Tests iOS/Support/Elements/SlateDetailElement.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 struct SlateDetailElement: PocketUIElement {

--- a/Tests iOS/Support/Elements/TabBarElement.swift
+++ b/Tests iOS/Support/Elements/TabBarElement.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 struct TabBarElement: PocketUIElement {

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -138,7 +138,6 @@ struct ClientAPIRequest {
 }
 
 extension ClientAPIRequest {
-
     var variableItemId: String {
         self.apolloRequestBody!.variableDict["itemID"] as! String
     }

--- a/Tests iOS/Support/String+Localization.swift
+++ b/Tests iOS/Support/String+Localization.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import Foundation
 
 extension String {

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import XCTest
 
 extension XCTestCase {


### PR DESCRIPTION
## Summary
Update our SwiftLint rules:
- redundant_string_enum_value
- file_header
- overridden_super_call (address issues in tests)

Fix some SwiftLint configurations by moving appropriate rules to `analyzer_rules`

## References 
N / A 

## Implementation Details
* Add two rules `redundant_string_enum_value` and `file_header` see warnings addressed in separate commits
* Address issues with `overridden_super_call` to match closely with Firefox's SwiftLint file
* Fix SwiftLint configurations and address remaining warnings after upgrading SwiftLint versions

## Test Steps
Build and run app as expected. All issues should be addressed and project should work normally.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
