### PR TITLE
refactor(feature-flags): check assignment from in-memory cache

### DIFF
--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -197,6 +197,10 @@ public class PocketSource: Source {
         space.makeRecomendationsSlateLineupController(by: SyncConstants.Home.slateLineupIdentifier)
     }
 
+    public func makeFeatureFlagsController() -> NSFetchedResultsController<FeatureFlag> {
+        space.makeFeatureFlagsController()
+    }
+
     public func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T? {
         space.viewObject(with: id)
     }

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -38,6 +38,8 @@ public protocol Source {
 
     func makeImagesController() -> ImagesController
 
+    func makeFeatureFlagsController() -> NSFetchedResultsController<FeatureFlag>
+
     func viewObject<T: NSManagedObject>(id: NSManagedObjectID) -> T?
 
     func viewRefresh(_ object: NSManagedObject, mergeChanges flag: Bool)

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -449,4 +449,17 @@ extension Space {
     func fetchFeatureFlags(in context: NSManagedObjectContext?) throws -> [FeatureFlag] {
         return try fetch(Requests.fetchFeatureFlags(), context: context)
     }
+
+    /// Returns an NSFetchedResultsController that fetches FeatureFlag objects.
+    func makeFeatureFlagsController() -> NSFetchedResultsController<FeatureFlag> {
+        let request = Requests.fetchFeatureFlags()
+        request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: false)]
+        let resultsController = NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: backgroundContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+        return resultsController
+    }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -56,7 +56,7 @@ extension MockSource {
             fatalError("\(Self.self)#\(#function) is not implemented")
         }
 
-        calls[Self.viewObject] = (calls[Self.backgroundObject] ?? []) + [BackgroundObjectCall(id: id)]
+        calls[Self.backgroundObject] = (calls[Self.backgroundObject] ?? []) + [BackgroundObjectCall(id: id)]
 
         return impl(id) as? T
     }
@@ -283,6 +283,37 @@ extension MockSource {
         }
 
         return calls[index] as? MakeArchiveControllerCall
+    }
+}
+
+// MARK: - Make feature flags controller
+extension MockSource {
+    static let makeFeatureFlagsController = "makeFeatureFlagController"
+    typealias MakeFeatureFlagsControllerImpl = () -> NSFetchedResultsController<FeatureFlag>
+
+    struct MakeFeatureFlagsControllerCall {
+    }
+
+    func stubMakeFeatureFlagsController(impl: @escaping MakeFeatureFlagsControllerImpl) {
+        implementations[Self.makeFeatureFlagsController] = impl
+    }
+
+    func makeFeatureFlagsController() -> NSFetchedResultsController<FeatureFlag> {
+        guard let impl = implementations[Self.makeFeatureFlagsController] as? MakeFeatureFlagsControllerImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.makeFeatureFlagsController] = (calls[Self.makeFeatureFlagsController] ?? []) + [MakeFeatureFlagsControllerCall()]
+
+        return impl()
+    }
+
+    func makeFeatureFlagsControllerCall(at index: Int) -> MakeFeatureFlagsControllerCall? {
+        guard let calls = calls[Self.makeFeatureFlagsController], calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? MakeFeatureFlagsControllerCall
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes an app hang (commonly seen on initial login) by utilizing in-memory caching of feature flags when checking assignments.

## Implementation Details

An app hang was commonly visible when initially signing in (with a large account) and immediately attempting to switch tabs. After pausing execution, it appeared as if Sentry, when requesting sampling rates, was forcing its closure(s) on the main thread, including downstream tasks, such as fetching an object from Core Data. I _think_ what was happening is that Sentry would call a closure on the main thread, with the side effect of fetching an object from a (background) context _from_ the main thread, where the context was being used heavily, and already on another thread.

This pull request fixes the fetching of feature flag (assignments / payloads) by utilizing an in-memory representation of the feature flags stored in Core Data, as feature flags are inserted / updated / deleted. This frees up any callees in search of feature flag details to utilize an in-memory cache of in-memory representations of those feature flags, which can then more safely be retrieved.

## Test Steps

- [ ] Log out from an account
- [ ] Log into an account with lots of items (the test account I used had ~1.5k)
- [ ] Upon login, immediately toggle between tabs, scrolling through content as desired.
- [ ] The app should not hang

## PR Checklist:

- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
