### PR TITLE
project: add pocket url type

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -50,6 +50,16 @@
 				<string>pocket-next</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.mozilla.pocket</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pocket</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
+++ b/PocketKit/Sources/Sync/Widgets/ItemWidgets/RecentSavesWidgetUpdateService.swift
@@ -55,7 +55,9 @@ public struct RecentSavesWidgetUpdateService {
         if let index = currentItems.firstIndex(where: { $0.url == savedItem.url }) {
             currentItems.remove(at: index)
         } else {
-            currentItems.removeLast()
+            if currentItems.isEmpty == false {
+                currentItems.removeLast()
+            }
         }
 
         let newItem = ItemContent(

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -40,7 +40,8 @@ class SavedItemViewModelTests: XCTestCase {
             consumerKey: consumerKey ?? self.consumerKey,
             userDefaults: userDefaults ?? self.userDefaults,
             user: user ?? self.user,
-            notificationCenter: notificationCenter ?? self.notificationCenter
+            notificationCenter: notificationCenter ?? self.notificationCenter,
+            recentSavesWidgetUpdateService: RecentSavesWidgetUpdateService(store: MockRecentSavesWidgetStore())
         )
     }
 

--- a/PocketKit/Tests/SaveToPocketKitTests/Support/MockRecentSavesWidgetStore.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/Support/MockRecentSavesWidgetStore.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sync
+import SharedPocketKit
+
+class MockRecentSavesWidgetStore: ItemWidgetsStore {
+    var topics: [SharedPocketKit.ItemContentContainer] = []
+    var kind: Sync.ItemWidgetKind = .unknown
+    func updateTopics(_ topics: [SharedPocketKit.ItemContentContainer]) throws { }
+}

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -39,8 +39,7 @@ class PocketSaveServiceTests: XCTestCase {
             apollo: client ?? self.client,
             expiringActivityPerformer: backgroundActivityPerformer ?? self.backgroundActivityPerformer,
             space: space ?? self.space,
-            osNotifications: osNotificationCenter ?? self.osNotificationCenter,
-            recentSavesWidgetUpdateService: RecentSavesWidgetUpdateService(store: MockRecentSavesWidgetStore())
+            osNotifications: osNotificationCenter ?? self.osNotificationCenter
         )
     }
 


### PR DESCRIPTION
Adds the `pocket` custom URL type to the project. I'm wondering if this will help with the sign-in problem on Sonoma…
