### PR TITLE
Native Collections: show native collection view from slate detail and recent saves

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -354,8 +354,7 @@ extension HomeViewController {
         case .none:
             readerSubscriptions = []
         case .collection(let viewModel):
-            let controller = CollectionViewController(model: viewModel)
-            navigationController?.pushViewController(controller, animated: true)
+            showCollection(viewModel)
         }
     }
 
@@ -386,6 +385,13 @@ extension HomeViewController {
         viewModel.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
         }.store(in: &slateDetailSubscriptions)
+        viewModel.$selectedCollectionViewModel
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] viewModel in
+            guard let viewModel else { return }
+                self?.showCollection(viewModel)
+            }
+            .store(in: &slateDetailSubscriptions)
     }
 
     func show(_ recommendation: RecommendationViewModel?) {
@@ -465,6 +471,11 @@ extension HomeViewController {
                 self?.popToPreviousScreen()
             }
         }.store(in: &readerSubscriptions)
+    }
+
+    private func showCollection(_ viewModel: CollectionViewModel) {
+        let controller = CollectionViewController(model: viewModel)
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     private func showRecommendation(forWebView viewModel: RecommendationViewModel) {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -335,22 +335,26 @@ extension HomeViewModel {
     }
 
     private func select(savedItem: SavedItem, at indexPath: IndexPath) {
-        let viewModel = SavedItemViewModel(
-            item: savedItem,
-            source: source,
-            tracker: tracker.childTracker(hosting: .articleView.screen),
-            pasteboard: UIPasteboard.general,
-            user: user,
-            store: store,
-            networkPathMonitor: networkPathMonitor,
-            userDefaults: userDefaults,
-            notificationCenter: notificationCenter
-        )
-
-        if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
-            selectedReadableType = .webViewSavedItem(viewModel)
+        if let slug = savedItem.item?.collection?.slug {
+            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
         } else {
-            selectedReadableType = .savedItem(viewModel)
+            let viewModel = SavedItemViewModel(
+                item: savedItem,
+                source: source,
+                tracker: tracker.childTracker(hosting: .articleView.screen),
+                pasteboard: UIPasteboard.general,
+                user: user,
+                store: store,
+                networkPathMonitor: networkPathMonitor,
+                userDefaults: userDefaults,
+                notificationCenter: notificationCenter
+            )
+
+            if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
+                selectedReadableType = .webViewSavedItem(viewModel)
+            } else {
+                selectedReadableType = .savedItem(viewModel)
+            }
         }
         tracker.track(event: Events.Home.RecentSavesCardContentOpen(url: savedItem.url, positionInList: indexPath.item))
     }

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -17,6 +17,8 @@ class SlateDetailViewModel {
 
     @Published var selectedReadableViewModel: RecommendationViewModel?
 
+    @Published var selectedCollectionViewModel: CollectionViewModel?
+
     @Published var presentedWebReaderURL: URL?
 
     @Published var selectedRecommendationToReport: Recommendation?
@@ -118,7 +120,9 @@ extension SlateDetailViewModel {
         let item = recommendation.item
         var destination: ContentOpen.Destination = .internal
 
-        if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
+        if let slug = recommendation.collectionSlug {
+            selectedCollectionViewModel = CollectionViewModel(slug: slug, source: source)
+        } else if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             guard let bestURL = URL(percentEncoding: item.bestURL) else { return }
             let url = pocketPremiumURL(bestURL, user: user)
             presentedWebReaderURL = url


### PR DESCRIPTION
## Summary
* This PR adds the native collections feature to slate detail and recent saves (Home)

## References 
* Issue number in branch name

## Implementation Details
* Update `HomeViewController`, `HomeViewModel`, `SlateDetailViewModel`: add logic to push the native collections view when a collection is selected from either recent saves or slate detail.

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Video

<p align=center>

<img height=500 src=https://github.com/Pocket/pocket-ios/assets/34376330/b906bf27-e078-49c0-85b0-1e7d95ca64be>

</p>
