### PR TITLE
feat(collections): add report + share for not saved collection

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -75,7 +75,8 @@ class CollectionViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         view.accessibilityIdentifier = "collection-view"
-
+        title = nil
+        navigationItem.largeTitleDisplayMode = .never
         hidesBottomBarWhenPushed = true
 
         navigationItem.rightBarButtonItems = [
@@ -145,6 +146,12 @@ class CollectionViewController: UIViewController {
         super.viewWillAppear(animated)
         model.fetch()
         metadata = CollectionMetadataPresenter(collectionViewModel: model)
+        self.tabBarController?.tabBar.isHidden = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
     }
 
     override func viewDidLoad() {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -293,7 +293,9 @@ extension HomeViewModel {
             source: source,
             tracker: tracker.childTracker(hosting: .slateDetail.screen),
             user: user,
+            store: store,
             userDefaults: userDefaults,
+            networkPathMonitor: networkPathMonitor,
             featureFlags: featureFlags
         ))
     }
@@ -302,7 +304,7 @@ extension HomeViewModel {
         var destination: ContentOpen.Destination = .internal
         let item = recommendation.item
 
-        if let slug = recommendation.collectionSlug {
+        if let slug = recommendation.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
             selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
         } else {
             let viewModel = RecommendationViewModel(
@@ -335,8 +337,8 @@ extension HomeViewModel {
     }
 
     private func select(savedItem: SavedItem, at indexPath: IndexPath) {
-        if let slug = savedItem.item?.collection?.slug {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source))
+        if let slug = savedItem.item?.collection?.slug, featureFlags.isAssigned(flag: .nativeCollections) {
+            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
         } else {
             let viewModel = SavedItemViewModel(
                 item: savedItem,

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -391,15 +391,15 @@ extension SavesContainerViewController {
 
         collection.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
-        }.store(in: &subscriptions)
+        }.store(in: &readableSubscriptions)
 
         collection.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
-        }.store(in: &subscriptions)
+        }.store(in: &readableSubscriptions)
 
         collection.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
-        }.store(in: &subscriptions)
+        }.store(in: &readableSubscriptions)
 
         collection.events.receive(on: DispatchQueue.main).sink { [weak self] event in
             switch event {

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationHostingController.swift
@@ -8,12 +8,12 @@ import Sync
 
 class ReportRecommendationHostingController: OnDismissHostingController<ReportRecommendationView> {
     init(
-        recommendation: Recommendation,
+        givenURL: String,
         tracker: Tracker,
         onDismiss: @escaping () -> Void
     ) {
         let view = ReportRecommendationView(
-            recommendation: recommendation,
+            givenURL: givenURL,
             tracker: tracker
         )
         super.init(rootView: view, onDismiss: onDismiss)

--- a/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportRecommendationView.swift
@@ -19,7 +19,7 @@ struct ReportRecommendationView: View {
         static let commentRowHeight: CGFloat = 92
     }
 
-    private let recommendation: Recommendation
+    private let givenURL: String
     private let tracker: Tracker
 
     private var submitAccessibilityIdentifier: String {
@@ -37,8 +37,8 @@ struct ReportRecommendationView: View {
 
     @FocusState private var isCommentFocused: Bool
 
-    init(recommendation: Recommendation, tracker: Tracker) {
-        self.recommendation = recommendation
+    init(givenURL: String, tracker: Tracker) {
+        self.givenURL = givenURL
         self.tracker = tracker
     }
 
@@ -95,10 +95,9 @@ struct ReportRecommendationView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
             dismiss()
         }
-        let item = recommendation.item
 
         // NOTE: As of 2/17/2023 The report view can only be called from the Home screen, so we assume that the SlateArticleReport event is the correct one.
-        tracker.track(event: Events.Home.SlateArticleReport(url: item.givenURL, reason: reason, comment: comment))
+        tracker.track(event: Events.Home.SlateArticleReport(url: givenURL, reason: reason, comment: comment))
     }
 
     private func selectionColor(for reason: ReportEntity.Reason) -> Color {

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -228,6 +228,37 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
     }
 
+    func test_report_updatesSelectedRecommendationToReport() {
+        let item = space.buildItem()
+        let collection = setupCollection(with: item)
+        let viewModel = subject(slug: collection.slug)
+
+        let reportExpectation = expectation(description: "expected item to be reported")
+        viewModel.$selectedItemToReport.dropFirst().sink { recommendation in
+            XCTAssertNotNil(recommendation)
+            reportExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Report")
+        wait(for: [reportExpectation], timeout: 1)
+    }
+
+    func test_share_updatesSharedActivity() throws {
+        let item = space.buildItem()
+        let collection = setupCollection(with: item)
+        let viewModel = subject(slug: collection.slug)
+
+        let shareExpectation = expectation(description: "expected item to be shared")
+        viewModel.$sharedActivity.dropFirst().sink { item in
+            XCTAssertNotNil(item)
+            shareExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.invokeAction(title: "Share")
+
+        wait(for: [shareExpectation], timeout: 1)
+    }
+
     private func setupCollection(with item: Item?) -> Collection {
         let story = space.buildCollectionStory(item: item)
 

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -20,6 +20,8 @@ class SlateDetailViewModelTests: XCTestCase {
     var user: User!
     var userDefaults: UserDefaults!
     var featureFlags: MockFeatureFlagService!
+    private var subscriptionStore: SubscriptionStore!
+    private var networkPathMonitor: MockNetworkPathMonitor!
 
     override func setUp() {
         super.setUp()
@@ -28,6 +30,8 @@ class SlateDetailViewModelTests: XCTestCase {
         space = .testSpace()
         userDefaults = UserDefaults(suiteName: "SlateDetailViewModelTests")
         user = PocketUser(userDefaults: userDefaults)
+        networkPathMonitor = MockNetworkPathMonitor()
+        subscriptionStore = MockSubscriptionStore()
         source.stubViewObject { identifier in
             self.space.viewObject(with: identifier)
         }
@@ -58,7 +62,9 @@ class SlateDetailViewModelTests: XCTestCase {
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             user: user ?? self.user,
+            store: subscriptionStore ?? self.subscriptionStore,
             userDefaults: userDefaults ?? self.userDefaults,
+            networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             featureFlags: featureFlags
         )
     }


### PR DESCRIPTION
## Summary
Add report and share actions for collections that have not been saved yet.
Additional Small Fixes
* Addressed build errors from main feature branch
* Add actions presentation logic to Home
* Fix Home spacing for collection view
* Add feature flags throughout

## References 
* IN-1603, IN-1602

## Implementation Details
* Refactor report view to be more flexible in taking a `url` as opposed to a `recommendation`
* Add report and share actions for Collection that is not a saved item
* Hide tab bar for native collection 

## Test Steps
Given I have opened a Collection in the native Collection view,
and the Collection is saved,
when I tap the overflow button and tap "Report",
then the Pocket report view should open, reporting the currently opened Collection.

Given I have opened a Collection in the native Collection view,
and the Collection is saved,
when I tap the overflow button and tap "Share",
then the system share sheet should open, sharing the URL of the collection.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-07-26 at 14 39 58](https://github.com/Pocket/pocket-ios/assets/6743397/0bb87085-1f03-4e09-8601-6133b3102cb3)