### PR TITLE
fix(emptystate): fix empty state title and subtitle

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -35,6 +35,11 @@ class EmptyStateCollectionViewCell: SwiftUICollectionViewCell<EmptyStateView<Emp
 }
 
 struct EmptyStateView<Content: View>: View {
+    enum Constants {
+        static var maxWidth: CGFloat {
+            return 380
+        }
+    }
     private let viewModel: EmptyStateViewModel
     private var content: Content?
 
@@ -56,6 +61,8 @@ struct EmptyStateView<Content: View>: View {
             VStack(alignment: .center, spacing: 20) {
                 if let headline = viewModel.headline {
                     Text(headline).style(.main)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: Constants.maxWidth)
                 }
 
                 if let subtitle = viewModel.detailText {
@@ -63,8 +70,14 @@ struct EmptyStateView<Content: View>: View {
                         VStack(alignment: .center, spacing: 5) {
                             Image(asset: icon)
                             Text(subtitle).style(.detail)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .frame(maxWidth: Constants.maxWidth)
                         }
-                    } else { Text(subtitle).style(.detail) }
+                    } else {
+                        Text(subtitle).style(.detail)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: Constants.maxWidth)
+                    }
                 }
                 if let content {
                     content
@@ -74,7 +87,7 @@ struct EmptyStateView<Content: View>: View {
                     }, label: {
                         Text(buttonText).style(.buttonLabel)
                             .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
-                            .frame(maxWidth: 320)
+                            .frame(maxWidth: Constants.maxWidth)
                     }).buttonStyle(ActionsPrimaryButtonStyle())
                     .sheet(isPresented: self.$showSafariView) {
                         SFSafariView(url: webURL)


### PR DESCRIPTION
## Summary
Fix title and subtitle in empty state

## References 
IN-1385

## Implementation Details
Discussed with Tais on creating a maxWidth on `380` for the empty state text. This will apply to iPhone and iPad. 

## Test Steps
Navigate to all the empty states and verify that they look like the screenshots below.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| iPhone | iPad | 
| ---- | ---- | 
| ![Simulator Screenshot - iPhone 13 mini - 2023-05-30 at 16 09 58](https://github.com/Pocket/pocket-ios/assets/6743397/22092577-58b8-4c7e-9f6b-739b1355e8b8) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-30 at 16 10 59](https://github.com/Pocket/pocket-ios/assets/6743397/38d0bc20-61d5-4498-a119-660553fabb7c) |
 ![Simulator Screenshot - iPhone 13 mini - 2023-05-30 at 16 09 53](https://github.com/Pocket/pocket-ios/assets/6743397/519629a0-cb47-4109-9c20-cff91707623f) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-30 at 16 10 47](https://github.com/Pocket/pocket-ios/assets/6743397/f8ab7af8-d2f5-4756-b765-f59cd13b7d7a)|
