### PR TITLE
fix(copy): update empty recent searches message

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -95,7 +95,7 @@
 "search.banner.errorMessage." = "We’re experiencing an error and can’t show you full search results. Please try again later.";
 "search.error.view.needsInternet" = "You must have an internet connection to view this item.";
 "search.recent" = "Recent searches";
-"search.recent.empty" = "Recent searches will appear here, so you can easily jump back in.";
+"search.recent.empty" = "Recent searches will appear here so you can jump back in easily.";
 "search.swipe.archive" = "Archive";
 "search.swipe.moveToSaves" = "Move to Saves";
 "search.edit.banner" = "Editing your search results is not available in this version of Pocket, but will be returning soon!";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -471,8 +471,8 @@ public enum Localization {
       }
     }
     public enum Recent {
-      /// Recent searches will appear here, so you can easily jump back in.
-      public static let empty = Localization.tr("Localizable", "search.recent.empty", fallback: "Recent searches will appear here, so you can easily jump back in.")
+      /// Recent searches will appear here so you can jump back in easily.
+      public static let empty = Localization.tr("Localizable", "search.recent.empty", fallback: "Recent searches will appear here so you can jump back in easily.")
     }
     public enum Results {
       public enum Empty {


### PR DESCRIPTION
## Summary
Quick change in search copy

## References 
[IN-1583](https://getpocket.atlassian.net/browse/IN-1583)

## Implementation Details
Update copy language

## Test Steps
1. Navigate to Search for premium user and view the empty recent search page. Confirm that the copy is updated. 

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 14 - 2023-09-06 at 14 12 51](https://github.com/Pocket/pocket-ios/assets/6743397/b46babca-45bc-43a6-9aef-9c6e0f7e23f3)