### PR TITLE
refactor(saveto): update URLExtractor logging

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
@@ -40,6 +40,11 @@ public extension Events.SaveTo {
             ]
         )
     }
+
+    /// Fired when the extension was unable to find a URL to save
+    static func unableToSave() -> Event {
+        return System(type: .unableToSave, source: .saveToPocketKit)
+    }
 }
 
 public extension Events.SaveTo.Tags {

--- a/PocketKit/Sources/Analytics/Events/System.swift
+++ b/PocketKit/Sources/Analytics/Events/System.swift
@@ -22,6 +22,8 @@ public struct System: Event, CustomStringConvertible {
         switch type {
         case .userMigration(let userMigrationState):
             return userMigrationState.id(source)
+        case .unableToSave:
+            return "ios.\(source).unableToSave"
         }
     }
 
@@ -29,6 +31,8 @@ public struct System: Event, CustomStringConvertible {
         switch type {
         case .userMigration(let userMigrationState):
             return userMigrationState.value(source)
+        case .unableToSave:
+            return nil
         }
     }
 
@@ -48,6 +52,7 @@ public struct System: Event, CustomStringConvertible {
 extension System {
     public enum SystemLogType {
         case userMigration(UserMigrationState)
+        case unableToSave
     }
 
     public enum UserMigrationState {

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -69,8 +69,7 @@ class SavedItemViewModel {
 
         for item in extensionItems {
             guard let url = try? await url(from: item) else {
-                // Breadcrumbs all the way down, but if we could genuinely not parse out a URL, capture that.
-                Log.capture(message: "Could not find URL in extensions items to save")
+                tracker.track(event: Events.SaveTo.unableToSave())
                 infoViewModel = .error
                 break
             }

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -69,6 +69,8 @@ class SavedItemViewModel {
 
         for item in extensionItems {
             guard let url = try? await url(from: item) else {
+                // Breadcrumbs all the way down, but if we could genuinely not parse out a URL, capture that.
+                Log.capture(message: "Could not find URL in extensions items to save")
                 infoViewModel = .error
                 break
             }

--- a/PocketKit/Sources/SaveToPocketKit/URLExtractor.swift
+++ b/PocketKit/Sources/SaveToPocketKit/URLExtractor.swift
@@ -9,14 +9,14 @@ enum URLExtractor {
     static func url(from itemProvider: ItemProvider) async -> String? {
         if itemProvider.hasItemConformingToTypeIdentifier("public.url") { // We're handed a URL
             guard let url = try? await itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil) as? URL else {
-                Log.capture(message: "Unable to load URL from itemProvider")
+                Log.breadcrumb(category: "urlExtractor", level: .error, message: "Unable to load item as URL from itemProvider for type identifier public.url")
                 return nil
             }
 
             return firstURL(in: url)
-        } else if itemProvider.hasItemConformingToTypeIdentifier("public.plain-text") { // We're handed a URL String
+        } else if itemProvider.hasItemConformingToTypeIdentifier("public.plain-text") { // We're handed a String that may contain a URL
             guard let string = try? await itemProvider.loadItem(forTypeIdentifier: "public.plain-text", options: nil) as? String else {
-                Log.capture(message: "Unable to load String from itemProvider")
+                Log.breadcrumb(category: "urlExtractor", level: .error, message: "Unable to load item as String from itemProvider for type identifier public.plain-text")
                 return nil
             }
 
@@ -24,7 +24,6 @@ enum URLExtractor {
                 return self.firstURL(in: url)
             }
 
-            Log.capture(message: "Unable to parse URL from from itemProvider String")
             return nil
         }
 
@@ -48,7 +47,7 @@ enum URLExtractor {
     ///     - string: The string from which to search for a URL
     private static func firstURL(in string: String) -> String? {
         guard let string = string.removingPercentEncoding, let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
-            Log.capture(message: "FirstURL setup failed")
+            Log.breadcrumb(category: "urlExtractor", level: .error, message: "firstURL setup for String failed")
             return nil
         }
 
@@ -60,7 +59,7 @@ enum URLExtractor {
             return string
         }
 
-        Log.breadcrumb(category: "urlExtractor", level: .warning, message: "Unable to find URL in \(string)")
+        Log.breadcrumb(category: "urlExtractor", level: .info, message: "Unable to find URL in \(string)")
         return nil
     }
 
@@ -79,7 +78,7 @@ enum URLExtractor {
     ///     - string: The string from which to search for a URL
     private static func firstURL(in url: URL) -> String? {
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            Log.capture(message: "Unable to generate URLComponents")
+            Log.breadcrumb(category: "urlExtractor", level: .error, message: "firstURL setup for URL failed")
             return nil
         }
 
@@ -94,7 +93,7 @@ enum URLExtractor {
         urlComponents.scheme = nil
 
         guard let inputString = urlComponents.string else {
-            Log.capture(message: "Unable to read URLComponents as String")
+            Log.breadcrumb(category: "urlExtractor", level: .error, message: "Unable to read URLComponents as String")
             return nil
         }
 


### PR DESCRIPTION
## Summary

Updates `Log` usage in `URLExtractor` to switch from `message` to `breadcrumb`. One `message` is newly captured if and only if no URL could be saved at the _end_ of parsing all item providers.

## Implementation Details

Most things that may happen in `URLExtractor` are not "actionable", but the final state of "couldn't save anything" _might_ be. So, if we breadcrumb up until the "couldn't save anything" scenario, we'll only have one general message that may prove fruitful, and all the things that might have led us there.

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
