### PR TITLE
fix(saveto): fall back to attempting public.url items as Data

### DIFF
--- a/PocketKit/Tests/SharedPocketKitTests/URLExtractorTests.swift
+++ b/PocketKit/Tests/SharedPocketKitTests/URLExtractorTests.swift
@@ -26,6 +26,26 @@ class URLExtractorTests: XCTestCase {
         XCTAssertEqual(extracted, "https://getpocket.com")
     }
 
+    func test_extract_whenItemProviderHasURL_asData_returnsURL() async {
+        let itemProvider = MockItemProvider()
+        itemProvider.stubHasItemConformingToTypeIdentifier { id in
+            return id == "public.url"
+        }
+        itemProvider.stubLoadItem { _, _ in
+            URL(string: "https://getpocket.com")!.dataRepresentation as NSSecureCoding
+        }
+
+        var extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+
+        itemProvider.stubLoadItem { _, _ in
+            URL(string: "https%3a%2f%2fgetpocket.com")! as NSSecureCoding
+        }
+
+        extracted = await URLExtractor.url(from: itemProvider)
+        XCTAssertEqual(extracted, "https://getpocket.com")
+    }
+
     func test_extract_whenItemProviderHasExternalAppURL_returnsURL() async {
         let itemProvider = MockItemProvider()
         itemProvider.stubHasItemConformingToTypeIdentifier { id in


### PR DESCRIPTION
## Summary

Fixes an issue where the "Save to Pocket" extension would not work when running the app on Apple Silicon.

## Implementation Details

On iOS, a `public.url` item would be provided to us as a `URL` type, but on Apple Silicon, it appears to be `Data`. This pull request introduces some basic logic where we first attempt to use the provided item as a `URL`, falling back to attempting as `Data`.

## Test Steps

- [ ] Install the app on an Apple Silicon machine
- [ ] Enable the "Save to Pocket" extension
- [ ] Open a URL in Safari
- [ ] Share to the "Save to Pocket" extension
- [ ] The item should be saved to your list, and the share extension should note that the item was saved

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
