### PR TITLE
feat(collections): add error / offline screen

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -92,6 +92,7 @@ class CollectionViewController: UIViewController {
         collectionView.register(cellClass: LoadingCell.self)
         collectionView.register(cellClass: CollectionMetadataCell.self)
         collectionView.register(cellClass: RecommendationCell.self)
+        collectionView.register(cellClass: EmptyStateCollectionViewCell.self)
 
         model.$snapshot.receive(on: DispatchQueue.main).sink { [weak self] snapshot in
             self?.dataSource.apply(snapshot)
@@ -171,6 +172,11 @@ class CollectionViewController: UIViewController {
 }
 
 private extension CollectionViewController {
+    enum Constants {
+        /// Height that centers the error section so that it appears approximately in the middle
+        static let errorSectionHeight: CGFloat = 0.65
+        static let errorSectionInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20)
+    }
     func section(for index: Int, environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
         let section = self.dataSource.sectionIdentifier(for: index)
         switch section {
@@ -262,6 +268,25 @@ private extension CollectionViewController {
             )
 
             return section
+        case .error:
+            let section = NSCollectionLayoutSection(
+                group: .vertical(
+                    layoutSize: .init(
+                        widthDimension: .fractionalWidth(1),
+                        heightDimension: .fractionalHeight(Constants.errorSectionHeight)
+                    ),
+                    subitems: [
+                        .init(
+                            layoutSize: .init(
+                                widthDimension: .fractionalWidth(1),
+                                heightDimension: .fractionalHeight(1)
+                            )
+                        )
+                    ]
+                )
+            )
+            section.contentInsets = Constants.errorSectionInsets
+            return section
         default:
             return .empty()
         }
@@ -287,6 +312,10 @@ private extension CollectionViewController {
         case .story(let story):
             let cell: RecommendationCell = collectionView.dequeueCell(for: indexPath)
             cell.configure(model: story)
+            return cell
+        case .error:
+            let cell: EmptyStateCollectionViewCell = collectionView.dequeueCell(for: indexPath)
+            cell.configure(parent: self, model.errorEmptyState)
             return cell
         }
     }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import CoreData
 import Localization
 import Analytics
+import Network
 
 /// View model that holds logic for the native collection view
 class CollectionViewModel: NSObject {
@@ -39,6 +40,7 @@ class CollectionViewModel: NSObject {
     private let user: User
     private let store: SubscriptionStore
     private let networkPathMonitor: NetworkPathMonitor
+    private var currentNetworkStatus: NWPath.Status?
     private let userDefaults: UserDefaults
     private let featureFlags: FeatureFlagServiceProtocol
     private let notificationCenter: NotificationCenter
@@ -80,6 +82,14 @@ class CollectionViewModel: NSObject {
         item?.savedItem?.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()
         }.store(in: &collectionItemSubscriptions)
+
+        networkPathMonitor.start(queue: .global())
+        currentNetworkStatus = networkPathMonitor.currentNetworkPath.status
+        observeNetworkChanges()
+    }
+
+    var hasLocalData: Bool {
+        !title.isEmpty
     }
 
     var title: String {
@@ -113,12 +123,19 @@ class CollectionViewModel: NSObject {
         } catch {
             // TODO: NATIVECOLLECTIONS - handle core data error here
         }
+
+        guard !isOffline else {
+            checkForLocalData()
+            return
+        }
+
         Task {
             do {
                 try await source.fetchCollection(by: collection.slug)
             } catch {
-                Log.capture(message: "Failed to fetch details for CollectionViewModel: \(error)")
                 // TODO: NATIVECOLLECTIONS - handle remote error here
+                self.snapshot = errorSnapshot()
+                Log.capture(message: "Failed to fetch details for CollectionViewModel: \(error)")
             }
         }
     }
@@ -228,6 +245,46 @@ class CollectionViewModel: NSObject {
     }
 }
 
+// MARK: Error / Offline
+extension CollectionViewModel {
+    var errorEmptyState: EmptyStateViewModel {
+        return ErrorEmptyState(featureFlags: featureFlags, user: user)
+    }
+
+    var isOffline: Bool {
+        return networkPathMonitor.currentNetworkPath.status == .unsatisfied
+    }
+
+    /// Check if collection does not have local data, then show error state
+    private func checkForLocalData() {
+        guard !hasLocalData else { return }
+        snapshot = self.errorSnapshot()
+        return
+    }
+
+    private func observeNetworkChanges() {
+        networkPathMonitor.updateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                self?.handleNetworkChange(path.status)
+            }
+        }
+    }
+
+    /// Observes network changes and fetch collection when user returns online
+    private func handleNetworkChange(_ status: NWPath.Status) {
+        guard status != currentNetworkStatus else {
+            return
+        }
+
+        if currentNetworkStatus == .unsatisfied, status == .satisfied {
+            // TODO: NATIVE COLLECTIONS - Handle fetching
+            self.snapshot = Self.loadingSnapshot()
+            fetch()
+        }
+        currentNetworkStatus = status
+    }
+}
+
 // MARK: - Cell Selection
 extension CollectionViewModel {
     func storyViewModel(for story: CollectionStory) -> CollectionStoryViewModel {
@@ -247,7 +304,7 @@ extension CollectionViewModel {
 
     func select(cell: CollectionViewModel.Cell) {
         switch cell {
-        case .loading, .collectionHeader:
+        case .loading, .collectionHeader, .error:
             return
         case .story(let storyViewModel):
             selectItem(with: storyViewModel.collectionStory)
@@ -296,6 +353,14 @@ private extension CollectionViewModel {
         return snapshot
     }
 
+    /// Builds snapshot for when user faces offline or error
+    func errorSnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.error])
+        snapshot.appendItems([.error], toSection: .error)
+        return snapshot
+    }
+    
     /// Builds and sets snapshot when collection stories are found in Core Data
     func setCollectionSnapshot(_ identifiers: [NSManagedObjectID]) {
         var collectionSnapshot = Snapshot()
@@ -341,12 +406,14 @@ extension CollectionViewModel {
         case loading
         case collectionHeader
         case collection(Collection)
+        case error
     }
 
     enum Cell: Hashable {
         case loading
         case collectionHeader
         case story(CollectionStoryViewModel)
+        case error
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -93,9 +93,11 @@ struct EmptyStateView<Content: View>: View {
                             .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                             .frame(maxWidth: Constants.maxWidth)
                     }).buttonStyle(ActionsPrimaryButtonStyle())
-                    .sheet(isPresented: self.$showSafariView) {
-                        SFSafariView(url: webURL)
-                    }
+                        .sheet(isPresented: self.$showSafariView) {
+                            SFSafariView(url: webURL)
+                        }
+                } else if case .reportIssue(let buttonText, let userEmail) = viewModel.buttonType {
+                    ReportIssueButton(text: buttonText, userEmail: userEmail)
                 }
             }
         }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
@@ -20,5 +20,5 @@ protocol EmptyStateViewModel {
 enum ButtonType {
     case normal(String)
     case premium(String)
-    case reportIssue(String)
+    case reportIssue(text: String, email: String)
 }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
@@ -5,12 +5,15 @@
 import Foundation
 import Textile
 import Localization
+import SharedPocketKit
 
 struct ErrorEmptyState: EmptyStateViewModel {
     private var featureFlags: FeatureFlagServiceProtocol
+    private var user: User
 
-    init(featureFlags: FeatureFlagServiceProtocol) {
+    init(featureFlags: FeatureFlagServiceProtocol, user: User) {
         self.featureFlags = featureFlags
+        self.user = user
     }
 
     let imageAsset: ImageAsset = .warning
@@ -23,7 +26,7 @@ struct ErrorEmptyState: EmptyStateViewModel {
 
     var buttonType: ButtonType? {
         if featureFlags.isAssigned(flag: .reportIssue) {
-            return .reportIssue(Localization.General.Error.sendReport)
+            return .reportIssue(text: Localization.General.Error.sendReport, email: user.email)
         }
         return nil
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -117,9 +117,9 @@ struct SearchEmptyView: View {
                 EmptyStateView(viewModel: viewModel) {
                     GetPocketPremiumButton(text: text)
                 }.padding(Margins.normal.rawValue)
-            case .reportIssue(let text):
+            case .reportIssue(let text, let userEmail):
                 EmptyStateView(viewModel: viewModel) {
-                    ReportIssueButton(text: text)
+                    ReportIssueButton(text: text, userEmail: userEmail)
                 }.padding(Margins.normal.rawValue)
             default:
                 EmptyView()
@@ -128,34 +128,6 @@ struct SearchEmptyView: View {
             EmptyStateView<EmptyView>(viewModel: viewModel)
                 .padding(Margins.normal.rawValue)
         }
-    }
-}
-
-struct ReportIssueButton: View {
-    enum Constants {
-        static let padding = EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
-        static let maxWidth: CGFloat = 320
-    }
-    @EnvironmentObject private var searchViewModel: SearchViewModel
-    private let text: String
-
-    init(text: String) {
-        self.text = text
-    }
-
-    var body: some View {
-        Button(action: {
-            searchViewModel.isPresentingReportIssue.toggle()
-        }, label: {
-            Text(text)
-                .style(.header.sansSerif.h7.with(color: .ui.white))
-                .padding(Constants.padding)
-                .frame(maxWidth: Constants.maxWidth)
-        }).buttonStyle(PocketButtonStyle(.primary))
-        .sheet(isPresented: $searchViewModel.isPresentingReportIssue) {
-            ReportIssueView(email: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue)
-        }
-        .accessibilityIdentifier("get-report-issue-button")
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -345,7 +345,7 @@ class SearchViewModel: ObservableObject {
                     self.trackSearchResultsPage(pageNumber: onlineSearch.pageNumberLoaded, scope: scope)
                 } else if case .failure(let error) = result {
                     guard case SearchServiceError.noInternet = error else {
-                        self.searchState = .emptyState(ErrorEmptyState(featureFlags: featureFlags))
+                        self.searchState = .emptyState(ErrorEmptyState(featureFlags: featureFlags, user: user))
                         return
                     }
                     self.searchState = .emptyState(OfflineEmptyState(type: scope))

--- a/PocketKit/Sources/PocketKit/Report/ReportIssueButton.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportIssueButton.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import SharedPocketKit
+import Textile
+
+struct ReportIssueButton: View {
+    @State var isPresentingReportIssue = false
+    enum Constants {
+        static let padding = EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
+        static let maxWidth: CGFloat = 320
+    }
+
+    private let text: String
+    private let userEmail: String
+
+    init(text: String, userEmail: String) {
+        self.text = text
+        self.userEmail = userEmail
+    }
+
+    var body: some View {
+        Button(action: {
+            isPresentingReportIssue.toggle()
+        }, label: {
+            Text(text)
+                .style(.header.sansSerif.h7.with(color: .ui.white))
+                .padding(Constants.padding)
+                .frame(maxWidth: Constants.maxWidth)
+        }).buttonStyle(PocketButtonStyle(.primary))
+        .sheet(isPresented: $isPresentingReportIssue) {
+            ReportIssueView(email: userEmail, submitIssue: submitIssue)
+        }
+        .accessibilityIdentifier("get-report-issue-button")
+    }
+
+    // Handle Sentry User Feedback Reporting
+    private func submitIssue(name: String, email: String, comments: String) {
+        Log.captureUserFeedback(message: "Report an issue", name: name, email: email, comments: comments)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -21,6 +21,7 @@ class CollectionViewModelTests: XCTestCase {
     private var featureFlags: FeatureFlagServiceProtocol!
     private var notificationCenter: NotificationCenter!
     private var collectionController: RichFetchedResultsController<CollectionStory>!
+    private var featureFlags: MockFeatureFlagService!
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -35,6 +36,7 @@ class CollectionViewModelTests: XCTestCase {
         notificationCenter = .default
 
         userDefaults = UserDefaults(suiteName: "CollectionViewModelTests")
+        featureFlags = MockFeatureFlagService()
         space = .testSpace()
         self.collectionController = space.makeCollectionStoriesController(slug: "slug")
     }
@@ -548,6 +550,115 @@ class CollectionViewModelTests: XCTestCase {
         }
         let collection = space.buildCollection(stories: [story], item: item)
         return collection
+    }
+
+    func test_snapshot_whenNetworkIsInitiallyAvailable_hasCorrectSnapshot() {
+        let item = space.buildItem()
+        let collection = setupCollection(with: item)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
+        XCTAssertNil(viewModel.snapshot.indexOfSection(.error))
+    }
+
+    func test_snapshot_whenNetworkIsUnavailable_andNoLocalData_hasCorrectSnapshot() throws {
+        networkPathMonitor.update(status: .unsatisfied)
+
+        let collection = space.buildCollection(slug: "collection-slug", title: "", authors: [], stories: [], item: nil)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
+
+        let snapshotExpectation = expectation(description: "expect a snapshot")
+
+        viewModel.$snapshot.dropFirst().sink { snapshot in
+            XCTAssertNotNil(snapshot.indexOfSection(.error))
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+            snapshotExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.fetch()
+        wait(for: [snapshotExpectation], timeout: 1)
+    }
+
+    func test_snapshot_whenOffline_thenReconnects_hasCorrectSnapshot() async {
+        networkPathMonitor.update(status: .unsatisfied)
+
+        let collection = space.buildCollection(slug: "collection-slug", title: "", authors: [], stories: [], item: nil)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        source.stubFetchCollection { _ in }
+
+        let viewModel = subject(collection: collection)
+
+        let loadingExpectation = expectation(description: "expect loading snapshot")
+        let errorSnapshotExpectation = expectation(description: "expect error snapshot")
+        var count = 0
+        viewModel.$snapshot.dropFirst().sink { snapshot in
+            count += 1
+            if count == 1 {
+                XCTAssertNotNil(snapshot.indexOfSection(.error))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+                errorSnapshotExpectation.fulfill()
+            } else if count == 2 {
+                XCTAssertNotNil(snapshot.indexOfSection(.loading))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
+                loadingExpectation.fulfill()
+            }
+        }.store(in: &subscriptions)
+
+        viewModel.fetch()
+        networkPathMonitor.update(status: .satisfied)
+
+        await fulfillment(of: [errorSnapshotExpectation, loadingExpectation], timeout: 1, enforceOrder: true)
+    }
+
+    // MARK: - Error Handling
+    func test_snapshot_withFetchingCollectionError_hasCorrectSnapshot() async throws {
+        let item = space.buildItem()
+        let collection = setupCollection(with: item)
+
+        let errorExpectation = expectation(description: "should throw an error")
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        source.stubFetchCollection { _ in
+            errorExpectation.fulfill()
+            throw CollectionServiceError.nullCollection
+        }
+
+        let viewModel = subject(collection: collection)
+        let errorSnapshotExpectation = expectation(description: "expect error snapshot")
+        let loadingExpectation = expectation(description: "expect loading snapshot")
+
+        var count = 0
+        viewModel.$snapshot.sink { snapshot in
+            count += 1
+            if count == 1 {
+                XCTAssertNotNil(snapshot.indexOfSection(.loading))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
+                errorSnapshotExpectation.fulfill()
+            } else if count == 2 {
+                XCTAssertNotNil(snapshot.indexOfSection(.error))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+                loadingExpectation.fulfill()
+            }
+        }.store(in: &subscriptions)
+
+        viewModel.fetch()
+
+        await fulfillment(of: [errorExpectation, errorSnapshotExpectation, loadingExpectation], timeout: 10)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -590,7 +590,7 @@ class CollectionViewModelTests: XCTestCase {
     func test_snapshot_whenNetworkIsUnavailable_andHasLocalData_hasCorrectSnapshot() throws {
         networkPathMonitor.update(status: .unsatisfied)
 
-        let collection =         let item = space.buildItem()
+        let item = space.buildItem()
         let collection = setupCollection(with: item)
 
         source.stubMakeCollectionStoriesController {
@@ -602,8 +602,8 @@ class CollectionViewModelTests: XCTestCase {
         let snapshotExpectation = expectation(description: "expect a snapshot")
 
         viewModel.$snapshot.dropFirst().sink { snapshot in
-            XCTAssertNotNil(snapshot.indexOfSection(.error))
-            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+            XCTAssertNotNil(snapshot.indexOfSection(.collectionHeader))
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .collectionHeader), [.collectionHeader])
             snapshotExpectation.fulfill()
         }.store(in: &subscriptions)
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -587,6 +587,30 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 1)
     }
 
+    func test_snapshot_whenNetworkIsUnavailable_andHasLocalData_hasCorrectSnapshot() throws {
+        networkPathMonitor.update(status: .unsatisfied)
+
+        let collection =         let item = space.buildItem()
+        let collection = setupCollection(with: item)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
+
+        let snapshotExpectation = expectation(description: "expect a snapshot")
+
+        viewModel.$snapshot.dropFirst().sink { snapshot in
+            XCTAssertNotNil(snapshot.indexOfSection(.error))
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+            snapshotExpectation.fulfill()
+        }.store(in: &subscriptions)
+
+        viewModel.fetch()
+        wait(for: [snapshotExpectation], timeout: 1)
+    }
+
     func test_snapshot_whenOffline_thenReconnects_hasCorrectSnapshot() async {
         networkPathMonitor.update(status: .unsatisfied)
 

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1519,3 +1519,37 @@ extension MockSource {
         return calls[index] as? FetchFeatureFlagCall
     }
 }
+
+// MARK: fetchCollection
+ extension MockSource {
+    private static let fetchCollection = "fetchCollection"
+    typealias FetchCollectionImpl = (String) async throws -> Void
+
+    struct FetchCollectionCall {
+        let slug: String
+    }
+
+    func stubFetchCollection(impl: @escaping FetchCollectionImpl) {
+        implementations[Self.fetchCollection] = impl
+    }
+
+    func fetchCollection(by slug: String) async throws {
+        guard let impl = implementations[Self.fetchCollection] as? FetchCollectionImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.fetchCollection] = (calls[Self.fetchCollection] ?? []) + [
+            FetchCollectionCall(slug: slug)
+        ]
+
+        try await impl(slug)
+    }
+
+    func fetchCollectionCall(at index: Int) -> FetchCollectionCall? {
+        guard let calls = calls[Self.fetchCollection], calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? FetchCollectionCall
+    }
+ }

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -136,7 +136,7 @@ extension Space {
 extension Space {
     @discardableResult
     func buildCollection(
-        slug: String = "slug-1",
+        slug: String = "slug",
         title: String = "collection-title",
         authors: [String] = [],
         stories: [CollectionStory] = [],


### PR DESCRIPTION
## Summary
Add offline / error screen for native collections

## References 
IN-1596

## Implementation Details
* Added `error` section to collections 
* Use network monitor to observe changes to network via `observeNetworkChanges` and `handleNetworkChange`
* Refactor `ReportIssueButton` to be more flexible and not tied to search
* Created error view by using `ErrorEmptyState(featureFlags: featureFlags, user: user)` for the empty state view

## Test Steps
- [x] Given I have tapped to open a Collection,
and the collection is being loaded remotely,
when the remote download errors,
then I should see an error view replacing the spinner.
- [x] Given I have tapped to open a Collection,
and then collection is being loaded remotely,
and there is no network connection available (i.e offline),
when the screen is presented,
then I should see an error view replacing the spinner.
- [x] Given I have tapped to open a Collection,
and there was no network connection available (i.e offline),
and the error view is visible,
when the network becomes available again,
then the collection should automatically attempt to be downloaded again, and the spinner should appear, replacing the error view.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-07-27 at 13 00 46](https://github.com/Pocket/pocket-ios/assets/6743397/ccd1a03c-4043-46c0-b8aa-e4be9b913f84)
