### PR TITLE
Add localized description to unknown sentry errors

### DIFF
--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -80,8 +80,7 @@ public extension ApolloClientProtocol {
         let skippableErrors = [403]
 
         guard let responseError = error as? ResponseCodeInterceptor.ResponseCodeError else {
-
-            Log.capture(message: "GraphQl Error - unknown error: \(error.localizedDescription)", filename: filename, line: line, column: column, funcName: funcName)
+            Log.capture(message: "GraphQl Error - unknown error: \(error)", filename: filename, line: line, column: column, funcName: funcName)
             return
         }
 

--- a/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
+++ b/PocketKit/Sources/Sync/ApolloClientProtocol+Extensions.swift
@@ -80,7 +80,8 @@ public extension ApolloClientProtocol {
         let skippableErrors = [403]
 
         guard let responseError = error as? ResponseCodeInterceptor.ResponseCodeError else {
-            Log.capture(message: "GraphQl Error - unknown error.", filename: filename, line: line, column: column, funcName: funcName)
+
+            Log.capture(message: "GraphQl Error - unknown error: \(error.localizedDescription)", filename: filename, line: line, column: column, funcName: funcName)
             return
         }
 


### PR DESCRIPTION
## Summary
Unknown errors are our highest cause of Sentry issues.
We check for one style of error and bundle the rest into 'unknown' which gives us no clarity into what is happening.

## References 
https://pocket.sentry.io/issues/4384022246/events/6b995ba2fd1e4736adb57f4a90a8a337/