### PR TITLE
feat(widgets): add iOS 17 specific code to handle background

### DIFF
--- a/PocketKit/Sources/ItemWidgetsKit/Views/ItemWidgetsContainerView.swift
+++ b/PocketKit/Sources/ItemWidgetsKit/Views/ItemWidgetsContainerView.swift
@@ -6,7 +6,7 @@ import Sync
 import SwiftUI
 
 /// Main view of an Item widget
-struct ItemsWidgetsContainerView: View {
+struct ItemWidgetsContainerView: View {
     @Environment(\.widgetFamily)
     private var widgetFamily
 

--- a/PocketKit/Sources/ItemWidgetsKit/Views/ItemsWidgetsContainerView.swift
+++ b/PocketKit/Sources/ItemWidgetsKit/Views/ItemsWidgetsContainerView.swift
@@ -33,10 +33,18 @@ struct ItemsWidgetsContainerView: View {
     }
 
     var body: some View {
-        makeContainerView()
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.ui.white1))
+        if #available(iOS 17.0, *) {
+            makeContainerView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .containerBackground(for: .widget) {
+                    Color(.ui.white1)
+                }
+        } else {
+            makeContainerView()
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.ui.white1))
+        }
     }
 
     @ViewBuilder

--- a/PocketKit/Sources/ItemWidgetsKit/Widgets/RecentSavesWidget.swift
+++ b/PocketKit/Sources/ItemWidgetsKit/Widgets/RecentSavesWidget.swift
@@ -18,7 +18,7 @@ public struct RecentSavesWidget: Widget {
 
     public var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: ItemWidgetsProvider(service: ItemWidgetsService.makeRecentSavesService())) { entry in
-            ItemsWidgetsContainerView(entry: entry)
+            ItemWidgetsContainerView(entry: entry)
                 .titleColor(entry.titleColor)
         }
         .configurationDisplayName(Localization.ItemWidgets.RecentSaves.title)
@@ -29,7 +29,7 @@ public struct RecentSavesWidget: Widget {
 
 public struct RecentSavesWidget_Previews: PreviewProvider {
     public static var previews: some View {
-        ItemsWidgetsContainerView(entry: ItemsListEntry(date: Date(), name: "Recent Saves", contentType: .items([ItemRowContent(content: .placeHolder, image: nil)])))
+        ItemWidgetsContainerView(entry: ItemsListEntry(date: Date(), name: "Recent Saves", contentType: .items([ItemRowContent(content: .placeHolder, image: nil)])))
             .previewContext(WidgetPreviewContext(family: .systemLarge))
     }
 }

--- a/PocketKit/Sources/ItemWidgetsKit/Widgets/RecommendationsWidget.swift
+++ b/PocketKit/Sources/ItemWidgetsKit/Widgets/RecommendationsWidget.swift
@@ -18,7 +18,7 @@ public struct RecommendationsWidget: Widget {
 
     public var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: ItemWidgetsProvider(service: ItemWidgetsService.makeRecommendationsService())) { entry in
-                ItemsWidgetsContainerView(entry: entry)
+                ItemWidgetsContainerView(entry: entry)
                 .titleColor(entry.titleColor)
         }
         .configurationDisplayName(Localization.ItemWidgets.Recommendations.title)


### PR DESCRIPTION
## Summary
* This PR introduces the `containerBackground` modifier in Widgets, necessary to build them on iOS 17.

> **Note**
In order for the CI to build this branch, we need to update it to Xcode 15

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
