### PR TITLE
Loading View - Replace spinner with shapes animation

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -329,3 +329,4 @@
 // Collection
 "collection.title" = "Collection";
 "collection.stories.count" = "%@ items";
+"collection.loadingView.message" = "Loading collection...";

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -231,6 +231,9 @@
 "Yes" = "Yes";
 "No" = "No";
 
+// Loading view
+"loadingView.message" = "Loading...";
+
 // No internet
 "No Internet Connection" = "No internet connection";
 "Looks like you're offline. Try checking your mobile data or wifi." = "Looks like you're offline. Try checking your mobile data or wifi.";
@@ -329,4 +332,3 @@
 // Collection
 "collection.title" = "Collection";
 "collection.stories.count" = "%@ items";
-"collection.loadingView.message" = "Loading collection...";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -181,6 +181,10 @@ public enum Localization {
   public enum Collection {
     /// Collection
     public static let title = Localization.tr("Localizable", "collection.title", fallback: "Collection")
+    public enum LoadingView {
+      /// Loading collection...
+      public static let message = Localization.tr("Localizable", "collection.loadingView.message", fallback: "Loading collection...")
+    }
     public enum Stories {
       /// %@ items
       public static func count(_ p1: Any) -> String {

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -181,10 +181,6 @@ public enum Localization {
   public enum Collection {
     /// Collection
     public static let title = Localization.tr("Localizable", "collection.title", fallback: "Collection")
-    public enum LoadingView {
-      /// Loading collection...
-      public static let message = Localization.tr("Localizable", "collection.loadingView.message", fallback: "Loading collection...")
-    }
     public enum Stories {
       /// %@ items
       public static func count(_ p1: Any) -> String {
@@ -305,6 +301,10 @@ public enum Localization {
       /// Tagged
       public static let tagged = Localization.tr("Localizable", "itemlist.filter.tagged", fallback: "Tagged")
     }
+  }
+  public enum LoadingView {
+    /// Loading...
+    public static let message = Localization.tr("Localizable", "loadingView.message", fallback: "Loading...")
   }
   public enum LoggedOut {
     public enum Offline {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewController.swift
@@ -84,6 +84,7 @@ class CollectionViewController: UIViewController {
         collectionView.delegate = self
 
         collectionView.register(cellClass: LoadingCell.self)
+        collectionView.register(cellClass: EmptyCell.self)
         collectionView.register(cellClass: CollectionMetadataCell.self)
         collectionView.register(cellClass: RecommendationCell.self)
         collectionView.register(cellClass: EmptyStateCollectionViewCell.self)
@@ -324,6 +325,9 @@ private extension CollectionViewController {
         switch viewModelCell {
         case .loading:
             let cell: LoadingCell = collectionView.dequeueCell(for: indexPath)
+            return cell
+        case .empty:
+            let cell: EmptyCell = collectionView.dequeueCell(for: indexPath)
             return cell
         case .collectionHeader:
             let metaCell: CollectionMetadataCell = collectionView.dequeueCell(for: indexPath)

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -352,7 +352,10 @@ private extension CollectionViewModel {
         snapshot.appendItems([.loading], toSection: .loading)
         return snapshot
     }
-
+    
+    /// Build an empty snapshot section, used at initialization time,
+    /// so we don't show the loading screen (previously set at init time)
+    /// when we have local data
     static func emptySnapshot() -> Snapshot {
         var snapshot = Snapshot()
         snapshot.appendSections([.empty])

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -75,7 +75,7 @@ class CollectionViewModel: NSObject {
 
         self.collectionController = source.makeCollectionStoriesController(slug: slug)
 
-        self.snapshot = Self.loadingSnapshot()
+        self.snapshot = Self.emptySnapshot()
         self.url = "https://getpocket.com/collections/\(slug)"
         super.init()
         collectionController.delegate = self
@@ -104,12 +104,13 @@ class CollectionViewModel: NSObject {
                 return
             }
             if isOffline {
-                snapshot = self.errorSnapshot()
+                snapshot = errorSnapshot()
             } else {
+                snapshot = Self.loadingSnapshot()
                 fetchRemoteCollection()
             }
         } catch {
-            self.snapshot = errorSnapshot()
+            snapshot = errorSnapshot()
             Log.capture(message: "Failed to fetch details for CollectionViewModel: \(error)")
         }
     }
@@ -119,7 +120,7 @@ class CollectionViewModel: NSObject {
             do {
                 try await source.fetchCollection(by: slug)
             } catch {
-                self.snapshot = errorSnapshot()
+                snapshot = errorSnapshot()
                 Log.capture(message: "Failed to fetch remote collection stories: \(error)")
             }
         }
@@ -294,7 +295,7 @@ extension CollectionViewModel {
 
     func select(cell: CollectionViewModel.Cell) {
         switch cell {
-        case .loading, .collectionHeader, .error:
+        case .loading, .collectionHeader, .error, .empty:
             return
         case .story(let storyViewModel):
             trackContentOpen(storyURL: storyViewModel.collectionStory.url)
@@ -349,6 +350,13 @@ private extension CollectionViewModel {
         var snapshot = Snapshot()
         snapshot.appendSections([.loading])
         snapshot.appendItems([.loading], toSection: .loading)
+        return snapshot
+    }
+
+    static func emptySnapshot() -> Snapshot {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.empty])
+        snapshot.appendItems([.empty], toSection: .empty)
         return snapshot
     }
 
@@ -432,6 +440,7 @@ private extension CollectionViewModel {
 
 extension CollectionViewModel {
     enum Section: Hashable {
+        case empty
         case loading
         case collectionHeader
         case collection(Collection)
@@ -439,6 +448,7 @@ extension CollectionViewModel {
     }
 
     enum Cell: Hashable {
+        case empty
         case loading
         case collectionHeader
         case story(CollectionStoryViewModel)

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -352,7 +352,7 @@ private extension CollectionViewModel {
         snapshot.appendItems([.loading], toSection: .loading)
         return snapshot
     }
-    
+
     /// Build an empty snapshot section, used at initialization time,
     /// so we don't show the loading screen (previously set at init time)
     /// when we have local data

--- a/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
@@ -21,7 +21,7 @@ class LoadingCell: UICollectionViewCell {
 extension LoadingCell {
     private func setupContentView() {
         contentView.backgroundColor = .clear
-        let view = UIView.embedSwiftUIView(PocketLoadingView.loadingIndicator(Localization.Collection.LoadingView.message))
+        let view = UIView.embedSwiftUIView(PocketLoadingView.loadingIndicator(Localization.LoadingView.message))
         contentView.addSubview(view)
         contentView.pinSubviewToAllEdges(view)
     }

--- a/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/LoadingCell.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import UIKit
+import Localization
+import SharedPocketKit
 import Textile
+import UIKit
 
 class LoadingCell: UICollectionViewCell {
     override init(frame: CGRect) {
@@ -12,24 +14,15 @@ class LoadingCell: UICollectionViewCell {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        fatalError("Storyboards are not welcome here 😆")
     }
 }
 
 extension LoadingCell {
     private func setupContentView() {
         contentView.backgroundColor = .clear
-
-        let activityIndicator = UIActivityIndicatorView(style: .large)
-        activityIndicator.color = UIColor(.ui.grey1)
-        contentView.addSubview(activityIndicator)
-
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
-        ])
-
-        activityIndicator.startAnimating()
+        let view = UIView.embedSwiftUIView(PocketLoadingView.loadingIndicator(Localization.Collection.LoadingView.message))
+        contentView.addSubview(view)
+        contentView.pinSubviewToAllEdges(view)
     }
 }

--- a/PocketKit/Sources/PocketKit/Settings/DeleteAccountView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/DeleteAccountView.swift
@@ -108,7 +108,7 @@ struct DeleteAccountView: View {
         .accessibilityIdentifier("delete-confirmation")
         .overlay {
             if viewModel.isDeletingAccount {
-                DeleteLoadingView()
+                PocketLoadingView.overlay(Localization.Settings.AccountManagement.DeleteAccount.deleting)
             }
         }
         .alert(isPresented: $viewModel.showErrorAlert) {
@@ -118,36 +118,6 @@ struct DeleteAccountView: View {
             viewModel.trackDeleteConfirmationImpression()
         }
     }
-}
-
-private struct DeleteLoadingView: View {
-    var body: some View {
-        VStack {
-            HStack {
-               Spacer()
-            }
-            Spacer()
-            LottieView(.loading)
-                .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 100)
-            Text(Localization.Settings.AccountManagement.DeleteAccount.deleting).style(.deleteAccountView.overlay)
-            Spacer()
-        }
-        .background(Color(.ui.grey3))
-        .foregroundColor(Color(.ui.white1))
-        .opacity(0.9)
-        .accessibilityIdentifier("deleting-overlay")
-    }
-}
-
-extension Style {
-    struct DeleteAccountView {
-        let header: Style = Style.header.sansSerif.h2.with(color: .ui.black1)
-        let warning: Style = Style.header.sansSerif.p2.with(color: .ui.black1).with(weight: .bold)
-        let body: Style = Style.header.sansSerif.p3.with(color: .ui.black1)
-        let overlay: Style = Style.header.sansSerif.p2.with(color: .ui.white).with(weight: .bold)
-    }
-
-    static let deleteAccountView = DeleteAccountView()
 }
 
 struct DeleteAccountView_PreviewProvider: PreviewProvider {

--- a/PocketKit/Sources/SharedPocketKit/PocketLoadingView.swift
+++ b/PocketKit/Sources/SharedPocketKit/PocketLoadingView.swift
@@ -30,7 +30,7 @@ public struct PocketLoadingView: View {
         .background(Color(backgroundColor))
         .foregroundColor(Color(foregroundColor))
         .opacity(0.9)
-        .accessibilityIdentifier("deleting-overlay")
+        .accessibilityIdentifier("loading-view")
     }
 }
 

--- a/PocketKit/Sources/SharedPocketKit/PocketLoadingView.swift
+++ b/PocketKit/Sources/SharedPocketKit/PocketLoadingView.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import Textile
+
+public struct PocketLoadingView: View {
+    let message: String
+    let textColor: ColorAsset
+    let backgroundColor: ColorAsset
+    let foregroundColor: ColorAsset
+    public init(_ message: String, textColor: ColorAsset, backgroundColor: ColorAsset, foregroundColor: ColorAsset) {
+        self.message = message
+        self.textColor = textColor
+        self.backgroundColor = backgroundColor
+        self.foregroundColor = foregroundColor
+    }
+    public var body: some View {
+        VStack {
+            HStack {
+               Spacer()
+            }
+            Spacer()
+            LottieView(.loading)
+                .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 100)
+            Text(message).style(.pocketLoadingView.loadingViewText(textColor))
+            Spacer()
+        }
+        .background(Color(backgroundColor))
+        .foregroundColor(Color(foregroundColor))
+        .opacity(0.9)
+        .accessibilityIdentifier("deleting-overlay")
+    }
+}
+
+// MARK: predefined styles
+public extension PocketLoadingView {
+    static func overlay(_ message: String) -> PocketLoadingView {
+        PocketLoadingView(message, textColor: .ui.white, backgroundColor: .ui.grey3, foregroundColor: .ui.white1)
+    }
+
+    static func loadingIndicator(_ message: String) -> PocketLoadingView {
+        PocketLoadingView(message, textColor: .ui.black1, backgroundColor: .ui.white1, foregroundColor: .ui.white1)
+    }
+}

--- a/PocketKit/Sources/SharedPocketKit/UIView+Utilities.swift
+++ b/PocketKit/Sources/SharedPocketKit/UIView+Utilities.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+public extension UIView {
+    /// Creates a UIView instance with a SwiftUI view embedded in it
+    /// - Parameter view: the original SwiftUI view
+    /// - Returns: the UIView instance
+    class func embedSwiftUIView<Content: View>(_ view: Content) -> UIView {
+        let controller = UIHostingController(rootView: view)
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        controller.view.backgroundColor = .clear
+        return controller.view
+    }
+
+    /// Add top, bottom, leading and trailing constraints between a view and a subview
+    /// - Parameters:
+    ///   - subview: the subview.
+    ///   - insets: optional edge insets.
+    func pinSubviewToAllEdges(_ subview: UIView, insets: UIEdgeInsets = .zero) {
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: subview.leadingAnchor, constant: -insets.left),
+            trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
+            topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
+            bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom),
+        ])
+    }
+}

--- a/PocketKit/Sources/Textile/Style/Style+DeleteAccountView.swift
+++ b/PocketKit/Sources/Textile/Style/Style+DeleteAccountView.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+public extension Style {
+    struct DeleteAccountView {
+        public let header: Style = Style.header.sansSerif.h2.with(color: .ui.black1)
+        public let warning: Style = Style.header.sansSerif.p2.with(color: .ui.black1).with(weight: .bold)
+        public let body: Style = Style.header.sansSerif.p3.with(color: .ui.black1)
+    }
+
+    static let deleteAccountView = DeleteAccountView()
+}

--- a/PocketKit/Sources/Textile/Style/Style+PocketLoadingView.swift
+++ b/PocketKit/Sources/Textile/Style/Style+PocketLoadingView.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+public extension Style {
+    struct PocketLoadingView {
+        public func loadingViewText(_ textColor: ColorAsset) -> Style {
+            Style.header.sansSerif.p2.with(color: textColor).with(weight: .bold)
+        }
+    }
+    static let pocketLoadingView = PocketLoadingView()
+}

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -802,6 +802,9 @@ class CollectionViewModelTests: XCTestCase {
                 XCTAssertNotNil(snapshot.indexOfSection(.loading))
                 XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
                 loadingExpectation.fulfill()
+            } else if count == 3 {
+                XCTAssertNotNil(snapshot.indexOfSection(.error))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
             }
         }.store(in: &subscriptions)
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -795,12 +795,12 @@ class CollectionViewModelTests: XCTestCase {
         viewModel.$snapshot.sink { snapshot in
             count += 1
             if count == 1 {
-                XCTAssertNotNil(snapshot.indexOfSection(.loading))
-                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
+                XCTAssertNotNil(snapshot.indexOfSection(.empty))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .empty), [.empty])
                 errorSnapshotExpectation.fulfill()
             } else if count == 2 {
-                XCTAssertNotNil(snapshot.indexOfSection(.error))
-                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .error), [.error])
+                XCTAssertNotNil(snapshot.indexOfSection(.loading))
+                XCTAssertEqual(snapshot.itemIdentifiers(inSection: .loading), [.loading])
                 loadingExpectation.fulfill()
             }
         }.store(in: &subscriptions)

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -30,7 +30,7 @@ struct PocketAppElement {
 
     /// Gets the delete overlay view, for some reason this is in the main app element.
     var deletingAccountOverlay: XCUIElement {
-        return app.otherElements["deleting-overlay"]
+        return app.otherElements["loading-view"]
     }
 
     var homeView: HomeViewElement {


### PR DESCRIPTION
This PR replaces the standard spinner animation with the shapes animation already used in account deletion

## Summary
* Generalized `DeleteLoadingView` by changing it into a configurable `PocketLoadingView`

## References 
* NA

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Tap on a collection that has not been loaded locally
* Verify that you see the animation (see video below)
* You should also see the same animation when loading home or a slate

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots


https://github.com/Pocket/pocket-ios/assets/34376330/997f0303-9dfc-4549-83e0-cbbf2c1797fc



