### PR TITLE
refactor(saveto): improve link extraction when sharing to pocket

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -996,7 +996,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1055,7 +1055,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
@@ -1083,7 +1083,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1113,7 +1113,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1138,7 +1138,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1163,7 +1163,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1195,7 +1195,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1227,7 +1227,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1289,7 +1289,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
@@ -1317,7 +1317,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1343,7 +1343,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1375,7 +1375,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1408,7 +1408,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1440,7 +1440,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1508,7 +1508,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1537,7 +1537,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1563,7 +1563,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1594,7 +1594,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1627,7 +1627,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1658,7 +1658,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterProAlphaNeue.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1689,7 +1689,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1720,7 +1720,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1788,7 +1788,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1817,7 +1817,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1842,7 +1842,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1873,7 +1873,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1906,7 +1906,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1937,7 +1937,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1969,7 +1969,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2002,7 +2002,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.2;
+				MARKETING_VERSION = 8.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SavedItemsList/SavedItem+ItemsListItem.swift
@@ -20,7 +20,8 @@ extension SavedItem: ItemsListItem {
     }
 
     var displayTitle: String {
-        item?.title ?? item?.bestURL.absoluteString ?? url.absoluteString
+        let itemTitle = item?.title?.isEmpty == false ? item?.title : nil
+        return itemTitle ?? item?.bestURL.absoluteString ?? url.absoluteString
     }
 
     var displayDomain: String? {

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -150,45 +150,11 @@ extension SavedItemViewModel {
         }
 
         for provider in providers {
-            let plainTextUTI = "public.plain-text"
-            let urlUTI = "public.url"
-
-            if provider.hasItemConformingToTypeIdentifier(plainTextUTI) {
-                guard let string = try? await provider.loadItem(forTypeIdentifier: plainTextUTI, options: nil) as? String,
-                      let url = retrieveURLFromString(with: string) else {
-                    continue
-                }
-
-                return url
-            } else if provider.hasItemConformingToTypeIdentifier(urlUTI) {
-                guard let url = try? await provider.loadItem(forTypeIdentifier: urlUTI, options: nil) as? URL else {
-                    continue
-                }
-
-                return url
-            } else {
-                continue
+            if let url = await URLExtractor.url(from: provider) {
+                return URL(string: url)
             }
         }
 
-        return nil
-    }
-
-    /// Modified from https://www.hackingwithswift.com/example-code/strings/how-to-detect-a-url-in-a-string-using-nsdatadetector
-    /// - Parameter inputString: string input used to search for a URL
-    /// - Returns: URL found within the string
-    private func retrieveURLFromString(with inputString: String) -> URL? {
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
-            Log.capture(message: "Unable to initialize detector")
-            return nil
-        }
-        let matches = detector.matches(in: inputString, options: [], range: NSRange(location: 0, length: inputString.utf16.count))
-
-        for match in matches {
-            guard let range = Range(match.range, in: inputString) else { continue }
-            let string = String(inputString[range])
-            return URL(string: string)
-        }
         return nil
     }
 }

--- a/PocketKit/Sources/SaveToPocketKit/URLExtractor.swift
+++ b/PocketKit/Sources/SaveToPocketKit/URLExtractor.swift
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SharedPocketKit
+
+enum URLExtractor {
+    static func url(from itemProvider: ItemProvider) async -> String? {
+        if itemProvider.hasItemConformingToTypeIdentifier("public.url") { // We're handed a URL
+            guard let url = try? await itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil) as? URL else {
+                Log.capture(message: "Unable to load URL from itemProvider")
+                return nil
+            }
+
+            return firstURL(in: url)
+        } else if itemProvider.hasItemConformingToTypeIdentifier("public.plain-text") { // We're handed a URL String
+            guard let string = try? await itemProvider.loadItem(forTypeIdentifier: "public.plain-text", options: nil) as? String else {
+                Log.capture(message: "Unable to load String from itemProvider")
+                return nil
+            }
+
+            if let firstURL = firstURL(in: string), let url = URL(string: firstURL) {
+                return self.firstURL(in: url)
+            }
+
+            Log.capture(message: "Unable to parse URL from from itemProvider String")
+            return nil
+        }
+
+        return nil
+    }
+
+    private static func isValidScheme(_ scheme: String) -> Bool {
+        let validSchemes = ["http", "https", "file", "ftp"]
+        return validSchemes.contains(scheme)
+    }
+
+    /// Returns the first URL found within a String, if one exists. Otherwise, nil. See Discussion
+    /// for example string arguments and their outputs.
+    ///
+    /// Example: "https://getpocket.com" -> "https://getpocket.com"
+    ///
+    /// Example: "foo=bar&url=https://getpocket.com" -> "https://getpocket.com"
+    ///
+    /// Example: "foo=bar" -> nil
+    /// - Parameters:
+    ///     - string: The string from which to search for a URL
+    private static func firstURL(in string: String) -> String? {
+        guard let string = string.removingPercentEncoding, let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            Log.capture(message: "FirstURL setup failed")
+            return nil
+        }
+
+        let matches = detector.matches(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count))
+
+        for match in matches {
+            guard let range = Range(match.range, in: string) else { continue }
+            let string = String(string[range])
+            return string
+        }
+
+        Log.breadcrumb(category: "urlExtractor", level: .warning, message: "Unable to find URL in \(string)")
+        return nil
+    }
+
+    /// Returns the first URL found within a URL, if one exists. Otherwise, nil.
+    ///
+    /// This is an overloaded function complementing firstURL(in:) that accepts a String.
+    /// This function will first check if the URL is one of [http, https, file, ftp]
+    /// and return the URL if so, otherwise the URL is "invalid". If invalid, the URL
+    /// will return the result of calling firstURL(in:) with the absolute string of the remaining URL.
+    ///
+    /// An example of an "invalid" URL from which a link should attempt to be extracted from
+    /// is something akin to "com.mozilla.pocket://save?url=https://getpocket.com", which would
+    /// return "https://getpocket.com" as the URL.
+    ///
+    /// - Parameters:
+    ///     - string: The string from which to search for a URL
+    private static func firstURL(in url: URL) -> String? {
+        guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            Log.capture(message: "Unable to generate URLComponents")
+            return nil
+        }
+
+        // If the scheme is one of: http, https, file, ftp, return the original URL,
+        // else, validly mangle the original (by removing the original scheme) to attempt to extract a new URL from
+        if let scheme = urlComponents.scheme, isValidScheme(scheme) == true {
+            return url.absoluteString
+        }
+
+        // Hacky way of removing the original scheme so that the first link present in its full path / query items
+        // can be used as the URL to save
+        urlComponents.scheme = nil
+
+        guard let inputString = urlComponents.string else {
+            Log.capture(message: "Unable to read URLComponents as String")
+            return nil
+        }
+
+        return firstURL(in: inputString)
+    }
+}

--- a/PocketKit/Tests/SaveToPocketKitTests/URLExtractorTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/URLExtractorTests.swift
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+@testable import SaveToPocketKit
+
+class URLExtractorTests: XCTestCase {
+    func test_extract_whenItemProviderHasURL_returnsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.url"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            URL(string: "https://getpocket.com")! as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+
+        itemProvider.stubLoadItem { _, _ in
+            URL(string: "https%3a%2f%2fgetpocket.com")! as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+    }
+
+    func test_extract_whenItemProviderHasExternalAppURL_returnsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.url"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            // TODO: Funky percent-encoded mumbojumbo
+            URL(string: "com.mozilla.pocket://save?url=https://getpocket.com?foo=bar")! as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com?foo=bar")
+
+        itemProvider.stubLoadItem { _, _ in
+            // TODO: Funky percent-encoded mumbojumbo
+            URL(string: "com.mozilla.pocket://save?url=https%3a%2f%2fgetpocket.com?foo=bar")! as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com?foo=bar")
+    }
+
+    func test_extract_whenItemProviderHasExternalAppURLWithNoFollowingURL_returnsNil() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.url"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            URL(string: "com.mozilla.pocket://save?this-is-not-a-url")! as NSSecureCoding
+        }
+
+        let extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertNil(extracted)
+    }
+
+    func test_extract_whenItemProviderHasString_containingOnlyURL_returnsStringAsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.plain-text"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            "https://getpocket.com" as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+
+        itemProvider.stubLoadItem { _, _ in
+            "https%3a%2f%2fgetpocket.com" as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+    }
+
+    func test_extract_whenItemProviderHasString_containingStringAndURL_returnsStringAsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.plain-text"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            "Hello, world. https://getpocket.com" as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+
+        itemProvider.stubLoadItem { _, _ in
+            "Hello, world. https%3a%2f%2fgetpocket.com" as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+    }
+
+    func test_extract_whenItemProviderHasStringAndExternalAppURL_returnsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.plain-text"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            "com.mozilla.pocket://save?url=https://getpocket.com" as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+
+        itemProvider.stubLoadItem { _, _ in
+            "com.mozilla.pocket://save?url=https%3a%2f%2fgetpocket.com%3Ffoo%3Dbar" as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com?foo=bar")
+    }
+
+    func test_extract_whenItemProviderHasString_containingStringAndNoURL_returnsNil() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.plain-text"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            "Hello, world." as NSSecureCoding
+        }
+
+        let extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertNil(extracted)
+    }
+}


### PR DESCRIPTION
## Summary

Improves link extraction when sharing from certain apps that may share a deep-link into their app (like Ivory).

## References 

IN-1469

## Implementation Details

- If the shared item is a URL
  - If the URL is http(s), use the URL
  - If the URL is not, attempt to find the first included link that _is_ http(s)
- If the shared item is a String
  - If the string _is_ a URL, use the string as a URL
  - If the string contains a URL, find the first included link that is http(s)
  - If the string does not contain a URL, do nothing (error) 

Any time a URL is used, percent encoding is first removed. This simplifies what's stored in the local db, as well as what's sent to the backend. We want to ensure as much consistency between platforms as we can, here.

## Test Steps

- [ ] Test from an app like Ivory (or other apps? Twitter?) and share a link to Pocket. The original URL to the post should be saved, and not a percent-encoded deep-link
- [ ] General Share extension regression test

## PR Checklist:

- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA