### PR TITLE
feat(killswitch) Add and enable featureflags for a Reader killswitch

### DIFF
--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -74,6 +74,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case traceSampling = "perm.ios.sentry.traces"
     case profileSampling = "perm.ios.sentry.profile"
     case reportIssue = "perm.ios.report_issue"
+    case disableReader = "perm.ios.disable_reader"
 
     /// Description to use in a debug menu
     var description: String {
@@ -90,6 +91,8 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "Percentage to use to sample profiles in Sentry"
         case .reportIssue:
             return "Enable the Report an Issue feature when users encounter an error"
+        case .disableReader:
+            return "Disable the Reader to force use of a Web view for viewing content"
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -107,7 +107,7 @@ class HomeViewModel: NSObject {
     private var subscriptions: [AnyCancellable] = []
     private var recentSavesCount: Int = 0
     private var store: SubscriptionStore
-    private let featureFlags: FeatureFlagService
+    private let featureFlags: FeatureFlagServiceProtocol
 
     private let recentSavesController: NSFetchedResultsController<SavedItem>
     private let recomendationsController: RichFetchedResultsController<Recommendation>
@@ -121,7 +121,7 @@ class HomeViewModel: NSObject {
         store: SubscriptionStore,
         userDefaults: UserDefaults,
         notificationCenter: NotificationCenter,
-        featureFlags: FeatureFlagService
+        featureFlags: FeatureFlagServiceProtocol
     ) {
         self.source = source
         self.tracker = tracker

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -107,6 +107,7 @@ class HomeViewModel: NSObject {
     private var subscriptions: [AnyCancellable] = []
     private var recentSavesCount: Int = 0
     private var store: SubscriptionStore
+    private let featureFlags: FeatureFlagService
 
     private let recentSavesController: NSFetchedResultsController<SavedItem>
     private let recomendationsController: RichFetchedResultsController<Recommendation>
@@ -119,7 +120,8 @@ class HomeViewModel: NSObject {
         user: User,
         store: SubscriptionStore,
         userDefaults: UserDefaults,
-        notificationCenter: NotificationCenter
+        notificationCenter: NotificationCenter,
+        featureFlags: FeatureFlagService
     ) {
         self.source = source
         self.tracker = tracker
@@ -130,6 +132,7 @@ class HomeViewModel: NSObject {
         self.store = store
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
+        self.featureFlags = featureFlags
 
         self.snapshot = {
             return Self.loadingSnapshot()
@@ -266,7 +269,8 @@ extension HomeViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .slateDetail.screen),
             user: user,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            featureFlags: featureFlags
         ))
     }
 
@@ -282,7 +286,7 @@ extension HomeViewModel {
         let item = recommendation.item
 
         var destination: ContentOpen.Destination = .internal
-        if item.shouldOpenInWebView {
+        if item.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             selectedReadableType = .webViewRecommendation(viewModel)
             destination = .external
         } else {
@@ -314,7 +318,7 @@ extension HomeViewModel {
             notificationCenter: notificationCenter
         )
 
-        if let item = savedItem.item, item.shouldOpenInWebView {
+        if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             selectedReadableType = .webViewSavedItem(viewModel)
         } else {
             selectedReadableType = .savedItem(viewModel)

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -33,9 +33,9 @@ class SlateDetailViewModel {
     private let user: User
     private let userDefaults: UserDefaults
     private var subscriptions: [AnyCancellable] = []
-    private let featureFlags: FeatureFlagService
+    private let featureFlags: FeatureFlagServiceProtocol
 
-    init(slate: Slate, source: Source, tracker: Tracker, user: User, userDefaults: UserDefaults, featureFlags: FeatureFlagService) {
+    init(slate: Slate, source: Source, tracker: Tracker, user: User, userDefaults: UserDefaults, featureFlags: FeatureFlagServiceProtocol) {
         self.slate = slate
         self.source = source
         self.tracker = tracker

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -33,14 +33,16 @@ class SlateDetailViewModel {
     private let user: User
     private let userDefaults: UserDefaults
     private var subscriptions: [AnyCancellable] = []
+    private let featureFlags: FeatureFlagService
 
-    init(slate: Slate, source: Source, tracker: Tracker, user: User, userDefaults: UserDefaults) {
+    init(slate: Slate, source: Source, tracker: Tracker, user: User, userDefaults: UserDefaults, featureFlags: FeatureFlagService) {
         self.slate = slate
         self.source = source
         self.tracker = tracker
         self.user = user
         self.userDefaults = userDefaults
         self.snapshot = Self.loadingSnapshot()
+        self.featureFlags = featureFlags
 
         NotificationCenter.default.publisher(
             for: NSManagedObjectContext.didSaveObjectsNotification,
@@ -114,7 +116,7 @@ extension SlateDetailViewModel {
 
         let item = recommendation.item
         var destination: ContentOpen.Destination = .internal
-        if item.shouldOpenInWebView {
+        if item.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             let url = pocketPremiumURL(item.bestURL, user: user)
             presentedWebReaderURL = url
             destination = .external

--- a/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Item/Item+Extensions.swift
@@ -19,8 +19,8 @@ public extension SavedItem {
         item == nil
     }
 
-    var shouldOpenInWebView: Bool {
-        item?.shouldOpenInWebView == true
+    func shouldOpenInWebView(override: Bool) -> Bool {
+        item?.shouldOpenInWebView(override: override) == true
     }
 
     var isSyndicated: Bool {
@@ -29,7 +29,11 @@ public extension SavedItem {
 }
 
 public extension Item {
-    var shouldOpenInWebView: Bool {
+    func shouldOpenInWebView(override: Bool) -> Bool {
+        if override == true {
+            return true
+        }
+
         if isSaved || isSyndicated {
             // We are legally allowed to open the item in reader view
             // BUT: if any of the following are true...

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -80,7 +80,8 @@ class MainViewModel: ObservableObject {
                 user: Services.shared.user,
                 store: Services.shared.subscriptionStore,
                 userDefaults: Services.shared.userDefaults,
-                notificationCenter: Services.shared.notificationCenter
+                notificationCenter: Services.shared.notificationCenter,
+                featureFlags: Services.shared.featureFlagService
             ),
             account: AccountViewModel(
                 appSession: Services.shared.appSession,

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -252,7 +252,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.shouldOpenInWebView {
+        if savedItem.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             return (readable, true)
         } else {
             return (readable, false)
@@ -628,7 +628,7 @@ extension SavedItemsListViewModel {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.shouldOpenInWebView {
+        if savedItem.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             selectedItem = .webView(readable)
 
             trackContentOpen(destination: .external, item: savedItem)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -467,7 +467,7 @@ extension SearchViewModel: SearchResultActionDelegate {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.shouldOpenInWebView {
+        if savedItem.shouldOpenInWebView(override: featureFlags.isAssigned(flag: .disableReader)) {
             trackOpenSearchItem(url: savedItem.url, index: index, destination: .internal)
             selectedItem = .webView(readable)
         } else {

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -28,6 +28,7 @@ class HomeViewModelTests: XCTestCase {
     var userDefaults: UserDefaults!
     var lastRefresh: UserDefaultsLastRefresh!
     var notificationCenter: NotificationCenter!
+    var featureFlags: MockFeatureFlagService!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -36,6 +37,7 @@ class HomeViewModelTests: XCTestCase {
         source = MockSource()
         networkPathMonitor = MockNetworkPathMonitor()
         notificationCenter = .default
+        featureFlags = MockFeatureFlagService()
 
         taskScheduler = MockBGTaskScheduler()
         userDefaults = .standard
@@ -96,7 +98,8 @@ class HomeViewModelTests: XCTestCase {
             user: user ?? self.user,
             store: subscriptionStore ?? self.subscriptionStore,
             userDefaults: userDefaults ?? self.userDefaults,
-            notificationCenter: notificationCenter ?? self.notificationCenter
+            notificationCenter: notificationCenter ?? self.notificationCenter,
+            featureFlags: featureFlags
         )
     }
 
@@ -541,6 +544,14 @@ class HomeViewModelTests: XCTestCase {
 
         let viewModel = subject()
 
+        featureFlags.stubIsAssigned { flag, variant in
+            if flag == .disableReader {
+                return false
+            }
+            XCTFail("Unknown feature flag")
+            return false
+        }
+
         let readableExpectation = expectation(description: "expected to update selected readable")
         readableExpectation.expectedFulfillmentCount = 2
         viewModel.$selectedReadableType.dropFirst().sink { readableType in
@@ -579,6 +590,14 @@ class HomeViewModelTests: XCTestCase {
         let viewModel = subject()
         let urlExpectation = expectation(description: "expected to update presented URL")
         urlExpectation.expectedFulfillmentCount = 3
+
+        featureFlags.stubIsAssigned { flag, variant in
+            if flag == .disableReader {
+                return false
+            }
+            XCTFail("Unknown feature flag")
+            return false
+        }
 
         viewModel.$selectedReadableType.dropFirst().sink { readableType in
             urlExpectation.fulfill()
@@ -629,6 +648,15 @@ class HomeViewModelTests: XCTestCase {
 
         let viewModel = subject()
         let readableExpectation = expectation(description: "expected to update selected readable")
+
+        featureFlags.stubIsAssigned { flag, variant in
+            if flag == .disableReader {
+                return false
+            }
+            XCTFail("Unknown feature flag")
+            return false
+        }
+        
         viewModel.$selectedReadableType.dropFirst().sink { readableType in
             switch readableType {
             case .savedItem, .webViewSavedItem:
@@ -659,6 +687,14 @@ class HomeViewModelTests: XCTestCase {
         let viewModel = subject()
         let urlExpectation = expectation(description: "expected to update presented URL")
         urlExpectation.expectedFulfillmentCount = 3
+
+        featureFlags.stubIsAssigned { flag, variant in
+            if flag == .disableReader {
+                return false
+            }
+            XCTFail("Unknown feature flag")
+            return false
+        }
 
         viewModel.$selectedReadableType.dropFirst().sink { readableType in
             urlExpectation.fulfill()

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -656,7 +656,7 @@ class HomeViewModelTests: XCTestCase {
             XCTFail("Unknown feature flag")
             return false
         }
-        
+
         viewModel.$selectedReadableType.dropFirst().sink { readableType in
             switch readableType {
             case .savedItem, .webViewSavedItem:

--- a/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ItemExtensionsTests.swift
@@ -24,14 +24,14 @@ class ItemExtensionsTests: XCTestCase {
         let savedItem: SavedItem = try space.createSavedItem()
         savedItem.item?.isArticle = false
 
-        XCTAssertEqual(savedItem.shouldOpenInWebView, true)
+        XCTAssertEqual(savedItem.shouldOpenInWebView(override: false), true)
     }
 
     func test_shouldOpenInWebView_andIsArticle_returnsFalse() throws {
         let savedItem: SavedItem = try space.createSavedItem()
         savedItem.item?.isArticle = true
 
-        XCTAssertEqual(savedItem.shouldOpenInWebView, false)
+        XCTAssertEqual(savedItem.shouldOpenInWebView(override: false), false)
     }
 
     func test_shouldOpenInWebView_withArticleComponents_returnsTrue() throws {


### PR DESCRIPTION
## Summary
See Title

## References 
https://featureflags.readitlater.com/projects/default/features/perm.ios.disable_reader

## Implementation Details
Add new feature flag
Change the shouldOpenInWebview computed var to a func
Add an override to the function to accept a boolean, if true always use the web.

## Test Steps
App should function as normal with the featureflag disabled
If enabled it should make all content; saves, archives and home screen render in the web view.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
