### PR TITLE
First Launch - clear session before the session is handled

### DIFF
--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -98,12 +98,6 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             Textiles.clearImageCache()
         }
 
-        SignOutOnFirstLaunch(
-            appSession: appSession,
-            user: user,
-            userDefaults: userDefaults
-        ).signOutOnFirstLaunch()
-
         if let guid = ProcessInfo.processInfo.environment["sessionGUID"],
            let accessToken = ProcessInfo.processInfo.environment["accessToken"],
            let userIdentifier = ProcessInfo.processInfo.environment["sessionUserID"] {

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -221,6 +221,11 @@ struct Services {
         if persistentContainer.didReset {
             onReset()
         }
+        SignOutOnFirstLaunch(
+            appSession: appSession,
+            user: user,
+            userDefaults: userDefaults
+        ).signOutOnFirstLaunch()
     }
 }
 


### PR DESCRIPTION
## Summary
* This PR fixes a bug where, at first launch, users were stuck in an endless loading 

## References 
* NA

## Implementation Details
* move clearing session in `Services.start()`

## Test Steps
* Install `develop` and log in
* Delete the app
* Check out this branch and launch
* Verify that the login screen appears

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
