### PR TITLE
fix(sync): log out on 403

### DIFF
--- a/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClient+Extensions.swift
@@ -126,10 +126,12 @@ private class UnauthorizedErrorInterceptor: ApolloErrorInterceptor {
         completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
     ) where Operation: ApolloAPI.GraphQLOperation {
         // This case will be sent from a ResponseCodeInterceptor, which is a part of the base DefaultInterceptorProvider
-        // that is used by our PrependingUnauthorizedInterceptorProvider. A 401 (Unauthorized) status code
+        // that is used by our PrependingUnauthorizedInterceptorProvider. A 401 (Unauthorized) or 403 (Forbidden)  status code
         // will cause this error to be handled. We can capture it, and post a notification  to then log a user out.
+        let invalidResponseCodes = [401, 403]
         if case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(response: let errorResponse, rawData: _) = error,
-           errorResponse?.statusCode == 401 {
+           let statusCode = errorResponse?.statusCode,
+           invalidResponseCodes.contains(statusCode) {
             NotificationCenter.default.post(name: .unauthorizedResponse, object: nil)
         }
 

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -98,7 +98,10 @@ public class Space {
             for entity in objectModel.entities {
                 let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entity.name!)
                 let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-                try backgroundContext.execute(deleteRequest)
+                deleteRequest.resultType = .resultTypeObjectIDs
+                let result = try backgroundContext.execute(deleteRequest) as? NSBatchDeleteResult
+                let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: result?.result as? [NSManagedObjectID] ?? []]
+                NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [backgroundContext])
             }
             backgroundContext.reset()
         }


### PR DESCRIPTION
## Summary

Update Sync to request a user signout when receiving a 403, in addition to a 401.

## Implementation Details

This adds on to pre-existing functionality where a 401 would sign a user out. Additionally, however, this "improves" logging by not capturing a 403 every time one is captured, since this was using up a _lot_ of Sentry allowance.

## PR Checklist:
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
