### PR TITLE
fix(filters): fix bug where tag menu appears when trying to sort

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -172,28 +172,13 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             case .favorites:
                 return NSPredicate(format: "isFavorite = true")
             case .tagged:
-                presentedTagsFilter = TagsFilterViewModel(
-                    source: source,
-                    tracker: tracker,
-                    userDefaults: userDefaults,
-                    user: user,
-                    selectAllAction: { [weak self] in
-                        self?.selectCell(with: .filterButton(.all))
-                    }
-                )
                 presentedTagsFilter?.$selectedTag.sink { [weak self] selectedTag in
-                    guard let selectedTag = selectedTag else { return }
-                    let predicate: NSPredicate
-                    switch selectedTag {
-                    case .notTagged:
-                        predicate = NSPredicate(format: "tags.@count = 0")
-                    case .tag(let name), .recent(let name):
-                        predicate = NSPredicate(format: "%@ IN tags.name", name)
-                    }
+                    guard let selectedTag, let predicate = self?.getPredicate(for: selectedTag) else { return }
                     self?.fetchItems(with: [predicate])
                     self?.updateSnapshotForTagFilter(with: selectedTag.name)
                 }.store(in: &subscriptions)
-                return nil
+
+                return getPredicate(for: presentedTagsFilter?.selectedTag)
             case .all:
                 return nil
             case .sortAndFilter:
@@ -202,9 +187,23 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         }
         applySorting()
         fetchItems(with: filters)
+        updateSnapshotForTagFilter(with: presentedTagsFilter?.selectedTag?.name)
     }
 
-    private func updateSnapshotForTagFilter(with name: String) {
+    private func getPredicate(for selectedTag: TagType?) -> NSPredicate? {
+        guard let selectedTag else { return nil }
+        switch selectedTag {
+        case .notTagged:
+            return NSPredicate(format: "tags.@count = 0")
+        case .tag(let name), .recent(let name):
+            return NSPredicate(format: "%@ IN tags.name", name)
+        }
+    }
+
+    /// Updates snapshot to add the selected tag chip cell under filters section
+    /// - Parameter name: tag name the user is using to filter their list
+    private func updateSnapshotForTagFilter(with name: String?) {
+        guard let name, selectedFilters.contains(.tagged) else { return }
         var snapshot = _snapshot
         let cells = snapshot.itemIdentifiers(inSection: .filters)
         snapshot.reloadItems(cells)
@@ -670,9 +669,6 @@ extension SavedItemsListViewModel {
     }
 
     private func handleFilterSelection(with filter: ItemsListFilter, sender: Any? = nil) {
-        let reTappedTagFilter = selectedFilters.contains(.tagged) && filter == .tagged
-        guard !reTappedTagFilter else { return }
-
         switch filter {
         case .listen:
             var title: String = ""
@@ -712,6 +708,15 @@ extension SavedItemsListViewModel {
                 sender: sender
             )
         case .tagged:
+            presentedTagsFilter = TagsFilterViewModel(
+                source: source,
+                tracker: tracker,
+                userDefaults: userDefaults,
+                user: user,
+                selectAllAction: { [weak self] in
+                    self?.selectCell(with: .filterButton(.all))
+                }
+            )
             filterTagAnalytics()
             selectedFilters.removeAll()
             selectedFilters.insert(filter)

--- a/Tests iOS/MyList/ArchiveFiltersTests.swift
+++ b/Tests iOS/MyList/ArchiveFiltersTests.swift
@@ -136,4 +136,17 @@ class ArchiveFiltersTests: XCTestCase {
         let tagEvent = await snowplowMicro.getFirstEvent(with: "global-nav.filterTags.selectRecentTag")
         tagEvent!.getUIContext()!.assertHas(type: "button")
     }
+
+    func test_archiveView_tappingSortPill_withSelectedTag_showsFilteredItems() {
+        app.launch().tabBar.savesButton.wait().tap()
+        app.saves.selectionSwitcher.archiveButton.wait().tap()
+        app.saves.filterButton(for: "Tagged").tap()
+        let tagsFilterView = app.saves.tagsFilterView.wait()
+        tagsFilterView.tag(matching: "tag 0").wait().tap()
+
+        app.saves.filterButton(for: "Sort").wait().tap()
+        app.sortMenu.sortOption("Oldest saved").wait().tap()
+
+        XCTAssertTrue(app.saves.itemView(at: 0).contains(string: "Archived Item 1"))
+    }
 }

--- a/Tests iOS/MyList/SavesFiltersTests.swift
+++ b/Tests iOS/MyList/SavesFiltersTests.swift
@@ -118,4 +118,17 @@ class SavesFiltersTests: XCTestCase {
         let tagEvent = await snowplowMicro.getFirstEvent(with: "global-nav.filterTags.selectRecentTag")
         tagEvent!.getUIContext()!.assertHas(type: "button")
     }
+
+    func test_savesView_tappingSortPill_withSelectedTag_showsFilteredItems() {
+        app.launch().tabBar.savesButton.wait().tap()
+        app.saves.filterButton(for: "Tagged").tap()
+        let tagsFilterView = app.saves.tagsFilterView.wait()
+        tagsFilterView.tag(matching: "tag 0").wait().tap()
+
+        app.saves.filterButton(for: "Sort").wait().tap()
+        app.sortMenu.sortOption("Oldest saved").wait().tap()
+
+        XCTAssertTrue(app.saves.itemView(at: 0).contains(string: "Item 2"))
+        XCTAssertTrue(app.saves.itemView(at: 1).contains(string: "Item 1"))
+    }
 }


### PR DESCRIPTION
## Summary
Address bug where tags menu appears when tapping on Sort filter after a user filters their list with a specific tag

## References 
IN-1256

## Implementation Details
* Move presenting tag view to `handleFilterSelection` from `fetch`
* Allow tags list to be filtered through sorting by passing the proper filter values to our local store. Created `getPredicate` to return the proper filter cases
* Added two UI tests to cover the scenario if a user filters their list by a specific tag and then taps on the sort option

## Test Steps
1. Nav to Saves
2. Tap Tagged filter
3. Select a tag
4. Click Sort / Filter in the filter menu
5. Confirm that tag menu does not appear and the list is sorted

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| Video Capture |
| --- | 
| https://github.com/Pocket/pocket-ios/assets/6743397/b7a2f33c-c9eb-4a1b-9d5a-238e2ad54900 |