### PR TITLE
feat(collection): add sub collections

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -508,11 +508,16 @@ extension HomeViewController {
             }
         }.store(in: &collectionSubscriptions)
 
-        viewModel.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readableType in
-            if let savedItem = readableType as? SavedItemViewModel {
+        viewModel.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+            switch readableType {
+            case .collection(let collection):
+                self?.showCollection(collection)
+            case .savedItem(let savedItem):
                 self?.show(savedItem)
-            } else if let recommendation = readableType as? RecommendationViewModel {
+            case .recommendation(let recommendation):
                 self?.show(recommendation)
+            default:
+                break
             }
         }.store(in: &collectionSubscriptions)
 

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -435,11 +435,16 @@ extension SavesContainerViewController {
             }
         }.store(in: &readableSubscriptions)
 
-        collection.$selectedReadableViewModel.receive(on: DispatchQueue.main).sink { [weak self] readableType in
-            if let savedItem = readableType as? SavedItemViewModel {
+        collection.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] readableType in
+            switch readableType {
+            case .collection(let collection):
+                self?.push(collection: collection)
+            case .savedItem(let savedItem):
                 self?.push(savedItem: savedItem)
-            } else if let recommendation = readableType as? RecommendationViewModel {
+            case .recommendation(let recommendation):
                 self?.show(recommendation)
+            default:
+                break
             }
         }.store(in: &readableSubscriptions)
 

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -192,6 +192,12 @@ extension Item {
             self.syndicatedArticle?.itemID = itemId
             self.syndicatedArticle?.title = syndicatedArticle.title
         }
+
+        if let slug = storyItem.collection?.slug {
+            let collection = (try? space.fetchCollection(by: slug, context: context)) ?? Collection(context: context, slug: slug, title: "", authors: [], stories: [])
+            collection.item = self
+            self.collection = collection
+        }
     }
 
     func update(from summary: ItemSummary, with space: Space) {


### PR DESCRIPTION
## Summary
Open sub-collections from a collection

## References 
IN-1606

## Implementation Details
* Change `selectedReadableViewModel` from `ReadableViewModel` to `ReadableType` and renamed to `selectedItem` to be more general to allow stories to have the native collection experience
* Refactor both home and saves to account for this change and perform presentation logic depending on the readable type
* Add `collection` property to `Item` for a story to determine if a story is a collection type or not

## Test Steps
- [ ] Given that I navigate to a native collection, 
and I view a story that is also a collection,
when I tap on that story, 
then I should see the native collection experience.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://github.com/Pocket/pocket-ios/assets/6743397/b87bbef2-1725-465e-ab4f-ac197704d2df

