### PR TITLE
feat(collections): implement analytics

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Collection.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Collection.swift
@@ -1,0 +1,240 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public extension Events {
+    struct Collection {}
+}
+
+public extension Events.Collection {
+    /**
+     * Fired when a user views the collection screen
+     */
+    static func screenView() -> Impression {
+        return Impression(
+            component: .screen,
+            requirement: .instant,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "collection.screen"
+            )
+        )
+    }
+
+    // MARK: Tracking Navbar Actions
+    /**
+     * Fired when a user Saves a card on a collection
+     */
+    static func saveClicked(url: String) -> Engagement {
+        return Engagement(
+            .save(contentEntity: ContentEntity(url: url)),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.save"
+            )
+        )
+    }
+
+    /**
+     * Fired when a user archives / unsaves a card on a collection
+     */
+    static func unsaveClicked(url: String) -> Engagement {
+        return Engagement(
+            .save(contentEntity: ContentEntity(url: url)),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.unsave"
+            )
+        )
+    }
+
+    /**
+     Fired when a user taps on the save icon in the collection nav bar and moves item from archive to save
+     */
+    static func moveFromArchiveToSavesClicked(url: String) -> Engagement {
+        return Engagement(
+            .save(contentEntity: ContentEntity(url: url)),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.un-archive"
+            )
+        )
+    }
+
+    /**
+     Fired when a user taps on overflow menu in nav bar within the collection screen
+     */
+    static func overflowClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on favorite in the overflow menu in nav bar within the collection screen if its a saved item
+     */
+    static func favoriteClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.favorite"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on unfavorite in the overflow menu in nav bar within the collection screen if its a saved item
+     */
+    static func unfavoriteClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.unfavorite"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on addTags in the overflow menu in nav bar within the collection screen if its a saved item
+     */
+    static func addTagsClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.addTag"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on delete in the overflow menu in nav bar within the collection screen if its a saved item
+     */
+    static func deleteClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.delete"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on share in the overflow menu in nav bar within the collection screen
+     */
+    static func shareClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.share"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on report in the overflow menu in nav bar within the collection screen if its a recommendation item
+     */
+    static func reportClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.overflow.report"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    // MARK: Tracking Story
+    /**
+     * Fired when a user clicks a card on a collection
+     */
+    static func contentOpen(
+        url: String
+    ) -> ContentOpen {
+        return ContentOpen(
+            trigger: .click,
+            contentEntity: ContentEntity(url: url),
+            uiEntity: UiEntity(.card, identifier: "collection.story.open")
+        )
+    }
+
+    /**
+     * Fired when a user Saves a card on a collection
+     */
+    static func storySaveClicked(url: String) -> Engagement {
+        return Engagement(
+            .save(contentEntity: ContentEntity(url: url)),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.story.save"
+            )
+        )
+    }
+
+    /**
+     * Fired when a user unSaves a card on a collection
+     */
+    static func storyUnSaveClicked(url: String) -> Engagement {
+        return Engagement(
+            .save(contentEntity: ContentEntity(url: url)),
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.story.unsave"
+            )
+        )
+    }
+
+    /**
+     Fired when a user taps on share button for a story in the overflow menu within the collection screen
+     */
+    static func storyShareClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.story.overflow.share"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+
+    /**
+     Fired when a user taps on report button for a story in the overflow menu within the collection screen
+     */
+    static func storyReportClicked(url: String) -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "collection.story.overflow.report"
+            ),
+            extraEntities: [
+                ContentEntity(url: url)
+            ]
+        )
+    }
+}

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -7,6 +7,7 @@ import PocketGraph
 import Textile
 import Localization
 import Sync
+import Analytics
 
 // Contains logic to present story data in RecommendationCell
 struct CollectionStoryViewModel: Hashable {
@@ -20,11 +21,13 @@ struct CollectionStoryViewModel: Hashable {
 
     private(set) var collectionStory: CollectionStory
     private let source: Source?
+    private let tracker: Tracker
     let overflowActions: [ItemAction]?
 
-    init(collectionStory: CollectionStory, source: Source? = nil, overflowActions: [ItemAction]?) {
+    init(collectionStory: CollectionStory, source: Source? = nil, tracker: Tracker, overflowActions: [ItemAction]?) {
         self.collectionStory = collectionStory
         self.source = source
+        self.tracker = tracker
         self.overflowActions = overflowActions
     }
 }
@@ -95,10 +98,25 @@ extension CollectionStoryViewModel: RecommendationCellViewModel {
     var primaryAction: ItemAction? {
         .recommendationPrimary { _ in
             if !self.collectionStory.isSaved {
+                trackStorySave()
                 self.source?.save(collectionStory: self.collectionStory)
             } else {
+                trackStoryUnSave()
                 self.source?.archive(collectionStory: self.collectionStory)
             }
         }
+    }
+}
+
+// MARK: - Analytics
+private extension CollectionStoryViewModel {
+    /// track user saving a story
+    func trackStorySave() {
+        tracker.track(event: Events.Collection.storySaveClicked(url: collectionStory.url))
+    }
+
+    /// track user unsaving a story
+    func trackStoryUnSave() {
+        tracker.track(event: Events.Collection.storyUnSaveClicked(url: collectionStory.url))
     }
 }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -112,8 +112,8 @@ class CollectionViewController: UIViewController {
             identifier: nil,
             options: [],
             children: [
-                UIDeferredMenuElement.uncached {
-                    completion in
+                UIDeferredMenuElement.uncached { [weak self] completion in
+                    self?.model.trackOverflow()
                     completion(actions.compactMap(UIAction.init))
                 }
             ]

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -470,7 +470,7 @@ extension SavesContainerViewController {
 
         let host = ReportRecommendationHostingController(
             givenURL: givenURL,
-            tracker: model.tracker.childTracker(hosting: .reportDialog),
+            tracker: model.tracker,
             onDismiss: { }
         )
 


### PR DESCRIPTION
## Summary
Implement analytics for native collections and verified that only good events are returned.

## References 
* IN-1600

## Implementation Details
Added the following analytic events
```
// Existing Analytics
collection.screen - user views native collection screen
collection.save - tapping on save icon in nav bar (has never been saved)
collection.unsave - tapping on archive icon in nav bar
collection.story.open - when a user taps on a story in a collection
collection.story.save - Fired when a user Saves a story in a collection
collection.story.unsave - Fired when a user unSaves a story in a collection

// New Analytics
collection.un-archive - tapping on save icon in nav bar (moves from archive to save)
collection.overflow - tapping on overflow menu
collection.overflow.favorite - tapping on overflow menu and favoriting the collection
collection.overflow.unfavorite - tapping on overflow menu and unfavoriting the collection
collection.overflow.addTag - tapping on overflow menu and adding tags to the collection
collection.overflow.delete - tapping on overflow menu and deletes the collection
collection.overflow.share - tapping on overflow menu and sharing the collection
collection.overflow.report - tapping on overflow menu and reporting the collection

collection.story.overflow.report - tapping on overflow menu and reporting the collection
collection.story.overflow.share - tapping on overflow menu and sharing the collection
```

## Test Steps
Verify that the analytic calls are being triggered properly. Please review the Analytics Actions spreadsheet.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
