### PR TITLE
feat(collections): add native collections experience to search

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -311,9 +311,9 @@ extension SavesContainerViewController {
         }.store(in: &subscriptions)
 
         // Search navigation
-        model.searchList.$selectedItem.sink { [weak self] selectedArchivedItem in
-            guard let selectedArchivedItem = selectedArchivedItem else { return }
-            self?.navigate(selectedItem: selectedArchivedItem)
+        model.searchList.$selectedItem.sink { [weak self] selectedItem in
+            guard let selectedItem = selectedItem else { return }
+            self?.navigate(selectedItem: selectedItem)
         }.store(in: &subscriptions)
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -466,7 +466,10 @@ extension SearchViewModel: SearchResultActionDelegate {
             notificationCenter: notificationCenter
         )
 
-        if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
+        if let collection = readable.collection, featureFlags.isAssigned(flag: .nativeCollections) {
+            let collectionViewModel = CollectionViewModel(collection: collection, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
+            selectedItem = .collection(collectionViewModel)
+        } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             trackOpenSearchItem(url: savedItem.url, index: index, destination: .internal)
             selectedItem = .webView(readable)
         } else {


### PR DESCRIPTION
## Summary
Open native collection experience from search

## References 
IN-1607

## Implementation Details
Add existing logic that we are using the present native collection from Home and Saves and add it over to Search

## Test Steps
- [ ] Given I am on the Saves tab and a Search has been triggered,
and I have at least one Collection that appears in the search results,
when I tap on the Collection item,
then the native Collection view should appear for the Collection.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

https://github.com/Pocket/pocket-ios/assets/6743397/57a40374-8afc-412e-ab7c-78dd9ecd93fd

