### PR TITLE
Native Collections: add Collection Slug to CorpusItem in Unified Home

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/CollectionSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CollectionSummary.graphql.swift
@@ -1,0 +1,38 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CollectionSummary: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment CollectionSummary on Collection {
+      __typename
+      slug
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Collection }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("slug", String.self),
+  ] }
+
+  public var slug: String { __data["slug"] }
+
+  public init(
+    slug: String
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": PocketGraph.Objects.Collection.typename,
+        "slug": slug,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(Self.self)
+      ]
+    ))
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
@@ -19,6 +19,10 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
           __typename
           ...SyndicatedArticleParts
         }
+        ... on Collection {
+          __typename
+          ...CollectionSummary
+        }
       }
     }
     """ }
@@ -90,9 +94,11 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
       .inlineFragment(AsSyndicatedArticle.self),
+      .inlineFragment(AsCollection.self),
     ] }
 
     public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+    public var asCollection: AsCollection? { _asInlineFragment() }
 
     public init(
       __typename: String
@@ -158,6 +164,45 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
             ObjectIdentifier(Self.self),
             ObjectIdentifier(CorpusItemParts.Target.self),
             ObjectIdentifier(SyndicatedArticleParts.self)
+          ]
+        ))
+      }
+    }
+
+    /// Target.AsCollection
+    ///
+    /// Parent Type: `Collection`
+    public struct AsCollection: PocketGraph.InlineFragment {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public typealias RootEntityType = CorpusItemParts.Target
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Collection }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .fragment(CollectionSummary.self),
+      ] }
+
+      public var slug: String { __data["slug"] }
+
+      public struct Fragments: FragmentContainer {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public var collectionSummary: CollectionSummary { _toFragment() }
+      }
+
+      public init(
+        slug: String
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": PocketGraph.Objects.Collection.typename,
+            "slug": slug,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(Self.self),
+            ObjectIdentifier(CorpusItemParts.Target.self),
+            ObjectIdentifier(CollectionSummary.self)
           ]
         ))
       }

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
@@ -118,6 +118,7 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
       public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
 
       public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+      public var asCollection: AsCollection? { _asInlineFragment() }
 
       public init(
         __typename: String
@@ -184,6 +185,46 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
               ObjectIdentifier(Self.self),
               ObjectIdentifier(CorpusRecommendationParts.CorpusItem.Target.self),
               ObjectIdentifier(SyndicatedArticleParts.self)
+            ]
+          ))
+        }
+      }
+
+      /// CorpusItem.Target.AsCollection
+      ///
+      /// Parent Type: `Collection`
+      public struct AsCollection: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = CorpusRecommendationParts.CorpusItem.Target
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Collection }
+        public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+          CollectionSummary.self,
+          CorpusItemParts.Target.AsCollection.self
+        ] }
+
+        public var slug: String { __data["slug"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var collectionSummary: CollectionSummary { _toFragment() }
+        }
+
+        public init(
+          slug: String
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": PocketGraph.Objects.Collection.typename,
+              "slug": slug,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(CorpusRecommendationParts.CorpusItem.Target.self),
+              ObjectIdentifier(CollectionSummary.self)
             ]
           ))
         }

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
@@ -168,6 +168,7 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
         public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
 
         public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+        public var asCollection: AsCollection? { _asInlineFragment() }
 
         public init(
           __typename: String
@@ -234,6 +235,46 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
                 ObjectIdentifier(Self.self),
                 ObjectIdentifier(CorpusSlateParts.Recommendation.CorpusItem.Target.self),
                 ObjectIdentifier(SyndicatedArticleParts.self)
+              ]
+            ))
+          }
+        }
+
+        /// Recommendation.CorpusItem.Target.AsCollection
+        ///
+        /// Parent Type: `Collection`
+        public struct AsCollection: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public typealias RootEntityType = CorpusSlateParts.Recommendation.CorpusItem.Target
+          public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Collection }
+          public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+            CollectionSummary.self,
+            CorpusItemParts.Target.AsCollection.self
+          ] }
+
+          public var slug: String { __data["slug"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var collectionSummary: CollectionSummary { _toFragment() }
+          }
+
+          public init(
+            slug: String
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": PocketGraph.Objects.Collection.typename,
+                "slug": slug,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(Self.self),
+                ObjectIdentifier(CorpusSlateParts.Recommendation.CorpusItem.Target.self),
+                ObjectIdentifier(CollectionSummary.self)
               ]
             ))
           }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
@@ -19,7 +19,7 @@ public class HomeSlateLineupQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [CorpusSlateParts.self, CorpusRecommendationParts.self, CorpusItemParts.self, SyndicatedArticleParts.self]
+      fragments: [CorpusSlateParts.self, CorpusRecommendationParts.self, CorpusItemParts.self, SyndicatedArticleParts.self, CollectionSummary.self]
     ))
 
   public var locale: String
@@ -152,6 +152,7 @@ public class HomeSlateLineupQuery: GraphQLQuery {
               public static var __parentType: ApolloAPI.ParentType { PocketGraph.Unions.CorpusTarget }
 
               public var asSyndicatedArticle: AsSyndicatedArticle? { _asInlineFragment() }
+              public var asCollection: AsCollection? { _asInlineFragment() }
 
               /// HomeSlateLineup.Slate.Recommendation.CorpusItem.Target.AsSyndicatedArticle
               ///
@@ -183,6 +184,30 @@ public class HomeSlateLineupQuery: GraphQLQuery {
                   public init(_dataDict: DataDict) { __data = _dataDict }
 
                   public var syndicatedArticleParts: SyndicatedArticleParts { _toFragment() }
+                }
+              }
+
+              /// HomeSlateLineup.Slate.Recommendation.CorpusItem.Target.AsCollection
+              ///
+              /// Parent Type: `Collection`
+              public struct AsCollection: PocketGraph.InlineFragment, ApolloAPI.CompositeInlineFragment {
+                public let __data: DataDict
+                public init(_dataDict: DataDict) { __data = _dataDict }
+
+                public typealias RootEntityType = HomeSlateLineupQuery.Data.HomeSlateLineup.Slate.Recommendation.CorpusItem.Target
+                public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Collection }
+                public static var __mergedSources: [any ApolloAPI.SelectionSet.Type] { [
+                  CollectionSummary.self,
+                  CorpusItemParts.Target.AsCollection.self
+                ] }
+
+                public var slug: String { __data["slug"] }
+
+                public struct Fragments: FragmentContainer {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public var collectionSummary: CollectionSummary { _toFragment() }
                 }
               }
             }

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
@@ -10,6 +10,10 @@ fragment CorpusItemParts on CorpusItem {
             __typename
             ...SyndicatedArticleParts
         }
+        ... on Collection {
+            __typename
+            ...CollectionSummary
+        }
     }
 }
 
@@ -39,4 +43,8 @@ query HomeSlateLineup($locale: String!) {
             ...CorpusSlateParts
         }
     }
+}
+
+fragment CollectionSummary on Collection {
+    slug
 }


### PR DESCRIPTION
## Summary
*This PR adds the `Collection.slug` to a `CorpusItem` fetched from Unified Home

## References 
* Issue number in branch name

## Implementation Details
* Update `unifiedHome.graphql`, add `CollectionSummary` (at this moment, it only contains `slug`)

## Test Steps
* No UI changes at the moment. If you want to test that we are actually pulling the slug, you can set a conditional breakpoint (or a printout) in `Item+remoteMapping.swift`, inside the method `func update(from corpusItem: CorpusSlateParts.Recommendation.CorpusItem, in space: Space)` and check (for collections only) that `corpusItem.target?.asCollection?.slug` is not nil and actually contains the slug that you are expecting.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
