### PR TITLE
Add new color for Darkmode URLs in Reader

### DIFF
--- a/Assets.xcassets/textfieldURL.colorset/Contents.json
+++ b/Assets.xcassets/textfieldURL.colorset/Contents.json
@@ -1,0 +1,33 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "tintColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.871",
+          "green" : "0.886",
+          "red" : "0.604"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import UIKit
+import Textile
 
 // An object that conforms to this protocol is commonly capable of responding to
 // (overridden) events that occur within a PocketTextView nested within a PocketTextCell.
@@ -60,7 +61,7 @@ class ArticleComponentTextView: UITextView {
         isScrollEnabled = false
         delegate = self
 
-        linkTextAttributes = [.foregroundColor: UIColor(named: "textfieldURL")]
+        linkTextAttributes = [.foregroundColor: ColorAsset.ui.textfieldURL as Any]
 
         interactions
             .filter { $0 is UIContextMenuInteraction }

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -60,6 +60,8 @@ class ArticleComponentTextView: UITextView {
         isScrollEnabled = false
         delegate = self
 
+        linkTextAttributes = [.foregroundColor: UIColor(named: "textfieldURL")]
+
         interactions
             .filter { $0 is UIContextMenuInteraction }
             .forEach { removeInteraction($0) }

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -61,7 +61,7 @@ class ArticleComponentTextView: UITextView {
         isScrollEnabled = false
         delegate = self
 
-        linkTextAttributes = [.foregroundColor: ColorAsset.ui.textfieldURL as Any]
+        linkTextAttributes = [.foregroundColor: UIColor(.ui.textfieldURL) as Any]
 
         interactions
             .filter { $0 is UIContextMenuInteraction }

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/textfieldURL.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/textfieldURL.colorset/Contents.json
@@ -18,9 +18,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.871",
-          "green" : "0.886",
-          "red" : "0.604"
+          "blue" : "0xDE",
+          "green" : "0xE2",
+          "red" : "0x9A"
         }
       },
       "idiom" : "universal"

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -23,7 +23,7 @@ public struct UIPalette {
 
     public let homeCellBackground = ColorAsset.ui("homeCellBackground")
     public let saveButtonText = ColorAsset.ui("saveButtonText")
-    public let textfieldURL = UIColor(named: "textfieldURL")
+    public let textfieldURL = ColorAsset.ui("textfieldURL")
 
     public let lapis1 = ColorAsset.ui("lapis1")
 

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -23,6 +23,7 @@ public struct UIPalette {
 
     public let homeCellBackground = ColorAsset.ui("homeCellBackground")
     public let saveButtonText = ColorAsset.ui("saveButtonText")
+    public let textfieldURL = UIColor(named: "textfieldURL")
 
     public let lapis1 = ColorAsset.ui("lapis1")
 


### PR DESCRIPTION
## Summary
The standard blue highlight was difficult to read against the dark background of darkmode. Added a more legible color for URLs

## References 
https://getpocket.atlassian.net/browse/IN-1608

## Implementation Details
Added the new color to the standard Asset catalog. Adding to the Textile catalog added the need to import Textile for just one color on one line and seemed excessive. 

## Test Steps
Open and item that is  displayed in Reader.
Check for URLs, all should be the new teal color in darkmode and the standard blue in light mode.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
<img width="564" alt="Screenshot 2023-08-09 at 11 58 12 AM" src="https://github.com/Pocket/pocket-ios/assets/8590135/03c95314-11e2-4343-a53e-85e231704606">
<img width="564" alt="Screenshot 2023-08-09 at 11 58 07 AM" src="https://github.com/Pocket/pocket-ios/assets/8590135/23fa1721-febc-4aa1-a2ec-9cdb74f55363">
