### PR TITLE
fix(leaks):

### DIFF
--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -7,14 +7,16 @@ import SwiftUI
 
 @main
 struct PocketApp: App {
+    @UIApplicationDelegateAdaptor var delegate: PocketAppDelegate
+
     @Environment(\.scenePhase)
     var scenePhase
 
-    @UIApplicationDelegateAdaptor var delegate: PocketAppDelegate
+    let rootViewModel = RootViewModel()
 
     var body: some Scene {
         WindowGroup {
-            RootView(model: RootViewModel())
+            RootView(model: rootViewModel)
         }.onChange(of: scenePhase) { newValue in
             delegate.scenePhaseDidChange(scenePhase)
         }


### PR DESCRIPTION
## Summary
* This PR prevents memory leaks and multiple instantiations of objects due to `WindowGroup` being called multiple times after we capture `scenePhase`, by injecting reference types generating from `RootViewModel` instead of instantiating it inside `WindowGroup`

## References 
* NA

## Implementation Details
* Update PocketApp, inject `RootViewModel` instead of instantiating it inside` WindowGroup`

## Test Steps
* Look into the memory graph and make sure there are no multiple instances of `HomeViewModel` or `MainViewModel`

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
