### PR TITLE
Item Widgets: fix vertical thumbnail size

### DIFF
--- a/PocketKit/Sources/ItemWidgetsKit/Views/ItemWidgetsRow.swift
+++ b/PocketKit/Sources/ItemWidgetsKit/Views/ItemWidgetsRow.swift
@@ -54,7 +54,7 @@ struct ItemThumbnail: View {
         image
             .resizable()
             .aspectRatio(contentMode: .fill)
-            .frame(width: maxThumbnailSize)
+            .frame(width: maxThumbnailSize, height: maxThumbnailSize / 1.4)
             .cornerRadius(16)
     }
 }


### PR DESCRIPTION
## Summary
* This PR sets a the vertical thumbnail size according to the set aspect ratio, to avoid layout issues

## Implementation Details
* Update `ItemWidgetsRow`, add a `height` value for the thumbnail frame

## Test Steps
* Build this branch, install one or more widgets, and make sure the UI looks good

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
