### PR TITLE
feat(collections): add saving and archiving a collection

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -389,6 +389,15 @@ extension SavesContainerViewController {
             return
         }
 
+        collection.events.receive(on: DispatchQueue.main).sink { [weak self] event in
+            switch event {
+            case .contentUpdated, .none:
+                break
+            case .archive, .delete:
+                self?.popToPreviousScreen(navigationController: self?.navigationController)
+            }
+        }.store(in: &readableSubscriptions)
+
         navigationController?.pushViewController(
             CollectionViewController(model: collection),
             animated: true


### PR DESCRIPTION
## Summary
* Add Save and Archive to Nav Bar for Collection
* Add buttons for overflow menu (no actions associated for now, only foundation added)
Note: this only applies to Saves currently, will create a PR for Home once the work to present from Home is merged in

## References 
IN-1552, IN-1553

## Implementation Details
* Add nav bar buttons for Collections (Sav / Archive, Open in Web, Overflow Menu)
* Follow logic from `ReadableHostViewController` and `SavedItemViewModel`

## Test Steps
**Archive**
- [x] Given I have opened a Collection in the Native collection view,
and the Collection is saved,
when I look at the navigation bar,
then I should see an Archive button
- [x] Given I have tapped on the Archive button in the navigation bar,
and the Collection has been archived,
then the Collection view should be dismissed (i.e popped from the navigation stack)
- [x] Given I have tapped on the Archive button in the navigation bar,
when the Collection view is dismissed,
and look at the origin card for the Collection,
then the Save button should be in the "Save" state
- [x] Given I have tapped on the Archive button in the navigation bar,
and the Collection view has been dismissed,
when I go back to Home and look at Recent Saves,
then the Collection should not be visible in Recent Saves
- [x] Given I have tapped on the Archive button in the navigation bar,
and the Collection view has been dismissed,
when I tap the Saves tab, and have Saves visible,
then the Collection should not visible in the list.
- [x] Given I have tapped on the Archive button in the navigation bar,
and the Collection view has been dismissed,
when I tap the Saves tab, and have Archive visible,
then the Collection should be the first item in the list.

**Saves**
- [x] Given I have tapped on the Save button in the navigation bar,
and the Collection has been saved,
when I look at the navigation bar,
then I should see an Archive button
- [x] Given I have tapped on the Save button in the navigation bar,
and the Collection has been saved,
when I look at the navigation bar,
then I should see an Overflow button with "Favorite", "Add tags", "Delete", and "Share" as visible options
- [x] Given I have tapped on the Save button in the navigation bar,
when I tap back in the Navigation bar,
and look at the origin card for the Collection,
then the Save button should be in the "Saved" state
- [x] Given I have tapped on the Save button in the navigation bar,
when I go back to Home and look at Recent Saves,
then the Collection should be the first item visible in Recent Saves
- [x] Given I have tapped on the Save button in the navigation bar,
when I go back and tap the Saves tab, and have Saves visible,
then the Collection should be the first item visible in the list.
- [x] Given I have tapped on the Save button in the navigation bar,
when I go back and tap the Saves tab, and have Archive visible,
then the Collection should not be visible in the list.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://github.com/Pocket/pocket-ios/assets/6743397/8497c0ee-fb3a-4412-9ec3-eadf0522ebc1

