### PR TITLE
feat(collections): update collection actions in overflow menu

### DIFF
--- a/PocketKit/Sources/PocketKit/Activity/PocketItemActivity.swift
+++ b/PocketKit/Sources/PocketKit/Activity/PocketItemActivity.swift
@@ -71,4 +71,17 @@ extension PocketItemActivity {
             sender: sender
         )
     }
+
+    static func fromCollection(
+        url: String,
+        additionalText: String? = nil,
+        sender: Any? = nil
+    ) -> PocketItemActivity {
+        return PocketItemActivity(
+            url: url,
+            additionalText: additionalText,
+            source: "pocket_collection",
+            sender: sender
+        )
+    }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -303,7 +303,7 @@ extension HomeViewModel {
         let item = recommendation.item
 
         if let slug = recommendation.collectionSlug {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
+            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
         } else {
             let viewModel = RecommendationViewModel(
                 recommendation: recommendation,

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -622,7 +622,7 @@ extension SavedItemsListViewModel {
 
         // TODO: Refactor when working on opening a collection, rather than several checks, we may be able to do one
         if readable.isCollection, let slug = readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
-            let collectionViewModel = CollectionViewModel(slug: slug, source: source)
+            let collectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
             selectedItem = .collection(collectionViewModel)
         } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             selectedItem = .webView(readable)

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -389,6 +389,10 @@ extension SavesContainerViewController {
             return
         }
 
+        collection.$presentedAlert.sink { [weak self] alert in
+            self?.present(alert: alert)
+        }.store(in: &subscriptions)
+
         collection.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             switch event {
             case .contentUpdated, .none:

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -393,6 +393,14 @@ extension SavesContainerViewController {
             self?.present(alert: alert)
         }.store(in: &subscriptions)
 
+        collection.$presentedAddTags.sink { [weak self] addTagsViewModel in
+            self?.present(viewModel: addTagsViewModel)
+        }.store(in: &subscriptions)
+
+        collection.$sharedActivity.sink { [weak self] activity in
+            self?.present(activity: activity)
+        }.store(in: &subscriptions)
+
         collection.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             switch event {
             case .contentUpdated, .none:

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Sync
+import Combine
+
+@testable import PocketKit
+@testable import Sync
+
+class CollectionViewModelTests: XCTestCase {
+    private var source: MockSource!
+    private var space: Space!
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        source = MockSource()
+        space = .testSpace()
+    }
+
+    override func tearDownWithError() throws {
+        try space.clear()
+        try super.tearDownWithError()
+    }
+
+    func subject(
+        slug: String,
+        source: Source? = nil
+    ) -> CollectionViewModel {
+        CollectionViewModel(slug: slug, source: source ?? self.source)
+    }
+
+    func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
+        let item = space.buildSavedItem().item
+        let collection = setupCollection(with: item)
+        let viewModel = subject(slug: collection.slug)
+
+        let expectArchive = expectation(description: "expect source.archive(_:)")
+        source.stubArchiveSavedItem { archivedSavedItem in
+            defer { expectArchive.fulfill() }
+            XCTAssertTrue(archivedSavedItem === item?.savedItem)
+        }
+
+        let expectArchiveEvent = expectation(description: "expect archive event")
+        viewModel.events.dropFirst().sink { event in
+            guard case .archive = event else {
+                XCTFail("Received unexpected event: \(String(describing: event))")
+                return
+            }
+
+            expectArchiveEvent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.archive()
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
+    }
+
+    func test_moveToSaves_withSavedItem_sendsRequestToSource_AndRefreshes() {
+        let item = space.buildSavedItem().item
+        let collection = setupCollection(with: item)
+        let viewModel = subject(slug: collection.slug)
+
+        let expectMoveToSaves = expectation(description: "expect source.unarchive(_:)")
+        source.stubUnarchiveSavedItem { unarchivedSavedItem in
+            defer { expectMoveToSaves.fulfill() }
+            XCTAssertTrue(unarchivedSavedItem === item?.savedItem)
+        }
+
+        viewModel.moveToSaves { _ in }
+
+        wait(for: [expectMoveToSaves], timeout: 1)
+    }
+
+    func test_moveToSaves_withoutSavedItem_sendsRequestToSource_AndRefreshes() {
+        let collection = setupCollection(with: nil)
+        let viewModel = subject(slug: collection.slug)
+
+        let expectMoveToSaves = expectation(description: "expect source.url(_:)")
+        source.stubSaveURL { url in
+            defer { expectMoveToSaves.fulfill() }
+            XCTAssertEqual(url, "https://getpocket.com/collections/slug-1")
+        }
+
+        viewModel.moveToSaves { _ in }
+
+        wait(for: [expectMoveToSaves], timeout: 1)
+    }
+
+    func test_savedCollection_buildsCorrectActions() {
+        // not-favorited, not-archived
+        let item = space.buildSavedItem(isFavorite: false, isArchived: false).item
+        let collection = setupCollection(with: item)
+
+        let viewModel = subject(slug: collection.slug)
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Favorite", "Add tags", "Delete", "Share"]
+        )
+
+        // favorited
+        item?.savedItem?.isFavorite = true
+
+        XCTAssertEqual(
+            viewModel._actions.map(\.title),
+            ["Unfavorite", "Add tags", "Delete", "Share"]
+        )
+    }
+
+    func test_favorite_delegatesToSource() {
+        let item = space.buildSavedItem(isFavorite: false).item
+        let collection = setupCollection(with: item)
+
+        let expectFavorite = expectation(description: "expect source.favorite(_:)")
+
+        source.stubFavoriteSavedItem { favoritedSavedItem in
+            defer { expectFavorite.fulfill() }
+            XCTAssertTrue(favoritedSavedItem.item === item)
+            XCTAssertTrue(favoritedSavedItem === item?.savedItem)
+        }
+
+        let viewModel = subject(slug: collection.slug)
+        viewModel.invokeAction(title: "Favorite")
+
+        wait(for: [expectFavorite], timeout: 1)
+    }
+
+    func test_unfavorite_delegatesToSource() {
+        let item = space.buildSavedItem(isFavorite: true).item
+        let collection = setupCollection(with: item)
+
+        let expectUnfavorite = expectation(description: "expect source.unfavorite(_:)")
+
+        source.stubUnfavoriteSavedItem { unfavoritedSavedItem in
+            defer { expectUnfavorite.fulfill() }
+            XCTAssertTrue(unfavoritedSavedItem.item === item)
+            XCTAssertTrue(unfavoritedSavedItem === item?.savedItem)
+        }
+
+        let viewModel = subject(slug: collection.slug)
+        viewModel.invokeAction(title: "Unfavorite")
+
+        wait(for: [expectUnfavorite], timeout: 1)
+    }
+
+    func test_delete_delegatesToSource_andSendsDeleteEvent() {
+        let item = space.buildSavedItem(isFavorite: true).item
+        let collection = setupCollection(with: item)
+        let viewModel = subject(slug: collection.slug)
+
+        let expectDelete = expectation(description: "expect source.delete(_:)")
+        source.stubDeleteSavedItem { deletedSavedItem in
+            defer { expectDelete.fulfill() }
+            XCTAssertTrue(deletedSavedItem.item === item)
+        }
+
+        let expectDeleteEvent = expectation(description: "expect delete event")
+        viewModel.events.dropFirst().sink { event in
+            guard case .delete = event else {
+                XCTFail("Received unexpected event: \(String(describing: event))")
+                return
+            }
+
+            expectDeleteEvent.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Delete")
+        viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
+
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
+    }
+
+    private func setupCollection(with item: Item?) -> Collection {
+        let story = space.buildCollectionStory(item: item)
+
+        source.stubFetchItem { url in
+            return item
+        }
+
+        return space.buildCollection(stories: [story])
+    }
+}
+
+extension CollectionViewModel {
+    func invokeAction(title: String) {
+        invokeAction(from: _actions, title: title)
+    }
+
+    func invokeAction(from actions: [ItemAction], title: String) {
+        actions.first(where: { $0.title == title })?.handler?(nil)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -132,6 +132,38 @@ extension Space {
     }
 }
 
+// MARK: - Collection
+extension Space {
+    @discardableResult
+    func buildCollection(
+        slug: String = "slug-1",
+        title: String = "collection-title",
+        authors: [String] = [],
+        stories: [CollectionStory] = []
+    ) -> Collection {
+        backgroundContext.performAndWait {
+            let collection: Collection = Collection(context: backgroundContext, slug: slug, title: title, authors: NSOrderedSet(array: authors), stories: NSOrderedSet(array: stories))
+
+            return collection
+        }
+    }
+
+    @discardableResult
+    func buildCollectionStory(
+        url: String = "story-url",
+        title: String = "story-title",
+        excerpt: String = "",
+        authors: [String] = [],
+        item: Item? = nil
+    ) -> CollectionStory {
+        backgroundContext.performAndWait {
+            let collectionStory: CollectionStory = CollectionStory(context: backgroundContext, url: url, title: title, excerpt: excerpt, authors: NSOrderedSet(array: authors))
+            collectionStory.item = item
+            return collectionStory
+        }
+    }
+}
+
 // MARK: - SlateLineup
 extension Space {
     @discardableResult


### PR DESCRIPTION
## Summary
Update actions for overflow menu for a saved collection. Currently, addressed for saved item on Saves / Archive. Future PR for Home and not saved collection item.

## References 
IN-1554, IN-1555, IN-1557, IN-1556

## Implementation Details
* Add functionality for the respective actions related to a saved collection (similar functionality to `SavedItemViewModel`)
* Create Unit test for `CollectioViewModel` to tests the actions

## Test Steps
- [x] Given I have tapped on the Save button in the navigation bar,
and the Collection has been saved,
when I look at the navigation bar,
then I should see an Overflow button with "Favorite", "Add tags", "Delete", and "Share" as visible options

**Favorite**
- [x] Given I have opened a Collection in the native Collection view,
and the Collection is saved, and the Collection is unfavorited,
when I tap the overflow button and tap "Favorite",
and tap the overflow button again,
then I should see "Unfavorite" instead of "Favorite"
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have favorited the Collection,
when I go back and view my Recent Saves in Home,
then the Collection item should have be in the "Favorited" state (highlighted star icon)
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have favorited the Collection,
when I go back and tap the Saves button, and have Saves visible,
then the Collection item should have be in the "Favorited" state (highlighted star icon)
- [x] Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have favorited the Collection,
when I go back and tap the Saves button, and have Saves visible, and have filtered to Favorites,
then the Collection item should be visible, and should be in the "Favorited" state (highlighted star icon)

**Unfavorite**
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved, and the Collection is favorited,
when I tap the overflow button,
then I should see "Unfavorite" as an option.
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved, and the Collection is favorited,
when I tap the overflow button and tap "Unfavorite",
and tap the overflow button again,
then I should see "Favorite" instead of "Unfavorite"
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have unfavorited the Collection,
when I go back and view my Recent Saves in Home,
then the Collection item should have be in the "Unfavorited" state (non-highlighted star icon)
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have unfavorited the Collection,
when I go back and tap the Saves button, and have Saves visible,
then the Collection item should have be in the "Unfavorited" state (non-highlighted star icon)
- [x]  Given I have opened a Collection in the native Collection view,
and the Collection is saved,
and have favorited the Collection,
when I go back and tap the Saves button, and have Saves visible, and have filtered to Favorites,
then the Collection item should not be visible

**Delete**
- [x]  Given I have opened a Collection in the native Collection view,
and I have tapped on the overflow button in the navigation bar,
and the collection has been saved or archived,
and have tapped "Delete"
and the Collection has been deleted,
then the Collection view should be dismissed (i.e popped from the navigation stack)
- [x]  Given I have opened a Collection in the native Collection view,
and I have tapped on the overflow button in the navigation bar,
and have tapped "Delete",
and the Collection has been deleted,
and the Collection view has been dismissed,
when I go back to Home and look at Recent Saves,
then the Collection should not be visible in Recent Saves
- [x]  Given I have opened a Collection in the native Collection view,
and I have tapped on the overflow button in the navigation bar,
and have tapped "Delete",
and the Collection has been deleted,
and the Collection view has been dismissed,
when I tap the Saves tab, and have Saves visible,
then the Collection should not visible in the list.
- [x]  Given I have opened a Collection in the native Collection view,
and I have tapped on the overflow button in the navigation bar,
and have tapped "Delete",
and the Collection has been deleted,
and the Collection view has been dismissed,
when I tap the Saves tab, and have Archive visible,
then the Collection should not visible in the list.

**Tags** 
- [x] Given I have opened a Collection in the native Collection view,
and the Collection is saved or archived,
and no tags have been added,
when I tap the overflow button,
then I should see "Add tags" 
- [ ] Given I have opened a Collection in the native Collection view,
and the Collection is saved or archived,
and I have tapped "Add tags" from the overflow button,
and have added and saved at least one tag,
when I tap the overflow button,
then I should see "Edit tags"
- [ ] Given I have opened a Collection in the native Collection view,
and the Collection is saved or archived,
and no tags have been added,
and I have tapped "Add tags" from the overflow button,
and have added and saved at least one tag,
when I go back to the Saves tab, and have Saves or Archive visible,
then I should see the tag(s) added to the Collection in the list
- [ ] Given I have opened a Collection in the native Collection view,
and the Collection is saved or archived,
and the Collection has at least one tag,
and I have tapped "Edit tags" from the overflow button,
and have removed all tags,
when I go back to the Saves tab,
then I should see no tags added to the Collection in the list

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
