### PR TITLE
feat(collections): open story from collections

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -18,11 +18,7 @@ struct CollectionStoryViewModel: Hashable {
         return lhs.storyModel == rhs.storyModel
     }
 
-    private let storyModel: CollectionStoryModel
-
-    init(storyModel: CollectionStoryModel) {
-        self.storyModel = storyModel
-    }
+    let storyModel: CollectionStoryModel
 }
 
 extension CollectionStoryViewModel: RecommendationCellViewModel {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -87,6 +87,7 @@ class CollectionViewController: UIViewController {
 
         collectionView.backgroundColor = UIColor(.ui.white1)
         collectionView.dataSource = dataSource
+        collectionView.delegate = self
 
         collectionView.register(cellClass: LoadingCell.self)
         collectionView.register(cellClass: CollectionMetadataCell.self)
@@ -220,14 +221,9 @@ private extension CollectionViewController {
             let width = environment.container.effectiveContentSize.width
             let margin: CGFloat = environment.traitCollection.shouldUseWideLayout() ? Margins.iPadNormal.rawValue : Margins.normal.rawValue
             let stories = collection.stories?.compactMap { $0 as? CollectionStory } ?? []
-            let storyModels = stories.map { CollectionStoryModel(
-                title: $0.title,
-                publisher: $0.publisher,
-                imageURL: $0.imageUrl,
-                excerpt: $0.excerpt,
-                timeToRead: $0.item?.timeToRead != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil,
-                isCollection: $0.item?.collection != nil
-            )}
+            let storyModels = stories.map {
+                model.createStoryViewModel(with: $0)
+            }
 
             let components = storyModels.reduce((CGFloat(0), [NSCollectionLayoutItem]())) { result, storyModel in
                 let currentHeight = result.0
@@ -296,5 +292,15 @@ private extension CollectionViewController {
             cell.configure(model: story)
             return cell
         }
+    }
+}
+
+extension CollectionViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = dataSource.itemIdentifier(for: indexPath) else {
+            return
+        }
+
+        model.select(cell: cell)
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -296,7 +296,8 @@ extension HomeViewModel {
             store: store,
             userDefaults: userDefaults,
             networkPathMonitor: networkPathMonitor,
-            featureFlags: featureFlags
+            featureFlags: featureFlags,
+            notificationCenter: notificationCenter
         ))
     }
 
@@ -305,7 +306,7 @@ extension HomeViewModel {
         let item = recommendation.item
 
         if let collection = recommendation.collection, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
+            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter))
         } else {
             let viewModel = RecommendationViewModel(
                 recommendation: recommendation,
@@ -338,7 +339,7 @@ extension HomeViewModel {
 
     private func select(savedItem: SavedItem, at indexPath: IndexPath) {
         if let collection = savedItem.item?.collection, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
+            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter))
         } else {
             let viewModel = SavedItemViewModel(
                 item: savedItem,

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -38,8 +38,9 @@ class SlateDetailViewModel {
     private let networkPathMonitor: NetworkPathMonitor
     private var subscriptions: [AnyCancellable] = []
     private let featureFlags: FeatureFlagServiceProtocol
+    private let notificationCenter: NotificationCenter
 
-    init(slate: Slate, source: Source, tracker: Tracker, user: User, store: SubscriptionStore, userDefaults: UserDefaults, networkPathMonitor: NetworkPathMonitor, featureFlags: FeatureFlagServiceProtocol) {
+    init(slate: Slate, source: Source, tracker: Tracker, user: User, store: SubscriptionStore, userDefaults: UserDefaults, networkPathMonitor: NetworkPathMonitor, featureFlags: FeatureFlagServiceProtocol, notificationCenter: NotificationCenter) {
         self.slate = slate
         self.source = source
         self.tracker = tracker
@@ -49,6 +50,7 @@ class SlateDetailViewModel {
         self.snapshot = Self.loadingSnapshot()
         self.featureFlags = featureFlags
         self.networkPathMonitor = networkPathMonitor
+        self.notificationCenter = notificationCenter
 
         NotificationCenter.default.publisher(
             for: NSManagedObjectContext.didSaveObjectsNotification,
@@ -125,7 +127,7 @@ extension SlateDetailViewModel {
         var destination: ContentOpen.Destination = .internal
 
         if let collection = recommendation.collection, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedCollectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
+            selectedCollectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
         } else if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             guard let bestURL = URL(percentEncoding: item.bestURL) else { return }
             let url = pocketPremiumURL(bestURL, user: user)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -621,7 +621,7 @@ extension SavedItemsListViewModel {
         )
 
         if let collection = readable.collection, featureFlags.isAssigned(flag: .nativeCollections) {
-            let collectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
+            let collectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
             selectedItem = .collection(collectionViewModel)
         } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             selectedItem = .webView(readable)

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -383,21 +383,42 @@ extension SavesContainerViewController {
         )
     }
 
+    func show(_ recommendation: RecommendationViewModel?) {
+        readableSubscriptions = []
+        guard let recommendation = recommendation else {
+            return
+        }
+
+        navigationController?.pushViewController(
+            ReadableHostViewController(readableViewModel: recommendation),
+            animated: true
+        )
+
+        recommendation.events.receive(on: DispatchQueue.main).sink { [weak self] event in
+            switch event {
+            case .contentUpdated:
+                break
+            case .archive, .delete:
+                self?.popToPreviousScreen(navigationController: self?.navigationController)
+            }
+        }.store(in: &readableSubscriptions)
+    }
+
     private func push(collection: CollectionViewModel?) {
         guard let collection else {
             readableSubscriptions = []
             return
         }
 
-        collection.$presentedAlert.sink { [weak self] alert in
+        collection.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
 
-        collection.$presentedAddTags.sink { [weak self] addTagsViewModel in
+        collection.$presentedAddTags.receive(on: DispatchQueue.main).sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
         }.store(in: &readableSubscriptions)
 
-        collection.$sharedActivity.sink { [weak self] activity in
+        collection.$sharedActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &readableSubscriptions)
 
@@ -408,6 +429,18 @@ extension SavesContainerViewController {
             case .archive, .delete:
                 self?.popToPreviousScreen(navigationController: self?.navigationController)
             }
+        }.store(in: &readableSubscriptions)
+
+        collection.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+            if let savedItem = readableType as? SavedItemViewModel {
+                self?.push(savedItem: savedItem)
+            } else if let recommendation = readableType as? RecommendationViewModel {
+                self?.show(recommendation)
+            }
+        }.store(in: &readableSubscriptions)
+
+        collection.$presentedStoryWebReaderURL.receive(on: DispatchQueue.main).sink { [weak self] url in
+            self?.present(url: url)
         }.store(in: &readableSubscriptions)
 
         navigationController?.pushViewController(

--- a/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
@@ -5,19 +5,23 @@
 import Foundation
 
 public struct CollectionStoryModel: Equatable, Hashable {
-    public init(title: String, publisher: String?, imageURL: String?, excerpt: Markdown, timeToRead: Int?, isCollection: Bool) {
+    public init(url: String, title: String, publisher: String?, imageURL: String?, excerpt: Markdown, timeToRead: Int?, isCollection: Bool, item: Item?) {
+        self.url = url
         self.title = title
         self.publisher = publisher
         self.imageURL = imageURL
         self.excerpt = excerpt
         self.timeToRead = timeToRead
         self.isCollection = isCollection
+        self.item = item
     }
 
+    public let url: String
     public let title: String
     public let publisher: String?
     public let imageURL: String?
     public let excerpt: Markdown
     public let timeToRead: Int?
+    public let item: Item?
     public let isCollection: Bool
 }

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -22,6 +22,7 @@ class SlateDetailViewModelTests: XCTestCase {
     var featureFlags: MockFeatureFlagService!
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
+    private var notificationCenter: NotificationCenter!
 
     override func setUp() {
         super.setUp()
@@ -32,6 +33,7 @@ class SlateDetailViewModelTests: XCTestCase {
         user = PocketUser(userDefaults: userDefaults)
         networkPathMonitor = MockNetworkPathMonitor()
         subscriptionStore = MockSubscriptionStore()
+        notificationCenter = .default
         source.stubViewObject { identifier in
             self.space.viewObject(with: identifier)
         }
@@ -55,7 +57,8 @@ class SlateDetailViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil,
         user: User? = nil,
-        userDefaults: UserDefaults? = nil
+        userDefaults: UserDefaults? = nil,
+        notificationCenter: NotificationCenter? = nil
     ) -> SlateDetailViewModel {
         SlateDetailViewModel(
             slate: slate,
@@ -65,7 +68,8 @@ class SlateDetailViewModelTests: XCTestCase {
             store: subscriptionStore ?? self.subscriptionStore,
             userDefaults: userDefaults ?? self.userDefaults,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
-            featureFlags: featureFlags
+            featureFlags: featureFlags,
+            notificationCenter: notificationCenter ?? self.notificationCenter
         )
     }
 


### PR DESCRIPTION
## Summary
Open stories from collections

Note: Unable to find a collection with ads, so did not validate the premium vs free user cane mentioned in test steps

## References 
IN-1551

## Implementation Details
* Created `createStoryViewModel` to clean up how we initialize the view model
* Added 2 published property to handle reader view and web view (`selectedReadableViewModel`, `presentedStoryWebReaderURL`)
* Main logic is in `selectItem` in which we check if an item is a saved item, recommendation (important in the case of a syndicated article) as well as utilizing current `shouldOpenInWebView` logic.

## Test Steps
Since saving / archiving is being worked on, we can save items in a collection via web and then validate that opening it up gives us the proper view.

- [ ] Given I am viewing the native Collection view as a free user,
when I tap on a story that is not a syndicated article and is not saved,
then the story should be opened in web view.

- [ ] Given I am viewing the native Collection view as a free user,
when I tap on a story that is not a syndicated article and is saved,
then the story should be opened in reader (if possible*), otherwise web view.
*if possible means that the logic should follow that of saved items; some items are required to be opened in web view. See Item.shouldOpenInWebView in Item+Extensions

- [ ] Given I am viewing the native Collection view as a free user,
when I tap on an item that is a syndicated article,
then the story should be opened in the reader.

- [ ] Given I am viewing the native Collection view as a premium user,
when I tap on a story that is not a syndicated article, is not saved, and is hosted by [Home | Pocket](http://getpocket.com/) ,
then the story should be opened in web view with no ads.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://github.com/Pocket/pocket-ios/assets/6743397/734940a6-abec-4bee-9e39-0d707a52359e