### PR TITLE
Universal Links - Add navigation to an article selected from a widget

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Home.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Home.swift
@@ -77,7 +77,7 @@ public extension Events.Home {
     /**
      Fired when a user clicks a card in the `Recent Saves` section
      */
-    static func RecentSavesCardContentOpen(url: String, positionInList: Int) -> ContentOpen {
+    static func RecentSavesCardContentOpen(url: String, positionInList: Int?) -> ContentOpen {
         return ContentOpen(
             contentEntity:
                 ContentEntity(url: url),
@@ -92,7 +92,7 @@ public extension Events.Home {
     /**
      Fired when a user clicks a card on Home using the /discover API
      */
-    static func SlateArticleContentOpen(url: String, positionInList: Int, slateId: String, slateRequestId: String, slateExperimentId: String, slateIndex: Int, slateLineupId: String, slateLineupRequestId: String, slateLineupExperimentId: String, recommendationId: String, destination: ContentOpen.Destination) -> ContentOpen {
+    static func SlateArticleContentOpen(url: String, positionInList: Int?, slateId: String, slateRequestId: String, slateExperimentId: String, slateIndex: Int?, slateLineupId: String, slateLineupRequestId: String, slateLineupExperimentId: String, recommendationId: String, destination: ContentOpen.Destination) -> ContentOpen {
         return ContentOpen(
             destination: destination,
             contentEntity:

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -16,6 +16,8 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
 
     var tracker: Tracker { get }
 
+    var readableSource: ReadableSource { get }
+
     var readerSettings: ReaderSettings { get }
     var presentedAlert: PocketAlert? { get set }
     var sharedActivity: PocketActivity? { get set }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -27,6 +27,8 @@ class RecommendationViewModel: ReadableViewModel {
 
     @Published var selectedRecommendationToReport: Recommendation?
 
+    let readableSource: ReadableSource
+
     private let recommendation: Recommendation
     private let source: Source
     private let pasteboard: Pasteboard
@@ -37,13 +39,22 @@ class RecommendationViewModel: ReadableViewModel {
     private var savedItemCancellable: AnyCancellable?
     private var savedItemSubscriptions: Set<AnyCancellable> = []
 
-    init(recommendation: Recommendation, source: Source, tracker: Tracker, pasteboard: Pasteboard, user: User, userDefaults: UserDefaults) {
+    init(
+        recommendation: Recommendation,
+        source: Source,
+        tracker: Tracker,
+        pasteboard: Pasteboard,
+        user: User,
+        userDefaults: UserDefaults,
+        readableSource: ReadableSource = .app
+    ) {
         self.recommendation = recommendation
         self.source = source
         self.tracker = tracker
         self.pasteboard = pasteboard
         self.user = user
         self.userDefaults = userDefaults
+        self.readableSource = readableSource
 
         self.savedItemCancellable = recommendation.item.publisher(for: \.savedItem).sink { [weak self] savedItem in
             self?.update(for: savedItem)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -41,6 +41,8 @@ class SavedItemViewModel: ReadableViewModel {
         "readingProgress.\(url)."
     }
 
+    let readableSource: ReadableSource
+
     let tracker: Tracker
 
     @Published private(set) var _actions: [ItemAction] = []
@@ -78,7 +80,8 @@ class SavedItemViewModel: ReadableViewModel {
         store: SubscriptionStore,
         networkPathMonitor: NetworkPathMonitor,
         userDefaults: UserDefaults,
-        notificationCenter: NotificationCenter
+        notificationCenter: NotificationCenter,
+        readableSource: ReadableSource = .app
     ) {
         self.item = item
         self.source = source
@@ -89,6 +92,7 @@ class SavedItemViewModel: ReadableViewModel {
         self.networkPathMonitor = networkPathMonitor
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
+        self.readableSource = readableSource
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -34,6 +34,8 @@ class CollectionViewModel: NSObject {
     @Published private(set) var actions: [ItemAction] = []
     @Published private(set) var isBeingDeallocated = false
 
+    let readableSource: ReadableSource
+
     private var collection: Collection?
     private let source: Source
     private let tracker: Tracker
@@ -61,7 +63,8 @@ class CollectionViewModel: NSObject {
         networkPathMonitor: NetworkPathMonitor,
         userDefaults: UserDefaults,
         featureFlags: FeatureFlagServiceProtocol,
-        notificationCenter: NotificationCenter
+        notificationCenter: NotificationCenter,
+        readableSource: ReadableSource = .app
     ) {
         self.slug = slug
         self.source = source
@@ -72,6 +75,7 @@ class CollectionViewModel: NSObject {
         self.userDefaults = userDefaults
         self.featureFlags = featureFlags
         self.notificationCenter = notificationCenter
+        self.readableSource = readableSource
 
         self.collectionController = source.makeCollectionStoriesController(slug: slug)
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -136,7 +136,6 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.accessibilityIdentifier = "home"
-        navigationController?.delegate = self
 
         observeModelChanges()
 
@@ -677,36 +676,7 @@ extension HomeViewController {
     }
 }
 
-extension HomeViewController: UINavigationControllerDelegate {
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        // By default, when pushing the reader, switching to landscape, and popping,
-        // the list will remain in landscape despite only supporting portrait.
-        // We have to programatically force the device orientation back to portrait,
-        // if the view controller we want to show _only_ supports portrait
-        // (e.g when popping from the reader).
-        if viewController.supportedInterfaceOrientations == .portrait, UIDevice.current.orientation.isLandscape {
-            UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: "orientation")
-        }
-    }
-
-    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        if viewController === self {
-            slateDetailSubscriptions = []
-            model.clearTappedSeeAll()
-            model.clearSelectedItem()
-        }
-
-        if viewController is SlateDetailViewController {
-            model.clearRecommendationToReport()
-            model.tappedSeeAll?.clearSelectedItem()
-        }
-    }
-
-    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
-        guard navigationController.traitCollection.userInterfaceIdiom == .phone else { return .all }
-        return navigationController.visibleViewController?.supportedInterfaceOrientations ?? .portrait
-    }
-
+extension HomeViewController {
     private func popToPreviousScreen() {
         if let presentedVC = navigationController?.presentedViewController {
             presentedVC.dismiss(animated: true) { [weak self] in

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -136,6 +136,8 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.accessibilityIdentifier = "home"
+        navigationController?.delegate = self
+
         observeModelChanges()
 
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -401,7 +403,7 @@ extension HomeViewController {
         guard let recommendation = recommendation else {
             return
         }
-
+        resetView(for: recommendation.readableSource)
         navigationController?.pushViewController(
             ReadableHostViewController(readableViewModel: recommendation),
             animated: true
@@ -438,6 +440,7 @@ extension HomeViewController {
     }
 
     func show(_ savedItem: SavedItemViewModel) {
+        resetView(for: savedItem.readableSource)
         readerSubscriptions.removeAll()
 
         navigationController?.pushViewController(
@@ -476,6 +479,7 @@ extension HomeViewController {
     }
 
     private func showCollection(_ viewModel: CollectionViewModel) {
+        resetView(for: viewModel.readableSource)
         let controller = CollectionViewController(model: viewModel)
         navigationController?.pushViewController(controller, animated: true)
 
@@ -550,6 +554,7 @@ extension HomeViewController {
     }
 
     private func showRecommendation(forWebView viewModel: RecommendationViewModel) {
+        resetView(for: viewModel.readableSource)
         viewModel.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readerSubscriptions)
@@ -569,6 +574,7 @@ extension HomeViewController {
     }
 
     private func showSavedItem(forWebView viewModel: SavedItemViewModel) {
+        resetView(for: viewModel.readableSource)
         viewModel.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readerSubscriptions)
@@ -658,6 +664,16 @@ extension HomeViewController {
         let hostingController = UIHostingController(rootView: AddTagsView(viewModel: viewModel))
         hostingController.modalPresentationStyle = .formSheet
         self.present(hostingController, animated: true)
+    }
+
+    /// Pops to the root and dismiss any modal, if required by the readable source
+    /// - Parameter readableSource: the readable source
+    private func resetView(for readableSource: ReadableSource) {
+        guard readableSource == .widget else {
+            return
+        }
+        navigationController?.popToRootViewController(animated: false)
+        dismiss(animated: false)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -34,6 +34,11 @@ enum ReadableType {
     }
 }
 
+enum ReadableSource {
+    case app
+    case widget
+}
+
 enum SeeAll {
     case saves
     case slate(SlateDetailViewModel)
@@ -301,12 +306,23 @@ extension HomeViewModel {
         ))
     }
 
-    private func select(recommendation: Recommendation, at indexPath: IndexPath) {
+    func select(recommendation: Recommendation, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app) {
         var destination: ContentOpen.Destination = .internal
         let item = recommendation.item
 
         if let slug = recommendation.collection?.slug ?? recommendation.item.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter))
+            selectedReadableType = .collection(CollectionViewModel(
+                slug: slug,
+                source: source,
+                tracker: tracker,
+                user: user,
+                store: store,
+                networkPathMonitor: networkPathMonitor,
+                userDefaults: userDefaults,
+                featureFlags: featureFlags,
+                notificationCenter: notificationCenter,
+                readableSource: readableSource
+            ))
         } else {
             let viewModel = RecommendationViewModel(
                 recommendation: recommendation,
@@ -314,7 +330,8 @@ extension HomeViewModel {
                 tracker: tracker.childTracker(hosting: .articleView.screen),
                 pasteboard: UIPasteboard.general,
                 user: user,
-                userDefaults: userDefaults
+                userDefaults: userDefaults,
+                readableSource: readableSource
             )
 
             if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
@@ -334,12 +351,23 @@ extension HomeViewModel {
         }
 
         let givenURL = item.givenURL
-        tracker.track(event: Events.Home.SlateArticleContentOpen(url: givenURL, positionInList: indexPath.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID, destination: destination))
+        tracker.track(event: Events.Home.SlateArticleContentOpen(url: givenURL, positionInList: indexPath?.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath?.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID, destination: destination))
     }
 
-    private func select(savedItem: SavedItem, at indexPath: IndexPath) {
+    func select(savedItem: SavedItem, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app) {
         if let slug = savedItem.item?.collection?.slug ?? savedItem.item?.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
-            selectedReadableType = .collection(CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter))
+            selectedReadableType = .collection(CollectionViewModel(
+                slug: slug,
+                source: source,
+                tracker: tracker,
+                user: user,
+                store: store,
+                networkPathMonitor: networkPathMonitor,
+                userDefaults: userDefaults,
+                featureFlags: featureFlags,
+                notificationCenter: notificationCenter,
+                readableSource: readableSource
+            ))
         } else {
             let viewModel = SavedItemViewModel(
                 item: savedItem,
@@ -350,7 +378,8 @@ extension HomeViewModel {
                 store: store,
                 networkPathMonitor: networkPathMonitor,
                 userDefaults: userDefaults,
-                notificationCenter: notificationCenter
+                notificationCenter: notificationCenter,
+                readableSource: readableSource
             )
 
             if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
@@ -359,7 +388,7 @@ extension HomeViewModel {
                 selectedReadableType = .savedItem(viewModel)
             }
         }
-        tracker.track(event: Events.Home.RecentSavesCardContentOpen(url: savedItem.url, positionInList: indexPath.item))
+        tracker.track(event: Events.Home.RecentSavesCardContentOpen(url: savedItem.url, positionInList: indexPath?.item))
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -17,7 +17,7 @@ class MainViewModel: ObservableObject {
     let saves: SavesContainerViewModel
     let account: AccountViewModel
     let source: Source
-    private let router: Router
+    private let urlValidator: UrlValidator
 
     @Published var selectedSection: AppSection = .home
 
@@ -117,7 +117,7 @@ class MainViewModel: ObservableObject {
             ),
             source: Services.shared.source,
             userDefaults: Services.shared.userDefaults,
-            router: Services.shared.router
+            urlValidator: Services.shared.urlValidator
         )
     }
 
@@ -127,14 +127,14 @@ class MainViewModel: ObservableObject {
         account: AccountViewModel,
         source: Source,
         userDefaults: UserDefaults,
-        router: Router
+        urlValidator: UrlValidator
     ) {
         self.saves = saves
         self.home = home
         self.account = account
         self.source = source
         self.userDefaults = userDefaults
-        self.router = router
+        self.urlValidator = urlValidator
 
         self.loadStartingAppSection()
         self.clearStartingAppSection()
@@ -224,7 +224,7 @@ extension MainViewModel {
     /// - Parameter url: the URL of the item to be displayed
     @MainActor
     func handle(_ url: URL) {
-        guard let itemUrl = router.getItemUrl(from: url) else {
+        guard let itemUrl = urlValidator.getItemUrl(from: url) else {
             return
         }
         // dismiss any modal from the Settings SwiftUI view

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -217,12 +217,28 @@ class MainViewModel: ObservableObject {
 
 // MARK: universal link handling
 extension MainViewModel {
+    /// handles universal links
+    /// Note: at the moment, the universal links are limited to
+    ///   - Logged in users
+    ///   - links coming from widgets
+    /// - Parameter url: the URL of the item to be displayed
+    @MainActor
     func handle(_ url: URL) {
         guard let itemUrl = router.getItemUrl(from: url) else {
             return
         }
-        // TODO: handle dismissal of any presented modal
+        // dismiss any modal from the Settings SwiftUI view
+        account.dismissAll()
+        // go to home
         selectedSection = .home
-        // TODO: pass itemUrl to HomeViewModel to select the correct readable type
+        guard let item = source.fetchViewContextItem(itemUrl) else {
+            return
+        }
+        // show the item associated to the given URL
+        if let savedItem = item.savedItem {
+            home.select(savedItem: savedItem, readableSource: .widget)
+        } else if let recommendation = item.recommendation {
+            home.select(recommendation: recommendation, readableSource: .widget)
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -22,12 +22,12 @@ public class RootViewModel: ObservableObject {
     private let source: Source
     private let userDefaults: UserDefaults
     private let widgetsSessionService: WidgetsSessionService
-    private let router: Router
+    private let urlValidator: UrlValidator
 
     private var subscriptions: Set<AnyCancellable> = []
 
     public convenience init() {
-        self.init(appSession: Services.shared.appSession, tracker: Services.shared.tracker, source: Services.shared.source, userDefaults: Services.shared.userDefaults, widgetsSessionService: Services.shared.widgetsSessionService, router: Services.shared.router)
+        self.init(appSession: Services.shared.appSession, tracker: Services.shared.tracker, source: Services.shared.source, userDefaults: Services.shared.userDefaults, widgetsSessionService: Services.shared.widgetsSessionService, urlValidator: Services.shared.urlValidator)
     }
 
     init(
@@ -36,14 +36,14 @@ public class RootViewModel: ObservableObject {
         source: Source,
         userDefaults: UserDefaults,
         widgetsSessionService: WidgetsSessionService,
-        router: Router
+        urlValidator: UrlValidator
     ) {
         self.appSession = appSession
         self.tracker = tracker
         self.source = source
         self.userDefaults = userDefaults
         self.widgetsSessionService = widgetsSessionService
-        self.router = router
+        self.urlValidator = urlValidator
 
         // Register for login notifications
         NotificationCenter.default.publisher(

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -47,7 +47,7 @@ struct Services {
     let widgetsSessionService: WidgetsSessionService
     let recentSavesWidgetUpdateService: RecentSavesWidgetUpdateService
     let recommendationsWidgetUpdateService: RecommendationsWidgetUpdateService
-    let router: Router
+    let urlValidator: UrlValidator
 
     private let persistentContainer: PersistentContainer
 
@@ -217,7 +217,7 @@ struct Services {
         recentSavesWidgetUpdateService = RecentSavesWidgetUpdateService(store: UserDefaultsItemWidgetsStore(userDefaults: userDefaults, key: .recentSavesWidget))
         recommendationsWidgetUpdateService = RecommendationsWidgetUpdateService(store: UserDefaultsItemWidgetsStore(userDefaults: userDefaults, key: .recommendationsWidget))
         widgetsSessionService = UserDefaultsWidgetSessionService(defaults: userDefaults)
-        router = Router()
+        urlValidator = UrlValidator()
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AccountViewModel.swift
@@ -245,3 +245,24 @@ extension AccountViewModel {
         tracker.track(event: Events.Settings.deleteRowTapped())
     }
 }
+
+// MARK: reset modal presentation
+extension AccountViewModel {
+    func dismissAll() {
+        isPresentingHelp = false
+        isPresentingTerms = false
+        isPresentingPrivacy = false
+        isPresentingSignOutConfirm = false
+        isPresentingPremiumUpgrade = false
+        isPresentingLicenses = false
+        isPresentingAccountManagement = false
+        isPresentingDeleteYourAccount = false
+        isPresentingCancelationHelp = false
+        isPresentingOfflineView = false
+        isPresentingRestoreSuccessful = false
+        isPresentingRestoreNotSuccessful = false
+        isPresentingPremiumStatus = false
+        isPresentingHooray = false
+        isPresentingDebugMenu = false
+    }
+}

--- a/PocketKit/Sources/PocketKit/UniversalLinks/UrlValidator.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/UrlValidator.swift
@@ -6,7 +6,8 @@ import Foundation
 import Network
 import Sync
 
-struct Router {
+/// A type that validates universal links and provides the related item url, if it exists.
+struct UrlValidator {
     func getItemUrl(from url: URL) -> String? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               components.scheme == Self.scheme, components.path == Self.path else {
@@ -17,7 +18,7 @@ struct Router {
     }
 }
 
-private extension Router {
+private extension UrlValidator {
     static let scheme = "pocket"
     static let host = "home"
     static let path = "/app/openURL"

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -661,6 +661,10 @@ extension PocketSource {
     public func fetchItem(_ url: String) -> Item? {
         return try? space.fetchItem(byURL: url)
     }
+
+    public func fetchViewContextItem(_ url: String) -> Item? {
+        return try? space.fetchItem(byURL: url, context: viewContext)
+    }
 }
 
 // MARK: - User Info

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -99,6 +99,8 @@ public protocol Source {
 
     func fetchItem(_ url: String) -> Item?
 
+    func fetchViewContextItem(_ url: String) -> Item?
+
     func searchSaves(search: String) -> [SavedItem]?
 
     func fetchOrCreateSavedItem(with url: String, and remoteParts: SavedItem.RemoteSavedItem?) -> SavedItem?

--- a/PocketKit/Tests/PocketKitTests/RouterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RouterTests.swift
@@ -1,8 +1,36 @@
-//
-//  File.swift
-//  
-//
-//  Created by Giorgio Ruscigno on 8/17/23.
-//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Foundation
+import XCTest
+
+@testable import PocketKit
+
+class RouterTests: XCTestCase {
+    static let validUrlNotFromWidgets = [
+        "https://getpocket.com/hooray/not-an-article-from-widgets",
+        "https://getpocket.com/are-you-there/no-i-am-not",
+        "https://getpucket.com/collections/this-may-be-a-collection",
+        "https://example.com/this-is-an-article"
+    ]
+
+    func testCorrectUrlReturnsItemUrl() {
+        let router = Router()
+        let correctUrlString = "pocket:/app/openURL?url=https://example.com/this_is_an_article/"
+        let correctUrl = URL(string: correctUrlString)
+        XCTAssertNotNil(correctUrl)
+        let itemUrl = router.getItemUrl(from: correctUrl!)
+        XCTAssertNotNil(itemUrl)
+        XCTAssertEqual(itemUrl, "https://example.com/this_is_an_article/")
+    }
+
+    func testWrongUrlReturnsNil() {
+        let router = Router()
+        let index = Int.random(in: 0..<Self.validUrlNotFromWidgets.count)
+        let wrongtUrlString = Self.validUrlNotFromWidgets[index]
+        let wrongUrl = URL(string: wrongtUrlString)
+        XCTAssertNotNil(wrongUrl)
+        let itemUrl = router.getItemUrl(from: wrongUrl!)
+        XCTAssertNil(itemUrl)
+    }
+}

--- a/PocketKit/Tests/PocketKitTests/RouterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RouterTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Giorgio Ruscigno on 8/17/23.
+//
+
+import Foundation

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,6 +8,10 @@ import CoreData
 import Combine
 
 class MockSource: Source {
+    func fetchViewContextItem(_ url: String) -> Sync.Item? {
+        return nil
+    }
+
     func save(collectionStory: Sync.CollectionStory) {
     }
 

--- a/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import PocketKit
 
-class RouterTests: XCTestCase {
+class UrlValidatorTests: XCTestCase {
     static let validUrlNotFromWidgets = [
         "https://getpocket.com/hooray/not-an-article-from-widgets",
         "https://getpocket.com/are-you-there/no-i-am-not",
@@ -15,22 +15,22 @@ class RouterTests: XCTestCase {
     ]
 
     func testCorrectUrlReturnsItemUrl() {
-        let router = Router()
+        let validator = UrlValidator()
         let correctUrlString = "pocket:/app/openURL?url=https://example.com/this_is_an_article/"
         let correctUrl = URL(string: correctUrlString)
         XCTAssertNotNil(correctUrl)
-        let itemUrl = router.getItemUrl(from: correctUrl!)
+        let itemUrl = validator.getItemUrl(from: correctUrl!)
         XCTAssertNotNil(itemUrl)
         XCTAssertEqual(itemUrl, "https://example.com/this_is_an_article/")
     }
 
     func testWrongUrlReturnsNil() {
-        let router = Router()
+        let validator = UrlValidator()
         let index = Int.random(in: 0..<Self.validUrlNotFromWidgets.count)
         let wrongtUrlString = Self.validUrlNotFromWidgets[index]
         let wrongUrl = URL(string: wrongtUrlString)
         XCTAssertNotNil(wrongUrl)
-        let itemUrl = router.getItemUrl(from: wrongUrl!)
+        let itemUrl = validator.getItemUrl(from: wrongUrl!)
         XCTAssertNil(itemUrl)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
@@ -6,14 +6,7 @@ import XCTest
 
 @testable import PocketKit
 
-class UrlValidatorTests: XCTestCase {
-    static let validUrlsNotFromWidgets = [
-        "https://getpocket.com/hooray/not-an-article-from-widgets",
-        "https://getpocket.com/are-you-there/no-i-am-not",
-        "https://getpucket.com/collections/this-may-be-a-collection",
-        "https://example.com/this-is-an-article"
-    ]
-
+class UrlValidatorTests: XCTestCase { 
     func testCorrectUrlReturnsItemUrl() {
         let validator = UrlValidator()
         let correctUrlString = "pocket:/app/openURL?url=https://example.com/this_is_an_article/"
@@ -26,9 +19,7 @@ class UrlValidatorTests: XCTestCase {
 
     func testInvalidUrlReturnsNil() {
         let validator = UrlValidator()
-        let index = Int.random(in: 0..<Self.validUrlsNotFromWidgets.count)
-        let invalidtUrlString = Self.validUrlsNotFromWidgets[index]
-        let invalidUrl = URL(string: invalidtUrlString)
+        let invalidUrl = URL(string: "https://getpocket.com/hooray/not-an-article-from-widgets")
         XCTAssertNotNil(invalidUrl)
         let itemUrl = validator.getItemUrl(from: invalidUrl!)
         XCTAssertNil(itemUrl)

--- a/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import PocketKit
 
-class UrlValidatorTests: XCTestCase { 
+class UrlValidatorTests: XCTestCase {
     func testCorrectUrlReturnsItemUrl() {
         let validator = UrlValidator()
         let correctUrlString = "pocket:/app/openURL?url=https://example.com/this_is_an_article/"

--- a/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/UrlValidatorTests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import PocketKit
 
 class UrlValidatorTests: XCTestCase {
-    static let validUrlNotFromWidgets = [
+    static let validUrlsNotFromWidgets = [
         "https://getpocket.com/hooray/not-an-article-from-widgets",
         "https://getpocket.com/are-you-there/no-i-am-not",
         "https://getpucket.com/collections/this-may-be-a-collection",
@@ -24,13 +24,13 @@ class UrlValidatorTests: XCTestCase {
         XCTAssertEqual(itemUrl, "https://example.com/this_is_an_article/")
     }
 
-    func testWrongUrlReturnsNil() {
+    func testInvalidUrlReturnsNil() {
         let validator = UrlValidator()
-        let index = Int.random(in: 0..<Self.validUrlNotFromWidgets.count)
-        let wrongtUrlString = Self.validUrlNotFromWidgets[index]
-        let wrongUrl = URL(string: wrongtUrlString)
-        XCTAssertNotNil(wrongUrl)
-        let itemUrl = validator.getItemUrl(from: wrongUrl!)
+        let index = Int.random(in: 0..<Self.validUrlsNotFromWidgets.count)
+        let invalidtUrlString = Self.validUrlsNotFromWidgets[index]
+        let invalidUrl = URL(string: invalidtUrlString)
+        XCTAssertNotNil(invalidUrl)
+        let itemUrl = validator.getItemUrl(from: invalidUrl!)
         XCTAssertNil(itemUrl)
     }
 }


### PR DESCRIPTION
## Summary
* This PR lets you tap on an article in a widget and show it in the app.

## References 
* Branch name

## Implementation Details
* Add `UrlValidator`, a type that validates urls against the supported universal links format(s)
* Update `MainViewModel`, add `handle(_ url: URL)`, which takes urls intercepted by the app, validates them and push the associated article to `HomeViewController`

## Test Steps
* Build/run this branch
* Login if necessary
* Install one or more widgets
* Tap on a widget item
* Verify that it shows correctly, regardless where you were in the app
* Go back, and verify you are on Home

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
