### PR TITLE
feature(braze): track deployment type

### DIFF
--- a/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
@@ -68,7 +68,7 @@ extension PocketBraze: BrazeProtocol {
             }
             // Could expand to include "development"
             let deployment = isTestFlight ? "testflight" : "app_store"
-            self?.braze.user.setCustomAttribute(key: "deployment", value: deployment)
+            self?.braze.user.setCustomAttribute(key: "ios_deployment", value: deployment)
         }
 
         let center = UNUserNotificationCenter.current()

--- a/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
@@ -61,6 +61,14 @@ extension PocketBraze: BrazeProtocol {
             // Braze SDK docs say this needs to be called from the main thread.
             // https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/analytics/setting_user_ids/#assigning-a-user-id
             self?.braze.changeUser(userId: session.userIdentifier)
+            // Was this build deployed through the App Store or through TestFlight?
+            var isTestFlight = false
+            if let receiptURL = Bundle.main.appStoreReceiptURL {
+                isTestFlight = receiptURL.path(percentEncoded: false).range(of: "sandboxreceipt") != nil
+            }
+            // Could expand to include "development"
+            let deployment = isTestFlight ? "testflight" : "app_store"
+            self?.braze.user.setCustomAttribute(key: "deployment", value: deployment)
         }
 
         let center = UNUserNotificationCenter.current()

--- a/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
+++ b/PocketKit/Sources/PocketKit/Notifications/PocketBraze.swift
@@ -64,7 +64,7 @@ extension PocketBraze: BrazeProtocol {
             // Was this build deployed through the App Store or through TestFlight?
             var isTestFlight = false
             if let receiptURL = Bundle.main.appStoreReceiptURL {
-                isTestFlight = receiptURL.path(percentEncoded: false).range(of: "sandboxreceipt") != nil
+                isTestFlight = receiptURL.path(percentEncoded: false).contains("sandboxreceipt")
             }
             // Could expand to include "development"
             let deployment = isTestFlight ? "testflight" : "app_store"


### PR DESCRIPTION
## Summary

Adds a _deployment_ attribute to the Braze user object, allowing us to distinguish TestFlight installations from App Store installations