### PR TITLE
Move the sink to recieve on the main thread, so the following navigat…

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -269,7 +269,7 @@ extension SavesContainerViewController {
             self?.present(activity: activity)
         }.store(in: &subscriptions)
 
-        model.savedItemsList.$selectedItem.sink { [weak self] selectedSavedItem in
+        model.savedItemsList.$selectedItem.receive(on: DispatchQueue.main).sink { [weak self] selectedSavedItem in
             guard let selectedSavedItem = selectedSavedItem else { return }
             self?.navigate(selectedItem: selectedSavedItem)
         }.store(in: &subscriptions)


### PR DESCRIPTION
…ions also happen on the main thread

## Summary
* Include short description of what this PR accomplishes

## References 
https://pocket.sentry.io/issues/4391276315/events/cc8121f80c094eea9e2f2df3ac4b8cf6/

## Implementation Details
Add `.recieve(on: DispatchQueue.main)` to the sink declaration.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
