### PR TITLE
feat(collections): update fonts to use sans-serif [MOSOIOS-52]

### DIFF
--- a/PocketKit/Sources/Textile/Views/Collection/Style+Collection.swift
+++ b/PocketKit/Sources/Textile/Views/Collection/Style+Collection.swift
@@ -6,8 +6,9 @@ public extension Style {
     static let collection = CollectionStyle()
     struct CollectionStyle {
         public let title: Style = .header
-            .serif
-            .title
+            .sansSerif
+            .h2
+            .with(color: .ui.black1)
             .with { (paragraph: ParagraphStyle) -> ParagraphStyle in
                 paragraph.with(lineHeight: .multiplier(0.925))
             }
@@ -19,11 +20,11 @@ public extension Style {
         public let detail: Style = .header.sansSerif.p4
             .with(color: .ui.black1)
 
-        public let excerpt: Style = .header.serif.p1
+        public let excerpt: Style = .header.sansSerif.p3
             .with(weight: .regular)
             .with(color: .ui.black1)
 
-        public let intro: Style = .header.serif.p1
+        public let intro: Style = .header.sansSerif.p3
             .with(color: .ui.black1)
 
         public let collection: Style = .header.sansSerif.p4


### PR DESCRIPTION
## Summary
Use only sans-serif for our native collection views

## References 
[MOSOIOS-52](https://mozilla-hub.atlassian.net/browse/MOSOIOS-52)

## Implementation Details
Update font styling in `CollectionStyle`
Fix some SwiftLint errors

## Test Steps
Navigate to a native collection view
Confirm font styling is only in sans-serif and matches screenshot below

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

![image](https://github.com/Pocket/pocket-ios/assets/6743397/6e6b13e9-72e0-4894-9d97-21849069189f)


[MOSOIOS-52]: https://mozilla-hub.atlassian.net/browse/MOSOIOS-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ