### PR TITLE
feat(saveto): log out from share extension on 401

### DIFF
--- a/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/LoggedOut/LoggedOutViewModel.swift
@@ -8,17 +8,7 @@ import Combine
 import Localization
 
 class LoggedOutViewModel {
-    let infoViewModel = InfoView.Model(
-        style: .error,
-        attributedText: NSAttributedString(
-            string: "Log in to Pocket to save",
-            style: .mainTextError
-        ),
-        attributedDetailText: NSAttributedString(
-            string: "Pocket couldn't save the link. Log in to the Pocket app and try saving again.",
-            style: .detailText
-        )
-    )
+    let infoViewModel: InfoView.Model = .loggedOut
 
     let dismissAttributedText = NSAttributedString(
         string: Localization.SaveToPocket.tapToDismiss,

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -118,11 +118,12 @@ class MainViewController: UIViewController {
                 viewModel: SavedItemViewModel(
                     appSession: appSession,
                     saveService: services.saveService,
-                    dismissTimer: Timer.TimerPublisher(interval: 3.0, runLoop: .main, mode: .default),
+                    dismissTimer: Timer.TimerPublisher(interval: 60.0, runLoop: .main, mode: .default),
                     tracker: Services.shared.tracker.childTracker(hosting: .saveExtension.screen),
                     consumerKey: Keys.shared.pocketApiConsumerKey,
                     userDefaults: userDefaults,
-                    user: Services.shared.user
+                    user: Services.shared.user,
+                    notificationCenter: notificationCenter
                 )
             )
         }

--- a/PocketKit/Sources/SaveToPocketKit/SaveToUserManagementService.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToUserManagementService.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SharedPocketKit
+import Sync
+import Combine
+
+protocol SaveToUserManagementServiceProtocol {
+    func logout()
+}
+
+final class SaveToUserManagementService: ObservableObject, SaveToUserManagementServiceProtocol {
+    let appSession: AppSession
+    let user: User
+    let notificationCenter: NotificationCenter
+
+    // Deletion state
+    @Published public private(set) var accountDeleted: Bool = false
+    var accountDeletedPublisher: Published<Bool>.Publisher { $accountDeleted }
+
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(appSession: AppSession, user: User, notificationCenter: NotificationCenter) {
+        self.appSession = appSession
+        self.user = user
+        self.notificationCenter = notificationCenter
+
+        notificationCenter
+            .publisher(for: .unauthorizedResponse)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                Task {
+                    await self.logout()
+                }
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Logs out the user
+    /// We do this on the main thread because the Notification Center will post to areas that will change the UI
+    @MainActor
+    func logout() {
+        // Post that we logged out to the rest of the app using the old session
+        notificationCenter.post(name: .userLoggedOut, object: appSession.currentSession)
+        user.clear()
+        appSession.currentSession = nil
+    }
+}

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -19,6 +19,11 @@ struct Services {
     let notificationCenter: NotificationCenter
     let braze: SaveToBraze
 
+    /// The user management service that will log a user out when the correct notification is posted.
+    /// This is marked as private since we do not need to access it, but we need it to be around for the lifetime
+    /// of a Services instance. When using `.shared`, this lifetime will exist for the duration of the share extension.
+    private let userManagementService: SaveToUserManagementServiceProtocol
+
     private let persistentContainer: PersistentContainer
 
     private init() {
@@ -53,5 +58,7 @@ struct Services {
             endpoint: Keys.shared.brazeAPIEndpoint,
             groupdID: Keys.shared.groupID
         )
+
+        userManagementService = SaveToUserManagementService(appSession: appSession, user: user, notificationCenter: notificationCenter)
     }
 }


### PR DESCRIPTION
## Summary

Logs out of the share extension when receiving a 401 from a GraphQL request. Logging out from the share extension will also log a user out from the app.

There is a tiny quirk where, since the save is async, we first will show that a URL could (not) be saved, followed by updating the UI _after_ the request is made, however long that takes.

## References 

IN-1615

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
