### PR TITLE
feat(sync): reset persistent container on load error

### DIFF
--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -7,11 +7,20 @@ import SwiftUI
 
 @main
 struct PocketApp: App {
+    @Environment(\.scenePhase)
+    var scenePhase
+
     @UIApplicationDelegateAdaptor var delegate: PocketAppDelegate
 
     var body: some Scene {
         WindowGroup {
             RootView(model: RootViewModel())
+        }.onChange(of: scenePhase) { newValue in
+            switch newValue {
+            case .active:
+                delegate.scenePhaseDidChange(scenePhase)
+            default: return
+            }
         }
     }
 }

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -332,3 +332,7 @@
 // Collection
 "collection.title" = "Collection";
 "collection.stories.count" = "%@ items";
+
+// Errors
+"error.problemOccurred" = "A problem occurred";
+"error.redownloading" = "We are re-downloading your saved articles to improve your experience.";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -188,6 +188,12 @@ public enum Localization {
       }
     }
   }
+  public enum Error {
+    /// A problem occurred
+    public static let problemOccurred = Localization.tr("Localizable", "error.problemOccurred", fallback: "A problem occurred")
+    /// We are re-downloading your saved articles to improve your experience.
+    public static let redownloading = Localization.tr("Localizable", "error.redownloading", fallback: "We are re-downloading your saved articles to improve your experience.")
+  }
   public enum Favourites {
     public enum Empty {
       /// Hit the star icon to favorite an article and find it faster.

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -12,7 +12,7 @@ import Kingfisher
 import Network
 
 struct Services {
-    static let shared: Services = { Services() }()
+    static let shared: Services = Services()
 
     let userDefaults: UserDefaults
     let appSession: AppSession
@@ -218,6 +218,13 @@ struct Services {
         recommendationsWidgetUpdateService = RecommendationsWidgetUpdateService(store: UserDefaultsItemWidgetsStore(userDefaults: userDefaults, key: .recommendationsWidget))
         widgetsSessionService = UserDefaultsWidgetSessionService(defaults: userDefaults)
         urlValidator = UrlValidator()
+    }
+
+    /// Starts up all services as required.
+    /// - Parameter onReset: The function to call if a service has been reset.
+    /// - Note: `onReset` can be called when a migration within the persistent container fails
+    func start(onReset: @escaping () -> Void) {
+        persistentContainer.load(onReset: onReset)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/UserManagementService.swift
+++ b/PocketKit/Sources/PocketKit/UserManagementService.swift
@@ -41,6 +41,16 @@ final class UserManagementService: ObservableObject, UserManagementServiceProtoc
                 }
             }
             .store(in: &subscriptions)
+
+        notificationCenter
+            .publisher(for: .migrationError)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                Task {
+                    await self.logout()
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     func deleteAccount() async throws {

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -18,6 +18,10 @@ class MainViewController: UIViewController {
     }
 
     convenience init(services: Services) {
+        services.start {
+            services.userDefaults.set(true, forKey: .forceRefreshFromExtension)
+        }
+
         Textiles.initialize()
 
         let appSession = services.appSession

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -61,4 +61,11 @@ struct Services {
 
         userManagementService = SaveToUserManagementService(appSession: appSession, user: user, notificationCenter: notificationCenter)
     }
+
+    /// Starts up all services as required.
+    /// - Parameter onReset: The function to call if a service has been reset.
+    /// - Note: `onReset` can be called when a migration within the persistent container fails.
+    func start(onReset: @escaping () -> Void) {
+        persistentContainer.load(onReset: onReset)
+    }
 }

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -11,4 +11,5 @@ public extension Notification.Name {
     static let bannerRequested = Notification.Name("com.mozilla.pocket.bannerRequested")
     static let serverError = Notification.Name("com.mozilla.pocket.serverError")
     static let unauthorizedResponse = Notification.Name("com.mozilla.pocket.unauthorizedResponse")
+    static let migrationError = Notification.Name("com.mozilla.pocket.migrationError")
 }

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -36,6 +36,7 @@ public extension UserDefaults {
         case widgetsLoggedIn = "RecentSavesWidgetLoggedInKey"
         case recentSavesWidget = "RecentSavesWidgetKey"
         case recommendationsWidget = "RecommendationsWidgetKey"
+        case forceRefreshFromExtension = "ForceRefreshFromExtentionKey"
 
         var isRemovable: Bool {
             switch self {

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -5,7 +5,11 @@
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -5,7 +5,11 @@
 import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -7,7 +7,11 @@ import CoreData
 @testable import Sync
 
 extension PersistentContainer {
-    static let testContainer = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+    static let testContainer: PersistentContainer = {
+        let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
+        container.load { }
+        return container
+    }()
 }
 
 extension Space {


### PR DESCRIPTION
Cherry-picks the persistent container crash fix from the `release/v8.0.7` branch, which is the only non-existent change when compared to develop

feat(sync): refresh all coordinators on persistent store reset

feat(sync): present banner on persistent store reset

feat(sync): present banner on persistent store reset

refactor(sync): start services in app delegate

feat(sync): start services on share extension launch

feat(sync): refresh app on persistent container reset from share extension

refactor(sync): start services earlier in-app

refactor(sync): cleanup self capture

docs(sync): add docs to relating to persistent container resets

feat(sync): add breadcrumb to persistent container reset

refactor: clean up scene phase change usage