### PR TITLE
Native Collections: cache stories in Core Data

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/CollectionAuthorSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CollectionAuthorSummary.graphql.swift
@@ -1,0 +1,38 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CollectionAuthorSummary: PocketGraph.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString { """
+    fragment CollectionAuthorSummary on CollectionAuthor {
+      __typename
+      name
+    }
+    """ }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("name", String.self),
+  ] }
+
+  public var name: String { __data["name"] }
+
+  public init(
+    name: String
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": PocketGraph.Objects.CollectionAuthor.typename,
+        "name": name,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(Self.self)
+      ]
+    ))
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Fragments/CollectionSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CollectionSummary.graphql.swift
@@ -8,6 +8,10 @@ public struct CollectionSummary: PocketGraph.SelectionSet, Fragment {
     fragment CollectionSummary on Collection {
       __typename
       slug
+      authors {
+        __typename
+        ...CollectionAuthorSummary
+      }
     }
     """ }
 
@@ -18,21 +22,63 @@ public struct CollectionSummary: PocketGraph.SelectionSet, Fragment {
   public static var __selections: [ApolloAPI.Selection] { [
     .field("__typename", String.self),
     .field("slug", String.self),
+    .field("authors", [Author].self),
   ] }
 
   public var slug: String { __data["slug"] }
+  public var authors: [Author] { __data["authors"] }
 
   public init(
-    slug: String
+    slug: String,
+    authors: [Author]
   ) {
     self.init(_dataDict: DataDict(
       data: [
         "__typename": PocketGraph.Objects.Collection.typename,
         "slug": slug,
+        "authors": authors._fieldData,
       ],
       fulfilledFragments: [
         ObjectIdentifier(Self.self)
       ]
     ))
+  }
+
+  /// Author
+  ///
+  /// Parent Type: `CollectionAuthor`
+  public struct Author: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .fragment(CollectionAuthorSummary.self),
+    ] }
+
+    public var name: String { __data["name"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var collectionAuthorSummary: CollectionAuthorSummary { _toFragment() }
+    }
+
+    public init(
+      name: String
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": PocketGraph.Objects.CollectionAuthor.typename,
+          "name": name,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(Self.self),
+          ObjectIdentifier(CollectionAuthorSummary.self)
+        ]
+      ))
+    }
   }
 }

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
@@ -183,6 +183,7 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
       ] }
 
       public var slug: String { __data["slug"] }
+      public var authors: [Author] { __data["authors"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -192,12 +193,14 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
       }
 
       public init(
-        slug: String
+        slug: String,
+        authors: [Author]
       ) {
         self.init(_dataDict: DataDict(
           data: [
             "__typename": PocketGraph.Objects.Collection.typename,
             "slug": slug,
+            "authors": authors._fieldData,
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
@@ -205,6 +208,40 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
             ObjectIdentifier(CollectionSummary.self)
           ]
         ))
+      }
+
+      /// Target.AsCollection.Author
+      ///
+      /// Parent Type: `CollectionAuthor`
+      public struct Author: PocketGraph.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+
+        public var name: String { __data["name"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var collectionAuthorSummary: CollectionAuthorSummary { _toFragment() }
+        }
+
+        public init(
+          name: String
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": PocketGraph.Objects.CollectionAuthor.typename,
+              "name": name,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(CollectionAuthorSummary.self)
+            ]
+          ))
+        }
       }
     }
   }

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
@@ -205,6 +205,7 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
         ] }
 
         public var slug: String { __data["slug"] }
+        public var authors: [Author] { __data["authors"] }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -214,12 +215,14 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
         }
 
         public init(
-          slug: String
+          slug: String,
+          authors: [Author]
         ) {
           self.init(_dataDict: DataDict(
             data: [
               "__typename": PocketGraph.Objects.Collection.typename,
               "slug": slug,
+              "authors": authors._fieldData,
             ],
             fulfilledFragments: [
               ObjectIdentifier(Self.self),
@@ -227,6 +230,40 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
               ObjectIdentifier(CollectionSummary.self)
             ]
           ))
+        }
+
+        /// CorpusItem.Target.AsCollection.Author
+        ///
+        /// Parent Type: `CollectionAuthor`
+        public struct Author: PocketGraph.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+
+          public var name: String { __data["name"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var collectionAuthorSummary: CollectionAuthorSummary { _toFragment() }
+          }
+
+          public init(
+            name: String
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": PocketGraph.Objects.CollectionAuthor.typename,
+                "name": name,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(Self.self),
+                ObjectIdentifier(CollectionAuthorSummary.self)
+              ]
+            ))
+          }
         }
       }
     }

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
@@ -255,6 +255,7 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
           ] }
 
           public var slug: String { __data["slug"] }
+          public var authors: [Author] { __data["authors"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -264,12 +265,14 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
           }
 
           public init(
-            slug: String
+            slug: String,
+            authors: [Author]
           ) {
             self.init(_dataDict: DataDict(
               data: [
                 "__typename": PocketGraph.Objects.Collection.typename,
                 "slug": slug,
+                "authors": authors._fieldData,
               ],
               fulfilledFragments: [
                 ObjectIdentifier(Self.self),
@@ -277,6 +280,40 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
                 ObjectIdentifier(CollectionSummary.self)
               ]
             ))
+          }
+
+          /// Recommendation.CorpusItem.Target.AsCollection.Author
+          ///
+          /// Parent Type: `CollectionAuthor`
+          public struct Author: PocketGraph.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+
+            public var name: String { __data["name"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var collectionAuthorSummary: CollectionAuthorSummary { _toFragment() }
+            }
+
+            public init(
+              name: String
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": PocketGraph.Objects.CollectionAuthor.typename,
+                  "name": name,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(Self.self),
+                  ObjectIdentifier(CollectionAuthorSummary.self)
+                ]
+              ))
+            }
           }
         }
       }

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
@@ -19,7 +19,7 @@ public class HomeSlateLineupQuery: GraphQLQuery {
         }
       }
       """#,
-      fragments: [CorpusSlateParts.self, CorpusRecommendationParts.self, CorpusItemParts.self, SyndicatedArticleParts.self, CollectionSummary.self]
+      fragments: [CorpusSlateParts.self, CorpusRecommendationParts.self, CorpusItemParts.self, SyndicatedArticleParts.self, CollectionSummary.self, CollectionAuthorSummary.self]
     ))
 
   public var locale: String
@@ -202,12 +202,32 @@ public class HomeSlateLineupQuery: GraphQLQuery {
                 ] }
 
                 public var slug: String { __data["slug"] }
+                public var authors: [Author] { __data["authors"] }
 
                 public struct Fragments: FragmentContainer {
                   public let __data: DataDict
                   public init(_dataDict: DataDict) { __data = _dataDict }
 
                   public var collectionSummary: CollectionSummary { _toFragment() }
+                }
+
+                /// HomeSlateLineup.Slate.Recommendation.CorpusItem.Target.AsCollection.Author
+                ///
+                /// Parent Type: `CollectionAuthor`
+                public struct Author: PocketGraph.SelectionSet {
+                  public let __data: DataDict
+                  public init(_dataDict: DataDict) { __data = _dataDict }
+
+                  public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.CollectionAuthor }
+
+                  public var name: String { __data["name"] }
+
+                  public struct Fragments: FragmentContainer {
+                    public let __data: DataDict
+                    public init(_dataDict: DataDict) { __data = _dataDict }
+
+                    public var collectionAuthorSummary: CollectionAuthorSummary { _toFragment() }
+                  }
                 }
               }
             }

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
@@ -47,4 +47,12 @@ query HomeSlateLineup($locale: String!) {
 
 fragment CollectionSummary on Collection {
     slug
+    authors {
+        __typename
+        ...CollectionAuthorSummary
+    }
+}
+
+fragment CollectionAuthorSummary on CollectionAuthor {
+    name
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -140,6 +140,10 @@ class SavedItemViewModel: ReadableViewModel {
         item.isCollection
     }
 
+    var collection: Collection? {
+        item.item?.collection
+    }
+
     var slug: String? {
         // TODO: Add check for slug and use this as fallback
         // Returns the slug from a collection url by validating that it is in the proper url format (ie. 0 represents "/", 1 represents "collections" and 2 represents the slug)

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -11,23 +11,23 @@ import Sync
 // Contains logic to present story data in RecommendationCell
 struct CollectionStoryViewModel: Hashable {
     public func hash(into hasher: inout Hasher) {
-        return hasher.combine(story)
+        return hasher.combine(storyModel)
     }
 
     public static func == (lhs: CollectionStoryViewModel, rhs: CollectionStoryViewModel) -> Bool {
-        return lhs.story == rhs.story
+        return lhs.storyModel == rhs.storyModel
     }
 
-    private let story: Story
+    private let storyModel: CollectionStoryModel
 
-    init(story: Story) {
-        self.story = story
+    init(storyModel: CollectionStoryModel) {
+        self.storyModel = storyModel
     }
 }
 
 extension CollectionStoryViewModel: RecommendationCellViewModel {
     var attributedCollection: NSAttributedString? {
-        guard story.isCollection else { return nil }
+        guard storyModel.isCollection else { return nil }
         return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
     }
 
@@ -59,11 +59,11 @@ extension CollectionStoryViewModel: RecommendationCellViewModel {
     }
 
     var title: String? {
-        story.title
+        storyModel.title
     }
 
     var imageURL: URL? {
-        guard let imageURL = story.imageURL else { return nil }
+        guard let imageURL = storyModel.imageURL else { return nil }
         return URL(string: imageURL)
     }
 
@@ -72,15 +72,15 @@ extension CollectionStoryViewModel: RecommendationCellViewModel {
     }
 
     var excerpt: Markdown {
-        story.excerpt
+        storyModel.excerpt
     }
 
     var domain: String? {
-        story.publisher
+        storyModel.publisher
     }
 
     var timeToRead: String? {
-        guard let timeToRead = story.timeToRead,
+        guard let timeToRead = storyModel.timeToRead,
               timeToRead > 0 else {
             return nil
         }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -219,11 +219,24 @@ private extension CollectionViewController {
         case .collection(let collection):
             let width = environment.container.effectiveContentSize.width
             let margin: CGFloat = environment.traitCollection.shouldUseWideLayout() ? Margins.iPadNormal.rawValue : Margins.normal.rawValue
-            let stories = collection.stories.compactMap { CollectionStoryViewModel(story: $0) }
+            let stories = collection.stories?.compactMap { $0 as? CollectionStory } ?? []
+            let storyModels = stories.map { CollectionStoryModel(
+                title: $0.title,
+                publisher: $0.publisher,
+                imageURL: $0.imageUrl,
+                excerpt: $0.excerpt,
+                timeToRead: $0.item?.timeToRead != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil,
+                isCollection: $0.item?.collection != nil
+            )}
 
-            let components = stories.reduce((CGFloat(0), [NSCollectionLayoutItem]())) { result, viewModel in
+            let components = storyModels.reduce((CGFloat(0), [NSCollectionLayoutItem]())) { result, storyModel in
                 let currentHeight = result.0
-                let height = RecommendationCell.fullHeight(viewModel: viewModel, availableWidth: width - (margin * 2)) + margin
+
+                let height = RecommendationCell.fullHeight(
+                    viewModel: CollectionStoryViewModel(storyModel: storyModel),
+                    availableWidth: width - (margin * 2)
+                ) + margin
+
                 var items = result.1
                 let item = NSCollectionLayoutItem(
                     layoutSize: NSCollectionLayoutSize(
@@ -278,7 +291,7 @@ private extension CollectionViewController {
                 intro: metadata?.attributedIntro
             ))
             return metaCell
-        case .stories(let story):
+        case .story(let story):
             let cell: RecommendationCell = collectionView.dequeueCell(for: indexPath)
             cell.configure(model: story)
             return cell

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -74,7 +74,7 @@ class CollectionViewModel: NSObject {
     }
 
     var authors: [String] {
-        source.fetchCollectionAuthors(by: collection.slug).map { $0.name }
+        ((collection.authors?.compactMap { $0 as? CollectionAuthor }) ?? [CollectionAuthor]()).map { $0.name }
     }
 
     var storiesCount: Int? {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -244,8 +244,8 @@ private extension CollectionViewModel {
         collectionSnapshot.appendSections([.collectionHeader, storiesSection])
         collectionSnapshot.appendItems([.collectionHeader], toSection: .collectionHeader)
 
-        let entities = IDs.map {
-            source.viewObject(id: $0) as! CollectionStory
+        let entities: [CollectionStory] = IDs.compactMap {
+            source.viewObject(id: $0) as? CollectionStory
         }
 
         let models = entities.map {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -6,6 +6,7 @@ import Sync
 import UIKit
 import SharedPocketKit
 import Combine
+import CoreData
 import Localization
 import Analytics
 
@@ -25,7 +26,7 @@ class CollectionViewModel {
     @Published private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
 
-    private let slug: String
+    private let collection: Collection
     private let source: Source
     private let tracker: Tracker
     private let user: User
@@ -38,7 +39,7 @@ class CollectionViewModel {
     private var collectionItemSubscriptions: Set<AnyCancellable> = []
 
     init(
-        slug: String,
+        collection: Collection,
         source: Source,
         tracker: Tracker,
         user: User,
@@ -46,7 +47,7 @@ class CollectionViewModel {
         networkPathMonitor: NetworkPathMonitor,
         userDefaults: UserDefaults
     ) {
-        self.slug = slug
+        self.collection = collection
         self.source = source
         self.tracker = tracker
         self.user = user
@@ -64,11 +65,11 @@ class CollectionViewModel {
     }
 
     var title: String {
-        collection?.title ?? ""
+        collection.title ?? ""
     }
 
     var authors: [String] {
-        collection?.authors ?? []
+        source.fetchCollectionAuthors(by: collection.slug).map { $0.name }
     }
 
     var storiesCount: Int? {
@@ -76,11 +77,11 @@ class CollectionViewModel {
     }
 
     var intro: Markdown? {
-        collection?.intro
+        collection.intro
     }
 
     var item: Item? {
-        return source.fetchItem(url)
+        return collection.item
     }
 
     var isArchived: Bool? {
@@ -254,7 +255,7 @@ extension CollectionViewModel {
     enum Section: Hashable {
         case loading
         case collectionHeader
-        case collection(CollectionModel)
+        case collection(Collection)
     }
 
     enum Cell: Hashable {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -105,6 +105,7 @@ class CollectionViewModel: NSObject {
                 try await source.fetchCollection(by: collection.slug)
             } catch {
                 Log.capture(message: "Failed to fetch details for CollectionViewModel: \(error)")
+                // TODO: NATIVECOLLECTIONS - handle remote error here
             }
         }
     }
@@ -236,6 +237,7 @@ private extension CollectionViewModel {
         return snapshot
     }
 
+    /// Builds a snapshot when collection stories are found in Core Data
     func buildCollectionSnapshot(_ IDs: [NSManagedObjectID]) -> Snapshot {
         var collectionSnapshot = Snapshot()
         let storiesSection = Section.collection(collection)

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -707,7 +707,7 @@ extension HomeViewModel: NSFetchedResultsControllerDelegate {
 
         if controller == self.recentSavesController {
             let reloadedItemIdentifiers: [Cell] = snapshot.reloadedItemIdentifiers.compactMap({ .recentSaves($0 as! NSManagedObjectID) })
-            let reconfiguredItemdIdentifiers: [Cell] = snapshot.reloadedItemIdentifiers.compactMap({ .recentSaves($0 as! NSManagedObjectID) })
+            let reconfiguredItemdIdentifiers: [Cell] = snapshot.reconfiguredItemIdentifiers.compactMap({ .recentSaves($0 as! NSManagedObjectID) })
             newSnapshot.reloadItems(reloadedItemIdentifiers)
             newSnapshot.reconfigureItems(reconfiguredItemdIdentifiers)
             updateRecentSavesWidget()
@@ -731,8 +731,8 @@ extension HomeViewModel: NSFetchedResultsControllerDelegate {
             newSnapshot.reloadItems(reloadedItemIdentifiers)
 
             // Gather all variations a recomendation could exist in for reconfigured identifiers
-            var reconfiguredItemIdentifiers: [Cell] = snapshot.reloadedItemIdentifiers.compactMap({ .recommendationHero($0 as! NSManagedObjectID) })
-            reconfiguredItemIdentifiers.append(contentsOf: snapshot.reloadedItemIdentifiers.compactMap({ .recommendationCarousel($0 as! NSManagedObjectID) }))
+            var reconfiguredItemIdentifiers: [Cell] = snapshot.reconfiguredItemIdentifiers.compactMap({ .recommendationHero($0 as! NSManagedObjectID) })
+            reconfiguredItemIdentifiers.append(contentsOf: snapshot.reconfiguredItemIdentifiers.compactMap({ .recommendationCarousel($0 as! NSManagedObjectID) }))
             // Filter to just the ones that exist in our snapshot
             reconfiguredItemIdentifiers = reconfiguredItemIdentifiers.filter({ existingItemIdentifiers.contains($0) })
             // Tell the new snapshot to reconfigure just the ones that exist

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -304,8 +304,8 @@ extension HomeViewModel {
         var destination: ContentOpen.Destination = .internal
         let item = recommendation.item
 
-        if let slug = recommendation.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
+        if let collection = recommendation.collection, featureFlags.isAssigned(flag: .nativeCollections) {
+            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
         } else {
             let viewModel = RecommendationViewModel(
                 recommendation: recommendation,
@@ -337,8 +337,8 @@ extension HomeViewModel {
     }
 
     private func select(savedItem: SavedItem, at indexPath: IndexPath) {
-        if let slug = savedItem.item?.collection?.slug, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
+        if let collection = savedItem.item?.collection, featureFlags.isAssigned(flag: .nativeCollections) {
+            selectedReadableType = .collection(CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults))
         } else {
             let viewModel = SavedItemViewModel(
                 item: savedItem,

--- a/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/SlateDetailViewModel.swift
@@ -124,8 +124,8 @@ extension SlateDetailViewModel {
         let item = recommendation.item
         var destination: ContentOpen.Destination = .internal
 
-        if let slug = recommendation.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedCollectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
+        if let collection = recommendation.collection, featureFlags.isAssigned(flag: .nativeCollections) {
+            selectedCollectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
         } else if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             guard let bestURL = URL(percentEncoding: item.bestURL) else { return }
             let url = pocketPremiumURL(bestURL, user: user)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -620,9 +620,8 @@ extension SavedItemsListViewModel {
             notificationCenter: notificationCenter
         )
 
-        // TODO: Refactor when working on opening a collection, rather than several checks, we may be able to do one
-        if readable.isCollection, let slug = readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
-            let collectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
+        if let collection = readable.collection, featureFlags.isAssigned(flag: .nativeCollections) {
+            let collectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults)
             selectedItem = .collection(collectionViewModel)
         } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             selectedItem = .webView(readable)

--- a/PocketKit/Sources/Sync/Article/ArticleComponent.swift
+++ b/PocketKit/Sources/Sync/Article/ArticleComponent.swift
@@ -229,4 +229,62 @@ extension ArticleComponent {
 
         self = .unsupported(UnsupportedComponent(type: marticle.__typename))
     }
+
+    init(_ marticle: GetCollectionBySlugQuery.Data.Collection.Story.Item.Marticle) {
+        if let parts = marticle.asMarticleText {
+            self.init(parts.fragments.marticleTextParts)
+            return
+        }
+
+        if let parts = marticle.asImage {
+            self.init(parts.fragments.imageParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleDivider {
+            self.init(parts.fragments.marticleDividerParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleTable {
+            self.init(parts.fragments.marticleTableParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleHeading {
+            self.init(parts.fragments.marticleHeadingParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleCodeBlock {
+            self.init(parts.fragments.marticleCodeBlockParts)
+            return
+        }
+
+        if let videoParts = marticle.asVideo?.fragments.videoParts {
+            do {
+                try self.init(videoParts)
+                return
+            } catch {
+                Log.capture(message: "Invalid source URL for video: \(error)")
+            }
+        }
+
+        if let parts = marticle.asMarticleBulletedList {
+            self.init(parts.fragments.marticleBulletedListParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleNumberedList {
+            self.init(parts.fragments.marticleNumberedListParts)
+            return
+        }
+
+        if let parts = marticle.asMarticleBlockquote {
+            self.init(parts.fragments.marticleBlockquoteParts)
+            return
+        }
+
+        self = .unsupported(UnsupportedComponent(type: marticle.__typename))
+    }
 }

--- a/PocketKit/Sources/Sync/Collection/CollectionService.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionService.swift
@@ -8,37 +8,25 @@ import PocketGraph
 import SharedPocketKit
 
 protocol CollectionService {
-    func fetchCollection(by identifier: String) async throws -> CollectionModel
-}
-
-// TODO: Refine error handling
-public enum CollectionServiceError: Error {
-    case anError
+    func fetchCollection(by identifier: String) async throws
 }
 
 class APICollectionService: CollectionService {
     private let apollo: ApolloClientProtocol
+    private let space: Space
 
-    init(apollo: ApolloClientProtocol) {
+    init(apollo: ApolloClientProtocol, space: Space) {
         self.apollo = apollo
+        self.space = space
     }
 
-    func fetchCollection(by slug: String) async throws -> CollectionModel {
+    func fetchCollection(by slug: String) async throws {
         let query = GetCollectionBySlugQuery(slug: slug)
 
         guard let remote = try await apollo.fetch(query: query).data?.collection else {
             Log.capture(message: "Error loading collection")
-            throw CollectionServiceError.anError
+            return
         }
-
-        // TODO: Add Core data changes and publish changes instead of returning model
-        return CollectionModel(
-            title: remote.title,
-            authors: remote.authors.compactMap { $0.name },
-            intro: remote.intro,
-            stories: remote.stories.compactMap {
-                Story(title: $0.title, publisher: $0.publisher, imageURL: $0.imageUrl, excerpt: $0.excerpt, timeToRead: $0.item?.timeToRead, isCollection: $0.item?.collection?.slug != nil)
-            }
-        )
+        try space.updateCollection(from: remote)
     }
 }

--- a/PocketKit/Sources/Sync/Collection/CollectionService.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionService.swift
@@ -11,6 +11,10 @@ protocol CollectionService {
     func fetchCollection(by identifier: String) async throws
 }
 
+enum CollectionServiceError: Error {
+    case nullCollection
+}
+
 class APICollectionService: CollectionService {
     private let apollo: ApolloClientProtocol
     private let space: Space
@@ -24,8 +28,8 @@ class APICollectionService: CollectionService {
         let query = GetCollectionBySlugQuery(slug: slug)
 
         guard let remote = try await apollo.fetch(query: query).data?.collection else {
-            Log.capture(message: "Error loading collection")
-            return
+            Log.capture(message: "CollectionService Error - the request returned a null collection")
+            throw CollectionServiceError.nullCollection
         }
         try space.updateCollection(from: remote)
     }

--- a/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
@@ -4,21 +4,16 @@
 
 import Foundation
 
-public struct CollectionModel: Equatable, Hashable {
-    public let title: String
-    public let authors: [String]
-    public let intro: Markdown?
-    public let stories: [Story]
-
-    public init(title: String, authors: [String], intro: Markdown?, stories: [Story]) {
+public struct StoryModel: Equatable, Hashable {
+    public init(title: String, publisher: String?, imageURL: String?, excerpt: Markdown, timeToRead: Int?, isCollection: Bool) {
         self.title = title
-        self.authors = authors
-        self.intro = intro
-        self.stories = stories
+        self.publisher = publisher
+        self.imageURL = imageURL
+        self.excerpt = excerpt
+        self.timeToRead = timeToRead
+        self.isCollection = isCollection
     }
-}
 
-public struct Story: Equatable, Hashable {
     public let title: String
     public let publisher: String?
     public let imageURL: String?

--- a/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionStoryModel.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct StoryModel: Equatable, Hashable {
+public struct CollectionStoryModel: Equatable, Hashable {
     public init(title: String, publisher: String?, imageURL: String?, excerpt: Markdown, timeToRead: Int?, isCollection: Bool) {
         self.title = title
         self.publisher = publisher

--- a/PocketKit/Sources/Sync/CoreData+Relationships/README.md
+++ b/PocketKit/Sources/Sync/CoreData+Relationships/README.md
@@ -1,6 +1,6 @@
 #  CoreData Relationships
 
-At Pocket we use NSFetchedResultsControllers to power our data views. These work great and update our views only when the object they are observing updates it's values. However it has a downside where CoreData will not tell NSFetchedResultsController to update if the object it is montioring has an update to any of its related objects.
+At Pocket we use NSFetchedResultsControllers to power our data views. These work great and update our views only when the object they are observing updates its values. However it has a downside where Core Data will not tell NSFetchedResultsController to update if the object it is montioring has an update to any of its related objects.
 
 For Pocket this causes problem for our Home screen where our root object is Recommendation, but we need to display changes to the Recommendation if the user clicks Save, which in itself is a completely different object.
 

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Collection+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Collection+CoreDataProperties.swift
@@ -14,10 +14,11 @@ extension Collection {
 
     @NSManaged public var intro: String?
     @NSManaged public var publishedAt: Date?
-    @NSManaged public var slug: String
-    @NSManaged public var title: String
-    @NSManaged public var authors: NSOrderedSet
-    @NSManaged public var stories: NSOrderedSet
+    @NSManaged public var slug: String?
+    @NSManaged public var title: String?
+    @NSManaged public var authors: NSOrderedSet?
+    @NSManaged public var stories: NSOrderedSet?
+    @NSManaged public var item: Item?
 }
 
 // MARK: Generated accessors for authors

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Collection+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Collection+CoreDataProperties.swift
@@ -14,7 +14,7 @@ extension Collection {
 
     @NSManaged public var intro: String?
     @NSManaged public var publishedAt: Date?
-    @NSManaged public var slug: String?
+    @NSManaged public var slug: String
     @NSManaged public var title: String?
     @NSManaged public var authors: NSOrderedSet?
     @NSManaged public var stories: NSOrderedSet?

--- a/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/Recommendation+CoreDataProperties.swift
@@ -26,6 +26,10 @@ extension Recommendation {
 extension Recommendation {
     /// The slug of the associated collection
     public var collectionSlug: String? {
-        self.item.collection?.slug
+        item.collection?.slug
+    }
+
+    public var collection: Collection? {
+        item.collection
     }
 }

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22189.1" systemVersion="23A5286i" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22203.2" systemVersion="23A5301g" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName="Author" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -12,6 +12,7 @@
         <attribute name="slug" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
         <relationship name="authors" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="CollectionAuthor" inverseName="collection" inverseEntity="CollectionAuthor"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Item" inverseName="collection" inverseEntity="Item"/>
         <relationship name="stories" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="CollectionStory" inverseName="collection" inverseEntity="CollectionStory"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -80,7 +81,7 @@
         <attribute name="videoness" optional="YES" attributeType="String"/>
         <attribute name="wordCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Author" inverseName="item" inverseEntity="Author"/>
-        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Collection"/>
+        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Collection" inverseName="item" inverseEntity="Collection"/>
         <relationship name="collectionStory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CollectionStory" inverseName="item" inverseEntity="CollectionStory"/>
         <relationship name="domainMetadata" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="DomainMetadata" inverseName="item" inverseEntity="DomainMetadata"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Image" inverseName="item" inverseEntity="Image"/>

--- a/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
+++ b/PocketKit/Sources/Sync/PocketModel.xcdatamodeld/PocketModel 3.xcdatamodel/contents
@@ -22,8 +22,8 @@
     </entity>
     <entity name="CollectionAuthor" representedClassName="CollectionAuthor" syncable="YES">
         <attribute name="name" attributeType="String"/>
-        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Collection" inverseName="authors" inverseEntity="Collection"/>
-        <relationship name="collectionStory" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CollectionStory" inverseName="authors" inverseEntity="CollectionStory"/>
+        <relationship name="collection" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="authors" inverseEntity="Collection"/>
+        <relationship name="collectionStory" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CollectionStory" inverseName="authors" inverseEntity="CollectionStory"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="name"/>

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -91,7 +91,7 @@ public class PocketSource: Source {
             operations: OperationFactory(),
             lastRefresh: UserDefaultsLastRefresh(defaults: defaults),
             slateService: APISlateService(apollo: apollo, space: space),
-            collectionService: APICollectionService(apollo: apollo),
+            collectionService: APICollectionService(apollo: apollo, space: space),
             featureFlagService: APIFeatureFlagService(apollo: apollo, space: space, appSession: appSession),
             networkMonitor: NWPathMonitor(),
             sessionProvider: appSession as! SessionProvider,
@@ -704,7 +704,7 @@ extension PocketSource {
 
 // MARK: - Collections
 extension PocketSource {
-    public func fetchCollection(by slug: String) async throws -> CollectionModel {
+    public func fetchCollection(by slug: String) async throws {
         try await collectionService.fetchCollection(by: slug)
     }
 }

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -201,6 +201,10 @@ public class PocketSource: Source {
         space.makeRecomendationsSlateLineupController(by: SyncConstants.Home.slateLineupIdentifier)
     }
 
+    public func makeCollectionStoriesController(slug: String) -> RichFetchedResultsController<CollectionStory> {
+        space.makeCollectionStoriesController(slug: slug)
+    }
+
     public func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
         space.viewObject(with: id)
     }
@@ -706,6 +710,10 @@ extension PocketSource {
 extension PocketSource {
     public func fetchCollection(by slug: String) async throws {
         try await collectionService.fetchCollection(by: slug)
+    }
+
+    public func fetchCollectionAuthors(by slug: String) -> [CollectionAuthor] {
+        (try? space.fetchCollectionAuthors(by: slug)) ?? []
     }
 }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
@@ -29,6 +29,7 @@ extension Collection {
             )
 
             story.sortOrder = NSNumber(value: $0.offset + 1)
+            story.publisher = $0.element.publisher
             if let remoteItem = $0.element.item {
                 let item = (try? space.fetchItem(byURL: remoteItem.givenUrl, context: context)) ??
                 Item(context: context, givenURL: remoteItem.givenUrl, remoteID: remoteItem.remoteID)

--- a/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
@@ -30,6 +30,7 @@ extension Collection {
 
             story.sortOrder = NSNumber(value: $0.offset + 1)
             story.publisher = $0.element.publisher
+            story.imageUrl = $0.element.imageUrl
             if let remoteItem = $0.element.item {
                 let item = (try? space.fetchItem(byURL: remoteItem.givenUrl, context: context)) ??
                 Item(context: context, givenURL: remoteItem.givenUrl, remoteID: remoteItem.remoteID)

--- a/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
@@ -7,6 +7,7 @@ import PocketGraph
 
 extension Collection {
     public typealias RemoteCollection = GetCollectionBySlugQuery.Data.Collection
+    public typealias RemoteAuthor = CorpusSlateParts.Recommendation.CorpusItem.Target.AsCollection.Author
 
     func update(from remote: RemoteCollection, in space: Space, context: NSManagedObjectContext) {
         intro = remote.intro
@@ -35,6 +36,12 @@ extension Collection {
                 story.item = item
             }
             return story
+        })
+    }
+
+    func updateAuthors(from remoteAuthors: [RemoteAuthor], in space: Space, context: NSManagedObjectContext) {
+        authors = try? NSOrderedSet(array: remoteAuthors.map {
+            try space.fetchCollectionAuthor(by: $0.name, context: context) ?? CollectionAuthor(context: context, name: $0.name)
         })
     }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import CoreData
+import PocketGraph
+
+extension Collection {
+    public typealias RemoteCollection = GetCollectionBySlugQuery.Data.Collection
+
+    func update(from remote: RemoteCollection, in space: Space, context: NSManagedObjectContext) {
+        intro = remote.intro
+        publishedAt = remote.publishedAt.flatMap { DateFormatter.clientAPI.date(from: $0) }
+        title = remote.title
+
+        authors = try? NSOrderedSet(array: remote.authors.map {
+            try space.fetchCollectionAuthor(by: $0.name) ?? CollectionAuthor(context: context, name: $0.name)
+        })
+
+        stories = try? NSOrderedSet(array: remote.stories.enumerated().map {
+            let story = try space.fetchCollectionStory(by: $0.element.url) ??
+            CollectionStory(
+                context: context,
+                url: $0.element.url,
+                title: $0.element.title,
+                excerpt: $0.element.excerpt,
+                authors: makeStoryAuthors(space: space, context: context, authors: $0.element.authors)
+            )
+
+            story.sortOrder = NSNumber(value: $0.offset + 1)
+            if let remoteItem = $0.element.item {
+                let item = (try? space.fetchItem(byURL: remoteItem.givenUrl, context: context)) ??
+                Item(context: context, givenURL: remoteItem.givenUrl, remoteID: remoteItem.remoteID)
+                item.update(from: remoteItem, in: space)
+                story.item = item
+            }
+            return story
+        })
+    }
+
+    private func makeStoryAuthors(space: Space, context: NSManagedObjectContext, authors: [RemoteCollection.Story.Author]) throws -> NSOrderedSet {
+        try NSOrderedSet(array: authors.map {
+            try space.fetchCollectionAuthor(by: $0.name) ?? CollectionAuthor(context: context, name: $0.name)
+        })
+    }
+}

--- a/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Collection+remoteMapping.swift
@@ -14,11 +14,11 @@ extension Collection {
         title = remote.title
 
         authors = try? NSOrderedSet(array: remote.authors.map {
-            try space.fetchCollectionAuthor(by: $0.name) ?? CollectionAuthor(context: context, name: $0.name)
+            try space.fetchCollectionAuthor(by: $0.name, context: context) ?? CollectionAuthor(context: context, name: $0.name)
         })
 
         stories = try? NSOrderedSet(array: remote.stories.enumerated().map {
-            let story = try space.fetchCollectionStory(by: $0.element.url) ??
+            let story = try space.fetchCollectionStory(by: $0.element.url, context: context) ??
             CollectionStory(
                 context: context,
                 url: $0.element.url,
@@ -40,7 +40,7 @@ extension Collection {
 
     private func makeStoryAuthors(space: Space, context: NSManagedObjectContext, authors: [RemoteCollection.Story.Author]) throws -> NSOrderedSet {
         try NSOrderedSet(array: authors.map {
-            try space.fetchCollectionAuthor(by: $0.name) ?? CollectionAuthor(context: context, name: $0.name)
+            try space.fetchCollectionAuthor(by: $0.name, context: context) ?? CollectionAuthor(context: context, name: $0.name)
         })
     }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -115,6 +115,7 @@ extension Item {
 
         if let slug = corpusItem.target?.asCollection?.slug {
             self.collection = (try? space.fetchCollection(by: slug, context: context)) ?? Collection(context: context, slug: slug, title: "", authors: [], stories: [])
+            collection?.item = self
         }
     }
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -114,8 +114,13 @@ extension Item {
         }
 
         if let slug = corpusItem.target?.asCollection?.slug {
-            self.collection = (try? space.fetchCollection(by: slug, context: context)) ?? Collection(context: context, slug: slug, title: "", authors: [], stories: [])
-            collection?.item = self
+            let collection = (try? space.fetchCollection(by: slug, context: context)) ?? Collection(context: context, slug: slug, title: "", authors: [], stories: [])
+            collection.item = self
+
+            if let authors = corpusItem.target?.asCollection?.authors {
+                collection.updateAuthors(from: authors, in: space, context: context)
+            }
+            self.collection = collection
         }
     }
 

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -143,6 +143,20 @@ public enum Requests {
         return request
     }
 
+    public static func fetchCollectionAuthor(by name: String) -> NSFetchRequest<CollectionAuthor> {
+        let request = CollectionAuthor.fetchRequest()
+        request.predicate = NSPredicate(format: "name = %@", name)
+        request.fetchLimit = 1
+        return request
+    }
+
+    public static func fetchCollectionStory(by url: String) -> NSFetchRequest<CollectionStory> {
+        let request = CollectionStory.fetchRequest()
+        request.predicate = NSPredicate(format: "url = %@", url)
+        request.fetchLimit = 1
+        return request
+    }
+
     public static func fetchTags() -> NSFetchRequest<Tag> {
         return Tag.fetchRequest()
     }

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -150,10 +150,37 @@ public enum Requests {
         return request
     }
 
+    public static func fetchCollectionAuthors(by slug: String) -> NSFetchRequest<CollectionAuthor> {
+        let request = CollectionAuthor.fetchRequest()
+        request.predicate = NSPredicate(format: "collection.slug = %@", slug)
+        return request
+    }
+
     public static func fetchCollectionStory(by url: String) -> NSFetchRequest<CollectionStory> {
         let request = CollectionStory.fetchRequest()
         request.predicate = NSPredicate(format: "url = %@", url)
         request.fetchLimit = 1
+        return request
+    }
+
+    public static func fetchCollectionStories(by slug: String) -> NSFetchRequest<CollectionStory> {
+        let request = CollectionStory.fetchRequest()
+        request.predicate = NSPredicate(format: "collection.slug = %@", slug)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \CollectionStory.sortOrder, ascending: true)]
+        return request
+    }
+
+    public static func fetchCollectionStories(by slug: String) -> RichFetchRequest<CollectionStory> {
+        let request = RichFetchRequest<CollectionStory>(entityName: "CollectionStory")
+        request.predicate = NSPredicate(format: "collection.slug = %@", slug)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \CollectionStory.sortOrder, ascending: true)]
+
+        request.relationshipKeyPathsForRefreshing = [
+            #keyPath(CollectionStory.item.savedItem.archivedAt),
+            #keyPath(CollectionStory.item.savedItem.isFavorite),
+            #keyPath(CollectionStory.item.savedItem.createdAt),
+        ]
+
         return request
     }
 

--- a/PocketKit/Sources/Sync/Requests.swift
+++ b/PocketKit/Sources/Sync/Requests.swift
@@ -163,13 +163,6 @@ public enum Requests {
         return request
     }
 
-    public static func fetchCollectionStories(by slug: String) -> NSFetchRequest<CollectionStory> {
-        let request = CollectionStory.fetchRequest()
-        request.predicate = NSPredicate(format: "collection.slug = %@", slug)
-        request.sortDescriptors = [NSSortDescriptor(keyPath: \CollectionStory.sortOrder, ascending: true)]
-        return request
-    }
-
     public static func fetchCollectionStories(by slug: String) -> RichFetchRequest<CollectionStory> {
         let request = RichFetchRequest<CollectionStory>(entityName: "CollectionStory")
         request.predicate = NSPredicate(format: "collection.slug = %@", slug)

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -69,7 +69,7 @@ public protocol Source {
 
     func fetchUnifiedHomeLineup() async throws
 
-    func fetchCollection(by slug: String) async throws -> CollectionModel
+    func fetchCollection(by slug: String) async throws
 
     func restore()
 

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -37,6 +37,8 @@ public protocol Source {
 
     func makeSearchService() -> SearchService
 
+    func makeCollectionStoriesController(slug: String) -> RichFetchedResultsController<CollectionStory>
+
     func makeImagesController() -> ImagesController
 
     func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
@@ -70,6 +72,8 @@ public protocol Source {
     func fetchUnifiedHomeLineup() async throws
 
     func fetchCollection(by slug: String) async throws
+
+    func fetchCollectionAuthors(by slug: String) -> [CollectionAuthor]
 
     func restore()
 

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -149,6 +149,10 @@ extension Space {
         return try fetch(Requests.fetchCollectionAuthor(by: name), context: context).first
     }
 
+    func fetchCollectionAuthors(by slug: String, context: NSManagedObjectContext? = nil) throws -> [CollectionAuthor] {
+        return try fetch(Requests.fetchCollectionAuthors(by: slug))
+    }
+
     func fetchCollectionStory(by url: String, context: NSManagedObjectContext? = nil) throws -> CollectionStory? {
         return try fetch(Requests.fetchCollectionStory(by: url), context: context).first
     }
@@ -174,6 +178,15 @@ extension Space {
             // then save the parent context
             try save()
         }
+    }
+
+    func makeCollectionStoriesController(slug: String) -> RichFetchedResultsController<CollectionStory> {
+        RichFetchedResultsController(
+            fetchRequest: Requests.fetchCollectionStories(by: slug),
+            managedObjectContext: viewContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -31,9 +31,6 @@ class CollectionViewModelTests: XCTestCase {
         userDefaults = UserDefaults(suiteName: "CollectionViewModelTests")
         space = .testSpace()
         self.collectionController = space.makeCollectionStoriesController(slug: "slug")
-        source.stubMakeCollectionStoriesController {
-            self.collectionController
-        }
     }
 
     override func tearDownWithError() throws {
@@ -44,11 +41,11 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     func subject(
-        slug: String,
+        collection: Collection,
         source: Source? = nil
     ) -> CollectionViewModel {
         CollectionViewModel(
-            collection: space.buildCollection(),
+            collection: collection,
             source: source ?? self.source,
             tracker: tracker ?? self.tracker,
             user: user ?? self.user,
@@ -61,7 +58,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
         let item = space.buildSavedItem().item
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         let expectArchive = expectation(description: "expect source.archive(_:)")
         source.stubArchiveSavedItem { archivedSavedItem in
@@ -86,7 +88,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_moveToSaves_withSavedItem_sendsRequestToSource_AndRefreshes() {
         let item = space.buildSavedItem().item
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         let expectMoveToSaves = expectation(description: "expect source.unarchive(_:)")
         source.stubUnarchiveSavedItem { unarchivedSavedItem in
@@ -104,7 +111,12 @@ class CollectionViewModelTests: XCTestCase {
 
     func test_moveToSaves_withoutSavedItem_sendsRequestToSource_AndRefreshes() {
         let collection = setupCollection(with: nil)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         let expectMoveToSaves = expectation(description: "expect source.url(_:)")
         source.stubSaveURL { url in
@@ -122,7 +134,11 @@ class CollectionViewModelTests: XCTestCase {
         let item = space.buildSavedItem(isFavorite: false, isArchived: false).item
         let collection = setupCollection(with: item)
 
-        let viewModel = subject(slug: collection.slug)
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
         XCTAssertEqual(
             viewModel._actions.map(\.title),
             ["Favorite", "Add tags", "Delete", "Share"]
@@ -149,7 +165,11 @@ class CollectionViewModelTests: XCTestCase {
             XCTAssertTrue(favoritedSavedItem === item?.savedItem)
         }
 
-        let viewModel = subject(slug: collection.slug)
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
         viewModel.invokeAction(title: "Favorite")
 
         wait(for: [expectFavorite], timeout: 1)
@@ -167,7 +187,11 @@ class CollectionViewModelTests: XCTestCase {
             XCTAssertTrue(unfavoritedSavedItem === item?.savedItem)
         }
 
-        let viewModel = subject(slug: collection.slug)
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
         viewModel.invokeAction(title: "Unfavorite")
 
         wait(for: [expectUnfavorite], timeout: 1)
@@ -177,7 +201,11 @@ class CollectionViewModelTests: XCTestCase {
         let item = space.buildSavedItem(tags: []).item
         let collection = setupCollection(with: item)
 
-        let viewModel = subject(slug: collection.slug)
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
         let hasCorrectTitle = viewModel._actions.contains { $0.title == "Add tags" }
         XCTAssertTrue(hasCorrectTitle)
     }
@@ -186,7 +214,11 @@ class CollectionViewModelTests: XCTestCase {
         let item = space.buildSavedItem(tags: ["tag 1"]).item
         let collection = setupCollection(with: item)
 
-        let viewModel = subject(slug: collection.slug)
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
         let hasCorrectTitle = viewModel._actions.contains { $0.title == "Edit tags" }
         XCTAssertTrue(hasCorrectTitle)
     }
@@ -194,7 +226,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_addTagsAction_sendsAddTagsViewModel() {
         let item = space.buildSavedItem(tags: ["tag 1"]).item
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         source.stubRetrieveTags { _ in return nil }
         source.stubFetchAllTags { return [] }
@@ -212,7 +249,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
         let item = space.buildSavedItem(isFavorite: true).item
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         let expectDelete = expectation(description: "expect source.delete(_:)")
         source.stubDeleteSavedItem { deletedSavedItem in
@@ -239,7 +281,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_report_updatesSelectedRecommendationToReport() {
         let item = space.buildItem()
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+
+        let viewModel = subject(collection: collection)
 
         let reportExpectation = expectation(description: "expected item to be reported")
         viewModel.$selectedItemToReport.dropFirst().sink { recommendation in
@@ -254,7 +301,12 @@ class CollectionViewModelTests: XCTestCase {
     func test_share_updatesSharedActivity() throws {
         let item = space.buildItem()
         let collection = setupCollection(with: item)
-        let viewModel = subject(slug: collection.slug)
+
+        source.stubMakeCollectionStoriesController {
+            self.collectionController
+        }
+        
+        let viewModel = subject(collection: collection)
 
         let shareExpectation = expectation(description: "expected item to be shared")
         viewModel.$sharedActivity.dropFirst().sink { item in
@@ -268,13 +320,13 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     private func setupCollection(with item: Item?) -> Collection {
-        let story = space.buildCollectionStory(item: item)
+        let story = space.buildCollectionStory()
 
         source.stubFetchItem { url in
             return item
         }
-
-        return space.buildCollection(stories: [story])
+        let collection = space.buildCollection(stories: [story], item: item)
+        return collection
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -305,7 +305,7 @@ class CollectionViewModelTests: XCTestCase {
         source.stubMakeCollectionStoriesController {
             self.collectionController
         }
-        
+
         let viewModel = subject(collection: collection)
 
         let shareExpectation = expectation(description: "expected item to be shared")

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,8 +8,7 @@ import CoreData
 import Combine
 
 class MockSource: Source {
-    func fetchCollection(by slug: String) async throws -> Sync.CollectionModel {
-        return CollectionModel(title: "", authors: [], intro: "", stories: [])
+    func fetchCollection(by slug: String) async throws {
     }
 
     var _events: SyncEvents = SyncEvents()
@@ -225,6 +224,48 @@ extension MockSource {
         }
 
         return calls[index] as? MakeRecentSavesControllerCall
+    }
+}
+
+// MARK: - Make collection stories controller
+extension MockSource {
+    private static let makeCollectionStoriesController = "makeCollectionStoriesController"
+    typealias MakeCollectionStoriesControllerImpl = () -> RichFetchedResultsController<Sync.CollectionStory>
+
+    struct MakeCollectionStoriesControllerCall {}
+
+    func stubMakeCollectionStoriesController(impl: @escaping MakeCollectionStoriesControllerImpl) {
+        implementations[Self.makeCollectionStoriesController] = impl
+    }
+
+    func makeCollectionStoriesController(slug: String) -> Sync.RichFetchedResultsController<Sync.CollectionStory> {
+        guard let impl = implementations[Self.makeCollectionStoriesController] as? MakeCollectionStoriesControllerImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.makeCollectionStoriesController] = (calls[Self.makeCollectionStoriesController] ?? []) + [MakeCollectionStoriesControllerCall()]
+
+        return impl()
+    }
+}
+
+// MARK: fetch collection authors
+extension MockSource {
+    private static let fetchCollectionAuthors = "fetchCollectionAuthors"
+    typealias FetchCollectionAuthorsImpl = (String) -> [Sync.CollectionAuthor]
+
+    struct FetchCollectionAuthorsCall {}
+
+    func stubFetchCollectionAuthors(impl: @escaping FetchCollectionAuthorsImpl) {
+        implementations[Self.fetchCollectionAuthors] = impl
+    }
+
+    func fetchCollectionAuthors(by slug: String) -> [Sync.CollectionAuthor] {
+        guard let impl = implementations[Self.fetchCollectionAuthors] as? FetchCollectionAuthorsImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+        calls[Self.fetchCollectionAuthors] = (calls[Self.fetchCollectionAuthors] ?? []) + [FetchCollectionAuthorsCall()]
+        return impl(slug)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -139,10 +139,12 @@ extension Space {
         slug: String = "slug-1",
         title: String = "collection-title",
         authors: [String] = [],
-        stories: [CollectionStory] = []
+        stories: [CollectionStory] = [],
+        item: Item? = nil
     ) -> Collection {
         backgroundContext.performAndWait {
             let collection: Collection = Collection(context: backgroundContext, slug: slug, title: title, authors: NSOrderedSet(array: authors), stories: NSOrderedSet(array: stories))
+            collection.item = item
 
             return collection
         }

--- a/PocketKit/Tests/SyncTests/Support/MockCollectionService.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockCollectionService.swift
@@ -11,7 +11,7 @@ class MockCollectionService: CollectionService {
 
 extension MockCollectionService {
     static let fetchCollection = "fetchCollection"
-    typealias FetchCollectionImpl = (String) async throws -> Sync.CollectionModel
+    typealias FetchCollectionImpl = (String) async throws -> Sync.CollectionStoryModel
 
     struct FetchCollectionCall {
         let slug: String
@@ -21,7 +21,7 @@ extension MockCollectionService {
         implementations[Self.fetchCollection] = impl
     }
 
-    func fetchCollection(by slug: String) async throws -> Sync.CollectionModel {
+    func fetchCollection(by slug: String) async throws {
         guard let impl = implementations[Self.fetchCollection] as? FetchCollectionImpl else {
             fatalError("\(Self.self).\(#function) has not been stubbed")
         }
@@ -30,7 +30,7 @@ extension MockCollectionService {
             FetchCollectionCall(slug: slug)
         ]
 
-        return try await impl(slug)
+        try await impl(slug)
     }
 
     func fetchCollectionCall(at index: Int) -> FetchCollectionCall? {


### PR DESCRIPTION
## Summary
* This PR uses Core Data to cache collection stories, and uses cached data (when available) to display collections in the native collections view

## References 
* branch name

## Implementation Details
* Update `CollectionViewModel`, `CollectionViewController`, use a `RichFetchedResultController` to cache collection stories and update the `UICollectionViewDiffableDataSource` accordingly

## Test Steps
* Tap Home, then scroll until you find a collection or
* Tap Home, enter a slate detail and scroll until you find a collection
* Tap the collection cell:
    - if it's the first time you access it, expect some loading time for the collection to load remotely
    - Navigate back, then re-select the same collection
    - make sure the collection loads rapidly

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots



https://github.com/Pocket/pocket-ios/assets/34376330/320aeb2d-1b0c-422d-9e48-e638375e7382





