### PR TITLE
fix(tests): update corpus item for ReportARecommendationTests

### DIFF
--- a/Tests iOS/Fixtures/recommendation-detail-2.json
+++ b/Tests iOS/Fixtures/recommendation-detail-2.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "__typename": "[type-name-here]",
+    "itemByUrl": {
+      "remoteID": "recommended-item-2",
+      "__typename": "[some-type-name]",
+      "givenUrl": "https://getpocket.com/explore/item/article-2",
+      "resolvedUrl": "https://getpocket.com/explore/item/article-2",
+      "title": "Slate 1, Recommendation 2",
+      "language": "en",
+      "topImageUrl": "http://example.com/slate-1-rec-2/top-image.png",
+      "timeToRead": 3,
+      "wordCount": 200,
+      "authors": [
+
+      ],
+      "collection": null,
+      "datePublished": "2021-01-01 12:01:01",
+      "images": [
+
+      ],
+      "excerpt": "Cursus Aenean Elit",
+      "domain": "slate-1-rec-2.example.com",
+      "domainMetadata": {
+        "__typename": "DomainMetadata",
+        "name": "Pocket",
+        "logo": "https://getpocket.com/logo.png"
+      },
+      "isArticle": true,
+      "hasImage": "HAS_IMAGES",
+      "hasVideo": "HAS_VIDEOS",
+      "syndicatedArticle": {
+        "__typename": "SyndicatedArticle",
+        "itemId": "recommended-item-2",
+        "title": "Slate 1, Rec 2",
+        "excerpt": "A better syndicated excerpt",
+        "mainImage": "http://example.com/slate-1-rec-2/top-image.png",
+        "publisher": {
+          "__typename": "Publisher",
+          "name": "Mozilla"
+        }
+      },
+      "marticle": #MARTICLE#
+    }
+  }
+}
+

--- a/Tests iOS/ReportARecommendationTests.swift
+++ b/Tests iOS/ReportARecommendationTests.swift
@@ -55,7 +55,7 @@ class ReportARecommendationTests: XCTestCase {
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let event = await snowplowMicro.getFirstEvent(with: "home.slate.article.report")
         event!.getReportContext()!.assertHas(reason: "other")
-        event!.getContentContext()!.assertHas(url: "http://localhost:8080/slate-1-rec-1")
+        event!.getContentContext()!.assertHas(url: "https://getpocket.com/collections/slate-1-rec-1")
     }
 
     @MainActor
@@ -93,7 +93,7 @@ class ReportARecommendationTests: XCTestCase {
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let event = await snowplowMicro.getFirstEvent(with: "home.slate.article.report")
         event!.getReportContext()!.assertHas(reason: "other")
-        event!.getContentContext()!.assertHas(url: "https://example.com/slate-1-rec-2")
+        event!.getContentContext()!.assertHas(url: "https://given.example.com/slate-1-rec-2")
     }
 
     @MainActor
@@ -105,7 +105,7 @@ class ReportARecommendationTests: XCTestCase {
 
         // Swipe down to a syndicated item
         app.homeView.element.swipeUp()
-        app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").wait().tap()
+        app.homeView.recommendationCell("Slate 1, Recommendation 2").wait().tap()
         app.readerView.readerToolbar.moreButton.tap()
         app.reportButton.wait().tap()
         app.reportView.wait()
@@ -113,6 +113,6 @@ class ReportARecommendationTests: XCTestCase {
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let reportEvent = await snowplowMicro.getFirstEvent(with: "reader.toolbar.report")
         reportEvent!.getUIContext()!.assertHas(type: "button")
-        reportEvent!.getContentContext()!.assertHas(url: "https://getpocket.com/explore/item/article-4")
+        reportEvent!.getContentContext()!.assertHas(url: "https://getpocket.com/explore/item/article-2")
     }
 }


### PR DESCRIPTION
## Summary
Fixes the following UI tests:
* ReportARecommendationTests

## References 
MOSOIOS-70

## Implementation Details
* Modify url strings to match those in `corpusSlates.json`
* Update syndicated item to use item-2 instead of item 4 as we had in our old slates.json file

## Test Steps
Run the `ReportARecommendationTests` tests and ensure that it passes locally.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| ReportARecommendation | 
| --- |
| ![image](https://github.com/Pocket/pocket-ios/assets/6743397/dd26a79e-8e5b-4675-9797-98ff7b98cbbc) | 
