### PR TITLE
fix(strings): remove translations for collections + saves

### DIFF
--- a/PocketKit/Sources/Localization/Localization+Constants.swift
+++ b/PocketKit/Sources/Localization/Localization+Constants.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Strings that should not be translated
+extension Localization {
+    public enum Constants {
+        public static let collection = "Collection"
+        public static let saves = "Saves"
+    }
+}

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -243,8 +243,6 @@
 "Share" = "Share";
 "carousel.listen" = "Listen";
 
-"Saves" = "Saves";
-
 "Display Settings" = "Display settings";
 "Font" = "Font";
 "Font Size" = "Font size";
@@ -330,7 +328,6 @@
 "itemWidgets.recommendations.description" = "Discover the most thought-provoking stories out there, curated by Pocket.";
 
 // Collection
-"collection.title" = "Collection";
 "collection.stories.count" = "%@ items";
 
 // Errors

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -108,8 +108,6 @@ public enum Localization {
   public static let saveWhatReallyInterestsYou = Localization.tr("Localizable", "Save what really interests you", fallback: "Save what really interests you")
   /// Saved
   public static let saved = Localization.tr("Localizable", "Saved", fallback: "Saved")
-  /// Saves
-  public static let saves = Localization.tr("Localizable", "Saves", fallback: "Saves")
   /// See all
   public static let seeAll = Localization.tr("Localizable", "See All", fallback: "See all")
   /// Settings
@@ -179,8 +177,6 @@ public enum Localization {
     public static let listen = Localization.tr("Localizable", "carousel.listen", fallback: "Listen")
   }
   public enum Collection {
-    /// Collection
-    public static let title = Localization.tr("Localizable", "collection.title", fallback: "Collection")
     public enum Stories {
       /// %@ items
       public static func count(_ p1: Any) -> String {

--- a/PocketKit/Sources/PocketKit/Collections/CollectionMetadata.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionMetadata.swift
@@ -25,7 +25,7 @@ struct CollectionMetadata {
     var attributedByline: NSAttributedString? {
         let byline = NSMutableAttributedString()
 
-        byline.append(NSAttributedString(string: Localization.Collection.title, style: .collection.collection))
+        byline.append(NSAttributedString(string: Localization.Constants.collection, style: .collection.collection))
 
         if !byline.string.isEmpty {
             byline.append(NSAttributedString(string: " • ", style: .collection.authors))

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -35,7 +35,7 @@ struct CollectionStoryViewModel: Hashable {
 extension CollectionStoryViewModel: RecommendationCellViewModel {
     var attributedCollection: NSAttributedString? {
         guard collectionStory.item?.isCollection == true else { return nil }
-        return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+        return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
     }
 
     var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeRecommendationCellViewModel.swift
@@ -33,7 +33,7 @@ class HomeRecommendationCellViewModel {
 extension HomeRecommendationCellViewModel: RecommendationCellViewModel {
     var attributedCollection: NSAttributedString? {
         guard recommendation.item.isCollection else { return nil }
-        return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+        return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
     }
 
     var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecentSavesItemCell.swift
@@ -32,7 +32,7 @@ class RecentSavesItemCell: HomeCarouselItemCell {
 
         var attributedCollection: NSAttributedString? {
             guard item.isCollection else { return nil }
-            return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+            return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
         }
 
         var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/RecommendationCarouselCell.swift
@@ -38,7 +38,7 @@ class RecommendationCarouselCell: HomeCarouselItemCell {
 
         var attributedCollection: NSAttributedString? {
             guard viewModel.recommendation.item.isCollection else { return nil }
-            return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+            return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
         }
 
         var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -37,7 +37,7 @@ public struct MainView: View {
                         } else {
                             Image(asset: .tabSavesDeselected)
                         }
-                        Text(Localization.saves)
+                        Text(Localization.Constants.saves)
                     }
                     .accessibilityIdentifier("saves-tab-bar-button")
                     .tag(MainViewModel.AppSection.saves)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListItemPresenter.swift
@@ -48,7 +48,7 @@ class ItemsListItemPresenter {
 
     var attributedCollection: NSAttributedString? {
         guard item.isCollection else { return nil }
-        return NSAttributedString(string: Localization.Collection.title, style: .recommendation.collection)
+        return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
     }
 
     var attributedTitle: NSAttributedString {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -27,7 +27,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     var selectionItem: SelectionItem {
         switch self.viewType {
         case .saves:
-            return SelectionItem(title: Localization.saves, image: .init(asset: .saves), selectedView: SelectedView.saves)
+            return SelectionItem(title: Localization.Constants.saves, image: .init(asset: .saves), selectedView: SelectedView.saves)
         case .archive:
             return SelectionItem(title: Localization.archive, image: .init(asset: .archive), selectedView: SelectedView.archive)
         }
@@ -669,7 +669,7 @@ extension SavedItemsListViewModel {
             var title: String = ""
             switch viewType {
             case .saves:
-                title = Localization.saves
+                title = Localization.Constants.saves
             case .archive:
                 title = Localization.archive
             }


### PR DESCRIPTION
## Summary
Remove strings `Collection` and `Saves` from being translated into its own enum

## References 
IN-1628

## Implementation Details
Create a new file that extends `Localization` and create a new enum `Constants` to hold strings that should not be translated.

## Test Steps
1. Run the application and verify the `Collection` and `Saves` are not being localized as they are feature names.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| Saves | Collection |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 - 2023-09-05 at 15 31 47](https://github.com/Pocket/pocket-ios/assets/6743397/34ffc8aa-ad11-420f-982d-8fe9c9aac39e) | ![Simulator Screenshot - iPhone 14 - 2023-09-05 at 15 32 17](https://github.com/Pocket/pocket-ios/assets/6743397/1e503475-4721-48dc-b9ca-5ee80ddb9d26) |
