### PR TITLE
feat(collections): create native collection view

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -218,9 +218,6 @@
 "premium.upgradeView.unlimitedHighlights" = "Unlimited highlights";
 "premium.upgradeView.premiumFonts" = "Premium fonts";
 
-// Collection
- "collection.title" = "Collection";
-
 //=======================
 //Old format
 
@@ -328,3 +325,7 @@
 "itemWidgets.recommendations.emptyMessage" = "You might be offline. Please check recommendations in your Pocket app";
 "itemWidgets.recommendations.title" = "Recommendations";
 "itemWidgets.recommendations.description" = "Discover the most thought-provoking stories out there, curated by Pocket.";
+
+// Collection
+"collection.title" = "Collection";
+"collection.stories.count" = "%@ items";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -181,6 +181,12 @@ public enum Localization {
   public enum Collection {
     /// Collection
     public static let title = Localization.tr("Localizable", "collection.title", fallback: "Collection")
+    public enum Stories {
+      /// %@ items
+      public static func count(_ p1: Any) -> String {
+        return Localization.tr("Localizable", "collection.stories.count", String(describing: p1), fallback: "%@ items")
+      }
+    }
   }
   public enum Favourites {
     public enum Empty {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -136,6 +136,21 @@ class SavedItemViewModel: ReadableViewModel {
         item.isArchived
     }
 
+    var isCollection: Bool {
+        item.isCollection
+    }
+
+    var slug: String? {
+        // TODO: Add check for slug and use this as fallback
+        // Returns the slug from a collection url by validating that it is in the proper url format (ie. 0 represents "/", 1 represents "collections" and 2 represents the slug)
+        guard let url = URL(string: url), url.host == "getpocket.com",
+              url.pathComponents.count >= 3,
+              url.pathComponents[safe: 1] == "collections" else {
+                 return nil
+             }
+        return url.pathComponents[safe: 2]
+    }
+
     var premiumURL: String? {
         pocketPremiumURL(url, user: user)
     }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionMetadataCell.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionMetadataCell.swift
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Kingfisher
+import Textile
+
+class CollectionMetadataCell: UICollectionViewCell {
+    enum Constants {
+        static let stackSpacing: CGFloat = 14
+        static let layoutMargins: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 14, right: 0)
+    }
+
+    struct Model {
+        let byline: NSAttributedString?
+        let itemCount: NSAttributedString?
+        let title: NSAttributedString?
+        let intro: NSAttributedString?
+    }
+
+    private let bylineTextView = ArticleComponentTextView()
+    private let itemCountView = ArticleComponentTextView()
+    private let titleTextView = ArticleComponentTextView()
+    private let introTextView = ArticleComponentTextView()
+
+    private var metaStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        return stack
+    }()
+
+    private var textStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        return stack
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        contentView.addSubview(textStack)
+        textStack.addArrangedSubview(metaStack)
+        textStack.addArrangedSubview(titleTextView)
+        textStack.addArrangedSubview(introTextView)
+        metaStack.addArrangedSubview(bylineTextView)
+        metaStack.addArrangedSubview(itemCountView)
+
+        contentView.layoutMargins = Constants.layoutMargins
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            textStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            textStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            textStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(model: Model) {
+        bylineTextView.attributedText = model.byline
+        itemCountView.attributedText = model.itemCount
+        titleTextView.attributedText = model.title
+        introTextView.attributedText = model.intro
+
+        bylineTextView.isHidden = model.byline == nil
+        itemCountView.isHidden = model.itemCount == nil
+        titleTextView.isHidden = model.title == nil
+        introTextView.isHidden = model.intro == nil
+
+        if model.byline == nil && model.itemCount == nil {
+            textStack.spacing = 0
+        } else {
+            textStack.spacing = Constants.stackSpacing
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Collections/CollectionMetadataCell.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionMetadataCell.swift
@@ -24,13 +24,13 @@ class CollectionMetadataCell: UICollectionViewCell {
     private let titleTextView = ArticleComponentTextView()
     private let introTextView = ArticleComponentTextView()
 
-    private var metaStack: UIStackView = {
+    private var metaStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
         return stack
     }()
 
-    private var textStack: UIStackView = {
+    private var textStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
         return stack
@@ -39,20 +39,20 @@ class CollectionMetadataCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        contentView.addSubview(textStack)
-        textStack.addArrangedSubview(metaStack)
-        textStack.addArrangedSubview(titleTextView)
-        textStack.addArrangedSubview(introTextView)
-        metaStack.addArrangedSubview(bylineTextView)
-        metaStack.addArrangedSubview(itemCountView)
+        contentView.addSubview(textStackView)
+        textStackView.addArrangedSubview(metaStackView)
+        textStackView.addArrangedSubview(titleTextView)
+        textStackView.addArrangedSubview(introTextView)
+        metaStackView.addArrangedSubview(bylineTextView)
+        metaStackView.addArrangedSubview(itemCountView)
 
         contentView.layoutMargins = Constants.layoutMargins
-        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            textStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            textStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-            textStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            textStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+            textStackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            textStackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            textStackView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            textStackView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
         ])
     }
 
@@ -72,9 +72,9 @@ class CollectionMetadataCell: UICollectionViewCell {
         introTextView.isHidden = model.intro == nil
 
         if model.byline == nil && model.itemCount == nil {
-            textStack.spacing = 0
+            textStackView.spacing = 0
         } else {
-            textStack.spacing = Constants.stackSpacing
+            textStackView.spacing = Constants.stackSpacing
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionMetadataPresenter.swift
@@ -61,6 +61,9 @@ struct CollectionMetadataPresenter {
         return mutable
     }
 
+    /// Calculates the size of the section for the collection metadata
+    /// - Parameter availableItemWidth: width that the section takes
+    /// - Returns: height to be used in calculating section height
     func size(for availableItemWidth: CGFloat) -> CGSize {
         var height: CGFloat = 0
 
@@ -95,6 +98,11 @@ struct CollectionMetadataPresenter {
         )
     }
 
+    /// Helper method that calculates the height of an attributed string
+    /// - Parameters:
+    ///   - attributedString: string that will be used to determine how much height it occupies
+    ///   - width: available width that the string will occupy
+    /// - Returns: calculated height that the string will take up based on width and attributed string
     private static func height(of attributedString: NSAttributedString, width: CGFloat) -> CGFloat {
         guard !attributedString.string.isEmpty else {
             return 0

--- a/PocketKit/Sources/PocketKit/Collections/CollectionMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionMetadataPresenter.swift
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Textile
+import Localization
+import Down
+
+// Contains logic to present metadata for a collection such as title, excerpt, stories count
+struct CollectionMetadataPresenter {
+    private let collectionViewModel: CollectionViewModel
+
+    init(collectionViewModel: CollectionViewModel) {
+        self.collectionViewModel = collectionViewModel
+    }
+
+    var attributedByline: NSAttributedString? {
+        let byline = NSMutableAttributedString()
+
+        byline.append(NSAttributedString(string: Localization.Collection.title, style: .collection.collection))
+
+        if !byline.string.isEmpty {
+            byline.append(NSAttributedString(string: " • ", style: .collection.authors))
+        }
+
+        let authors = collectionViewModel.authors
+        if !authors.isEmpty {
+            let authorNames = authors.compactMap { $0 }
+            let authorNamesString = ListFormatter.localizedString(byJoining: authorNames) as NSString
+            let attributedAuthorNames = NSMutableAttributedString(string: authorNamesString as String, style: .collection.authors)
+
+            byline.append(attributedAuthorNames)
+        }
+        return byline
+    }
+
+    var attributedTitle: NSAttributedString? {
+        return NSAttributedString(string: collectionViewModel.title, style: .collection.title)
+    }
+
+    var attributedCount: NSAttributedString? {
+        guard let count = collectionViewModel.storiesCount else { return nil }
+
+        return NSAttributedString(string: Localization.Collection.Stories.count(count), style: .collection.detail)
+    }
+
+    var attributedIntro: NSAttributedString? {
+        guard let intro = collectionViewModel.intro,
+              let str = NSAttributedString.styled(
+                markdown: intro,
+                styler: NSMutableAttributedString.collectionStyler(bodyStyle: .collection.intro)
+              )
+        else {
+            return nil
+        }
+        let mutable = NSMutableAttributedString(attributedString: str)
+        // Down seems to be replacing double newline characters with paragraph separators, so we are reversing that here
+        // https://github.com/johnxnguyen/Down/issues/269
+        mutable.mutableString.replaceOccurrences(of: "\u{2029}", with: "\n\n", range: NSRange(location: 0, length: mutable.string.count))
+        return mutable
+    }
+
+    func size(for availableItemWidth: CGFloat) -> CGSize {
+        var height: CGFloat = 0
+
+        if let byline = attributedByline {
+            height += Self.height(of: byline, width: availableItemWidth)
+        }
+
+        if let itemCount = attributedCount {
+            height += Self.height(of: itemCount, width: availableItemWidth)
+        }
+
+        if let title = attributedTitle {
+            if height > 0 {
+                height += CollectionMetadataCell.Constants.stackSpacing
+            }
+
+            height += Self.height(of: title, width: availableItemWidth)
+        }
+
+        if let intro = attributedIntro {
+            if height > 0 {
+                height += CollectionMetadataCell.Constants.stackSpacing
+            }
+            height += Self.height(of: intro, width: availableItemWidth)
+        }
+
+        height += CollectionMetadataCell.Constants.layoutMargins.bottom
+
+        return CGSize(
+            width: availableItemWidth,
+            height: height
+        )
+    }
+
+    private static func height(of attributedString: NSAttributedString, width: CGFloat) -> CGFloat {
+        guard !attributedString.string.isEmpty else {
+            return 0
+        }
+
+        let rect = attributedString.boundingRect(
+            with: CGSize(width: width, height: .infinity),
+            options: [.usesFontLeading, .usesLineFragmentOrigin],
+            context: nil
+        )
+
+        return rect.height.rounded(.up)
+    }
+}

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import PocketGraph
+import Textile
+import Localization
+import Sync
+
+// Contains logic to present story data in RecommendationCell
+struct CollectionStoryViewModel: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(story)
+    }
+
+    public static func == (lhs: CollectionStoryViewModel, rhs: CollectionStoryViewModel) -> Bool {
+        return lhs.story == rhs.story
+    }
+
+    private let story: Story
+
+    init(story: Story) {
+        self.story = story
+    }
+}
+
+extension CollectionStoryViewModel: RecommendationCellViewModel {
+    var attributedCollection: NSAttributedString? {
+        guard story.isCollection else { return nil }
+        return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+    }
+
+    var attributedTitle: NSAttributedString {
+        NSAttributedString(string: title ?? "", style: .recommendation.title)
+    }
+
+    var attributedDomain: NSAttributedString {
+        NSAttributedString(string: domain ?? "", style: .recommendation.domain)
+    }
+
+    var attributedExcerpt: NSAttributedString? {
+        guard let str = NSAttributedString.styled(
+                markdown: excerpt,
+                styler: NSMutableAttributedString.collectionStyler(bodyStyle: .recommendation.excerpt)
+              )
+        else {
+            return nil
+        }
+        let mutable = NSMutableAttributedString(attributedString: str)
+        // Down seems to be replacing double newline characters with paragraph separators, so we are reversing that here
+        // https://github.com/johnxnguyen/Down/issues/269
+        mutable.mutableString.replaceOccurrences(of: "\u{2029}", with: "\n\n", range: NSRange(location: 0, length: mutable.string.count))
+        return mutable
+     }
+
+    var attributedTimeToRead: NSAttributedString {
+        NSAttributedString(string: timeToRead ?? "", style: .recommendation.timeToRead)
+    }
+
+    var title: String? {
+        story.title
+    }
+
+    var imageURL: URL? {
+        guard let imageURL = story.imageURL else { return nil }
+        return URL(string: imageURL)
+    }
+
+    var saveButtonMode: RecommendationSaveButton.Mode {
+        .save
+    }
+
+    var excerpt: Markdown {
+        story.excerpt
+    }
+
+    var domain: String? {
+        story.publisher
+    }
+
+    var timeToRead: String? {
+        guard let timeToRead = story.timeToRead,
+              timeToRead > 0 else {
+            return nil
+        }
+
+        return Localization.Home.Recommendation.readTime(timeToRead)
+    }
+
+    var overflowActions: [ItemAction]? {
+        return nil
+    }
+
+    var primaryAction: ItemAction? {
+        return nil
+    }
+}

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Foundation
 import Sync
 import UIKit
 import SharedPocketKit

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Sync
+import UIKit
+import SharedPocketKit
+
+// View model that holds logic for the native collection view
+class CollectionViewModel {
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
+
+    @Published var snapshot: Snapshot
+
+    private let slug: String
+    private let source: Source
+    private var collection: CollectionModel?
+
+    init(slug: String, source: Source) {
+        self.slug = slug
+        self.source = source
+        self.snapshot = Self.loadingSnapshot()
+    }
+
+    var title: String {
+        collection?.title ?? ""
+    }
+
+    var authors: [String] {
+        collection?.authors ?? []
+    }
+
+    var storiesCount: Int? {
+        collection?.stories.count
+    }
+
+    var intro: Markdown? {
+        collection?.intro
+    }
+
+    func fetch() {
+        Task {
+            do {
+                self.collection = try await source.fetchCollection(by: slug)
+                let snapshot = buildSnapshot()
+                guard snapshot.numberOfItems != 0 else { return }
+                self.snapshot = snapshot
+            } catch {
+                Log.capture(message: "Failed to fetch details for CollectionViewModel: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Cell Selection
+extension CollectionViewModel {
+    func select(cell: CollectionViewModel.Cell, at indexPath: IndexPath) {
+        switch cell {
+        case .loading:
+            return
+        case .collectionHeader:
+            return
+        case .stories:
+            return
+        }
+    }
+}
+
+private extension CollectionViewModel {
+    static func loadingSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.loading])
+        snapshot.appendItems([.loading], toSection: .loading)
+        return snapshot
+    }
+
+    func buildSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+
+        guard let collection else { return snapshot }
+
+        let section: CollectionViewModel.Section = .collection(collection)
+        snapshot.appendSections([.collectionHeader, section])
+        snapshot.appendItems([.collectionHeader], toSection: .collectionHeader)
+
+        collection.stories.forEach { story in
+            let storyViewModel = CollectionStoryViewModel(story: story)
+            snapshot.appendItems(
+                [.stories(storyViewModel)],
+                toSection: section
+            )
+        }
+
+        return snapshot
+    }
+}
+
+extension CollectionViewModel {
+    enum Section: Hashable {
+        case loading
+        case collectionHeader
+        case collection(CollectionModel)
+    }
+
+    enum Cell: Hashable {
+        case loading
+        case collectionHeader
+        case stories(CollectionStoryViewModel)
+    }
+}

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -83,6 +83,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case profileSampling = "perm.ios.sentry.profile"
     case reportIssue = "perm.ios.report_issue"
     case disableReader = "perm.ios.disable_reader"
+    case nativeCollections = "perm.ios.native_collections"
 
     /// Description to use in a debug menu
     var description: String {
@@ -101,6 +102,8 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "Enable the Report an Issue feature when users encounter an error"
         case .disableReader:
             return "Disable the Reader to force use of a Web view for viewing content"
+        case .nativeCollections:
+            return "Enable native collections instead of opening collections in web view"
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -40,6 +40,10 @@ extension HomeRecommendationCellViewModel: RecommendationCellViewModel {
         NSAttributedString(string: title ?? "", style: .recommendation.heroTitle)
     }
 
+    var attributedExcerpt: NSAttributedString? {
+        return nil
+    }
+
     var attributedDomain: NSAttributedString {
         NSAttributedString(string: domain ?? "", style: .recommendation.domain)
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -10,6 +10,7 @@ import Localization
 enum SelectedItem {
     case readable(SavedItemViewModel?)
     case webView(SavedItemViewModel?)
+    case collection(CollectionViewModel?)
 
     func clearPresentedWebReaderURL() {
         switch self {
@@ -33,7 +34,7 @@ enum SelectedItem {
         switch self {
         case .readable(let readable):
             readable?.clearIsPresentingReaderSettings()
-        case .webView:
+        case .webView, .collection:
             break
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -620,7 +620,11 @@ extension SavedItemsListViewModel {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
+        // TODO: Refactor when working on opening a collection, rather than several checks, we may be able to do one
+        if readable.isCollection, let slug = readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
+            let collectionViewModel = CollectionViewModel(slug: slug, source: source)
+            selectedItem = .collection(collectionViewModel)
+        } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             selectedItem = .webView(readable)
 
             trackContentOpen(destination: .external, item: savedItem)
@@ -823,6 +827,8 @@ extension SavedItemsListViewModel {
             readable?.clearPresentedWebReaderURL()
         case .webView:
             selectedItem = nil
+        case .collection:
+            break
         case .none:
             break
         }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -319,6 +319,8 @@ extension SavesContainerViewController {
 
     private func navigate(selectedItem: SelectedItem) {
         switch selectedItem {
+        case .collection(let collection):
+            self.push(collection: collection)
         case .readable(let readable):
             self.push(savedItem: readable)
         case .webView(let readable):
@@ -377,6 +379,18 @@ extension SavesContainerViewController {
 
         navigationController?.pushViewController(
             ReadableHostViewController(readableViewModel: readable),
+            animated: true
+        )
+    }
+
+    private func push(collection: CollectionViewModel?) {
+        guard let collection else {
+            readableSubscriptions = []
+            return
+        }
+
+        navigationController?.pushViewController(
+            CollectionViewController(model: collection),
             animated: true
         )
     }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -45,6 +45,8 @@ class SavesContainerViewModel {
             return readableViewModel?.webViewActivityItems(url: url) ?? []
         case .none:
             return []
+        case .some(.collection):
+            return []
         }
     }
 

--- a/PocketKit/Sources/Sync/Collection/CollectionModel.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionModel.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public struct CollectionModel: Equatable, Hashable {
+    public let title: String
+    public let authors: [String]
+    public let intro: Markdown?
+    public let stories: [Story]
+
+    public init(title: String, authors: [String], intro: Markdown?, stories: [Story]) {
+        self.title = title
+        self.authors = authors
+        self.intro = intro
+        self.stories = stories
+    }
+}
+
+public struct Story: Equatable, Hashable {
+    public let title: String
+    public let publisher: String?
+    public let imageURL: String?
+    public let excerpt: Markdown
+    public let timeToRead: Int?
+    public let isCollection: Bool
+}

--- a/PocketKit/Sources/Sync/Collection/CollectionService.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionService.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Apollo
+import Foundation
+import PocketGraph
+import SharedPocketKit
+
+protocol CollectionService {
+    func fetchCollection(by identifier: String) async throws -> CollectionModel
+}
+
+// TODO: Refine error handling
+public enum CollectionServiceError: Error {
+    case anError
+}
+
+class APICollectionService: CollectionService {
+    private let apollo: ApolloClientProtocol
+
+    init(apollo: ApolloClientProtocol) {
+        self.apollo = apollo
+    }
+
+    func fetchCollection(by slug: String) async throws -> CollectionModel {
+        let query = GetCollectionBySlugQuery(slug: slug)
+
+        guard let remote = try await apollo.fetch(query: query).data?.collection else {
+            Log.capture(message: "Error loading collection")
+            throw CollectionServiceError.anError
+        }
+
+        // TODO: Add Core data changes and publish changes instead of returning model
+        return CollectionModel(
+            title: remote.title,
+            authors: remote.authors.compactMap { $0.name },
+            intro: remote.intro,
+            stories: remote.stories.compactMap {
+                Story(title: $0.title, publisher: $0.publisher, imageURL: $0.imageUrl, excerpt: $0.excerpt, timeToRead: $0.item?.timeToRead, isCollection: $0.item?.collection?.slug != nil)
+            }
+        )
+    }
+}

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -27,6 +27,7 @@ public class PocketSource: Source {
     private let apollo: ApolloClientProtocol
     private let lastRefresh: LastRefresh
     private let slateService: SlateService
+    private let collectionService: CollectionService
     private let featureFlagService: FeatureFlagLoadingService
     private let networkMonitor: NetworkPathMonitor
     private let retrySignal: PassthroughSubject<Void, Never>
@@ -90,6 +91,7 @@ public class PocketSource: Source {
             operations: OperationFactory(),
             lastRefresh: UserDefaultsLastRefresh(defaults: defaults),
             slateService: APISlateService(apollo: apollo, space: space),
+            collectionService: APICollectionService(apollo: apollo),
             featureFlagService: APIFeatureFlagService(apollo: apollo, space: space, appSession: appSession),
             networkMonitor: NWPathMonitor(),
             sessionProvider: appSession as! SessionProvider,
@@ -108,6 +110,7 @@ public class PocketSource: Source {
         operations: SyncOperationFactory,
         lastRefresh: LastRefresh,
         slateService: SlateService,
+        collectionService: CollectionService,
         featureFlagService: FeatureFlagLoadingService,
         networkMonitor: NetworkPathMonitor,
         sessionProvider: SessionProvider,
@@ -121,6 +124,7 @@ public class PocketSource: Source {
         self.operations = operations
         self.lastRefresh = lastRefresh
         self.slateService = slateService
+        self.collectionService = collectionService
         self.featureFlagService = featureFlagService
         self.networkMonitor = networkMonitor
         self.retrySignal = .init()
@@ -630,6 +634,13 @@ extension PocketSource {
 
             return remoteItem.marticle?.isEmpty == false
         }
+    }
+}
+
+// MARK: - Collections
+extension PocketSource {
+    public func fetchCollection(by slug: String) async throws -> CollectionModel {
+        try await collectionService.fetchCollection(by: slug)
     }
 }
 

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -5,6 +5,7 @@
 import Combine
 import CoreData
 import Foundation
+import PocketGraph
 
 public enum InitialDownloadState {
     case unknown
@@ -67,6 +68,8 @@ public protocol Source {
     func filterTags(with input: String, excluding tags: [String]) -> [Tag]?
 
     func fetchUnifiedHomeLineup() async throws
+
+    func fetchCollection(by slug: String) async throws -> CollectionModel
 
     func restore()
 

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -22,6 +22,14 @@ public extension NSAttributedString {
         return nil
     }
 
+    static func collectionStyler(bodyStyle: Style? = nil) -> Styler {
+        var styling: FontStyling = BlancoOSFStyling()
+        if let bodyStyle = bodyStyle {
+            styling = styling.with(body: bodyStyle)
+        }
+        return CollectionStyler(styling: styling)
+    }
+
     static func defaultStyler(
         with modifier: StylerModifier,
         bodyStyle: Style? = nil

--- a/PocketKit/Sources/Textile/Style/Style+Recommendation.swift
+++ b/PocketKit/Sources/Textile/Style/Style+Recommendation.swift
@@ -25,5 +25,11 @@ public extension Style {
         public let timeToRead: Style = .header.sansSerif.p4.with(color: .ui.grey8).with { paragraph in
             paragraph.with(lineBreakMode: .byTruncatingTail)
         }.with(maxScaleSize: 22)
+
+        public let excerpt: Style = .header.sansSerif.p4
+            .with(color: .ui.black1)
+            .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+                paragraph.with(lineSpacing: 4)
+            }
     }
 }

--- a/PocketKit/Sources/Textile/Views/Collection/CollectionStyler.swift
+++ b/PocketKit/Sources/Textile/Views/Collection/CollectionStyler.swift
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+import Down
+
+// Styles markdown for native collections
+public class CollectionStyler: Styler {
+    private let styling: FontStyling
+    enum Constants {
+        static let paragraphIndent: CGFloat = 20
+    }
+
+    public init(styling: FontStyling) {
+        self.styling = styling
+    }
+
+    public func style(document str: NSMutableAttributedString) {
+    }
+
+    public func style(blockQuote str: NSMutableAttributedString, nestDepth: Int) {
+        str.updateStyle { existingStyle in
+            styling.body.with(color: .ui.grey4).with(slant: .italic)
+        }
+
+        // Modifies blockquote to be indented
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.firstLineHeadIndent = Constants.paragraphIndent
+        paragraphStyle.headIndent = Constants.paragraphIndent
+        str.addAttributes([
+            NSAttributedString.Key.paragraphStyle: paragraphStyle
+        ], range: NSRange(location: 0, length: str.length))
+    }
+
+    public func style(list str: NSMutableAttributedString, nestDepth: Int) {
+    }
+
+    public func style(listItemPrefix str: NSMutableAttributedString) {
+    }
+
+    public func style(item str: NSMutableAttributedString, prefixLength: Int) {
+    }
+
+    public func style(codeBlock str: NSMutableAttributedString, fenceInfo: String?) {
+    }
+
+    public func style(htmlBlock str: NSMutableAttributedString) {
+    }
+
+    public func style(customBlock str: NSMutableAttributedString) {
+    }
+
+    public func style(paragraph str: NSMutableAttributedString) {
+    }
+
+    public func style(heading str: NSMutableAttributedString, level: Int) {
+        var headingStyle: Style
+        switch level {
+        case 1: headingStyle = styling.h1
+        case 2: headingStyle = styling.h2
+        case 3: headingStyle = styling.h3
+        case 4: headingStyle = styling.h4
+        case 5: headingStyle = styling.h5
+        case 6: headingStyle = styling.h6
+        default: headingStyle = styling.bolding(style: styling.body)
+        }
+
+        str.updateStyle { existingStyle in
+            guard let existingStyle = existingStyle else {
+                return headingStyle
+            }
+
+            headingStyle = headingStyle.with(slant: existingStyle.fontDescriptor.slant)
+
+            if existingStyle.fontDescriptor.family == styling.monospace.fontDescriptor.family {
+                headingStyle = headingStyle
+                    .with(family: existingStyle.fontDescriptor.family)
+                    .with(backgroundColor: .ui.grey6)
+            }
+
+            return headingStyle
+        }
+    }
+
+    public func style(thematicBreak str: NSMutableAttributedString) {
+    }
+
+    public func style(text str: NSMutableAttributedString) {
+        str.updateStyle { _ in
+            styling.body
+        }
+    }
+
+    public func style(softBreak str: NSMutableAttributedString) {
+    }
+
+    public func style(lineBreak str: NSMutableAttributedString) {
+    }
+
+    public func style(code str: NSMutableAttributedString) {
+        str.updateStyle { existingStyle in
+            styling.monospace.with(backgroundColor: .ui.grey6)
+        }
+    }
+
+    public func style(htmlInline str: NSMutableAttributedString) {
+    }
+
+    public func style(customInline str: NSMutableAttributedString) {
+    }
+
+    public func style(emphasis str: NSMutableAttributedString) {
+        str.updateStyle { existingStyle in
+            (existingStyle ?? styling.body).with(slant: .italic)
+        }
+    }
+
+    public func style(strong str: NSMutableAttributedString) {
+        str.updateStyle { existingStyle in
+            let style = existingStyle ?? styling.body
+            return styling.bolding(style: style)
+        }
+    }
+
+    public func style(link str: NSMutableAttributedString, title: String?, url: String?) {
+        str.updateStyle { existingStyle in
+            (existingStyle ?? styling.body).with(underlineStyle: .single)
+        }
+
+        if let urlString = url, let url = URL(string: urlString) {
+            let range = NSRange(location: 0, length: str.length)
+            str.addAttribute(.link, value: url, range: range)
+        }
+    }
+
+    public func style(image str: NSMutableAttributedString, title: String?, url: String?) {
+    }
+}

--- a/PocketKit/Sources/Textile/Views/Collection/Style+Collection.swift
+++ b/PocketKit/Sources/Textile/Views/Collection/Style+Collection.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+public extension Style {
+    static let collection = CollectionStyle()
+    struct CollectionStyle {
+        public let title: Style = .header
+            .serif
+            .title
+            .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
+                paragraph.with(lineHeight: .multiplier(0.925))
+            }
+
+        public let authors: Style = .header.sansSerif.p4
+            .with(color: .ui.black1)
+            .with(weight: .medium)
+
+        public let detail: Style = .header.sansSerif.p4
+            .with(color: .ui.black1)
+
+        public let excerpt: Style = .header.serif.p1
+            .with(weight: .regular)
+            .with(color: .ui.black1)
+
+        public let intro: Style = .header.serif.p1
+            .with(color: .ui.black1)
+
+        public let collection: Style = .header.sansSerif.p4
+            .with(color: .ui.teal2)
+            .with(weight: .bold)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,6 +8,10 @@ import CoreData
 import Combine
 
 class MockSource: Source {
+    func fetchCollection(by slug: String) async throws -> Sync.CollectionModel {
+        return CollectionModel(title: "", authors: [], intro: "", stories: [])
+    }
+
     var _events: SyncEvents = SyncEvents()
     var events: AnyPublisher<SyncEvent, Never> {
         _events.eraseToAnyPublisher()

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -19,6 +19,7 @@ class PocketSourceTests: XCTestCase {
     var operations: MockOperationFactory!
     var lastRefresh: MockLastRefresh!
     var slateService: MockSlateService!
+    var collectionService: MockCollectionService!
     var networkMonitor: MockNetworkPathMonitor!
     var sessionProvider: MockSessionProvider!
     var backgroundTaskManager: MockBackgroundTaskManager!
@@ -36,6 +37,7 @@ class PocketSourceTests: XCTestCase {
         operations = MockOperationFactory()
         lastRefresh = MockLastRefresh()
         slateService = MockSlateService()
+        collectionService = MockCollectionService()
         networkMonitor = MockNetworkPathMonitor()
         sessionProvider = MockSessionProvider(session: nil)
         backgroundTaskManager = MockBackgroundTaskManager()
@@ -65,6 +67,7 @@ class PocketSourceTests: XCTestCase {
         operations: OperationFactory? = nil,
         lastRefresh: LastRefresh? = nil,
         slateService: SlateService? = nil,
+        collectionService: CollectionService? = nil,
         networkMonitor: NetworkPathMonitor? = nil,
         sessionProvider: SessionProvider? = nil,
         osNotificationCenter: OSNotificationCenter? = nil,
@@ -78,6 +81,7 @@ class PocketSourceTests: XCTestCase {
             operations: operations ?? self.operations,
             lastRefresh: lastRefresh ?? self.lastRefresh,
             slateService: slateService ?? self.slateService,
+            collectionService: collectionService ?? self.collectionService,
             featureFlagService: featureFlagService ?? self.featureFlagService,
             networkMonitor: networkMonitor ?? self.networkMonitor,
             sessionProvider: sessionProvider ?? self.sessionProvider,

--- a/PocketKit/Tests/SyncTests/Support/MockCollectionService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockCollectionService.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@testable import Sync
+
+class MockCollectionService: CollectionService {
+    var implementations: [String: Any] = [:]
+    var calls: [String: [Any]] = [:]
+}
+
+extension MockCollectionService {
+    static let fetchCollection = "fetchCollection"
+    typealias FetchCollectionImpl = (String) async throws -> Sync.CollectionModel
+
+    struct FetchCollectionCall {
+        let slug: String
+    }
+
+    func stubFetchSlateLineup(impl: @escaping FetchCollectionImpl) {
+        implementations[Self.fetchCollection] = impl
+    }
+
+    func fetchCollection(by slug: String) async throws -> Sync.CollectionModel {
+        guard let impl = implementations[Self.fetchCollection] as? FetchCollectionImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.fetchCollection] = (calls[Self.fetchCollection] ?? []) + [
+            FetchCollectionCall(slug: slug)
+        ]
+
+        return try await impl(slug)
+    }
+
+    func fetchCollectionCall(at index: Int) -> FetchCollectionCall? {
+        guard let calls = calls[Self.fetchCollection],
+              calls.count > index,
+              let call = calls[index] as? FetchCollectionCall else {
+                  return nil
+              }
+
+        return call
+    }
+}


### PR DESCRIPTION
## Summary
Create native collection view (focused on UI portion)

## References 
IN-1549

## Implementation Details
* Created native collection view in UIKit using `CollectionViewController`, `CollectionViewModel` (based on `SlateDetailViewController`, `SlateDetailViewModel`)
* For the metadata of collection, created `CollectionMetadataCell` and `CollectionMetadataPresenter` (based on ArticleMetadataPresenter)
* For the stories, created `CollectionStoryViewModel` (based on `HomeRecommendationCellViewModel`) and uses `RecommendationCell`
* Added feature flag for native collections `perm.ios.native_collections`
* Added logic to open a collection on Saves in `SavedItemsListViewModel` as well as API service `CollectionService` to retrieve graphQL data which will be refactored in the future

## Test Steps
1. Navigate to a collection in Saves list
2. Tap on the collection
3. Confirm that the native collection appears in the proper layout and format

## PR Checklist:
- N/A Added Unit / UI tests - No UI at this point of time, unit tests will be worked on in future tickets
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
https://github.com/Pocket/pocket-ios/assets/6743397/6a5f240a-514a-4810-ab4a-7c90d4629228