### PR TITLE
feat(collections): add overflow actions for stories - report and share

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -9,7 +9,7 @@ import Localization
 import Sync
 
 // Contains logic to present story data in RecommendationCell
-class CollectionStoryViewModel: Hashable {
+struct CollectionStoryViewModel: Hashable {
     public func hash(into hasher: inout Hasher) {
         return hasher.combine(collectionStory)
     }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -9,7 +9,7 @@ import Localization
 import Sync
 
 // Contains logic to present story data in RecommendationCell
-struct CollectionStoryViewModel: Hashable {
+class CollectionStoryViewModel: Hashable {
     public func hash(into hasher: inout Hasher) {
         return hasher.combine(collectionStory)
     }
@@ -20,10 +20,12 @@ struct CollectionStoryViewModel: Hashable {
 
     private(set) var collectionStory: CollectionStory
     private let source: Source?
+    let overflowActions: [ItemAction]?
 
-    init(collectionStory: CollectionStory, source: Source? = nil) {
+    init(collectionStory: CollectionStory, source: Source? = nil, overflowActions: [ItemAction]?) {
         self.collectionStory = collectionStory
         self.source = source
+        self.overflowActions = overflowActions
     }
 }
 
@@ -88,10 +90,6 @@ extension CollectionStoryViewModel: RecommendationCellViewModel {
         }
 
         return Localization.Home.Recommendation.readTime(timeToRead)
-    }
-
-    var overflowActions: [ItemAction]? {
-        return nil
     }
 
     var primaryAction: ItemAction? {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -226,7 +226,7 @@ private extension CollectionViewController {
                 let currentHeight = result.0
 
                 let height = RecommendationCell.fullHeight(
-                    viewModel: CollectionStoryViewModel(collectionStory: story),
+                    viewModel: model.storyViewModel(for: story),
                     availableWidth: width - (margin * 2)
                 ) + margin
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -495,7 +495,7 @@ extension HomeViewController {
             self?.present(activity: activity)
         }.store(in: &collectionSubscriptions)
 
-        viewModel.$selectedItemToReport.receive(on: DispatchQueue.main).sink { [weak self] item in
+        viewModel.$selectedCollectionItemToReport.receive(on: DispatchQueue.main).sink { [weak self] item in
             self?.report(item?.givenURL)
         }.store(in: &collectionSubscriptions)
 
@@ -516,8 +516,17 @@ extension HomeViewController {
             }
         }.store(in: &collectionSubscriptions)
 
+        // MARK: Story Presentation
         viewModel.$presentedStoryWebReaderURL.sink { [weak self] url in
             self?.present(url: url?.absoluteString)
+        }.store(in: &collectionSubscriptions)
+
+        viewModel.$sharedStoryActivity.receive(on: DispatchQueue.main).sink { [weak self] activity in
+            self?.present(activity: activity)
+        }.store(in: &collectionSubscriptions)
+
+        viewModel.$selectedStoryToReport.receive(on: DispatchQueue.main).sink { [weak self] item in
+            self?.report(item?.givenURL)
         }.store(in: &collectionSubscriptions)
     }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -28,6 +28,7 @@ class MainViewModel: ObservableObject {
     convenience init() {
         self.init(
             saves: SavesContainerViewModel(
+                tracker: Services.shared.tracker,
                 searchList: SearchViewModel(
                     networkPathMonitor: NWPathMonitor(),
                     user: Services.shared.user,

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -475,11 +475,11 @@ extension SavesContainerViewController {
         )
 
         host.modalPresentationStyle = .formSheet
-        guard let presentedVC = self.presentedViewController else {
+        guard let presentedViewController else {
             self.present(host, animated: true)
             return
         }
-        presentedVC.present(host, animated: true)
+        presentedViewController.present(host, animated: true)
     }
 
     private func present(alert: PocketAlert?) {

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -6,6 +6,7 @@ import Combine
 import Sync
 import UIKit
 import SharedPocketKit
+import Analytics
 
 @MainActor
 class SavesContainerViewModel {
@@ -16,17 +17,20 @@ class SavesContainerViewModel {
 
     @Published var selection: Selection = .saves
 
+    let tracker: Tracker
     let searchList: SearchViewModel
     let savedItemsList: SavedItemsListViewModel
     let archivedItemsList: SavedItemsListViewModel
     let addSavedItemModel: AddSavedItemViewModel
 
     init(
+        tracker: Tracker,
         searchList: SearchViewModel,
         savedItemsList: SavedItemsListViewModel,
         archivedItemsList: SavedItemsListViewModel,
         addSavedItemModel: AddSavedItemViewModel
     ) {
+        self.tracker = tracker
         self.searchList = searchList
         self.savedItemsList = savedItemsList
         self.archivedItemsList = archivedItemsList


### PR DESCRIPTION
## Summary
Add overflow actions for stories (reporting / sharing)

## References 
IN-1561, IN-1562

## Implementation Details
* Add `overflowActions` for stories and created published properties on `CollectionViewModel` so that presentation logic can be triggered from `HomeViewController` similar to how we do with slate details

## Test Steps
Please verify through both Home, Saves

- [ ] Given I have opened a Collection in the native Collection view,
and have scrolled to any Story,
when I tap the overflow menu,
and tap "Share",
then a share sheet with a link to the Story should open

- [ ] Given I have opened a Collection in the native Collection view,
and have scrolled to any Story,
when I tap the overflow menu,
and tap "Report",
then a Report view for the Story should open

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://github.com/Pocket/pocket-ios/assets/6743397/1e5fa97b-ed68-4c31-9721-e30c9e8805ab

