### PR TITLE
fix(tests): add corpusItem field to updated-list fixture for PullToRefreshTests

### DIFF
--- a/Tests iOS/Fixtures/updated-list.json
+++ b/Tests iOS/Fixtures/updated-list.json
@@ -76,6 +76,7 @@
               "isArchived": false,
               "isFavorite": false,
               "tags": [],
+              "corpusItem": null,
               "item": {
                 "__typename": "Item",
                 "remoteID": "item-2",


### PR DESCRIPTION
## Summary
Fixes the following UI tests:
* PullToRefreshTests

## References 
MOSOIOS-69

## Implementation Details
* Add corpusItem field to all items in the `updated-list` fixture

## Test Steps
Run the `PullToRefreshTests` tests and ensure that it passes locally.

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| PullToRefreshTests | 
| --- |
| ![image](https://github.com/Pocket/pocket-ios/assets/6743397/32ef0a43-50d3-43ae-bc1d-5f261f0c6d2a)|