### PR TITLE
fix(syndication): add syndicated icon to collections stories

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -43,7 +43,8 @@ extension CollectionStoryViewModel: RecommendationCellViewModel {
     }
 
     var attributedDomain: NSAttributedString {
-        NSAttributedString(string: domain ?? "", style: .recommendation.domain)
+        let detailString = NSMutableAttributedString(string: domain ?? "", style: .recommendation.domain)
+        return collectionStory.item?.isSyndicated == true ? detailString.addSyndicatedIndicator(with: .recommendation.domain) : detailString
     }
 
     var attributedExcerpt: NSAttributedString? {

--- a/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
@@ -41,7 +41,7 @@ class RecentSavesItemCell: HomeCarouselItemCell {
 
         var attributedDomain: NSAttributedString {
             let detailString = NSMutableAttributedString(string: domain ?? "", style: .recommendation.domain)
-            return item.isSyndicated ?? false ? detailString.addSyndicatedIndicator(with: .recommendation.domain) : detailString
+            return item.isSyndicated ? detailString.addSyndicatedIndicator(with: .recommendation.domain) : detailString
         }
 
         var attributedTimeToRead: NSAttributedString {


### PR DESCRIPTION
## Summary
Add syndicated article checkmark to collection stories (missed this one!)

## References 
IN-1580

## Implementation Details
See implementation details here: 
https://github.com/Pocket/pocket-ios/pull/855

## Test Steps
1. Navigate to Popular Collections
2. Find this collection: https://getpocket.com/collections/you-can-procrastinate-laterheres-how-to-get-things-done-now?utm_source=pocket_collection
3. Navigate down to the story called "Procrastinate Better" (see screenshot)

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 14 - 2023-09-01 at 12 29 43](https://github.com/Pocket/pocket-ios/assets/6743397/d552b6ab-ce03-4944-b4be-9fc8b90e68cd)
