### PR TITLE
feat(collections): add error / offline view

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -92,6 +92,7 @@ class CollectionViewController: UIViewController {
         collectionView.register(cellClass: LoadingCell.self)
         collectionView.register(cellClass: CollectionMetadataCell.self)
         collectionView.register(cellClass: RecommendationCell.self)
+        collectionView.register(cellClass: EmptyStateCollectionViewCell.self)
 
         model.$snapshot.receive(on: DispatchQueue.main).sink { [weak self] snapshot in
             self?.dataSource.apply(snapshot)
@@ -171,6 +172,11 @@ class CollectionViewController: UIViewController {
 }
 
 private extension CollectionViewController {
+    enum Constants {
+        /// Height that centers the error section so that it appears approximately in the middle
+        static let errorSectionHeight: CGFloat = 0.65
+        static let errorSectionInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20)
+    }
     func section(for index: Int, environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
         let section = self.dataSource.sectionIdentifier(for: index)
         switch section {
@@ -262,6 +268,25 @@ private extension CollectionViewController {
             )
 
             return section
+        case .error:
+            let section = NSCollectionLayoutSection(
+                group: .vertical(
+                    layoutSize: .init(
+                        widthDimension: .fractionalWidth(1),
+                        heightDimension: .fractionalHeight(Constants.errorSectionHeight)
+                    ),
+                    subitems: [
+                        .init(
+                            layoutSize: .init(
+                                widthDimension: .fractionalWidth(1),
+                                heightDimension: .fractionalHeight(1)
+                            )
+                        )
+                    ]
+                )
+            )
+            section.contentInsets = Constants.errorSectionInsets
+            return section
         default:
             return .empty()
         }
@@ -287,6 +312,10 @@ private extension CollectionViewController {
         case .story(let story):
             let cell: RecommendationCell = collectionView.dequeueCell(for: indexPath)
             cell.configure(model: story)
+            return cell
+        case .error:
+            let cell: EmptyStateCollectionViewCell = collectionView.dequeueCell(for: indexPath)
+            cell.configure(parent: self, model.errorEmptyState)
             return cell
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateView.swift
@@ -93,9 +93,11 @@ struct EmptyStateView<Content: View>: View {
                             .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                             .frame(maxWidth: Constants.maxWidth)
                     }).buttonStyle(ActionsPrimaryButtonStyle())
-                    .sheet(isPresented: self.$showSafariView) {
-                        SFSafariView(url: webURL)
-                    }
+                        .sheet(isPresented: self.$showSafariView) {
+                            SFSafariView(url: webURL)
+                        }
+                } else if case .reportIssue(let buttonText, let userEmail) = viewModel.buttonType {
+                    ReportIssueButton(text: buttonText, userEmail: userEmail)
                 }
             }
         }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/EmptyStateViewModel.swift
@@ -20,5 +20,5 @@ protocol EmptyStateViewModel {
 enum ButtonType {
     case normal(String)
     case premium(String)
-    case reportIssue(String)
+    case reportIssue(text: String, email: String)
 }

--- a/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
+++ b/PocketKit/Sources/PocketKit/MyList/EmptyStates/Search/ErrorEmptyState.swift
@@ -5,12 +5,15 @@
 import Foundation
 import Textile
 import Localization
+import SharedPocketKit
 
 struct ErrorEmptyState: EmptyStateViewModel {
     private var featureFlags: FeatureFlagServiceProtocol
+    private var user: User
 
-    init(featureFlags: FeatureFlagServiceProtocol) {
+    init(featureFlags: FeatureFlagServiceProtocol, user: User) {
         self.featureFlags = featureFlags
+        self.user = user
     }
 
     let imageAsset: ImageAsset = .warning
@@ -23,7 +26,7 @@ struct ErrorEmptyState: EmptyStateViewModel {
 
     var buttonType: ButtonType? {
         if featureFlags.isAssigned(flag: .reportIssue) {
-            return .reportIssue(Localization.General.Error.sendReport)
+            return .reportIssue(text: Localization.General.Error.sendReport, email: user.email)
         }
         return nil
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -117,9 +117,9 @@ struct SearchEmptyView: View {
                 EmptyStateView(viewModel: viewModel) {
                     GetPocketPremiumButton(text: text)
                 }.padding(Margins.normal.rawValue)
-            case .reportIssue(let text):
+            case .reportIssue(let text, let userEmail):
                 EmptyStateView(viewModel: viewModel) {
-                    ReportIssueButton(text: text)
+                    ReportIssueButton(text: text, userEmail: userEmail)
                 }.padding(Margins.normal.rawValue)
             default:
                 EmptyView()
@@ -128,34 +128,6 @@ struct SearchEmptyView: View {
             EmptyStateView<EmptyView>(viewModel: viewModel)
                 .padding(Margins.normal.rawValue)
         }
-    }
-}
-
-struct ReportIssueButton: View {
-    enum Constants {
-        static let padding = EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
-        static let maxWidth: CGFloat = 320
-    }
-    @EnvironmentObject private var searchViewModel: SearchViewModel
-    private let text: String
-
-    init(text: String) {
-        self.text = text
-    }
-
-    var body: some View {
-        Button(action: {
-            searchViewModel.isPresentingReportIssue.toggle()
-        }, label: {
-            Text(text)
-                .style(.header.sansSerif.h7.with(color: .ui.white))
-                .padding(Constants.padding)
-                .frame(maxWidth: Constants.maxWidth)
-        }).buttonStyle(PocketButtonStyle(.primary))
-        .sheet(isPresented: $searchViewModel.isPresentingReportIssue) {
-            ReportIssueView(email: searchViewModel.userEmail, submitIssue: searchViewModel.submitIssue)
-        }
-        .accessibilityIdentifier("get-report-issue-button")
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -345,7 +345,7 @@ class SearchViewModel: ObservableObject {
                     self.trackSearchResultsPage(pageNumber: onlineSearch.pageNumberLoaded, scope: scope)
                 } else if case .failure(let error) = result {
                     guard case SearchServiceError.noInternet = error else {
-                        self.searchState = .emptyState(ErrorEmptyState(featureFlags: featureFlags))
+                        self.searchState = .emptyState(ErrorEmptyState(featureFlags: featureFlags, user: user))
                         return
                     }
                     self.searchState = .emptyState(OfflineEmptyState(type: scope))

--- a/PocketKit/Sources/PocketKit/Report/ReportIssueButton.swift
+++ b/PocketKit/Sources/PocketKit/Report/ReportIssueButton.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import SharedPocketKit
+import Textile
+
+struct ReportIssueButton: View {
+    @State var isPresentingReportIssue = false
+    enum Constants {
+        static let padding = EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
+        static let maxWidth: CGFloat = 320
+    }
+
+    private let text: String
+    private let userEmail: String
+
+    init(text: String, userEmail: String) {
+        self.text = text
+        self.userEmail = userEmail
+    }
+
+    var body: some View {
+        Button(action: {
+            isPresentingReportIssue.toggle()
+        }, label: {
+            Text(text)
+                .style(.header.sansSerif.h7.with(color: .ui.white))
+                .padding(Constants.padding)
+                .frame(maxWidth: Constants.maxWidth)
+        }).buttonStyle(PocketButtonStyle(.primary))
+        .sheet(isPresented: $isPresentingReportIssue) {
+            ReportIssueView(email: userEmail, submitIssue: submitIssue)
+        }
+        .accessibilityIdentifier("get-report-issue-button")
+    }
+
+    // Handle Sentry User Feedback Reporting
+    private func submitIssue(name: String, email: String, comments: String) {
+        Log.captureUserFeedback(message: "Report an issue", name: name, email: email, comments: comments)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -14,9 +14,6 @@ class MockSource: Source {
     func archive(collectionStory: Sync.CollectionStory) {
     }
 
-    func fetchCollection(by slug: String) async throws {
-    }
-
     var _events: SyncEvents = SyncEvents()
     var events: AnyPublisher<SyncEvent, Never> {
         _events.eraseToAnyPublisher()
@@ -1519,3 +1516,37 @@ extension MockSource {
         return calls[index] as? FetchFeatureFlagCall
     }
 }
+
+// MARK: fetchCollection
+ extension MockSource {
+    private static let fetchCollection = "fetchCollection"
+    typealias FetchCollectionImpl = (String) async throws -> Void
+
+    struct FetchCollectionCall {
+        let slug: String
+    }
+
+    func stubFetchCollection(impl: @escaping FetchCollectionImpl) {
+        implementations[Self.fetchCollection] = impl
+    }
+
+    func fetchCollection(by slug: String) async throws {
+        guard let impl = implementations[Self.fetchCollection] as? FetchCollectionImpl else {
+            fatalError("\(Self.self)#\(#function) has not been stubbed")
+        }
+
+        calls[Self.fetchCollection] = (calls[Self.fetchCollection] ?? []) + [
+            FetchCollectionCall(slug: slug)
+        ]
+
+        try await impl(slug)
+    }
+
+    func fetchCollectionCall(at index: Int) -> FetchCollectionCall? {
+        guard let calls = calls[Self.fetchCollection], calls.count > index else {
+            return nil
+        }
+
+        return calls[index] as? FetchCollectionCall
+    }
+ }

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -136,7 +136,7 @@ extension Space {
 extension Space {
     @discardableResult
     func buildCollection(
-        slug: String = "slug-1",
+        slug: String = "slug",
         title: String = "collection-title",
         authors: [String] = [],
         stories: [CollectionStory] = [],


### PR DESCRIPTION
## Summary
Add offline / error screen for native collections

## References 
IN-1596

## Implementation Details
* Added `error` section to collections 
* Use network monitor to observe changes to network via `observeNetworkChanges` and `handleNetworkChange`
* Refactor `ReportIssueButton` to be more flexible and not tied to search
* Created error view by using `ErrorEmptyState(featureFlags: featureFlags, user: user)` for the empty state view

## Test Steps
- [x] Given I have tapped to open a Collection,
and the collection is being loaded remotely,
when the remote download errors,
then I should see an error view replacing the spinner.
- [x] Given I have tapped to open a Collection,
and then collection is being loaded remotely,
and there is no network connection available (i.e offline),
when the screen is presented,
then I should see an error view replacing the spinner.
- [x] Given I have tapped to open a Collection,
and there was no network connection available (i.e offline),
and the error view is visible,
when the network becomes available again,
then the collection should automatically attempt to be downloaded again, and the spinner should appear, replacing the error view.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| Screenshot | 
| --- | 
| ![Simulator Screenshot - iPhone 14 Pro - 2023-07-27 at 13 00 46](https://github.com/Pocket/pocket-ios/assets/6743397/ccd1a03c-4043-46c0-b8aa-e4be9b913f84)|

https://github.com/Pocket/pocket-ios/assets/6743397/9f2c2ab3-c609-4b48-a108-27bc01e0b69a

