### PR TITLE
fix(tags): update tags logic in shared extension

### DIFF
--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -35,7 +35,7 @@ class PocketAddTagsViewModel: AddTagsViewModel {
     /// Fetches recent tags to display to the user only if premium and user has more than 3 tags
     var recentTags: [TagType] {
         guard user.status == .premium && fetchAllTags.count > 3 else { return [] }
-        return recentTagsFactory.recentTags.sorted().compactMap { TagType.recent($0) }
+        return recentTagsFactory.recentTags.compactMap { TagType.recent($0) }.reversed()
     }
 
     /// Fetches all tags associated with item

--- a/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TagsFilterViewModel.swift
@@ -25,7 +25,7 @@ class TagsFilterViewModel: ObservableObject {
     /// Fetches recent tags to display to the user only if premium and user has more than 3 tags
     var recentTags: [TagType] {
         guard user.status == .premium && fetchedTags.count > 3 else { return [] }
-        return recentTagsFactory.recentTags.sorted().compactMap { TagType.recent($0) }
+        return recentTagsFactory.recentTags.compactMap { TagType.recent($0) }.reversed()
     }
 
     @Published var selectedTag: TagType?

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -24,13 +24,11 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
 
     var recentTags: [TagType] {
         guard user.status == .premium && fetchAllTags.count > 3 else { return [] }
-        return recentTagsFactory.recentTags.sorted().compactMap { TagType.recent($0) }
+        return recentTagsFactory.recentTags.compactMap { TagType.recent($0) }.reversed()
     }
 
     /// Fetches all tags associated with item
-    private var itemTagNames: [String] {
-        item?.tags?.compactMap { ($0 as? Tag)?.name } ?? []
-    }
+    private var originalTagNames: [String]
 
     /// Fetches all tags associated with a user
     private var fetchAllTags: [Tag] {
@@ -53,7 +51,8 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
         self.user = user
         self.recentTagsFactory = RecentTagsProvider(userDefaults: userDefaults, key: UserDefaults.Key.recentTags)
 
-        tags = itemTagNames
+        originalTagNames = item?.tags?.compactMap { ($0 as? Tag)?.name } ?? []
+        tags = originalTagNames
         allOtherTags()
 
         userInputListener = $newTagInput
@@ -71,13 +70,12 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
     func addTags() {
         trackSaveTagsToItem()
         saveAction(tags)
-        recentTagsFactory.updateRecentTags(with: itemTagNames, and: tags)
+        recentTagsFactory.updateRecentTags(with: originalTagNames, and: tags)
     }
 
     /// Fetch all tags associated with an item to show user
     func allOtherTags() {
-        // TODO: Remove ! when we have non-null on tagName
-        otherTags = retrieveAction(tags)?.map { .tag($0.name) } ?? []
+        otherTags = retrieveAction(tags)?.map { .tag($0.name) }.sorted() ?? []
         trackAllTagsImpression()
     }
 

--- a/PocketKit/Sources/SharedPocketKit/Tags/RecentTagsProvider.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/RecentTagsProvider.swift
@@ -30,18 +30,22 @@ public class RecentTagsProvider {
         }
     }
 
-    /// Update recent tags list after user adds tags to an item
+    /// Update recent tags list after user adds tags to an item by comparing the original tags associated with the item with the updated tags associated with the item
     /// - Parameters:
-    ///   - originalTags: list of tags originally associated with item
-    ///   - inputTags: list of tags saved to the item
-    public func updateRecentTags(with originalTags: [String], and inputTags: [String]) {
-       var newTags = inputTags
+    ///   - originalTags: list of tags originally associated with item before any updates from the user
+    ///   - updatedTags: updated list of tags associated with the items after the user taps save in add tags view
+    public func updateRecentTags(with originalTags: [String], and updatedTags: [String]) {
+        var newTags = updatedTags
+
+        // Filter out the tags from the list of updated tags that also exist in the original tags for the item
         if !originalTags.isEmpty {
-           newTags = inputTags.filter { !originalTags.contains($0) }
-       }
-       newTags.forEach { tag in
-           guard !recentTags.contains(tag) else { return }
-           recentTags.append(tag)
-       }
-   }
+            newTags = updatedTags.filter { !originalTags.contains($0) }
+        }
+
+        // Check if new tags list should be added to recent tags
+        newTags.forEach { tag in
+            guard !recentTags.contains(tag) else { return }
+            recentTags.append(tag)
+        }
+    }
 }

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -182,7 +182,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
 
         let viewModel = subject(item: item, user: MockUser(status: .premium)) { }
         wait(for: [expectRetrieveTagsCall], timeout: 10)
-        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 1"), TagType.recent("tag 2"), TagType.recent("tag 3")])
+        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() {
@@ -216,17 +216,17 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
-    func test_allOtherTags_retrievesValidTagNames() {
-        let item = space.buildSavedItem(tags: ["tag 1"])
+    func test_allOtherTags_retrievesValidTagNames_inSortedOrder() {
+        let item = space.buildSavedItem(tags: ["a"])
         let expectRetrieveTagsCall = expectation(description: "expect source.retrieveTags(excluding:)")
         expectRetrieveTagsCall.assertForOverFulfill = false
         source.stubRetrieveTags { [weak self] _ in
             defer { expectRetrieveTagsCall.fulfill() }
             let tag2: Tag = Tag(context: self!.space.backgroundContext)
             let tag3: Tag = Tag(context: self!.space.backgroundContext)
-            tag2.name = "tag 2"
+            tag2.name = "c"
             tag2.remoteID = tag2.name.uppercased()
-            tag3.name = "tag 3"
+            tag3.name = "b"
             return [tag2, tag3]
         }
         source.stubFetchAllTags { return [] }
@@ -235,7 +235,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         viewModel.allOtherTags()
 
         wait(for: [expectRetrieveTagsCall], timeout: 10)
-        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
+        XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
         XCTAssertNotNil(source.retrieveTagsCall(at: 0))
     }
 

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -65,10 +65,10 @@ class TagsFilterViewModelTests: XCTestCase {
         _ = try? space.createSavedItem(createdAt: Date() + 1, tags: ["tag 2"])
         _ = try? space.createSavedItem(createdAt: Date() + 2, tags: ["tag 3"])
         _ = try? space.createSavedItem(createdAt: Date() + 3, tags: ["tag 4"])
+
         let savedTags = try? space.fetchTags(isArchived: false)
         let viewModel = subject(user: MockUser(status: .premium), fetchedTags: savedTags) { }
-
-        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 1"), TagType.recent("tag 2"), TagType.recent("tag 3")])
+        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() {

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -146,7 +146,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
             }
         ) { _ in
         }
-        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 1"), TagType.recent("tag 2"), TagType.recent("tag 3")])
+        XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() throws {
@@ -190,27 +190,46 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
-    func test_allOtherTags_retrievesValidTagNames() throws {
-        let item = space.buildSavedItem(tags: ["tag 1"])
+    func test_allOtherTags_retrievesValidTagNames_inSortedOrder() throws {
+        let item = space.buildSavedItem(tags: ["a"])
         try space.save()
         let viewModel = subject(
             item: space.viewObject(with: item.objectID) as! SavedItem,
             retrieveAction: { _ in
-            var tags: [Tag] = []
-            for index in 2...3 {
-                let tag: Tag = Tag(context: self.space.viewContext)
-                tag.name = "tag \(index)"
-                tag.remoteID = tag.name.uppercased()
-                tags.append(tag)
-            }
-                return tags
+                let tag2: Tag = Tag(context: self.space.viewContext)
+                let tag3: Tag = Tag(context: self.space.viewContext)
+                tag2.name = "c"
+                tag2.remoteID = tag2.name.uppercased()
+                tag3.name = "b"
+                return [tag2, tag3]
             }
         ) { _ in
         }
 
         viewModel.allOtherTags()
 
-        XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
+        XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
+    }
+
+    func test_recentTags_inMostRecentOrder() throws {
+        let item = space.buildSavedItem(tags: ["a"])
+        try space.save()
+        let viewModel = subject(
+            item: space.viewObject(with: item.objectID) as! SavedItem,
+            retrieveAction: { _ in
+                let tag2: Tag = Tag(context: self.space.viewContext)
+                let tag3: Tag = Tag(context: self.space.viewContext)
+                tag2.name = "c"
+                tag2.remoteID = tag2.name.uppercased()
+                tag3.name = "b"
+                return [tag2, tag3]
+            }
+        ) { _ in
+        }
+
+        viewModel.allOtherTags()
+
+        XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
     }
 
     func test_removeTag_withValidName_updatesTags() throws {

--- a/PocketKit/Tests/SharedPocketKitTests/RecentTagProviderTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/RecentTagProviderTests.swift
@@ -28,6 +28,17 @@ class RecentTagProviderTests: XCTestCase {
         )
     }
 
+    func test_initial_recentTags() throws {
+        let recentTagsProvider = subject()
+        XCTAssertEqual(recentTagsProvider.recentTags, [])
+    }
+
+    func test_getInitialRecentTags_withEmptyTags_hasNoRecentTags() throws {
+        let recentTagsProvider = subject()
+        recentTagsProvider.getInitialRecentTags(with: [])
+        XCTAssertEqual(recentTagsProvider.recentTags, [])
+    }
+
     func test_recentTags_showsValidArray() {
         userDefaults.setValue(["tag 0", "tag 1", "tag 2"], forKey: UserDefaults.Key.recentTags)
         let recentTagsProvider = subject()
@@ -47,6 +58,11 @@ class RecentTagProviderTests: XCTestCase {
         XCTAssertEqual(recentTagsProvider.recentTags, ["tag 0", "tag 1", "tag 2"])
     }
 
+    func test_updateRecentTags_withEmptyTags_hasNoRecentTags() {
+        let recentTagsProvider = subject()
+        recentTagsProvider.updateRecentTags(with: [], and: [])
+        XCTAssertEqual(recentTagsProvider.recentTags, [])
+    }
     func test_updateRecentTags_withNoOriginalTags_andNewInputTag_showsValidArray() {
         let recentTagsProvider = subject()
         recentTagsProvider.updateRecentTags(with: [], and: ["tag 3"])


### PR DESCRIPTION
## Summary
Update logic for tags in shared extension:
* Fix recent tags that are not being updated and fix order to be most recently used
* Sort tags alphabetically unless a recent tag

## References 
IN-1569, IN-1598

## Implementation Details
* `itemTagNames` was being updated and not providing to correct value so created a clearer variable `originalTagNames` that gets set on the object's init method instead of being a computed property; therefore provided the wrong input values for the recent tag provider
* Notice that recent tags were being sorted alphabetically instead of being sorted by most recently used
* Update `other tags` to be sorted in alphabetical order in `SaveToAddTagsViewModel.swift`

## Test Steps

**Fix recent tags that are not being updated**
- [ ] Given that I add a tag to a saved item in the app,
when I save another item via the share extension, 
and navigate to the Add Tags screen,
then I should see that the recent tags updated with that tag. 

**Sort tags alphabetically unless a recent tag**
- [ ] Given that I save an item via the shared extension,
and I navigate to the Add Tags screen, 
then I should see that the tags are sorted alphabetically in the `My tags` section.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 09 37 58](https://github.com/Pocket/pocket-ios/assets/6743397/cc205dce-73af-4d7b-bf4b-de8d19e630bc)
