### PR TITLE
feat(migration): force user migration after app transfer

### DIFF
--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -14,6 +14,7 @@ public extension UserDefaults {
         case toggleOriginalView = "AccountViewModel.ToggleOriginalView"
         case appBadgeToggle = "Settings.ToggleAppBadge"
         case legacyUserMigration = "com.mozilla.pocket.next.migration.legacyUser"
+        case orgTransferMigration = "com.mozilla.pocket.next.migration.org"
         case dateLastRefresh = "HomeRefreshCoordinator.dateLastRefreshKey"
         case lastRefreshedTagsAt = "lastRefreshedTagsAt"
         case lastRefreshedArchiveAt = "lastRefreshedArchiveAt"

--- a/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/LegacyUserMigrationTests.swift
@@ -70,6 +70,7 @@ extension LegacyUserMigrationTests {
 extension LegacyUserMigrationTests {
     func test_perform_whenNotRequired_doesNotThrowError() {
         let migration = subject()
+        userDefaults.set(true, forKey: LegacyUserMigration.orgTransferKey)
         userDefaults.set(true, forKey: LegacyUserMigration.migrationKey)
         userDefaults.set("key", forKey: LegacyUserMigration.decryptionKey)
         encryptedStore.stubDecryptStore { key in
@@ -226,4 +227,74 @@ extension LegacyUserMigrationTests {
         wait(for: [expectation], timeout: 5)
     }
 }
+
+// MARK: - org transfer
+extension LegacyUserMigrationTests {
+    // App update path from 7 (old org) -> 8 (new org, transfer)
+    func test_perform_whenOrgTransferNotCompleted_andOtherwiseNotCompleted_updatesSession() throws {
+        userDefaults.set("key", forKey: LegacyUserMigration.decryptionKey)
+        let migration = subject()
+
+        encryptedStore.stubDecryptStore { key in
+            let correct: [String: Any] = [
+                "guid": "guid",
+                "accessToken": "accessToken",
+                "uid": "uid",
+                "version": "7.0.0"
+            ]
+
+            return try! JSONSerialization.data(withJSONObject: correct)
+        }
+
+        let result = try migration.attemptMigration { }
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(appSession.currentSession?.guid, "guid")
+        XCTAssertEqual(appSession.currentSession?.accessToken, "accessToken")
+        XCTAssertEqual(appSession.currentSession?.userIdentifier, "uid")
+    }
+
+    // App update path from 7 (old org) -> 8 (old org, complete) -> 8 (new org, transfer)
+    func test_perform_whenOrgTransferNotCompleted_butOtherwiseCompleted_updatesSession() throws {
+        userDefaults.set(true, forKey: LegacyUserMigration.migrationKey)
+        userDefaults.set("key", forKey: LegacyUserMigration.decryptionKey)
+        let migration = subject()
+
+        encryptedStore.stubDecryptStore { key in
+            let correct: [String: Any] = [
+                "guid": "guid",
+                "accessToken": "accessToken",
+                "uid": "uid",
+                "version": "8.0.0"
+            ]
+
+            return try! JSONSerialization.data(withJSONObject: correct)
+        }
+
+        let result = try migration.attemptMigration { }
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(appSession.currentSession?.guid, "guid")
+        XCTAssertEqual(appSession.currentSession?.accessToken, "accessToken")
+        XCTAssertEqual(appSession.currentSession?.userIdentifier, "uid")
+    }
+
+    // App update path from: 7 (old org) -> 8 (new org, already transferred)
+    // or 8 (old org) -> 8 (new org, already transferred)
+    func test_perform_whenOrgTransferCompleted_doesNotRun() {
+        userDefaults.set(true, forKey: UserDefaults.Key.orgTransferMigration)
+        let migration = subject()
+
+        do {
+            let result = try migration.attemptMigration {
+                XCTFail("Migration should not be attempted")
+            }
+
+            XCTAssertFalse(result, "Migration should not be attempted")
+        } catch {
+            XCTFail("Error should not be thrown")
+        }
+    }
+}
+
 // swiftlint:enable force_try


### PR DESCRIPTION
## Summary

Upon performing an app transfer, users will have to be migrated once again to ensure their session information is moved into the keychain, as the previous keychain is unavailable after app transfer. 

This pull request should _only_ be merged when preparing the first app update after app transfer.

## References 

IN-1540

## Implementation Details

This is an extension of the legacy user migration, which is live and seems to be working properly. This pull request forces the migration to be run (again) if the app has not been transferred into the new org. However, this "force" is secondary to the original logic for necessitating a migration (e.g 7 -> 8). 

This migration is _really_ in place for users who were logged into Pocket 8 pre-transfer, and "migrating" the keychain over post-transfer. The ways this works is that a current user login mimics the store used by the legacy app. Even on a fresh Pocket 8 install, this store will exist. Since this (mimic) store exists, we can reuse the same logic as when migrating from 7 -> 8, because the underlying store requirement exists on-disk.

## Test Steps

I'm not sure we can test this, other than "live". I've written unit tests to ensure it'll be force-ran, though.

## PR Checklist:

- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
