### PR TITLE
feat(reportIssue): add UI refinements

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "reportIssue.name" = "Name";
 "reportIssue.email" = "E-mail";
 "reportIssue.comment" = "What happened?";
+"reportIssue.optional" = "optional";
 "reportIssue.submitIssue.title" = "Submit issue";
 
 //Archive

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -362,6 +362,8 @@ public enum Localization {
     public static let header = Localization.tr("Localizable", "reportIssue.header", fallback: "Report an issue")
     /// Name
     public static let name = Localization.tr("Localizable", "reportIssue.name", fallback: "Name")
+    /// optional
+    public static let `optional` = Localization.tr("Localizable", "reportIssue.optional", fallback: "optional")
     public enum SubmitIssue {
       /// Submit issue
       public static let title = Localization.tr("Localizable", "reportIssue.submitIssue.title", fallback: "Submit issue")

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -73,6 +73,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case debugMenu = "perm.ios.debug.menu"
     case traceSampling = "perm.ios.sentry.traces"
     case profileSampling = "perm.ios.sentry.profile"
+    case reportIssue = "perm.ios.reportIssue"
 
     /// Description to use in a debug menu
     var description: String {
@@ -87,6 +88,8 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "Percentage to use to sample traces in Sentry"
         case .profileSampling:
             return "Percentage to use to sample profiles in Sentry"
+        case .reportIssue:
+            return "Enable the Report Issue view for users to send feedback to Sentry"
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -73,7 +73,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case debugMenu = "perm.ios.debug.menu"
     case traceSampling = "perm.ios.sentry.traces"
     case profileSampling = "perm.ios.sentry.profile"
-    case reportIssue = "perm.ios.reportIssue"
+    case reportIssue = "perm.ios.report_issue"
 
     /// Description to use in a debug menu
     var description: String {
@@ -89,7 +89,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
         case .profileSampling:
             return "Percentage to use to sample profiles in Sentry"
         case .reportIssue:
-            return "Enable the Report Issue view for users to send feedback to Sentry"
+            return "Enable the Report an Issue feature when users encounter an error"
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -62,7 +62,7 @@ struct LoggedOutView: View {
                 image: .accountDeleted,
                 title: Localization.Login.DeletedAccount.Banner.title,
                 detail: Localization.Login.DeletedAccount.Banner.detail,
-                action: BannerModifier.BannerData.BannerAction(
+                action: BannerAction(
                     text: Localization.Login.DeletedAccount.Banner.action,
                     style: PocketButtonStyle(.primary)
                 ) {

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -32,6 +32,7 @@ class MainViewModel: ObservableObject {
                     networkPathMonitor: NWPathMonitor(),
                     user: Services.shared.user,
                     userDefaults: Services.shared.userDefaults,
+                    featureFlags: Services.shared.featureFlagService,
                     source: Services.shared.source,
                     tracker: Services.shared.tracker.childTracker(hosting: .saves.search),
                     store: Services.shared.subscriptionStore,

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
@@ -7,12 +7,24 @@ import Textile
 import Localization
 
 struct ErrorEmptyState: EmptyStateViewModel {
+    private var featureFlags: FeatureFlagServiceProtocol
+
+    init(featureFlags: FeatureFlagServiceProtocol) {
+        self.featureFlags = featureFlags
+    }
+
     let imageAsset: ImageAsset = .warning
     let maxWidth: CGFloat = Width.normal.rawValue
     let icon: ImageAsset? = nil
     let headline: String? = Localization.General.oops
     let detailText: String? = Localization.Search.errorMessage
-    let buttonType: ButtonType? = .reportIssue(Localization.General.Error.sendReport)
     let webURL: URL? = nil
     let accessibilityIdentifier = "error-empty-state"
+
+    var buttonType: ButtonType? {
+        if featureFlags.isAssigned(flag: .reportIssue) {
+            return .reportIssue(Localization.General.Error.sendReport)
+        }
+        return nil
+    }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -76,7 +76,7 @@ struct ResultsView: View {
         .accessibilityIdentifier("search-results")
         .banner(data: viewModel.bannerData, show: $viewModel.showBanner, bottomOffset: 0)
         .sheet(isPresented: $viewModel.isPresentingReportIssue, content: {
-            ReportIssueView(email: viewModel.userEmail, submitIssue: viewModel.submitIssue, isEnabled: viewModel.showReportIssueView)
+            ReportIssueView(email: viewModel.userEmail, submitIssue: viewModel.submitIssue)
         })
         .alert(isPresented: $showingAlert) {
             Alert(title: Text(Localization.Search.Error.View.needsInternet), dismissButton: .default(Text("OK")))
@@ -125,11 +125,8 @@ struct SearchEmptyView: View {
                 EmptyView()
             }
         } else {
-            EmptyStateView(viewModel: viewModel) {
-                ReportIssueButton(text: "Welcome")
-            }.padding(Margins.normal.rawValue)
-//            EmptyStateView<EmptyView>(viewModel: viewModel)
-//                .padding(Margins.normal.rawValue)
+            EmptyStateView<EmptyView>(viewModel: viewModel)
+                .padding(Margins.normal.rawValue)
         }
     }
 }
@@ -156,7 +153,7 @@ struct ReportIssueButton: View {
                 .frame(maxWidth: Constants.maxWidth)
         }).buttonStyle(PocketButtonStyle(.primary))
         .sheet(isPresented: $searchViewModel.isPresentingReportIssue) {
-            ReportIssueView(email: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue, isEnabled: searchViewModel.showReportIssueView)
+            ReportIssueView(email: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue)
         }
         .accessibilityIdentifier("get-report-issue-button")
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -76,7 +76,7 @@ struct ResultsView: View {
         .accessibilityIdentifier("search-results")
         .banner(data: viewModel.bannerData, show: $viewModel.showBanner, bottomOffset: 0)
         .sheet(isPresented: $viewModel.isPresentingReportIssue, content: {
-            ReportIssueView(userEmail: viewModel.userEmail, submitIssue: viewModel.submitIssue)
+            ReportIssueView(email: viewModel.userEmail, submitIssue: viewModel.submitIssue, isEnabled: viewModel.showReportIssueView)
         })
         .alert(isPresented: $showingAlert) {
             Alert(title: Text(Localization.Search.Error.View.needsInternet), dismissButton: .default(Text("OK")))
@@ -125,8 +125,11 @@ struct SearchEmptyView: View {
                 EmptyView()
             }
         } else {
-            EmptyStateView<EmptyView>(viewModel: viewModel)
-                .padding(Margins.normal.rawValue)
+            EmptyStateView(viewModel: viewModel) {
+                ReportIssueButton(text: "Welcome")
+            }.padding(Margins.normal.rawValue)
+//            EmptyStateView<EmptyView>(viewModel: viewModel)
+//                .padding(Margins.normal.rawValue)
         }
     }
 }
@@ -153,7 +156,7 @@ struct ReportIssueButton: View {
                 .frame(maxWidth: Constants.maxWidth)
         }).buttonStyle(PocketButtonStyle(.primary))
         .sheet(isPresented: $searchViewModel.isPresentingReportIssue) {
-            ReportIssueView(userEmail: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue)
+            ReportIssueView(email: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue, isEnabled: searchViewModel.showReportIssueView)
         }
         .accessibilityIdentifier("get-report-issue-button")
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -44,6 +44,7 @@ class SearchViewModel: ObservableObject {
     private let user: User
     private let store: SubscriptionStore
     private let userDefaults: UserDefaults
+    private var featureFlags: FeatureFlagServiceProtocol
     private let source: Source
     private let premiumUpgradeViewModelFactory: PremiumUpgradeViewModelFactory
     private let notificationCenter: NotificationCenter
@@ -109,6 +110,10 @@ class SearchViewModel: ObservableObject {
         SearchScope.allCases.map { $0.rawValue }
     }
 
+    var showReportIssueView: Bool {
+        featureFlags.isAssigned(flag: .reportIssue)
+    }
+
     private var recentSearches: [String] {
         get {
             userDefaults.stringArray(forKey: SearchViewModel.recentSearchesKey) ?? []
@@ -121,6 +126,7 @@ class SearchViewModel: ObservableObject {
     init(networkPathMonitor: NetworkPathMonitor,
          user: User,
          userDefaults: UserDefaults,
+         featureFlags: FeatureFlagServiceProtocol,
          source: Source,
          tracker: Tracker,
          store: SubscriptionStore,
@@ -129,6 +135,7 @@ class SearchViewModel: ObservableObject {
         self.networkPathMonitor = networkPathMonitor
         self.user = user
         self.userDefaults = userDefaults
+        self.featureFlags = featureFlags
         self.source = source
         self.tracker = tracker
         self.store = store

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -89,14 +89,14 @@ class SearchViewModel: ObservableObject {
             image: .warning,
             title: Localization.Search.limitedResults,
             detail: Localization.Search.Banner.errorMessage,
-            action: reportButton(with: featureFlags)
+            action: reportButton()
         )
         return isOffline ? offlineView : errorView
     }
 
     /// Handles whether to show a report button for a banner
-    private func reportButton(with featureFlagsService: FeatureFlagServiceProtocol) -> BannerAction? {
-        if featureFlagsService.isAssigned(flag: .reportIssue) {
+    private func reportButton() -> BannerAction? {
+        if featureFlags.isAssigned(flag: .reportIssue) {
             return BannerAction(
                 text: Localization.General.Error.sendReport,
                 style: PocketButtonStyle(.primary, .small)

--- a/PocketKit/Sources/Textile/Style/Style+SwiftUI.swift
+++ b/PocketKit/Sources/Textile/Style/Style+SwiftUI.swift
@@ -65,6 +65,7 @@ public extension Text {
             .foregroundColor(Color(style.colorAsset))
             .multilineTextAlignment(SwiftUI.TextAlignment(style.paragraph.alignment))
             .lineSpacing(style.paragraph.lineSpacing ?? 0)
+            .italic(style.fontDescriptor.slant == .italic)
     }
 }
 

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -5,6 +5,9 @@
 import SwiftUI
 import UIKit
 
+// Added for code convenience
+public typealias BannerAction = BannerModifier.BannerData.BannerAction
+
 public struct BannerModifier: ViewModifier {
     enum Constants {
         static let imageMaxWidth: CGFloat = 83

--- a/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
+++ b/PocketKit/Sources/Textile/Views/Banner/BottomNotification.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
-import UIKit
 
 // Added for code convenience
 public typealias BannerAction = BannerModifier.BannerData.BannerAction

--- a/PocketKit/Sources/Textile/Views/Report/ReportField.swift
+++ b/PocketKit/Sources/Textile/Views/Report/ReportField.swift
@@ -14,7 +14,7 @@ struct ReportField: View {
     let height: CGFloat
 
     var body: some View {
-        Section(header: Text(header).style(.recommendation.textStyle).textCase(nil)) {
+        Section(header: ReportHeader(title: header)) {
             TextField("", text: userInput)
                 .style(.recommendation.textStyle)
                 .padding()

--- a/PocketKit/Sources/Textile/Views/Report/ReportHeader.swift
+++ b/PocketKit/Sources/Textile/Views/Report/ReportHeader.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Localization
+
+struct ReportHeader: View {
+    var title: String
+    var isOptional: Bool = true
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(title)
+                .style(.recommendation.textStyle)
+                .textCase(nil)
+            if isOptional {
+                Text(" - \(Localization.ReportIssue.optional)")
+                    .style(.recommendation.textStyle.with(slant: .italic))
+                    .textCase(nil)
+            }
+        }
+    }
+}

--- a/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
+++ b/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
@@ -15,74 +15,97 @@ public struct ReportIssueView: View {
         static let lineWidth: CGFloat = 1
     }
 
-    private var submitIssue: (String, String, String) -> Void
-
-    public init(userEmail: String, submitIssue: @escaping (String, String, String) -> Void) {
-        _email = State(initialValue: userEmail)
-        self.submitIssue = submitIssue
-    }
-
     @Environment(\.dismiss)
     private var dismiss
     @State private var name = ""
-    @State private var email: String
     @State private var reportComment = ""
 
-    public var body: some View {
-        Form {
-            Section(header: Text(Localization.ReportIssue.header)) {
-                Text(Localization.ReportIssue.description)
-                    .style(.recommendation.textStyle)
-                    .padding([.top], Constants.padding)
-                    .listRowBackground(Color.clear)
-            }.listRowInsets(EdgeInsets())
+    private let email: String
+    private var submitIssue: (String, String, String) -> Void
+    private let isEnabled: Bool
 
-            ReportField(userInput: $name, header: Localization.ReportIssue.name, height: Constants.defaultRowHeight)
+    public init(email: String, submitIssue: @escaping (String, String, String) -> Void, isEnabled: Bool) {
+        self.email = email
+        self.submitIssue = submitIssue
+        self.isEnabled = isEnabled
+    }
+
+    public var body: some View {
+        if isEnabled {
+            Text("Report an Issue has been disabled.")
+        } else {
+            Form {
+                Section(header: Text(Localization.ReportIssue.header)) {
+                    Text(Localization.ReportIssue.description)
+                        .style(.recommendation.textStyle)
+                        .padding([.top], Constants.padding)
+                        .listRowBackground(Color.clear)
+                }.listRowInsets(EdgeInsets())
+
+                Section(
+                    header: ReportHeader(title: Localization.ReportIssue.email, isOptional: false)
+                ) {
+                    Text(email)
+                        .style(.recommendation.textStyle.with(color: .ui.grey5))
+                        .listRowBackground(Color.clear)
+                }.listRowInsets(EdgeInsets())
+
+                ReportField(
+                    userInput: $name,
+                    header: Localization.ReportIssue.name,
+                    height: Constants.defaultRowHeight
+                )
                 .accessibilityIdentifier("name-field")
 
-            ReportField(userInput: $email, header: Localization.ReportIssue.email, height: Constants.defaultRowHeight)
-                .accessibilityIdentifier("email-field")
+                Section(
+                    header: ReportHeader(title: Localization.ReportIssue.comment)
+                ) {
+                    TextEditor(text: $reportComment)
+                        .style(.recommendation.textStyle)
+                        .padding()
+                        .frame(height: Constants.commentRowHeight)
+                        .overlay(RoundedRectangle(cornerRadius: Constants.cornerRadius).strokeBorder(Color.black, style: StrokeStyle(lineWidth: Constants.lineWidth)))
+                        .accessibilityIdentifier("comment-section")
+                }.listRowInsets(EdgeInsets())
 
-            Section(header: Text(Localization.ReportIssue.comment).style(.recommendation.textStyle).textCase(nil)) {
-                TextEditor(text: $reportComment)
-                    .style(.recommendation.textStyle)
-                    .padding()
-                    .frame(height: Constants.commentRowHeight)
-                    .overlay(RoundedRectangle(cornerRadius: Constants.cornerRadius).strokeBorder(Color.black, style: StrokeStyle(lineWidth: Constants.lineWidth)))
-                    .accessibilityIdentifier("comment-section")
-            }.listRowInsets(EdgeInsets())
-
-            Button(action: {
-                submitIssue(name, email, reportComment)
-                dismiss()
-            }) {
-                Text(Localization.ReportIssue.SubmitIssue.title)
+                Button(action: {
+                    submitIssue(name, email, reportComment)
+                    dismiss()
+                }) {
+                    Text(Localization.ReportIssue.SubmitIssue.title)
+                }
+                .listRowBackground(Rectangle().foregroundColor(.clear))
+                .listRowInsets(EdgeInsets())
+                .buttonStyle(PocketButtonStyle(.primary))
+                .accessibilityIdentifier("submit-issue")
             }
-            .listRowBackground(Rectangle().foregroundColor(.clear))
-            .listRowInsets(EdgeInsets())
-            .buttonStyle(PocketButtonStyle(.primary))
-            .accessibilityIdentifier("submit-issue")
+            .padding([.top, .bottom], Constants.padding)
+            .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
+            .accessibilityIdentifier("report-issue")
         }
-        .padding([.top, .bottom], Constants.padding)
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .background(Color.clear)
-        .accessibilityIdentifier("report-issue")
     }
 }
 
 struct ReportIssueView_PreviewProvider: PreviewProvider {
     static var previews: some View {
-        ReportIssueView(userEmail: "user@email.com", submitIssue: { _, email, _ in
+        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
             print(email)
-            })
-            .previewDisplayName("Report Issue - Light")
-            .preferredColorScheme(.light)
+        }, isEnabled: true)
+        .previewDisplayName("Report Issue - Light")
+        .preferredColorScheme(.light)
 
-        ReportIssueView(userEmail: "user@email.com", submitIssue: { _, email, _ in
+        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
             print(email)
-        })
-            .previewDisplayName("Report Issue - Dark")
-            .preferredColorScheme(.dark)
+        }, isEnabled: true)
+        .previewDisplayName("Report Issue - Dark")
+        .preferredColorScheme(.dark)
+
+        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
+            print(email)
+        }, isEnabled: false)
+        .previewDisplayName("Report Issue - Not Enabled")
+        .preferredColorScheme(.light)
     }
 }

--- a/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
+++ b/PocketKit/Sources/Textile/Views/Report/ReportIssueView.swift
@@ -22,89 +22,92 @@ public struct ReportIssueView: View {
 
     private let email: String
     private var submitIssue: (String, String, String) -> Void
-    private let isEnabled: Bool
 
-    public init(email: String, submitIssue: @escaping (String, String, String) -> Void, isEnabled: Bool) {
+    public init(email: String, submitIssue: @escaping (String, String, String) -> Void) {
         self.email = email
         self.submitIssue = submitIssue
-        self.isEnabled = isEnabled
     }
 
     public var body: some View {
-        if isEnabled {
-            Text("Report an Issue has been disabled.")
-        } else {
-            Form {
-                Section(header: Text(Localization.ReportIssue.header)) {
-                    Text(Localization.ReportIssue.description)
-                        .style(.recommendation.textStyle)
-                        .padding([.top], Constants.padding)
-                        .listRowBackground(Color.clear)
-                }.listRowInsets(EdgeInsets())
+        Form {
+            Section(header: Text(Localization.ReportIssue.header)) {
+                Text(Localization.ReportIssue.description)
+                    .style(.recommendation.textStyle)
+                    .padding([.top], Constants.padding)
+                    .listRowBackground(Color.clear)
+            }.listRowInsets(EdgeInsets())
 
-                Section(
-                    header: ReportHeader(title: Localization.ReportIssue.email, isOptional: false)
-                ) {
-                    Text(email)
-                        .style(.recommendation.textStyle.with(color: .ui.grey5))
-                        .listRowBackground(Color.clear)
-                }.listRowInsets(EdgeInsets())
+            Section(
+                header: ReportHeader(title: Localization.ReportIssue.email, isOptional: false)
+            ) {
+                Text(email)
+                    .style(.recommendation.textStyle.with(color: .ui.grey5))
+                    .listRowBackground(Color.clear)
+            }.listRowInsets(EdgeInsets())
 
-                ReportField(
-                    userInput: $name,
-                    header: Localization.ReportIssue.name,
-                    height: Constants.defaultRowHeight
-                )
-                .accessibilityIdentifier("name-field")
+            ReportField(
+                userInput: $name,
+                header: Localization.ReportIssue.name,
+                height: Constants.defaultRowHeight
+            )
+            .accessibilityIdentifier("name-field")
 
-                Section(
-                    header: ReportHeader(title: Localization.ReportIssue.comment)
-                ) {
-                    TextEditor(text: $reportComment)
-                        .style(.recommendation.textStyle)
-                        .padding()
-                        .frame(height: Constants.commentRowHeight)
-                        .overlay(RoundedRectangle(cornerRadius: Constants.cornerRadius).strokeBorder(Color.black, style: StrokeStyle(lineWidth: Constants.lineWidth)))
-                        .accessibilityIdentifier("comment-section")
-                }.listRowInsets(EdgeInsets())
+            Section(
+                header: ReportHeader(title: Localization.ReportIssue.comment)
+            ) {
+                TextEditor(text: $reportComment)
+                    .style(.recommendation.textStyle)
+                    .padding()
+                    .frame(height: Constants.commentRowHeight)
+                    .overlay(RoundedRectangle(cornerRadius: Constants.cornerRadius).strokeBorder(Color.black, style: StrokeStyle(lineWidth: Constants.lineWidth)))
+                    .accessibilityIdentifier("comment-section")
+            }.listRowInsets(EdgeInsets())
 
-                Button(action: {
-                    submitIssue(name, email, reportComment)
-                    dismiss()
-                }) {
-                    Text(Localization.ReportIssue.SubmitIssue.title)
-                }
-                .listRowBackground(Rectangle().foregroundColor(.clear))
-                .listRowInsets(EdgeInsets())
-                .buttonStyle(PocketButtonStyle(.primary))
-                .accessibilityIdentifier("submit-issue")
+            Button(action: {
+                submitIssue(name, email, reportComment)
+                dismiss()
+            }) {
+                Text(Localization.ReportIssue.SubmitIssue.title)
             }
-            .padding([.top, .bottom], Constants.padding)
-            .formStyle(.grouped)
-            .scrollContentBackground(.hidden)
-            .background(Color.clear)
-            .accessibilityIdentifier("report-issue")
+            .listRowBackground(Rectangle().foregroundColor(.clear))
+            .listRowInsets(EdgeInsets())
+            .buttonStyle(PocketButtonStyle(.primary))
+            .accessibilityIdentifier("submit-issue")
         }
+        .padding([.top, .bottom], Constants.padding)
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .background(Color.clear)
+        .accessibilityIdentifier("report-issue")
     }
 }
 
 struct ReportIssueView_PreviewProvider: PreviewProvider {
     static var previews: some View {
-        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
-            print(email)
-        }, isEnabled: true)
+        ReportIssueView(
+            email: "user@email.com",
+            submitIssue: { _, email, _ in
+                print(email)
+            }
+        )
         .previewDisplayName("Report Issue - Light")
         .preferredColorScheme(.light)
 
-        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
-            print(email)
-        }, isEnabled: true)
+        ReportIssueView(
+            email: "user@email.com",
+            submitIssue: { _, email, _ in
+                print(email)
+            }
+        )
         .previewDisplayName("Report Issue - Dark")
         .preferredColorScheme(.dark)
 
-        ReportIssueView(email: "user@email.com", submitIssue: { _, email, _ in
-            print(email)
-        }, isEnabled: false)
+        ReportIssueView(
+            email: "user@email.com",
+            submitIssue: { _, email, _ in
+                print(email)
+            }
+        )
         .previewDisplayName("Report Issue - Not Enabled")
         .preferredColorScheme(.light)
     }

--- a/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/SearchViewModelTests.swift
@@ -23,6 +23,7 @@ class SearchViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var itemsController: MockSavedItemsController!
     private var notificationCenter: NotificationCenter!
+    private var featureFlags: MockFeatureFlagService!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -30,6 +31,7 @@ class SearchViewModelTests: XCTestCase {
         source = MockSource()
         tracker = MockTracker()
         userDefaults = UserDefaults(suiteName: "SearchViewModelTests")
+        featureFlags = MockFeatureFlagService()
         space = .testSpace()
         notificationCenter = .default
         searchService = MockSearchService()
@@ -61,6 +63,7 @@ class SearchViewModelTests: XCTestCase {
         networkPathMonitor: NetworkPathMonitor? = nil,
         user: User,
         userDefaults: UserDefaults? = nil,
+        featureFlags: FeatureFlagServiceProtocol? = nil,
         source: Source? = nil,
         tracker: Tracker? = nil,
         notificationCenter: NotificationCenter? = nil
@@ -75,6 +78,7 @@ class SearchViewModelTests: XCTestCase {
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user,
             userDefaults: userDefaults ?? self.userDefaults,
+            featureFlags: featureFlags ?? self.featureFlags,
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             store: subscriptionStore ?? self.subscriptionStore,

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -5,6 +5,10 @@
 import XCTest
 import Sails
 import NIO
+import Apollo
+import ApolloAPI
+import ApolloTestSupport
+import PocketGraphTestMocks
 
 class SearchTests: XCTestCase {
     var server: Application!
@@ -329,8 +333,8 @@ class SearchTests: XCTestCase {
     }
 
     // MARK: - Search Error State
-    func test_search_showsErrorView_andReportView() {
-        server.routes.post("/graphql") { request, eventLoop -> FutureResponse in
+    func test_search_showsErrorView() {
+        server.routes.post("/graphql") { request, eventLoop -> Response in
             let apiRequest = ClientAPIRequest(request)
             if apiRequest.isForSearch(.archive) {
                 return Response(status: .internalServerError)
@@ -344,10 +348,7 @@ class SearchTests: XCTestCase {
         let searchField = app.navigationBar.searchFields["Search"].wait()
         searchField.tap()
         searchField.typeText("item\n")
-
         app.saves.searchEmptyStateView(for: "error-empty-state").wait()
-        app.reportIssueButton.wait().tap()
-        openReportIssueView()
     }
 
     func test_search_forSaves_forPremiumUser_showsErrorBanner() {


### PR DESCRIPTION
## Summary
Add refinements to our Report an Issue UI and added a feature flag to show / hide the report an issue button for the empty state view and banner view

## References 
IN-1524

## Implementation Details
* Created new `ReportHeader` view and modify `ReportIssueView` to prevent users from editing their email
* Created feature flag `perm.ios.report_issue` that determines whether to show or hide the report button for the error empty state and error banner view

## Test Steps
- [ ] Given that the user reports an issue, when they see their email populate, then they should not be able to edit it.
- [ ] Given that the user reports an issue, when they first encounter the view, then they should see optional next to both name and comment.
- [ ] Given that the feature flag is off, then the user should not be able to see report an issue button for any of the views.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| iPhone | 
| ------  |
| ![image](https://github.com/Pocket/pocket-ios/assets/6743397/1a638721-2aed-4f1a-8e04-89efc28b6d63) |