### PR TITLE
Native Collections: open collections in native view from Unified Home

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -353,6 +353,9 @@ extension HomeViewController {
             present(url: viewModel.premiumURL)
         case .none:
             readerSubscriptions = []
+        case .collection(let viewModel):
+            let controller = CollectionViewController(model: viewModel)
+            navigationController?.pushViewController(controller, animated: true)
         }
     }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -15,6 +15,7 @@ enum ReadableType {
     case savedItem(SavedItemViewModel)
     case webViewRecommendation(RecommendationViewModel)
     case webViewSavedItem(SavedItemViewModel)
+    case collection(CollectionViewModel)
 
     func clearIsPresentingReaderSettings() {
         switch self {
@@ -26,6 +27,9 @@ enum ReadableType {
             recommendationViewModel.clearPresentedWebReaderURL()
         case .webViewSavedItem(let savedItemViewModel):
             savedItemViewModel.clearPresentedWebReaderURL()
+        case .collection:
+            // TODO: NATIVECOLLECTIONS - we might need to do some additional cleanup here
+            break
         }
     }
 }
@@ -295,6 +299,10 @@ extension HomeViewModel {
     }
 
     private func select(recommendation: Recommendation, at indexPath: IndexPath) {
+        if let slug = recommendation.collectionSlug {
+            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
+            return
+        }
         let viewModel = RecommendationViewModel(
             recommendation: recommendation,
             source: source,
@@ -682,7 +690,7 @@ extension HomeViewModel {
         case .savedItem(let viewModel),
                 .webViewSavedItem(let viewModel):
             return viewModel.webViewActivityItems(url: url)
-        case .none:
+        case .collection, .none:
             return []
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -299,28 +299,27 @@ extension HomeViewModel {
     }
 
     private func select(recommendation: Recommendation, at indexPath: IndexPath) {
-        if let slug = recommendation.collectionSlug {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
-            return
-        }
-        let viewModel = RecommendationViewModel(
-            recommendation: recommendation,
-            source: source,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            pasteboard: UIPasteboard.general,
-            user: user,
-            userDefaults: userDefaults
-        )
+        var destination: ContentOpen.Destination = .internal
         let item = recommendation.item
 
-        var destination: ContentOpen.Destination = .internal
-
-        if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
-            selectedReadableType = .webViewRecommendation(viewModel)
-            destination = .external
+        if let slug = recommendation.collectionSlug {
+            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
         } else {
-            selectedReadableType = .recommendation(viewModel)
-            destination = .internal
+            let viewModel = RecommendationViewModel(
+                recommendation: recommendation,
+                source: source,
+                tracker: tracker.childTracker(hosting: .articleView.screen),
+                pasteboard: UIPasteboard.general,
+                user: user,
+                userDefaults: userDefaults
+            )
+
+            if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
+                selectedReadableType = .webViewRecommendation(viewModel)
+                destination = .external
+            } else {
+                selectedReadableType = .recommendation(viewModel)
+            }
         }
 
         guard

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -17,6 +17,7 @@ extension Recommendation {
     @NSManaged public var remoteID: String
     @NSManaged public var title: String?
     @NSManaged public var analyticsID: String
+    @NSManaged public var collectionSlug: String?
     @NSManaged public var item: Item
     @NSManaged public var slate: Slate?
     @NSManaged public var image: Image?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -17,9 +17,15 @@ extension Recommendation {
     @NSManaged public var remoteID: String
     @NSManaged public var title: String?
     @NSManaged public var analyticsID: String
-    @NSManaged public var collectionSlug: String?
     @NSManaged public var item: Item
     @NSManaged public var slate: Slate?
     @NSManaged public var image: Image?
     @NSManaged public var sortIndex: NSNumber?
+}
+
+extension Recommendation {
+    /// The slug of the associated collection
+    public var collectionSlug: String? {
+        self.item.collection?.slug
+    }
 }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
@@ -100,7 +100,6 @@
     </entity>
     <entity name="Recommendation" representedClassName="Recommendation" syncable="YES">
         <attribute name="analyticsID" attributeType="String"/>
-        <attribute name="collectionSlug" optional="YES" attributeType="String"/>
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="remoteID" attributeType="String"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22189.1" systemVersion="23A5286i" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -100,6 +100,7 @@
     </entity>
     <entity name="Recommendation" representedClassName="Recommendation" syncable="YES">
         <attribute name="analyticsID" attributeType="String"/>
+        <attribute name="collectionSlug" optional="YES" attributeType="String"/>
         <attribute name="excerpt" optional="YES" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="remoteID" attributeType="String"/>

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -115,6 +115,10 @@ extension Item {
                 self.syndicatedArticle?.image = Image(src: imageSrc, context: context)
             }
         }
+
+        if let slug = corpusItem.target?.asCollection?.slug {
+            self.collection = (try? space.fetchCollection(by: slug, context: context)) ?? Collection(context: context, slug: slug, title: "", authors: [], stories: [])
+        }
     }
 
     func update(from summary: ItemSummary, with space: Space) {

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -56,6 +56,7 @@ extension Recommendation {
     func update(from remote: RemoteCorpusRecommendation, in space: Space, context: NSManagedObjectContext) {
         title = remote.corpusItem.title
         excerpt = remote.corpusItem.excerpt
+        collectionSlug = remote.corpusItem.target?.asCollection?.slug
         imageURL = URL(string: remote.corpusItem.imageUrl)
         image = Image(src: remote.corpusItem.imageUrl, context: context)
         let url = remote.corpusItem.url

--- a/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/SlateLineup+remoteMapping.swift
@@ -56,7 +56,6 @@ extension Recommendation {
     func update(from remote: RemoteCorpusRecommendation, in space: Space, context: NSManagedObjectContext) {
         title = remote.corpusItem.title
         excerpt = remote.corpusItem.excerpt
-        collectionSlug = remote.corpusItem.target?.asCollection?.slug
         imageURL = URL(string: remote.corpusItem.imageUrl)
         image = Image(src: remote.corpusItem.imageUrl, context: context)
         let url = remote.corpusItem.url

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -136,6 +136,13 @@ public enum Requests {
         return request
     }
 
+    public static func fetchCollection(by slug: String) -> NSFetchRequest<Collection> {
+        let request = Collection.fetchRequest()
+        request.predicate = NSPredicate(format: "slug = %@", slug)
+        request.fetchLimit = 1
+        return request
+    }
+
     public static func fetchTags() -> NSFetchRequest<Tag> {
         return Tag.fetchRequest()
     }

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -139,6 +139,13 @@ public class Space {
     }
 }
 
+// MARK: Collection
+extension Space {
+    func fetchCollection(by slug: String, context: NSManagedObjectContext? = nil) throws -> Collection? {
+        return try fetch(Requests.fetchCollection(by: slug), context: context).first
+    }
+}
+
 // MARK: Image
 extension Space {
     func makeImagesController() -> NSFetchedResultsController<Image> {

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -562,6 +562,9 @@ class HomeViewModelTests: XCTestCase {
                 readableExpectation.fulfill()
             case .savedItem, .webViewSavedItem, .none:
                 XCTFail("Expected recommendation, but got \(String(describing: readableType))")
+            default:
+                // TODO: we might want to add a check here
+                break
             }
         }.store(in: &subscriptions)
 
@@ -669,6 +672,9 @@ class HomeViewModelTests: XCTestCase {
                 readableExpectation.fulfill()
             case .savedItem, .webViewSavedItem, .recommendation, .none:
                 XCTFail("Expected web view saved item, but got \(String(describing: readableType))")
+            default:
+                // TODO: we might want to add a check here
+                break
             }
         }.store(in: &subscriptions)
 
@@ -714,6 +720,9 @@ class HomeViewModelTests: XCTestCase {
                 readableExpectation.fulfill()
             case .webViewRecommendation, .recommendation, .none:
                 XCTFail("Expected recommendation, but got \(String(describing: readableType))")
+            default:
+                // TODO: we might want to add a check here
+                break
             }
         }.store(in: &subscriptions)
 
@@ -812,6 +821,9 @@ class HomeViewModelTests: XCTestCase {
                 readableExpectation.fulfill()
             case .savedItem, .webViewRecommendation, .recommendation, .none:
                 XCTFail("Expected web view saved item, but got \(String(describing: readableType))")
+            default:
+                // TODO: we might want to add a check here
+                break
             }
         }.store(in: &subscriptions)
 


### PR DESCRIPTION
## Summary
* This PR allows opening collections in the native view from Home

## References 
* Issue number in branch name

## Implementation Details
* Add `collection` readable type
* Add `collectionSlug` field to `Recommendation

## Test Steps
* go to Home
* tap on a collection
* make sure it opens in the native view

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
