### PR TITLE
fix(Sentry) Change a log to a breadcrumb

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -611,7 +611,7 @@ extension HomeViewModel {
                 let slate = recommendation.slate,
                 let slateLineup = slate.slateLineup
             else {
-                Log.capture(message: "Tried to display recommendation without slate and slatelineup, not logging analytics")
+                Log.breadcrumb(category: "home", level: .debug, message: "Tried to display recommendation without slate and slatelineup, not logging analytics")
                 return
             }
 


### PR DESCRIPTION
## Summary
When a Recommendation doesn't have a slate/slateLineup we were logging a message, the only thing we didn't do after this was to log analytics.
Therefore I moved the message log to a breadcrumb.

## References 
https://getpocket.atlassian.net/browse/IN-1284

## PR Checklist:
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA