### PR TITLE
Unified Home

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
@@ -1,0 +1,166 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment CorpusItemParts on CorpusItem {
+      __typename
+      id
+      url
+      title
+      excerpt
+      imageUrl
+      publisher
+      target {
+        __typename
+        ... on SyndicatedArticle {
+          __typename
+          ...SyndicatedArticleParts
+        }
+      }
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusItem }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("id", PocketGraph.ID.self),
+    .field("url", PocketGraph.Url.self),
+    .field("title", String.self),
+    .field("excerpt", String.self),
+    .field("imageUrl", PocketGraph.Url.self),
+    .field("publisher", String.self),
+    .field("target", Target?.self),
+  ] }
+
+  /// The GUID that is stored on an approved corpus item
+  public var id: PocketGraph.ID { __data["id"] }
+  /// The URL of the Approved Item.
+  public var url: PocketGraph.Url { __data["url"] }
+  /// The title of the Approved Item.
+  public var title: String { __data["title"] }
+  /// The excerpt of the Approved Item.
+  public var excerpt: String { __data["excerpt"] }
+  /// The image URL for this item's accompanying picture.
+  public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+  /// The name of the online publication that published this story.
+  public var publisher: String { __data["publisher"] }
+  /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+  public var target: Target? { __data["target"] }
+
+  public init(
+    id: PocketGraph.ID,
+    url: PocketGraph.Url,
+    title: String,
+    excerpt: String,
+    imageUrl: PocketGraph.Url,
+    publisher: String,
+    target: Target? = nil
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": PocketGraph.Objects.CorpusItem.typename,
+        "id": id,
+        "url": url,
+        "title": title,
+        "excerpt": excerpt,
+        "imageUrl": imageUrl,
+        "publisher": publisher,
+        "target": target._fieldData,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(Self.self)
+      ]
+    ))
+  }
+
+  /// Target
+  ///
+  /// Parent Type: `CorpusTarget`
+  public struct Target: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .inlineFragment(AsSyndicatedArticle.self),
+    ] }
+
+    public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+
+    public init(
+      __typename: String
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": __typename,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(Self.self)
+        ]
+      ))
+    }
+
+    /// Target.AsSyndicatedArticle
+    ///
+    /// Parent Type: `SyndicatedArticle`
+    public struct AsSyndicatedArticle: PocketGraph.InlineFragment {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public typealias RootEntityType = CorpusItemParts.Target
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .fragment(SyndicatedArticleParts.self),
+      ] }
+
+      /// The item id of this Syndicated Article
+      public var itemId: PocketGraph.ID? { __data["itemId"] }
+      /// Primary image to use in surfacing this content
+      public var mainImage: String? { __data["mainImage"] }
+      /// Title of syndicated article
+      public var title: String { __data["title"] }
+      /// Excerpt 
+      public var excerpt: String? { __data["excerpt"] }
+      /// The manually set publisher information for this article
+      public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+      public struct Fragments: FragmentContainer {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+      }
+
+      public init(
+        itemId: PocketGraph.ID? = nil,
+        mainImage: String? = nil,
+        title: String,
+        excerpt: String? = nil,
+        publisher: SyndicatedArticleParts.Publisher? = nil
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+            "itemId": itemId,
+            "mainImage": mainImage,
+            "title": title,
+            "excerpt": excerpt,
+            "publisher": publisher._fieldData,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(Self.self),
+            ObjectIdentifier(CorpusItemParts.Target.self),
+            ObjectIdentifier(SyndicatedArticleParts.self)
+          ]
+        ))
+      }
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
@@ -1,0 +1,193 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment CorpusRecommendationParts on CorpusRecommendation {
+      __typename
+      id
+      corpusItem {
+        __typename
+        ...CorpusItemParts
+      }
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusRecommendation }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("id", PocketGraph.ID.self),
+    .field("corpusItem", CorpusItem.self),
+  ] }
+
+  /// Clients should include this id in the `corpus_recommendation` Snowplow entity for impression, content_open, and engagement events related to this recommendation. This id is different across users, across requests, and across corpus items. The recommendation-api service associates metadata with this id to join and aggregate recommendations in our data warehouse.
+  public var id: PocketGraph.ID { __data["id"] }
+  /// Content meta data.
+  public var corpusItem: CorpusItem { __data["corpusItem"] }
+
+  public init(
+    id: PocketGraph.ID,
+    corpusItem: CorpusItem
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": PocketGraph.Objects.CorpusRecommendation.typename,
+        "id": id,
+        "corpusItem": corpusItem._fieldData,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(Self.self)
+      ]
+    ))
+  }
+
+  /// CorpusItem
+  ///
+  /// Parent Type: `CorpusItem`
+  public struct CorpusItem: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusItem }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .fragment(CorpusItemParts.self),
+    ] }
+
+    /// The GUID that is stored on an approved corpus item
+    public var id: PocketGraph.ID { __data["id"] }
+    /// The URL of the Approved Item.
+    public var url: PocketGraph.Url { __data["url"] }
+    /// The title of the Approved Item.
+    public var title: String { __data["title"] }
+    /// The excerpt of the Approved Item.
+    public var excerpt: String { __data["excerpt"] }
+    /// The image URL for this item's accompanying picture.
+    public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+    /// The name of the online publication that published this story.
+    public var publisher: String { __data["publisher"] }
+    /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+    public var target: Target? { __data["target"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var corpusItemParts: CorpusItemParts { _toFragment() }
+    }
+
+    public init(
+      id: PocketGraph.ID,
+      url: PocketGraph.Url,
+      title: String,
+      excerpt: String,
+      imageUrl: PocketGraph.Url,
+      publisher: String,
+      target: Target? = nil
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": PocketGraph.Objects.CorpusItem.typename,
+          "id": id,
+          "url": url,
+          "title": title,
+          "excerpt": excerpt,
+          "imageUrl": imageUrl,
+          "publisher": publisher,
+          "target": target._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(Self.self),
+          ObjectIdentifier(CorpusItemParts.self)
+        ]
+      ))
+    }
+
+    /// CorpusItem.Target
+    ///
+    /// Parent Type: `CorpusTarget`
+    public struct Target: PocketGraph.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
+
+      public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+
+      public init(
+        __typename: String
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": __typename,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(Self.self)
+          ]
+        ))
+      }
+
+      /// CorpusItem.Target.AsSyndicatedArticle
+      ///
+      /// Parent Type: `SyndicatedArticle`
+      public struct AsSyndicatedArticle: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = CorpusRecommendationParts.CorpusItem.Target
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+        public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+          SyndicatedArticleParts.self,
+          CorpusItemParts.Target.AsSyndicatedArticle.self
+        ] }
+
+        /// The item id of this Syndicated Article
+        public var itemId: PocketGraph.ID? { __data["itemId"] }
+        /// Primary image to use in surfacing this content
+        public var mainImage: String? { __data["mainImage"] }
+        /// Title of syndicated article
+        public var title: String { __data["title"] }
+        /// Excerpt 
+        public var excerpt: String? { __data["excerpt"] }
+        /// The manually set publisher information for this article
+        public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+        }
+
+        public init(
+          itemId: PocketGraph.ID? = nil,
+          mainImage: String? = nil,
+          title: String,
+          excerpt: String? = nil,
+          publisher: SyndicatedArticleParts.Publisher? = nil
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+              "itemId": itemId,
+              "mainImage": mainImage,
+              "title": title,
+              "excerpt": excerpt,
+              "publisher": publisher._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(CorpusRecommendationParts.CorpusItem.Target.self),
+              ObjectIdentifier(SyndicatedArticleParts.self)
+            ]
+          ))
+        }
+      }
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
@@ -1,0 +1,244 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment CorpusSlateParts on CorpusSlate {
+      __typename
+      id
+      headline
+      subheadline
+      recommendations {
+        __typename
+        ...CorpusRecommendationParts
+      }
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusSlate }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("id", PocketGraph.ID.self),
+    .field("headline", String.self),
+    .field("subheadline", String?.self),
+    .field("recommendations", [Recommendation].self),
+  ] }
+
+  /// UUID
+  public var id: PocketGraph.ID { __data["id"] }
+  /// The display headline for the slate. Surface context may be required to render determine what to display. This will depend on if we connect the copy to the Surface, SlateExperiment, or Slate.
+  public var headline: String { __data["headline"] }
+  /// A smaller, secondary headline that can be displayed to provide additional context on the slate.
+  public var subheadline: String? { __data["subheadline"] }
+  /// Recommendations for the current request context.
+  public var recommendations: [Recommendation] { __data["recommendations"] }
+
+  public init(
+    id: PocketGraph.ID,
+    headline: String,
+    subheadline: String? = nil,
+    recommendations: [Recommendation]
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": PocketGraph.Objects.CorpusSlate.typename,
+        "id": id,
+        "headline": headline,
+        "subheadline": subheadline,
+        "recommendations": recommendations._fieldData,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(Self.self)
+      ]
+    ))
+  }
+
+  /// Recommendation
+  ///
+  /// Parent Type: `CorpusRecommendation`
+  public struct Recommendation: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusRecommendation }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .fragment(CorpusRecommendationParts.self),
+    ] }
+
+    /// Clients should include this id in the `corpus_recommendation` Snowplow entity for impression, content_open, and engagement events related to this recommendation. This id is different across users, across requests, and across corpus items. The recommendation-api service associates metadata with this id to join and aggregate recommendations in our data warehouse.
+    public var id: PocketGraph.ID { __data["id"] }
+    /// Content meta data.
+    public var corpusItem: CorpusItem { __data["corpusItem"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var corpusRecommendationParts: CorpusRecommendationParts { _toFragment() }
+    }
+
+    public init(
+      id: PocketGraph.ID,
+      corpusItem: CorpusItem
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": PocketGraph.Objects.CorpusRecommendation.typename,
+          "id": id,
+          "corpusItem": corpusItem._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(Self.self),
+          ObjectIdentifier(CorpusRecommendationParts.self)
+        ]
+      ))
+    }
+
+    /// Recommendation.CorpusItem
+    ///
+    /// Parent Type: `CorpusItem`
+    public struct CorpusItem: PocketGraph.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusItem }
+
+      /// The GUID that is stored on an approved corpus item
+      public var id: PocketGraph.ID { __data["id"] }
+      /// The URL of the Approved Item.
+      public var url: PocketGraph.Url { __data["url"] }
+      /// The title of the Approved Item.
+      public var title: String { __data["title"] }
+      /// The excerpt of the Approved Item.
+      public var excerpt: String { __data["excerpt"] }
+      /// The image URL for this item's accompanying picture.
+      public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+      /// The name of the online publication that published this story.
+      public var publisher: String { __data["publisher"] }
+      /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+      public var target: Target? { __data["target"] }
+
+      public struct Fragments: FragmentContainer {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public var corpusItemParts: CorpusItemParts { _toFragment() }
+      }
+
+      public init(
+        id: PocketGraph.ID,
+        url: PocketGraph.Url,
+        title: String,
+        excerpt: String,
+        imageUrl: PocketGraph.Url,
+        publisher: String,
+        target: Target? = nil
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": PocketGraph.Objects.CorpusItem.typename,
+            "id": id,
+            "url": url,
+            "title": title,
+            "excerpt": excerpt,
+            "imageUrl": imageUrl,
+            "publisher": publisher,
+            "target": target._fieldData,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(Self.self),
+            ObjectIdentifier(CorpusItemParts.self)
+          ]
+        ))
+      }
+
+      /// Recommendation.CorpusItem.Target
+      ///
+      /// Parent Type: `CorpusTarget`
+      public struct Target: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
+
+        public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+
+        public init(
+          __typename: String
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": __typename,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(Self.self)
+            ]
+          ))
+        }
+
+        /// Recommendation.CorpusItem.Target.AsSyndicatedArticle
+        ///
+        /// Parent Type: `SyndicatedArticle`
+        public struct AsSyndicatedArticle: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public typealias RootEntityType = CorpusSlateParts.Recommendation.CorpusItem.Target
+          public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+          public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+            SyndicatedArticleParts.self,
+            CorpusItemParts.Target.AsSyndicatedArticle.self
+          ] }
+
+          /// The item id of this Syndicated Article
+          public var itemId: PocketGraph.ID? { __data["itemId"] }
+          /// Primary image to use in surfacing this content
+          public var mainImage: String? { __data["mainImage"] }
+          /// Title of syndicated article
+          public var title: String { __data["title"] }
+          /// Excerpt 
+          public var excerpt: String? { __data["excerpt"] }
+          /// The manually set publisher information for this article
+          public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+          }
+
+          public init(
+            itemId: PocketGraph.ID? = nil,
+            mainImage: String? = nil,
+            title: String,
+            excerpt: String? = nil,
+            publisher: SyndicatedArticleParts.Publisher? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": PocketGraph.Objects.SyndicatedArticle.typename,
+                "itemId": itemId,
+                "mainImage": mainImage,
+                "title": title,
+                "excerpt": excerpt,
+                "publisher": publisher._fieldData,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(Self.self),
+                ObjectIdentifier(CorpusSlateParts.Recommendation.CorpusItem.Target.self),
+                ObjectIdentifier(SyndicatedArticleParts.self)
+              ]
+            ))
+          }
+        }
+      }
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
@@ -1,0 +1,194 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class HomeSlateLineupQuery: GraphQLQuery {
+  public static let operationName: String = "HomeSlateLineup"
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
+    definition: .init(
+      #"""
+      query HomeSlateLineup($locale: String!) {
+        homeSlateLineup(locale: $locale) {
+          __typename
+          id
+          slates {
+            __typename
+            ...CorpusSlateParts
+          }
+        }
+      }
+      """#,
+      fragments: [CorpusSlateParts.self, CorpusRecommendationParts.self, CorpusItemParts.self, SyndicatedArticleParts.self]
+    ))
+
+  public var locale: String
+
+  public init(locale: String) {
+    self.locale = locale
+  }
+
+  public var __variables: Variables? { ["locale": locale] }
+
+  public struct Data: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("homeSlateLineup", HomeSlateLineup.self, arguments: ["locale": .variable("locale")]),
+    ] }
+
+    /// Get ranked corpus slates and recommendations to deliver a unified Home experience. The locale argument determines the UI and recommendation content language.
+    public var homeSlateLineup: HomeSlateLineup { __data["homeSlateLineup"] }
+
+    /// HomeSlateLineup
+    ///
+    /// Parent Type: `CorpusSlateLineup`
+    public struct HomeSlateLineup: PocketGraph.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusSlateLineup }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("id", PocketGraph.ID.self),
+        .field("slates", [Slate].self),
+      ] }
+
+      /// UUID
+      public var id: PocketGraph.ID { __data["id"] }
+      /// Slates.
+      public var slates: [Slate] { __data["slates"] }
+
+      /// HomeSlateLineup.Slate
+      ///
+      /// Parent Type: `CorpusSlate`
+      public struct Slate: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusSlate }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .fragment(CorpusSlateParts.self),
+        ] }
+
+        /// UUID
+        public var id: PocketGraph.ID { __data["id"] }
+        /// The display headline for the slate. Surface context may be required to render determine what to display. This will depend on if we connect the copy to the Surface, SlateExperiment, or Slate.
+        public var headline: String { __data["headline"] }
+        /// A smaller, secondary headline that can be displayed to provide additional context on the slate.
+        public var subheadline: String? { __data["subheadline"] }
+        /// Recommendations for the current request context.
+        public var recommendations: [Recommendation] { __data["recommendations"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var corpusSlateParts: CorpusSlateParts { _toFragment() }
+        }
+
+        /// HomeSlateLineup.Slate.Recommendation
+        ///
+        /// Parent Type: `CorpusRecommendation`
+        public struct Recommendation: PocketGraph.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusRecommendation }
+
+          /// Clients should include this id in the `corpus_recommendation` Snowplow entity for impression, content_open, and engagement events related to this recommendation. This id is different across users, across requests, and across corpus items. The recommendation-api service associates metadata with this id to join and aggregate recommendations in our data warehouse.
+          public var id: PocketGraph.ID { __data["id"] }
+          /// Content meta data.
+          public var corpusItem: CorpusItem { __data["corpusItem"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var corpusRecommendationParts: CorpusRecommendationParts { _toFragment() }
+          }
+
+          /// HomeSlateLineup.Slate.Recommendation.CorpusItem
+          ///
+          /// Parent Type: `CorpusItem`
+          public struct CorpusItem: PocketGraph.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CorpusItem }
+
+            /// The GUID that is stored on an approved corpus item
+            public var id: PocketGraph.ID { __data["id"] }
+            /// The URL of the Approved Item.
+            public var url: PocketGraph.Url { __data["url"] }
+            /// The title of the Approved Item.
+            public var title: String { __data["title"] }
+            /// The excerpt of the Approved Item.
+            public var excerpt: String { __data["excerpt"] }
+            /// The image URL for this item's accompanying picture.
+            public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+            /// The name of the online publication that published this story.
+            public var publisher: String { __data["publisher"] }
+            /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+            public var target: Target? { __data["target"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var corpusItemParts: CorpusItemParts { _toFragment() }
+            }
+
+            /// HomeSlateLineup.Slate.Recommendation.CorpusItem.Target
+            ///
+            /// Parent Type: `CorpusTarget`
+            public struct Target: PocketGraph.SelectionSet {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
+
+              public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+
+              /// HomeSlateLineup.Slate.Recommendation.CorpusItem.Target.AsSyndicatedArticle
+              ///
+              /// Parent Type: `SyndicatedArticle`
+              public struct AsSyndicatedArticle: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+                public let __data: DataDict
+                public init(_dataDict: DataDict) { __data = _dataDict }
+
+                public typealias RootEntityType = HomeSlateLineupQuery.Data.HomeSlateLineup.Slate.Recommendation.CorpusItem.Target
+                public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.SyndicatedArticle }
+                public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+                  SyndicatedArticleParts.self,
+                  CorpusItemParts.Target.AsSyndicatedArticle.self
+                ] }
+
+                /// The item id of this Syndicated Article
+                public var itemId: PocketGraph.ID? { __data["itemId"] }
+                /// Primary image to use in surfacing this content
+                public var mainImage: String? { __data["mainImage"] }
+                /// Title of syndicated article
+                public var title: String { __data["title"] }
+                /// Excerpt 
+                public var excerpt: String? { __data["excerpt"] }
+                /// The manually set publisher information for this article
+                public var publisher: SyndicatedArticleParts.Publisher? { __data["publisher"] }
+
+                public struct Fragments: FragmentContainer {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusItem.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusItem.graphql.swift
@@ -1,0 +1,13 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  /// Represents an item that is in the Corpus and its associated manually edited metadata.
+  /// TODO: CorpusItem to implement PocketResource when it becomes available.
+  static let CorpusItem = Object(
+    typename: "CorpusItem",
+    implementedInterfaces: []
+  )
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusRecommendation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusRecommendation.graphql.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  static let CorpusRecommendation = Object(
+    typename: "CorpusRecommendation",
+    implementedInterfaces: []
+  )
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusSlate.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusSlate.graphql.swift
@@ -1,0 +1,12 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  /// This is the same as Slate but in this type all recommendations are backed by CorpusItems. This means that the editorial team has editorial control over the items served by this endpoint.
+  static let CorpusSlate = Object(
+    typename: "CorpusSlate",
+    implementedInterfaces: []
+  )
+}

--- a/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusSlateLineup.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Objects/CorpusSlateLineup.graphql.swift
@@ -1,0 +1,12 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  /// A collection of slates.
+  static let CorpusSlateLineup = Object(
+    typename: "CorpusSlateLineup",
+    implementedInterfaces: []
+  )
+}

--- a/PocketKit/Sources/PocketGraph/Schema/SchemaMetadata.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/SchemaMetadata.graphql.swift
@@ -41,6 +41,16 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "CollectionAuthor": return PocketGraph.Objects.CollectionAuthor
     case "CollectionStory": return PocketGraph.Objects.CollectionStory
     case "CollectionStoryAuthor": return PocketGraph.Objects.CollectionStoryAuthor
+    case "SlateLineup": return PocketGraph.Objects.SlateLineup
+    case "Slate": return PocketGraph.Objects.Slate
+    case "Recommendation": return PocketGraph.Objects.Recommendation
+    case "CuratedInfo": return PocketGraph.Objects.CuratedInfo
+    case "UnleashAssignmentList": return PocketGraph.Objects.UnleashAssignmentList
+    case "UnleashAssignment": return PocketGraph.Objects.UnleashAssignment
+    case "CorpusSlateLineup": return PocketGraph.Objects.CorpusSlateLineup
+    case "CorpusSlate": return PocketGraph.Objects.CorpusSlate
+    case "CorpusRecommendation": return PocketGraph.Objects.CorpusRecommendation
+    case "CorpusItem": return PocketGraph.Objects.CorpusItem
     case "MarticleText": return PocketGraph.Objects.MarticleText
     case "MarticleDivider": return PocketGraph.Objects.MarticleDivider
     case "MarticleTable": return PocketGraph.Objects.MarticleTable
@@ -53,12 +63,6 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "UnMarseable": return PocketGraph.Objects.UnMarseable
     case "BulletedListElement": return PocketGraph.Objects.BulletedListElement
     case "NumberedListElement": return PocketGraph.Objects.NumberedListElement
-    case "SlateLineup": return PocketGraph.Objects.SlateLineup
-    case "Slate": return PocketGraph.Objects.Slate
-    case "Recommendation": return PocketGraph.Objects.Recommendation
-    case "CuratedInfo": return PocketGraph.Objects.CuratedInfo
-    case "UnleashAssignmentList": return PocketGraph.Objects.UnleashAssignmentList
-    case "UnleashAssignment": return PocketGraph.Objects.UnleashAssignment
     case "TagConnection": return PocketGraph.Objects.TagConnection
     case "TagEdge": return PocketGraph.Objects.TagEdge
     case "SavedItemSearchResultConnection": return PocketGraph.Objects.SavedItemSearchResultConnection

--- a/PocketKit/Sources/PocketGraph/Schema/Unions/CorpusTarget.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/Unions/CorpusTarget.graphql.swift
@@ -1,0 +1,16 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Unions {
+  /// TODO: Make this type implement PocketResource when available.
+  /// https://getpocket.atlassian.net/wiki/spaces/PE/pages/2771714049/The+Future+of+Item
+  static let CorpusTarget = Union(
+    name: "CorpusTarget",
+    possibleTypes: [
+      Objects.SyndicatedArticle.self,
+      Objects.Collection.self
+    ]
+  )
+}

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
@@ -1,0 +1,42 @@
+fragment CorpusItemParts on CorpusItem {
+    id
+    url
+    title
+    excerpt
+    imageUrl
+    publisher
+    target {
+        ... on SyndicatedArticle {
+            __typename
+            ...SyndicatedArticleParts
+        }
+    }
+}
+
+fragment CorpusRecommendationParts on CorpusRecommendation {
+    id
+    corpusItem {
+        __typename
+        ...CorpusItemParts
+    }
+}
+
+fragment CorpusSlateParts on CorpusSlate {
+    id
+    headline
+    subheadline
+    recommendations {
+        __typename
+        ...CorpusRecommendationParts
+    }
+}
+
+query HomeSlateLineup($locale: String!) {
+    homeSlateLineup(locale: $locale) {
+        id
+        slates {
+            __typename
+            ...CorpusSlateParts
+        }
+    }
+}

--- a/PocketKit/Sources/PocketGraphTestMocks/CorpusItem+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/CorpusItem+Mock.graphql.swift
@@ -1,0 +1,42 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import PocketGraph
+
+public class CorpusItem: MockObject {
+  public static let objectType: Object = PocketGraph.Objects.CorpusItem
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<CorpusItem>>
+
+  public struct MockFields {
+    @Field<String>("excerpt") public var excerpt
+    @Field<PocketGraph.ID>("id") public var id
+    @Field<PocketGraph.Url>("imageUrl") public var imageUrl
+    @Field<String>("publisher") public var publisher
+    @Field<CorpusTarget>("target") public var target
+    @Field<String>("title") public var title
+    @Field<PocketGraph.Url>("url") public var url
+  }
+}
+
+public extension Mock where O == CorpusItem {
+  convenience init(
+    excerpt: String? = nil,
+    id: PocketGraph.ID? = nil,
+    imageUrl: PocketGraph.Url? = nil,
+    publisher: String? = nil,
+    target: AnyMock? = nil,
+    title: String? = nil,
+    url: PocketGraph.Url? = nil
+  ) {
+    self.init()
+    _set(excerpt, for: \.excerpt)
+    _set(id, for: \.id)
+    _set(imageUrl, for: \.imageUrl)
+    _set(publisher, for: \.publisher)
+    _set(target, for: \.target)
+    _set(title, for: \.title)
+    _set(url, for: \.url)
+  }
+}

--- a/PocketKit/Sources/PocketGraphTestMocks/CorpusRecommendation+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/CorpusRecommendation+Mock.graphql.swift
@@ -1,0 +1,27 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import PocketGraph
+
+public class CorpusRecommendation: MockObject {
+  public static let objectType: Object = PocketGraph.Objects.CorpusRecommendation
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<CorpusRecommendation>>
+
+  public struct MockFields {
+    @Field<CorpusItem>("corpusItem") public var corpusItem
+    @Field<PocketGraph.ID>("id") public var id
+  }
+}
+
+public extension Mock where O == CorpusRecommendation {
+  convenience init(
+    corpusItem: Mock<CorpusItem>? = nil,
+    id: PocketGraph.ID? = nil
+  ) {
+    self.init()
+    _set(corpusItem, for: \.corpusItem)
+    _set(id, for: \.id)
+  }
+}

--- a/PocketKit/Sources/PocketGraphTestMocks/CorpusSlate+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/CorpusSlate+Mock.graphql.swift
@@ -1,0 +1,33 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import PocketGraph
+
+public class CorpusSlate: MockObject {
+  public static let objectType: Object = PocketGraph.Objects.CorpusSlate
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<CorpusSlate>>
+
+  public struct MockFields {
+    @Field<String>("headline") public var headline
+    @Field<PocketGraph.ID>("id") public var id
+    @Field<[CorpusRecommendation]>("recommendations") public var recommendations
+    @Field<String>("subheadline") public var subheadline
+  }
+}
+
+public extension Mock where O == CorpusSlate {
+  convenience init(
+    headline: String? = nil,
+    id: PocketGraph.ID? = nil,
+    recommendations: [Mock<CorpusRecommendation>]? = nil,
+    subheadline: String? = nil
+  ) {
+    self.init()
+    _set(headline, for: \.headline)
+    _set(id, for: \.id)
+    _set(recommendations, for: \.recommendations)
+    _set(subheadline, for: \.subheadline)
+  }
+}

--- a/PocketKit/Sources/PocketGraphTestMocks/CorpusSlateLineup+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/CorpusSlateLineup+Mock.graphql.swift
@@ -1,0 +1,27 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import PocketGraph
+
+public class CorpusSlateLineup: MockObject {
+  public static let objectType: Object = PocketGraph.Objects.CorpusSlateLineup
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<CorpusSlateLineup>>
+
+  public struct MockFields {
+    @Field<PocketGraph.ID>("id") public var id
+    @Field<[CorpusSlate]>("slates") public var slates
+  }
+}
+
+public extension Mock where O == CorpusSlateLineup {
+  convenience init(
+    id: PocketGraph.ID? = nil,
+    slates: [Mock<CorpusSlate>]? = nil
+  ) {
+    self.init()
+    _set(id, for: \.id)
+    _set(slates, for: \.slates)
+  }
+}

--- a/PocketKit/Sources/PocketGraphTestMocks/MockObject+Unions.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/MockObject+Unions.graphql.swift
@@ -6,5 +6,6 @@ import PocketGraph
 
 public extension MockObject {
   typealias ItemResult = Union
+  typealias CorpusTarget = Union
   typealias MarticleComponent = Union
 }

--- a/PocketKit/Sources/PocketGraphTestMocks/Query+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/Query+Mock.graphql.swift
@@ -16,6 +16,7 @@ public class Query: MockObject {
     @Field<Slate>("getSlate") public var getSlate
     @available(*, deprecated, message: "Please use queries specific to the surface ex. setMomentSlate. If a named query for your surface does not yet exit please reach out to the Data Products team and they will happily provide you with a named query.")
     @Field<SlateLineup>("getSlateLineup") public var getSlateLineup
+    @Field<CorpusSlateLineup>("homeSlateLineup") public var homeSlateLineup
     @Field<Item>("itemByItemId") public var itemByItemId
     @Field<User>("user") public var user
   }
@@ -27,6 +28,7 @@ public extension Mock where O == Query {
     collection: Mock<Collection>? = nil,
     getSlate: Mock<Slate>? = nil,
     getSlateLineup: Mock<SlateLineup>? = nil,
+    homeSlateLineup: Mock<CorpusSlateLineup>? = nil,
     itemByItemId: Mock<Item>? = nil,
     user: Mock<User>? = nil
   ) {
@@ -35,6 +37,7 @@ public extension Mock where O == Query {
     _set(collection, for: \.collection)
     _set(getSlate, for: \.getSlate)
     _set(getSlateLineup, for: \.getSlateLineup)
+    _set(homeSlateLineup, for: \.homeSlateLineup)
     _set(itemByItemId, for: \.itemByItemId)
     _set(user, for: \.user)
   }

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -45,7 +45,7 @@ class HomeRefreshCoordinator: RefreshCoordinator {
                 }
                 do {
                     self.isRefreshing = true
-                    try await self.source.fetchSlateLineup()
+                    try await self.source.fetchUnifiedHomeLineup()
                     self.lastRefresh.refreshedHome()
                     Log.breadcrumb(category: "refresh", level: .info, message: "Home Refresh Occur")
                 } catch {

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -45,7 +45,7 @@ class HomeRefreshCoordinator: RefreshCoordinator {
                 }
                 do {
                     self.isRefreshing = true
-                    try await self.source.fetchSlateLineup(SyncConstants.Home.slateLineupIdentifier)
+                    try await self.source.fetchSlateLineup()
                     self.lastRefresh.refreshedHome()
                     Log.breadcrumb(category: "refresh", level: .info, message: "Home Refresh Occur")
                 } catch {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -607,8 +607,7 @@ extension PocketSource {
 
 // MARK: - Slates/Recommendations
 extension PocketSource {
-    public func fetchSlateLineup(_ identifier: String) async throws {
-        // try await slateService.fetchSlateLineup(identifier)
+    public func fetchSlateLineup() async throws {
         try await slateService.fetchHomeSlateLineup()
     }
 

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -608,7 +608,8 @@ extension PocketSource {
 // MARK: - Slates/Recommendations
 extension PocketSource {
     public func fetchSlateLineup(_ identifier: String) async throws {
-        try await slateService.fetchSlateLineup(identifier)
+        // try await slateService.fetchSlateLineup(identifier)
+        try await slateService.fetchHomeSlateLineup()
     }
 
     public func fetchDetails(for recommendation: Recommendation) async throws -> Bool {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -607,7 +607,7 @@ extension PocketSource {
 
 // MARK: - Slates/Recommendations
 extension PocketSource {
-    public func fetchSlateLineup() async throws {
+    public func fetchUnifiedHomeLineup() async throws {
         try await slateService.fetchHomeSlateLineup()
     }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -86,6 +86,38 @@ extension Item {
         givenURL = remote.givenUrl
     }
 
+    func update(from corpusItem: CorpusSlateParts.Recommendation.CorpusItem, in space: Space) {
+        remoteID = corpusItem.id
+        givenURL = corpusItem.url
+        title = corpusItem.title
+        topImageURL = URL(string: corpusItem.imageUrl)
+        domain = corpusItem.publisher
+        // TODO: add language
+        excerpt = corpusItem.excerpt
+
+        guard let context = managedObjectContext else {
+            return
+        }
+
+        if let topImageURL {
+            addToImages(Image(url: topImageURL, context: context))
+        }
+
+        // TODO: add authors
+
+        if let syndicatedArticle = corpusItem.target?.asSyndicatedArticle, let itemId = syndicatedArticle.itemId {
+            self.syndicatedArticle = (try? space.fetchSyndicatedArticle(byItemId: itemId, context: context)) ?? SyndicatedArticle(context: context)
+            self.syndicatedArticle?.itemID = itemId
+            self.syndicatedArticle?.publisherName = syndicatedArticle.publisher?.name
+            self.syndicatedArticle?.title = syndicatedArticle.title
+            self.syndicatedArticle?.excerpt = syndicatedArticle.excerpt
+            self.syndicatedArticle?.imageURL = syndicatedArticle.mainImage.flatMap(URL.init(string:))
+            if let imageSrc = syndicatedArticle.mainImage {
+                self.syndicatedArticle?.image = Image(src: imageSrc, context: context)
+            }
+        }
+    }
+
     func update(from summary: ItemSummary, with space: Space) {
         remoteID = summary.remoteID
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -87,7 +87,6 @@ extension Item {
     }
 
     func update(from corpusItem: CorpusSlateParts.Recommendation.CorpusItem, in space: Space) {
-        remoteID = corpusItem.id
         givenURL = corpusItem.url
         title = corpusItem.title
         topImageURL = URL(string: corpusItem.imageUrl)

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -92,7 +92,7 @@ extension Item {
         title = corpusItem.title
         topImageURL = URL(string: corpusItem.imageUrl)
         domain = corpusItem.publisher
-        // TODO: add language
+        // TODO: UNIFIEDHOME - add language
         excerpt = corpusItem.excerpt
 
         guard let context = managedObjectContext else {
@@ -103,7 +103,7 @@ extension Item {
             addToImages(Image(url: topImageURL, context: context))
         }
 
-        // TODO: add authors
+        // TODO: UNIFIEDHOME - add authors
 
         if let syndicatedArticle = corpusItem.target?.asSyndicatedArticle, let itemId = syndicatedArticle.itemId {
             self.syndicatedArticle = (try? space.fetchSyndicatedArticle(byItemId: itemId, context: context)) ?? SyndicatedArticle(context: context)

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -92,7 +92,7 @@ public enum Requests {
 
     public static func fetchRecomendations(by lineupIdentifier: String) -> RichFetchRequest<Recommendation> {
         let request = RichFetchRequest<Recommendation>(entityName: "Recommendation")
-        request.predicate = NSPredicate(format: "slate.slateLineup.remoteID = %@ AND item != NULL", lineupIdentifier)
+        request.predicate = NSPredicate(format: "item != NULL")
         request.sortDescriptors = [
             NSSortDescriptor(keyPath: \Recommendation.slate?.sortIndex, ascending: true),
             NSSortDescriptor(keyPath: \Recommendation.sortIndex, ascending: true),

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -92,6 +92,7 @@ public enum Requests {
 
     public static func fetchRecomendations(by lineupIdentifier: String) -> RichFetchRequest<Recommendation> {
         let request = RichFetchRequest<Recommendation>(entityName: "Recommendation")
+        // We only search for valid recommendations without specifying a lineup, since the lineup will be only 1 (from unified home)
         request.predicate = NSPredicate(format: "item != NULL")
         request.sortDescriptors = [
             NSSortDescriptor(keyPath: \Recommendation.slate?.sortIndex, ascending: true),

--- a/PocketKit/Sources/Sync/Slates/SlateService.swift
+++ b/PocketKit/Sources/Sync/Slates/SlateService.swift
@@ -8,7 +8,7 @@ import PocketGraph
 import SharedPocketKit
 
 protocol SlateService {
-    func fetchSlateLineup(_ identifier: String) async throws
+    func fetchHomeSlateLineup() async throws
 }
 
 class APISlateService: SlateService {
@@ -23,13 +23,14 @@ class APISlateService: SlateService {
         self.space = space
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws {
-        let query = GetSlateLineupQuery(lineupID: identifier, maxRecommendations: SyncConstants.Home.recomendationsPerSlateFromSlateLineup)
+    func fetchHomeSlateLineup() async throws {
+        let query = HomeSlateLineupQuery(locale: Locale.preferredLanguages.first ?? "en-US")
 
-        guard let remote = try await apollo.fetch(query: query).data?.getSlateLineup else {
-            Log.capture(message: "Error loading slate lineup")
+        guard let remote = try await apollo.fetch(query: query).data?.homeSlateLineup else {
+            Log.capture(message: "Error loading unified home lineup")
             return
         }
-        try space.updateLineup(from: remote)
+
+        try space.updateHomeLineup(from: remote)
     }
 }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -66,7 +66,7 @@ public protocol Source {
 
     func filterTags(with input: String, excluding tags: [String]) -> [Tag]?
 
-    func fetchSlateLineup(_ identifier: String) async throws
+    func fetchSlateLineup() async throws
 
     func restore()
 

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -66,7 +66,7 @@ public protocol Source {
 
     func filterTags(with input: String, excluding tags: [String]) -> [Tag]?
 
-    func fetchSlateLineup() async throws
+    func fetchUnifiedHomeLineup() async throws
 
     func restore()
 

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -122,8 +122,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh(isForced: true) { }
 
         wait(for: [fetchExpectation], timeout: 10)
-
-        XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
+        XCTAssertNotNil(source.fetchSlateLineupCall(at: 0))
     }
 // TODO: Renable once we fix our singleton use in tests
 //    func test_coordinator_whenEnterForeground_whenDataIsNotStale_doesNotRefreshHome() {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -874,16 +874,16 @@ extension MockSource {
         return call
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws {
+    func fetchUnifiedHomeLineup() async throws {
         guard let impl = implementations[Self.fetchSlateLineup] as? FetchSlateLineupImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
         calls[Self.fetchSlateLineup] = (calls[Self.fetchSlateLineup] ?? []) + [
-            FetchSlateLineupCall(identifier: identifier)
+            FetchSlateLineupCall(identifier: "")
         ]
 
-        impl(identifier)
+        impl("")
     }
 }
 

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -39,31 +39,28 @@ class APISlateServiceTests: XCTestCase {
 extension APISlateServiceTests {
     @MainActor
     func test_fetchSlateLineup_performsCorrectQuery() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "slates", asResultType: GetSlateLineupQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "corpusSlates", asResultType: HomeSlateLineupQuery.self)
 
         let service = subject()
-        try await service.fetchSlateLineup("slate-lineup-identifier")
+        try await service.fetchHomeSlateLineup()
 
-        let fetchCall: MockApolloClient.FetchCall<GetSlateLineupQuery>? = apollo.fetchCall(at: 0)
+        let fetchCall: MockApolloClient.FetchCall<HomeSlateLineupQuery>? = apollo.fetchCall(at: 0)
         XCTAssertNotNil(fetchCall)
-        XCTAssertEqual(fetchCall?.query.lineupID, "slate-lineup-identifier")
-        XCTAssertEqual(fetchCall?.query.maxRecommendations, SyncConstants.Home.recomendationsPerSlateFromSlateLineup)
+        XCTAssertEqual(fetchCall?.query.locale, Locale.preferredLanguages.first)
     }
 
     @MainActor
     func test_fetchSlateLineup_emptySpace_savesLineupInSpace() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "slates", asResultType: GetSlateLineupQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "corpusSlates", asResultType: HomeSlateLineupQuery.self)
 
         let service = subject()
-        try await service.fetchSlateLineup("slate-lineup-identifier")
+        try await service.fetchHomeSlateLineup()
 
         let lineups = try space.fetchSlateLineups()
         XCTAssertEqual(lineups.count, 1)
 
-        let lineup = lineups[0]
+        let lineup = lineups.first!
         XCTAssertEqual(lineup.remoteID, "slate-lineup-1")
-        XCTAssertEqual(lineup.requestID, "slate-lineup-1-request")
-        XCTAssertEqual(lineup.experimentID, "slate-lineup-1-experiment")
 
         let slates = lineup.slates?.compactMap { $0 as? Slate } ?? []
         XCTAssertEqual(slates.count, 2)
@@ -71,8 +68,6 @@ extension APISlateServiceTests {
         do {
             let slate = slates[0]
             XCTAssertEqual(slate.remoteID, "slate-1")
-            XCTAssertEqual(slate.requestID, "slate-1-request")
-            XCTAssertEqual(slate.experimentID, "slate-1-experiment")
             XCTAssertEqual(slate.name, "Slate 1")
             XCTAssertEqual(slate.slateDescription, "The description of slate 1")
 
@@ -87,22 +82,10 @@ extension APISlateServiceTests {
                 XCTAssertNotNil(item)
                 XCTAssertEqual(item.remoteID, "item-1")
                 XCTAssertEqual(item.givenURL, "https://given.example.com/slate-1-rec-1")
-                XCTAssertEqual(item.resolvedURL, "https://resolved.example.com/rec-1")
                 XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
-                XCTAssertEqual(item.language, "en")
                 XCTAssertEqual(item.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
-                XCTAssertEqual(item.timeToRead, 1)
                 XCTAssertEqual(item.excerpt, "Cursus Aenean Elit")
-                XCTAssertEqual(item.datePublished?.timeIntervalSince1970, 1609502461)
                 XCTAssertEqual(item.domain, "slate-1-rec-1.example.com")
-                XCTAssertEqual(item.domainMetadata?.name, "Lifehacker")
-                XCTAssertEqual(item.domainMetadata?.logo?.absoluteString, "https://slate-1-rec-1.example.com/logo.png")
-                XCTAssertEqual(item.isArticle, true)
-                XCTAssertEqual(item.hasImage, .hasImages)
-                XCTAssertEqual(item.hasVideo, .hasVideos)
-
-                let images = item.images?.compactMap { $0 as? Image } ?? []
-                XCTAssertEqual(images[0].source, URL(string: "http://example.com/rec-1/image-1.jpg"))
             }
 
             do {
@@ -115,8 +98,6 @@ extension APISlateServiceTests {
         do {
             let slate = slates[1]
             XCTAssertEqual(slate.remoteID, "slate-2")
-            XCTAssertEqual(slate.requestID, "slate-2-request")
-            XCTAssertEqual(slate.experimentID, "slate-2-experiment")
             XCTAssertEqual(slate.name, "Slate 2")
             XCTAssertEqual(slate.slateDescription, "The description of slate 2")
 
@@ -132,7 +113,7 @@ extension APISlateServiceTests {
 
     @MainActor
     func test_fetchSlateLineup_existingSlateLineup_updatesExistingSpace() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "slates", asResultType: GetSlateLineupQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "corpusSlates", asResultType: HomeSlateLineupQuery.self)
 
         let item = space.buildItem(remoteID: "item-1-seed")
         let recommendation = space.buildRecommendation(remoteID: "slate-1-recommendation-1-seed", item: item)
@@ -141,7 +122,7 @@ extension APISlateServiceTests {
         try self.space.save()
 
         let service = subject()
-        try await service.fetchSlateLineup("slate-lineup-identifier")
+        try await service.fetchHomeSlateLineup()
 
         // 1. Update existing slate lineup
         let lineups = try space.fetchSlateLineups()
@@ -168,7 +149,7 @@ extension APISlateServiceTests {
 
     @MainActor
     func test_fetchSlateLineup_existingSlateLineup_hasSavedItems_keepsItems() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "slates", asResultType: GetSlateLineupQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "corpusSlates", asResultType: HomeSlateLineupQuery.self)
 
         let item = space.buildItem(remoteID: "item-1-seed")
         space.buildSavedItem(item: item)
@@ -178,7 +159,7 @@ extension APISlateServiceTests {
         try self.space.save()
 
         let service = subject()
-        try await service.fetchSlateLineup("slate-lineup-identifier")
+        try await service.fetchHomeSlateLineup()
 
         let items = try space.fetchItems()
         XCTAssertEqual(items.count, 4)
@@ -186,16 +167,16 @@ extension APISlateServiceTests {
 
     @MainActor
     func test_fetchSlateLineup_existingItem_updatesExistingItem() async throws {
-        apollo.stubFetch(toReturnFixtureNamed: "slates", asResultType: GetSlateLineupQuery.self)
+        apollo.stubFetch(toReturnFixtureNamed: "corpusSlates", asResultType: HomeSlateLineupQuery.self)
 
-        // fetchSlateLineup "cleans" all unsaved items before fetching,
+        // fetchUnifiedHomeLineup "cleans" all unsaved items before fetching,
         // so we have to fake a saved item for the item to update
         let item = space.buildItem(title: "Item 1 Seed", givenURL: "https://given.example.com/slate-1-rec-1")
         space.buildSavedItem(item: item)
         try self.space.save()
 
         let service = subject()
-        try await service.fetchSlateLineup("slate-lineup-identifier")
+        try await service.fetchHomeSlateLineup()
 
         XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
     }

--- a/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/APISlateServiceTests.swift
@@ -80,7 +80,6 @@ extension APISlateServiceTests {
 
                 let item = recommendation.item
                 XCTAssertNotNil(item)
-                XCTAssertEqual(item.remoteID, "item-1")
                 XCTAssertEqual(item.givenURL, "https://given.example.com/slate-1-rec-1")
                 XCTAssertEqual(item.title, "Slate 1, Recommendation 1")
                 XCTAssertEqual(item.topImageURL?.absoluteString, "http://example.com/slate-1-rec-1/top-image.png")
@@ -144,7 +143,7 @@ extension APISlateServiceTests {
         let items = try space.fetchItems()
         XCTAssertEqual(items.count, 3)
         let itemIDs = items.map { $0.remoteID }
-        XCTAssertEqual(Set(itemIDs), ["item-1", "item-2", "item-3"])
+        XCTAssertEqual(Set(itemIDs), ["slate-1-rec-1slate-1", "slate-2-rec-1slate-2", "slate-1-rec-2slate-1"])
     }
 
     @MainActor

--- a/PocketKit/Tests/SyncTests/Fixtures/corpusSlates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/corpusSlates.json
@@ -1,0 +1,95 @@
+{
+    "data": {
+        "homeSlateLineup": {
+            "id": "slate-lineup-1",
+            "__typename": "[some-type-name]",
+            "slates": [
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-1",
+                    "headline": "Slate 1",
+                    "subheadline": "The description of slate 1",
+                    "recommendations": [
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-1-rec-1",
+                            "corpusItem": {
+                                "__typename": "[some-type-name]",
+                                "id": "item-1",
+                                "url": "https://given.example.com/slate-1-rec-1",
+                                "title": "Slate 1, Recommendation 1",
+                                "excerpt": "Cursus Aenean Elit",
+                                "imageUrl": "http://example.com/slate-1-rec-1/top-image.png",
+                                "publisher":"slate-1-rec-1.example.com",
+                                "target": {
+                                    "__typename": "[some-type-name]",
+                                    "itemId": "slate-1-rec-1-corpusItem-1-syndicated",
+                                    "mainImage": "image-1-1-1",
+                                    "title": "syndicatedTitle-1-1-1",
+                                    "excerpt": "syndicatedExcerpt-1-1-1",
+                                    "publisher": {
+                                      "name": "syndicatedPublisher-1-1-1"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-1-rec-2",
+                            "corpusItem": {
+                                "__typename": "[some-type-name]",
+                                "id": "item-2",
+                                "url": "https://given.example.com/slate-1-rec-2",
+                                "title": "Slate 1, Recommendation 2",
+                                "excerpt": "Cursus Aenean Elit",
+                                "imageUrl": "http://example.com/slate-1-rec-2/top-image.png",
+                                "publisher":"slate-1-rec-2.example.com",
+                                "target": {
+                                    "__typename": "[some-type-name]",
+                                    "itemId": "slate-1-rec-2-corpusItem-2-syndicated",
+                                    "mainImage": "image-1-2-2",
+                                    "title": "syndicatedTitle-1-2-2",
+                                    "excerpt": "syndicatedExcerpt-1-2-2",
+                                    "publisher": {
+                                      "name": "syndicatedPublisher-1-2-2"
+                                    }
+                                }
+                            }
+                        },
+                    ],
+                },
+                {
+                    "__typename": "[some-type-name]",
+                    "id": "slate-2",
+                    "headline": "Slate 2",
+                    "subheadline": "The description of slate 2",
+                    "recommendations": [
+                        {
+                            "__typename": "[some-type-name]",
+                            "id": "slate-2-rec-1",
+                            "corpusItem": {
+                                "__typename": "[some-type-name]",
+                                "id": "item-3",
+                                "url": "https://given.example.com/slate-2-rec-1",
+                                "title": "Slate 2, Recommendation 1",
+                                "excerpt": "Cursus Aenean Elit",
+                                "imageUrl": "http://example.com/slate-2-rec-1/top-image.png",
+                                "publisher":"slate-2-rec-1.example.com",
+                                "target": {
+                                    "__typename": "[some-type-name]",
+                                    "itemId": "slate-2-rec-1-corpusItem-3-syndicated",
+                                    "mainImage": "image-2-1-3",
+                                    "title": "syndicatedTitle-2-1-3",
+                                    "excerpt": "syndicatedExcerpt-2-1-3",
+                                    "publisher": {
+                                      "name": "syndicatedPublisher-2-1-3"
+                                    }
+                                }
+                            }
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+}

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -291,8 +291,8 @@ class PocketSourceTests: XCTestCase {
         slateService.stubFetchSlateLineup { _ in }
 
         let source = subject()
-        try await source.fetchSlateLineup("slate-lineup-identifier")
-        XCTAssertEqual(slateService.fetchSlateLineupCall(at: 0)?.identifier, "slate-lineup-identifier")
+        try await source.fetchUnifiedHomeLineup()
+        XCTAssertNotNil(slateService.fetchSlateLineupCall(at: 0))
     }
 
     func test_savesController_returnsAFetchedResultsController() throws {

--- a/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockSlateService.swift
@@ -21,16 +21,16 @@ extension MockSlateService {
         implementations[Self.fetchSlateLineup] = impl
     }
 
-    func fetchSlateLineup(_ identifier: String) async throws {
+    func fetchHomeSlateLineup() async throws {
         guard let impl = implementations[Self.fetchSlateLineup] as? FetchSlateLineupImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
 
         calls[Self.fetchSlateLineup] = (calls[Self.fetchSlateLineup] ?? []) + [
-            FetchSlateLineupCall(identifier: identifier)
+            FetchSlateLineupCall(identifier: "")
         ]
 
-        try await impl(identifier)
+        try await impl("")
     }
 
     func fetchSlateLineupCall(at index: Int) -> FetchSlateLineupCall? {


### PR DESCRIPTION
## Summary
* This PR replaces the legacy Home recommendations with Unified Home. The new Api is used to fetch slates and recommendations. The UI structure remains the same.

## References 
* See ticket number in the branch name

## Implementation Details
* PocketGraph: introduce new `Corpus` entities
* Update `SlateService`, replace existing lineup query with `homeSlateLineup`
* Core Data: map `SlateLineup`, `Slate` and `Recommendation` to corresponding `Corpus` entities

> **Note**
Analytics updates and Core Data entity renaming will happen in a separate PR


## Test Steps
* Build/run this branch
* Ho to Home and make sure you see the unified home slates (Today's Pocket Hits, For you, etc)
* Make sure recommendations are readable and actionable as they should be (e.g. save)
* Make sure Home works as expected from a UI standpoint

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

<p align=center>

<img height=500 src=https://github.com/Pocket/pocket-ios/assets/34376330/5d7f9f82-c400-4062-8ae4-4b968ab66f6f>
</p>
