### PR TITLE
fix(sync): reset persistent container on load error

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -1104,7 +1104,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1163,7 +1163,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
@@ -1191,7 +1191,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1221,7 +1221,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro";
@@ -1246,7 +1246,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1271,7 +1271,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1303,7 +1303,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1335,7 +1335,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.PushNotifica";
@@ -1367,7 +1367,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1398,7 +1398,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.PushStory";
@@ -1466,7 +1466,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1495,7 +1495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro;
 				PRODUCT_NAME = Pocket;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1520,7 +1520,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterProAlphaNeue.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1551,7 +1551,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1584,7 +1584,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1615,7 +1615,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.PushNotificationStoryExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1648,7 +1648,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterPro.Widget-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1680,7 +1680,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterPro.Widget-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1712,7 +1712,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ideashower.ReadItLaterPro.Widget-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.Widget-Exten";
@@ -1745,7 +1745,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1778,7 +1778,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.0.6;
+				MARKETING_VERSION = 8.0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ideashower.ReadItLaterPro.AddToPocketExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Bitrise com.ideashower.ReadItLaterPro.AddToPocketE";

--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -7,11 +7,20 @@ import SwiftUI
 
 @main
 struct PocketApp: App {
+    @Environment(\.scenePhase)
+    var scenePhase
+
     @UIApplicationDelegateAdaptor var delegate: PocketAppDelegate
 
     var body: some Scene {
         WindowGroup {
             RootView(model: RootViewModel())
+        }.onChange(of: scenePhase) { newValue in
+            switch newValue {
+            case .active:
+                delegate.scenePhaseDidChange(scenePhase)
+            default: return
+            }
         }
     }
 }

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -329,3 +329,7 @@
 // Collection
 "collection.title" = "Collection";
 "collection.stories.count" = "%@ items";
+
+// Errors
+"error.problemOccurred" = "A problem occurred";
+"error.redownloading" = "We are re-downloading your saved articles to improve your experience.";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -188,6 +188,12 @@ public enum Localization {
       }
     }
   }
+  public enum Error {
+    /// A problem occurred
+    public static let problemOccurred = Localization.tr("Localizable", "error.problemOccurred", fallback: "A problem occurred")
+    /// We are re-downloading your saved articles to improve your experience.
+    public static let redownloading = Localization.tr("Localizable", "error.redownloading", fallback: "We are re-downloading your saved articles to improve your experience.")
+  }
   public enum Favourites {
     public enum Empty {
       /// Hit the star icon to favorite an article and find it faster.

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -12,7 +12,7 @@ import Kingfisher
 import Network
 
 struct Services {
-    static let shared: Services = { Services() }()
+    static let shared: Services = Services()
 
     let userDefaults: UserDefaults
     let appSession: AppSession
@@ -216,6 +216,13 @@ struct Services {
         recentSavesWidgetUpdateService = RecentSavesWidgetUpdateService(store: UserDefaultsItemWidgetsStore(userDefaults: userDefaults, key: .recentSavesWidget))
         recommendationsWidgetUpdateService = RecommendationsWidgetUpdateService(store: UserDefaultsItemWidgetsStore(userDefaults: userDefaults, key: .recommendationsWidget))
         widgetsSessionService = UserDefaultsWidgetSessionService(defaults: userDefaults)
+    }
+
+    /// Starts up all services as required.
+    /// - Parameter onReset: The function to call if a service has been reset.
+    /// - Note: `onReset` can be called when a migration within the persistent container fails
+    func start(onReset: @escaping () -> Void) {
+        persistentContainer.load(onReset: onReset)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/UserManagementService.swift
+++ b/PocketKit/Sources/PocketKit/UserManagementService.swift
@@ -41,6 +41,16 @@ final class UserManagementService: ObservableObject, UserManagementServiceProtoc
                 }
             }
             .store(in: &subscriptions)
+
+        notificationCenter
+            .publisher(for: .migrationError)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                Task {
+                    await self.logout()
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     func deleteAccount() async throws {

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -18,6 +18,10 @@ class MainViewController: UIViewController {
     }
 
     convenience init(services: Services) {
+        services.start {
+            services.userDefaults.set(true, forKey: .forceRefreshFromExtension)
+        }
+
         Textiles.initialize()
 
         let appSession = services.appSession

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -54,4 +54,11 @@ struct Services {
             groupdID: Keys.shared.groupID
         )
     }
+
+    /// Starts up all services as required.
+    /// - Parameter onReset: The function to call if a service has been reset.
+    /// - Note: `onReset` can be called when a migration within the persistent container fails.
+    func start(onReset: @escaping () -> Void) {
+        persistentContainer.load(onReset: onReset)
+    }
 }

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -11,4 +11,5 @@ public extension Notification.Name {
     static let bannerRequested = Notification.Name("com.mozilla.pocket.bannerRequested")
     static let serverError = Notification.Name("com.mozilla.pocket.serverError")
     static let unauthorizedResponse = Notification.Name("com.mozilla.pocket.unauthorizedResponse")
+    static let migrationError = Notification.Name("com.mozilla.pocket.migrationError")
 }

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -36,6 +36,7 @@ public extension UserDefaults {
         case widgetsLoggedIn = "RecentSavesWidgetLoggedInKey"
         case recentSavesWidget = "RecentSavesWidgetKey"
         case recommendationsWidget = "RecommendationsWidgetKey"
+        case forceRefreshFromExtension = "ForceRefreshFromExtentionKey"
 
         var isRemovable: Bool {
             switch self {

--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
@@ -20,22 +20,21 @@ public struct RecentSavesWidgetUpdateService {
     /// Update the recent saves using the given array of `SavedItem`
     /// - Parameter items: the given array
     public func update(_ items: [SavedItem], _ name: String) {
+        let saves = items.map {
+            ItemContent(
+                url: $0.url,
+                title: $0.item?.title ?? $0.url,
+                imageUrl: $0.item?.topImageURL?.absoluteString,
+                bestDomain: $0.item?.domainMetadata?.name ?? $0.item?.domain ?? URL(percentEncoding: $0.url)?.host ?? "",
+                timeToRead: ($0.item?.timeToRead) != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil
+            )
+        }
+        let saveTopic = [ItemContentContainer(name: name, items: saves)]
+        // avoid triggering widget updates if stored data did not change
+        guard store.topics != saveTopic else {
+            return
+        }
         savesUpdateQueue.async {
-            let saves = items.map {
-                ItemContent(
-                    url: $0.url,
-                    title: $0.item?.title ?? $0.url,
-                    imageUrl: $0.item?.topImageURL?.absoluteString,
-                    bestDomain: $0.item?.domainMetadata?.name ?? $0.item?.domain ?? URL(percentEncoding: $0.url)?.host ?? "",
-                    timeToRead: ($0.item?.timeToRead) != nil ? Int(truncating: ($0.item?.timeToRead)!) : nil
-                )
-            }
-            let saveTopic = [ItemContentContainer(name: name, items: saves)]
-            // avoid triggering widget updates if stored data did not change
-            guard store.topics != saveTopic else {
-                return
-            }
-
             do {
                 try store.updateTopics(saveTopic)
                 reloadWidget()

--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
@@ -22,12 +22,12 @@ public struct RecommendationsWidgetUpdateService {
     /// Update the recommendations using a collection of slates, normalized to `[String: [Recommendation]]`
     /// - Parameter items: the given collection of normalized slates
     public func update(_ topics: [String: [Recommendation]]) {
+        let newTopics: [ItemContentContainer] = topics.map { makeItemContentContainer($0.key, $0.value) }
+        // avoid triggering widget updates if stored data did not change
+        guard store.topics != newTopics else {
+            return
+        }
         recommendationsUpdateQueue.async {
-            let newTopics: [ItemContentContainer] = topics.map { makeItemContentContainer($0.key, $0.value) }
-            // avoid triggering widget updates if stored data did not change
-            guard store.topics != newTopics else {
-                return
-            }
             do {
                 try store.updateTopics(newTopics)
                 reloadWidget()

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -5,7 +5,11 @@
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -5,7 +5,11 @@
 import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -7,7 +7,11 @@ import CoreData
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {


### PR DESCRIPTION
## Summary

Fixes an issue where the app would crash if a migration in the model version would error.

## References 

IN-1349

## Implementation Details

This pull request includes loading a persistent container outside of initialization, but very early in the app and share extension lifecycle.

The basic premise is: when loading the persistent container, attempt to load a store, and if that load fails, destroy and re-add the store, thus rebuilding an empty store from scratch. See comments for more details.

Upon reset, the app has to force-refresh all refresh coordinators, to act similar to login; sync ALL the on-disk data since it was removed in the reset. This will also present a toast in the main app. We have to force-refresh since there's a possibility a sync won't be called due to the refresh interval criteria not being met, which would cause apps to display no data. By force-refreshing, we reload all views across the app. 

## Test Steps

**Simulator Only**
- [ ] Checkout v8.0.5
- [ ] Build and run, login, and stop the build mid-sync
- [ ] Open the underlying Core Data SQLite database in an app like DB Browser
- [ ] Find the `PersistentSyncTask' table, and in any available rows, NULL-out `syncTaskContainer`, saving the changes
- [ ] Checkout this branch
- [ ] Launch the app
- [ ] The app should not crash, and a toast should appear that items are being redownloaded.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
