### PR TITLE
Widget Update services - remove Core Data logic from async operations

### DIFF
--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
@@ -20,22 +20,21 @@ public struct RecentSavesWidgetUpdateService {
     /// Update the recent saves using the given array of `SavedItem`
     /// - Parameter items: the given array
     public func update(_ items: [SavedItem], _ name: String) {
+        let saves = items.map {
+            ItemContent(
+                url: $0.url,
+                title: $0.item?.title ?? $0.url,
+                imageUrl: $0.item?.topImageURL?.absoluteString,
+                bestDomain: $0.item?.domainMetadata?.name ?? $0.item?.domain ?? URL(percentEncoding: $0.url)?.host ?? "",
+                timeToRead: ($0.item?.timeToRead) != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil
+            )
+        }
+        let saveTopic = [ItemContentContainer(name: name, items: saves)]
+        // avoid triggering widget updates if stored data did not change
+        guard store.topics != saveTopic else {
+            return
+        }
         savesUpdateQueue.async {
-            let saves = items.map {
-                ItemContent(
-                    url: $0.url,
-                    title: $0.item?.title ?? $0.url,
-                    imageUrl: $0.item?.topImageURL?.absoluteString,
-                    bestDomain: $0.item?.domainMetadata?.name ?? $0.item?.domain ?? URL(percentEncoding: $0.url)?.host ?? "",
-                    timeToRead: ($0.item?.timeToRead) != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil
-                )
-            }
-            let saveTopic = [ItemContentContainer(name: name, items: saves)]
-            // avoid triggering widget updates if stored data did not change
-            guard store.topics != saveTopic else {
-                return
-            }
-
             do {
                 try store.updateTopics(saveTopic)
                 reloadWidget()

--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
@@ -22,12 +22,12 @@ public struct RecommendationsWidgetUpdateService {
     /// Update the recommendations using a collection of slates, normalized to `[String: [Recommendation]]`
     /// - Parameter items: the given collection of normalized slates
     public func update(_ topics: [String: [Recommendation]]) {
+        let newTopics: [ItemContentContainer] = topics.map { makeItemContentContainer($0.key, $0.value) }
+        // avoid triggering widget updates if stored data did not change
+        guard store.topics != newTopics else {
+            return
+        }
         recommendationsUpdateQueue.async {
-            let newTopics: [ItemContentContainer] = topics.map { makeItemContentContainer($0.key, $0.value) }
-            // avoid triggering widget updates if stored data did not change
-            guard store.topics != newTopics else {
-                return
-            }
             do {
                 try store.updateTopics(newTopics)
                 reloadWidget()


### PR DESCRIPTION

## Summary
* This PR attempts to fix a crash that we are seeing in `RecentSavesWidgetUpdateService` and `RecommendationsWidgetUpdateService`, by removing Core Data logic from the async operations happening in a private queue

## References 
* NA

## Implementation Details
* See summary

## Test Steps
* There are not specific repro steps for the issue. You can try run and update/force update Home a few times and see if there's any crash in either service

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
