### PR TITLE
Cherry Pick Release v8.0.8 into develop and other fixes

### DIFF
--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -12,13 +12,18 @@ struct PocketApp: App {
     @Environment(\.scenePhase)
     var scenePhase
 
-    let rootViewModel = RootViewModel()
+    let rootViewModel: RootViewModel
+
+    init() {
+        self.rootViewModel = RootViewModel()
+        rootViewModel.start()
+    }
 
     var body: some Scene {
         WindowGroup {
             RootView(model: rootViewModel)
         }.onChange(of: scenePhase) { newValue in
-            delegate.scenePhaseDidChange(scenePhase)
+            rootViewModel.scenePhaseDidChange(newValue)
         }
     }
 }

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -325,7 +325,7 @@
 "itemWidgets.recentSaves.emptyMessage" = "Start building your Pocket list.";
 "itemWidgets.recentSaves.title" = "Recent Saves";
 "itemWidgets.recentSaves.description" = "Access your most recently saved articles.";
-"itemWidgets.recommendations.emptyMessage" = "You might be offline. Please check recommendations in your Pocket app";
+"itemWidgets.recommendations.emptyMessage" = "You might be offline. Please check your network connection.";
 "itemWidgets.recommendations.title" = "Recommendations";
 "itemWidgets.recommendations.description" = "Discover the most thought-provoking stories out there, curated by Pocket.";
 

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -288,8 +288,8 @@ public enum Localization {
     public enum Recommendations {
       /// Discover the most thought-provoking stories out there, curated by Pocket.
       public static let description = Localization.tr("Localizable", "itemWidgets.recommendations.description", fallback: "Discover the most thought-provoking stories out there, curated by Pocket.")
-      /// You might be offline. Please check recommendations in your Pocket app
-      public static let emptyMessage = Localization.tr("Localizable", "itemWidgets.recommendations.emptyMessage", fallback: "You might be offline. Please check recommendations in your Pocket app")
+      /// You might be offline. Please check your network connection.
+      public static let emptyMessage = Localization.tr("Localizable", "itemWidgets.recommendations.emptyMessage", fallback: "You might be offline. Please check your network connection.")
       /// Recommendations
       public static let title = Localization.tr("Localizable", "itemWidgets.recommendations.title", fallback: "Recommendations")
     }

--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -65,9 +65,9 @@ class AppBadgeSetup {
     }
 
     private func updateBadgeValue(numberOfSaves: Int) {
-//        DispatchQueue.main.async { [weak self] in
-//            self?.badgeProvider.applicationIconBadgeNumber = numberOfSaves
-//            self?.completion?()
-//        }
+        DispatchQueue.main.async { [weak self] in
+            self?.badgeProvider.applicationIconBadgeNumber = numberOfSaves
+            self?.completion?()
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
+++ b/PocketKit/Sources/PocketKit/AppBadgeTracker.swift
@@ -65,9 +65,9 @@ class AppBadgeSetup {
     }
 
     private func updateBadgeValue(numberOfSaves: Int) {
-        DispatchQueue.main.async { [weak self] in
-            self?.badgeProvider.applicationIconBadgeNumber = numberOfSaves
-            self?.completion?()
-        }
+//        DispatchQueue.main.async { [weak self] in
+//            self?.badgeProvider.applicationIconBadgeNumber = numberOfSaves
+//            self?.completion?()
+//        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -37,6 +37,8 @@ class ReadableViewController: UIViewController {
 
     private var subscriptions: [AnyCancellable] = []
 
+    private var isReloading = false
+
     private var userScrollProgress: IndexPath?
 
     private lazy var collectionView: UICollectionView = UICollectionView(
@@ -129,8 +131,11 @@ class ReadableViewController: UIViewController {
     }
 
     private func reload() {
+        guard !isReloading else { return }
+        isReloading = true
         presenters?.forEach { $0.clearCache() }
         collectionView.reloadData()
+        isReloading = false
     }
 
     private func updateContent() {

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -745,6 +745,7 @@ extension HomeViewModel: NSFetchedResultsControllerDelegate {
 
         if isOffline {
             // If we are offline don't try and do anything with Slates, and let the snapshot show the offline
+            setRecommendationsWidgetOffline()
             self.snapshot = newSnapshot
             return
         }
@@ -790,7 +791,7 @@ private extension HomeViewModel {
 private extension HomeViewModel {
     func updateRecommendationsWidget() {
         guard let sections = recomendationsController.sections, !sections.isEmpty else {
-            recommendationsWidgetUpdateService.update([:])
+            setRecommendationsWidgetOffline()
             return
         }
 
@@ -800,5 +801,9 @@ private extension HomeViewModel {
             }
         }
         recommendationsWidgetUpdateService.update(topics)
+    }
+
+    func setRecommendationsWidgetOffline() {
+        recommendationsWidgetUpdateService.update([:])
     }
 }

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -54,11 +54,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.notificationCenter = services.notificationCenter
 
         super.init()
-
-        services.start { [weak self] in
-            guard let self else { return }
-            self.persistentContainerDidReset()
-        }
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -165,21 +160,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         return PocketAppDelegate.phoneOrientationLock
     }
 
-    /// Called when a `ScenePhase` change to active has been detected by the SwiftUI
-    ///  lifecycle (in `PocketApp`, forwarded to here.
-    public func scenePhaseDidChange(_ scenePhase: ScenePhase) {
-        switch scenePhase {
-        case .active:
-            // Upon becoming active, if an extension (e.g SaveTo) requested that we force-refresh the app (e.g due to a
-            // persistent container reset), then perform the same reset logic as if the app had explicitly performed a reset.
-            if userDefaults.bool(forKey: .forceRefreshFromExtension) {
-                persistentContainerDidReset()
-                userDefaults.set(false, forKey: .forceRefreshFromExtension)
-            }
-        default: return
-        }
-    }
-
     /// Attempt to migrate a legacy (v7) account to v8
     func migrateLegacyAccount() {
         let legacyUserMigration = LegacyUserMigration(
@@ -245,23 +225,5 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             environment: environment
         )
         Adjust.appDidLaunch(adjustConfig)
-    }
-
-    /// Performs actions based on the result of the Services persistent container being reset.
-    func persistentContainerDidReset() {
-        // Since there will be a loss of on-disk data during a reset (read: destroy / add), we want
-        // to perform the same type of sync we would on initial login. An example use case is Home - there is
-        // a possibility that Home _had_ content, but the app was updated (with a failed migration) before the
-        // next allowed refresh interval for Home. Thus, Home wouldn't load data. This is similar across other
-        // portions of the app, such as a user's items.
-        refreshCoordinators.forEach { $0.refresh(isForced: true) { } }
-
-        // Upon reset, let the user know (as a toast) that a problem occurred, and that we're redownloading their data
-        let data = BannerModifier.BannerData(
-            image: .error,
-            title: Localization.Error.problemOccurred,
-            detail: Localization.Error.redownloading
-        )
-        notificationCenter.post(name: .bannerRequested, object: data)
     }
 }

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -29,6 +29,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
     private let notificationRelay: NotificationRelay
     private let featureFlags: FeatureFlagServiceProtocol
     private let notificationCenter: NotificationCenter
+    private var appBadgeSetup: AppBadgeSetup?
 
     let notificationService: PushNotificationService
 
@@ -146,6 +147,12 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             // listens for log in / out events to appropriately start / stop.
             subscriptionStore.start()
         }
+
+        appBadgeSetup = AppBadgeSetup(
+            source: source,
+            userDefaults: userDefaults,
+            badgeProvider: application
+        )
 
         return true
     }

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -35,7 +35,6 @@ struct Services {
     let v3Client: V3ClientProtocol
     let instantSync: InstantSyncProtocol
     let braze: BrazeProtocol
-    let appBadgeSetup: AppBadgeSetup
     let subscriptionStore: SubscriptionStore
     let userManagementService: UserManagementServiceProtocol
     let lastRefresh: LastRefresh
@@ -181,11 +180,6 @@ struct Services {
             instantSync: instantSync
         )
 
-        appBadgeSetup = AppBadgeSetup(
-            source: source,
-            userDefaults: userDefaults,
-            badgeProvider: UIApplication.shared
-        )
         subscriptionStore = PocketSubscriptionStore(user: user, receiptService: AppStoreReceiptService(client: v3Client))
 
         userManagementService = UserManagementService(

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -218,7 +218,9 @@ struct Services {
     /// - Parameter onReset: The function to call if a service has been reset.
     /// - Note: `onReset` can be called when a migration within the persistent container fails
     func start(onReset: @escaping () -> Void) {
-        persistentContainer.load(onReset: onReset)
+        if persistentContainer.didReset {
+            onReset()
+        }
     }
 }
 

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -11,17 +11,23 @@ import Sync
 import Adjust
 
 class MainViewController: UIViewController {
-    private let childViewController: UIViewController
+    static let services: Services = {
+        let services = Services.shared
 
-    convenience init() {
-        self.init(services: .shared)
-    }
-
-    convenience init(services: Services) {
         services.start {
             services.userDefaults.set(true, forKey: .forceRefreshFromExtension)
         }
 
+        return services
+    }()
+
+    private let childViewController: UIViewController
+
+    convenience init() {
+        self.init(services: Self.services)
+    }
+
+    convenience init(services: Services) {
         Textiles.initialize()
 
         let appSession = services.appSession

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -128,7 +128,7 @@ class MainViewController: UIViewController {
                 viewModel: SavedItemViewModel(
                     appSession: appSession,
                     saveService: services.saveService,
-                    dismissTimer: Timer.TimerPublisher(interval: 60.0, runLoop: .main, mode: .default),
+                    dismissTimer: Timer.TimerPublisher(interval: 3.0, runLoop: .main, mode: .default),
                     tracker: Services.shared.tracker.childTracker(hosting: .saveExtension.screen),
                     consumerKey: Keys.shared.pocketApiConsumerKey,
                     userDefaults: userDefaults,

--- a/PocketKit/Sources/SaveToPocketKit/Services.swift
+++ b/PocketKit/Sources/SaveToPocketKit/Services.swift
@@ -66,6 +66,8 @@ struct Services {
     /// - Parameter onReset: The function to call if a service has been reset.
     /// - Note: `onReset` can be called when a migration within the persistent container fails.
     func start(onReset: @escaping () -> Void) {
-        persistentContainer.load(onReset: onReset)
+        if persistentContainer.didReset {
+            onReset()
+        }
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/ItemContent.swift
+++ b/PocketKit/Sources/SharedPocketKit/ItemContent.swift
@@ -25,7 +25,7 @@ public struct ItemContentContainer: Codable, Equatable {
 }
 
 /// A Core Data agnostic version of an `Item`.
-public struct ItemContent: Codable, Equatable {
+public struct ItemContent: Codable {
     public let url: String
     public let title: String
     public let imageUrl: String?
@@ -59,6 +59,12 @@ public struct ItemContent: Codable, Equatable {
         components.path = "/app/openURL"
         components.queryItems = [URLQueryItem(name: "url", value: url)]
         return components.url!
+    }
+}
+
+extension ItemContent: Equatable {
+    public static func == (lhs: ItemContent, rhs: ItemContent) -> Bool {
+        return lhs.url == rhs.url
     }
 }
 

--- a/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/RetriableOperation.swift
@@ -98,7 +98,8 @@ class RetriableOperation: AsyncOperation {
     private func clearPersistentTask() {
         do {
             Log.info("Deleting persistent task with objectID \(self.syncTaskId)")
-            try space.delete([self.syncTaskId], for: PersistentSyncTask.entity())
+            guard let task = space.backgroundObject(with: syncTaskId) as? PersistentSyncTask else { return }
+            space.delete(task)
             try space.save()
         } catch {
             Log.capture(error: error)

--- a/PocketKit/Sources/Sync/PersistentContainer.swift
+++ b/PocketKit/Sources/Sync/PersistentContainer.swift
@@ -63,9 +63,6 @@ public class PersistentContainer: NSPersistentContainer {
         storeDescription.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
         storeDescription.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         storeDescription.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
-
-        spotlightIndexer = CoreDataSpotlightDelegate(forStoreWith: storeDescription, coordinator: self.persistentStoreCoordinator)
-        spotlightIndexer?.startSpotlightIndexing()
     }
 
     /// Attempts to load the persistent container. If the load errors, the persistent container
@@ -86,6 +83,10 @@ public class PersistentContainer: NSPersistentContainer {
                 }
             }
         }
+
+        guard let storeDescription = persistentStoreDescriptions.first else { return }
+        spotlightIndexer = CoreDataSpotlightDelegate(forStoreWith: storeDescription, coordinator: self.persistentStoreCoordinator)
+        spotlightIndexer?.startSpotlightIndexing()
     }
 }
 

--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecommendationsWidgetsUpdateService.swift
@@ -24,7 +24,7 @@ public struct RecommendationsWidgetUpdateService {
     public func update(_ topics: [String: [Recommendation]]) {
         let newTopics: [ItemContentContainer] = topics.map { makeItemContentContainer($0.key, $0.value) }
         // avoid triggering widget updates if stored data did not change
-        guard store.topics != newTopics else {
+        guard (store.topics.sorted { $0.name > $1.name }) != (newTopics.sorted { $0.name > $1.name }) else {
             return
         }
         recommendationsUpdateQueue.async {

--- a/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -7,7 +7,6 @@
 extension PersistentContainer {
     static let testContainer: PersistentContainer = {
         let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
-        container.load { }
         return container
     }()
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/PersistentContainer+testContainer.swift
@@ -7,7 +7,6 @@ import Sync
 extension PersistentContainer {
     static let testContainer: PersistentContainer = {
         let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
-        container.load { }
         return container
     }()
 }

--- a/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
+++ b/PocketKit/Tests/SyncTests/Support/PersistentContainer+testContainer.swift
@@ -9,7 +9,6 @@ import CoreData
 extension PersistentContainer {
     static let testContainer: PersistentContainer = {
         let container = PersistentContainer(storage: .inMemory, groupID: "group.com.ideashower.ReadItLaterPro")
-        container.load { }
         return container
     }()
 }


### PR DESCRIPTION
## Summary
* Add the hot fix `v8.0.8` to `develop`
* This PR also fixes: 
    * unit tests reflecting `PersistentContainer` refactor
    * Recommendations widget 
       * avoid unnecessary updates
       * improve offline handling
    * Dismiss timer on `SavedItemViewController`/`SavedItemViewModel`, resetting it back to 3 seconds (was 60)
    * A lag when loading a saved item from the Recent Saves widget

## References 
* NA

## Implementation Details
* See summary

## Test Steps
* Build/run this branch
* Save an item via the share extension, and make sure that:
   * your pre-existing items still appear in Saves
   * The share screen disappears after a few seconds (3)
* Install a recommendations widget
* Tap an entry and make sure that it opens in the app
* Go back to the widget and make sure the content does not update multiple times right after it shows on screen
* Go offline, and make sure the recommendations widget shows the offline message. Double check that the Home Screen in the app also shows offline
* Go back online and make sure recommendations reappear in the widget (and in the app, to double check)
* Install a recent saves widget
* Tap on an item and make sure it appears in the app without significant delays

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
