### PR TITLE
ci: update bitrise signing

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -1194,8 +1194,8 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Pocket_iOS_Release.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
@@ -1208,7 +1208,7 @@
 				MARKETING_VERSION = 8.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1245,8 +1245,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				INFOPLIST_FILE = "Tests iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -1305,8 +1305,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_ENTITLEMENTS = PushNotificationServiceExtension/PushNotificationServiceExtension.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1322,7 +1322,7 @@
 				MARKETING_VERSION = 8.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.PushNotifica";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1368,8 +1368,8 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_ENTITLEMENTS = PushNotificationStoryExtension/PushNotificationStoryExtension.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1385,7 +1385,7 @@
 				MARKETING_VERSION = 8.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.PushStory";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1682,8 +1682,8 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = ItemWidgets/ItemWidgets.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1699,6 +1699,7 @@
 				MARKETING_VERSION = 8.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterPro.Widget-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.Widget-Exten";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1747,8 +1748,8 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SaveToPocket/SaveToPocket.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				ENABLE_BITCODE = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1764,7 +1765,7 @@
 				MARKETING_VERSION = 8.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.AddToPocketE";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -229,10 +229,6 @@ workflows:
             - configuration: Release
             - xcconfig_content: CURRENT_PROJECT_VERSION = $BITRISE_BUILD_NUMBER
             - export_method: app-store
-            - automatic_code_signing: api-key
-            - api_key_path: "$BITRISEIO_APP_STORE_CONNECT_API_ID_URL"
-            - api_key_id: "$APP_STORE_API_ID"
-            - api_key_issuer_id: "$APP_STORE_API_ISSUER_ID"
       - deploy-to-bitrise-io@2: {}
       - deploy-to-bitrise-io@2:
           inputs:
@@ -254,10 +250,6 @@ workflows:
             - artifact_sources: release-build.release-build
       - fastlane@3:
           inputs:
-            - automatic_code_signing: api-key
-            - api_key_path: "$BITRISEIO_APP_STORE_CONNECT_API_ID_URL"
-            - api_key_id: "$APP_STORE_API_ID"
-            - api_key_issuer_id: "$APP_STORE_API_ISSUER_ID"
             - verbose_log: 'yes'
             - lane: beta_internal
 
@@ -274,10 +266,6 @@ workflows:
                 COMPILER_INDEX_STORE_ENABLE = NO
                 CURRENT_PROJECT_VERSION = $BITRISE_BUILD_NUMBER
             - configuration: Debug
-            - automatic_code_signing: api-key
-            - api_key_path: "$BITRISEIO_APP_STORE_CONNECT_API_ID_URL"
-            - api_key_id: "$APP_STORE_API_ID"
-            - api_key_issuer_id: "$APP_STORE_API_ISSUER_ID"
       - deploy-to-bitrise-io@2: {}
       - cache-push@2: {}
       - slack@3:

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,3 @@
 team_id(ENV["APPLE_DEVELOPER_PORTAL_ID"]) # Developer Portal Team ID
 itc_team_id(ENV["APPLE_APP_STORE_CONNECT_ID"]) # App Store Connect Team ID'
+FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD = ENV["APPLE_ACCOUNT_PW"] # App-specific password

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,3 +1,4 @@
 team_id(ENV["APPLE_DEVELOPER_PORTAL_ID"]) # Developer Portal Team ID
-itc_team_id(ENV["APPLE_APP_STORE_CONNECT_ID"]) # App Store Connect Team ID'
-FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD = ENV["APPLE_ACCOUNT_PW"] # App-specific password
+itc_team_id(ENV["APPLE_APP_STORE_CONNECT_ID"]) # App Store Connect Team ID
+ENV["FASTLANE_USER"] = ENV["APPLE_ACCOUNT_ID"] # App Store Connect User
+ENV["FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD"] = ENV["APPLE_ACCOUNT_PW"] # App-specific password for FASTLANE_USER

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ platform :ios do
 
     # Upload to testflight for our internal apps store connect nightly builds.
     upload_to_testflight(
-      skip_waiting_for_build_processing: false,
-      ipa: BITRISE_IPA_PATH
+      skip_waiting_for_build_processing: true,
+      ipa: BITRISE_IPA_PATH,
       apple_id: APPLE_ID,
       # groups: ['Nightly Internal Builds'], # Temporarily disable until another solution is available, as this doesn't work with app-specific passwords
       # submit_beta_review: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,14 +21,14 @@ platform :ios do
   desc "Push a new beta build to TestFlight Internal Testers via CI"
   lane :beta_internal do
 
-    #upload to testflight for our internal apps store connect nightly builds.
+    # Upload to testflight for our internal apps store connect nightly builds.
     upload_to_testflight(
-      apple_id: APPLE_ID,
       skip_waiting_for_build_processing: false,
-      groups: ['Nightly Internal Builds'],
-      submit_beta_review: false,
-      ipa: BITRISE_IPA_PATH,
-      expire_previous_builds: true
+      ipa: BITRISE_IPA_PATH
+      apple_id: APPLE_ID,
+      # groups: ['Nightly Internal Builds'], # Temporarily disable until another solution is available, as this doesn't work with app-specific passwords
+      # submit_beta_review: false,
+      # expire_previous_builds: true
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@
 # update_fastlane
 
 BITRISE_IPA_PATH = ENV["BITRISE_IPA_PATH"]
+APPLE_ID = ENV["APP_ID"]
 default_platform(:ios)
 
 platform :ios do
@@ -22,6 +23,7 @@ platform :ios do
 
     #upload to testflight for our internal apps store connect nightly builds.
     upload_to_testflight(
+      apple_id: APPLE_ID,
       skip_waiting_for_build_processing: false,
       groups: ['Nightly Internal Builds'],
       submit_beta_review: false,


### PR DESCRIPTION
## Summary

Updates bitrise signing to use manual provisioning profiles, and apple ID-based auth for TestFlight uploads. This removes waiting for builds to process, as well as submitting the release build to a specific group, since those features are not currently available when using account-based auth.

## Implementation Details

After app transfer, we were required to change our API-key based authentication to account-based authentication, and the featureset when using account-based auth is smaller; i.e, we can only submit to TestFlight, and no longer wait for a build to stop processing, or submit to a group. 