### PR TITLE
Widgets - Add analytics event for opening recent saves or recommendations from a widget

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Widgets.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Widgets.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+public extension Events {
+    struct Widgets {}
+}
+
+public extension Events.Widgets {
+    /// Fired when a user taps a card in the `Recent Saves Widget`
+    static func RecentSavesCardContentOpen(url: String) -> ContentOpen {
+        return ContentOpen(
+            contentEntity:
+                ContentEntity(url: url),
+            uiEntity: UiEntity(
+                .card,
+                identifier: "widget.recent.open"
+            )
+        )
+    }
+
+     /// Fired when a user taps a card in the `Recommendations Widget`
+    static func SlateArticleContentOpen(url: String, recommendationId: String, destination: ContentOpen.Destination) -> ContentOpen {
+        return ContentOpen(
+            destination: destination,
+            contentEntity:
+                ContentEntity(url: url),
+            uiEntity: UiEntity(
+                .card,
+                identifier: "widget.slate.article.open"
+            ),
+            extraEntities: [
+                ContentEntity(url: url),
+                CorpusRecommendationEntity(id: recommendationId)
+            ]
+        )
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -351,7 +351,50 @@ extension HomeViewModel {
         }
 
         let givenURL = item.givenURL
-        tracker.track(event: Events.Home.SlateArticleContentOpen(url: givenURL, positionInList: indexPath?.item, slateId: slate.remoteID, slateRequestId: slate.requestID, slateExperimentId: slate.experimentID, slateIndex: indexPath?.section, slateLineupId: slateLineup.remoteID, slateLineupRequestId: slateLineup.requestID, slateLineupExperimentId: slateLineup.experimentID, recommendationId: recommendation.analyticsID, destination: destination))
+        trackSlateArticleOpen(
+            url: givenURL,
+            positionInList: indexPath?.item,
+            slateIndex: indexPath?.section,
+            slate: slate,
+            slateLineup: slateLineup,
+            destination: destination,
+            recommendationId: recommendation.analyticsID,
+            source: readableSource
+        )
+    }
+
+    private func trackSlateArticleOpen(
+        url: String,
+        positionInList: Int?,
+        slateIndex: Int?,
+        slate: Slate,
+        slateLineup: SlateLineup,
+        destination: ContentOpen.Destination,
+        recommendationId: String,
+        source: ReadableSource
+    ) {
+        switch source {
+        case .app:
+            tracker.track(event: Events.Home.SlateArticleContentOpen(
+                url: url,
+                positionInList: positionInList,
+                slateId: slate.remoteID,
+                slateRequestId: slate.requestID,
+                slateExperimentId: slate.experimentID,
+                slateIndex: slateIndex,
+                slateLineupId: slateLineup.remoteID,
+                slateLineupRequestId: slateLineup.requestID,
+                slateLineupExperimentId: slateLineup.experimentID,
+                recommendationId: recommendationId,
+                destination: destination
+            ))
+        case .widget:
+            tracker.track(event: Events.Widgets.SlateArticleContentOpen(
+                url: url,
+                recommendationId: recommendationId,
+                destination: destination
+            ))
+        }
     }
 
     func select(savedItem: SavedItem, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app) {
@@ -388,7 +431,16 @@ extension HomeViewModel {
                 selectedReadableType = .savedItem(viewModel)
             }
         }
-        tracker.track(event: Events.Home.RecentSavesCardContentOpen(url: savedItem.url, positionInList: indexPath?.item))
+        trackRecentSavesOpen(url: savedItem.url, positionInList: indexPath?.item, source: readableSource)
+    }
+
+    private func trackRecentSavesOpen(url: String, positionInList: Int?, source: ReadableSource) {
+        switch source {
+        case .app:
+            tracker.track(event: Events.Home.RecentSavesCardContentOpen(url: url, positionInList: positionInList))
+        case .widget:
+            tracker.track(event: Events.Widgets.RecentSavesCardContentOpen(url: url))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
* This PR adds new `content_open` Identifiers to track items opened from a widget

## References 
* in branch name

## Implementation Details
* Add `Events.Widgets` to track `content_open` events from a widget. There are two new identifiers
    * `widget.recent.open` (recent saves)
    * `widget.slate.article.open` (recommendations)
* Update `HomeViewModel` to track the appropriate event identifier depending if an item is being opened from Home or a Widget

## Test Steps
* Build/run this branch
* Run SnowPlow micro (follow instructions on Confluence under "Testing Analytics for iOS Next")
> [!NOTE]
> When editing the scheme to run snowplow micro, make sure all the necessary arguments are selected, otherwise the events could be mistakenly be marked as `bad` or just not be recorded.
* Install one or more widget(s)
* Tap one or more items, then query snowplow micro and make sure that the event identifiers listed above appear in the `good` list

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
