### PR TITLE
feat(sync): log out user on 401 GraphQL response

### DIFF
--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -10,4 +10,5 @@ public extension Notification.Name {
     static let listUpdated = Notification.Name("com.mozilla.pocket.listUpdated")
     static let bannerRequested = Notification.Name("com.mozilla.pocket.bannerRequested")
     static let serverError = Notification.Name("com.mozilla.pocket.serverError")
+    static let unauthorizedResponse = Notification.Name("com.mozilla.pocket.unauthorizedResponse")
 }

--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -39,6 +39,12 @@ final class PushNotificationServiceTests: XCTestCase {
         subject = PushNotificationService(source: source, tracker: tracker, appSession: appSession, braze: braze, instantSync: instantSync)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subscriptions = []
+    }
+
     func test_onLogin_didCallSubscribers() {
         let sessionExpectation = expectation(description: "published error event")
 

--- a/PocketKit/Tests/PocketKitTests/UserManagementServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/UserManagementServiceTests.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import XCTest
+import Combine
+import SharedPocketKit
+@testable import PocketKit
+
+class UserManagementServiceTests: XCTestCase {
+    var subscriptions: Set<AnyCancellable>!
+    var appSession: AppSession!
+    var user: MockUser!
+    var notificationCenter: NotificationCenter!
+    var source: MockSource!
+    var service: UserManagementService!
+
+    override func setUp() {
+        super.setUp()
+
+        subscriptions = []
+
+        appSession = AppSession(keychain: MockKeychain(), groupID: "pocket")
+        user = MockUser()
+        notificationCenter = .default
+        source = MockSource()
+        service = UserManagementService(
+            appSession: appSession,
+            user: user,
+            notificationCenter: notificationCenter,
+            source: source
+        )
+    }
+
+    func test_unauthorizedResponse_logsOutUser() {
+        let loggedOutExpectation = expectation(description: "user was loggeed out")
+        notificationCenter
+            .publisher(for: .userLoggedOut)
+            .sink { _ in
+                loggedOutExpectation.fulfill()
+            }
+            .store(in: &subscriptions)
+
+        let clearExpectation = expectation(description: "user was cleared")
+        user.stubClear {
+            clearExpectation.fulfill()
+        }
+
+        notificationCenter.post(name: .unauthorizedResponse, object: nil)
+
+        wait(for: [loggedOutExpectation, clearExpectation])
+
+        XCTAssertNil(appSession.currentSession)
+    }
+}


### PR DESCRIPTION
## Summary

Log a user out of the app when a GraphQL responds with a 401 for any given request.

## References 

IN-1347

## Implementation Details

See code comments.

TL;DR: Add async interceptor that published a notification when there is a GraphQL response with a 401 status code, handle that notification in `UserManagementService` by logging out.

## Test Steps

- [ ] Launch the app as a logged in user, and view Saves
- [ ] Add a breakpoint in Proxyman (or Charles) for a GraphQL request for fetching saves
- [ ] Use the breakpoint to return a 401 for the fetch saves request
- [ ] The app should complete the request and log the user out

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
