### PR TITLE
fix(tests): reader tests and share an item tests

### DIFF
--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -39,6 +39,7 @@ struct ReaderSettingsView: View {
                         in: Constants.allowedAdjustments,
                         step: Constants.adjustmentStep
                     )
+                    .accessibilityIdentifier("reader-settings-stepper")
                 }
             }
             .navigationBarHidden(true)

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -132,24 +132,21 @@ class ReaderTests: XCTestCase {
     @MainActor
     func test_tappingSave_savesItem() async {
         app.launch()
-        app.homeView
-            .recommendationCell("Slate 1, Recommendation 1")
-            .wait()
 
         // Swipe down to a syndicated item
-        scrollTo(element: app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").element, in: app.homeView.element, direction: .up)
-        app.homeView.recommendationCell("Syndicated Article Slate 2, Rec 2").wait().tap()
+        scrollTo(element: app.homeView.recommendationCell("Slate 1, Recommendation 2").element, in: app.homeView.element, direction: .up)
+        app.homeView.recommendationCell("Slate 1, Recommendation 2").wait().tap()
         app.readerView.readerToolbar.moreButton.wait().tap()
         app.readerView.saveButton.wait().tap()
 
         app.readerView.backButton.wait().tap()
         app.tabBar.savesButton.wait().tap()
-        app.saves.itemView(matching: "Slate 2, Recommendation 2").wait()
+        app.saves.itemView(matching: "Slate 1, Recommendation 2").wait()
 
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let reportEvent = await snowplowMicro.getFirstEvent(with: "reader.toolbar.save")
         reportEvent!.getUIContext()!.assertHas(type: "button")
-        reportEvent!.getContentContext()!.assertHas(url: "https://getpocket.com/explore/item/article-4")
+        reportEvent!.getContentContext()!.assertHas(url: "https://getpocket.com/explore/item/article-2")
     }
 
 //  NOTE: Commented out for now, Daniel is unable to get these to fail locally, but they always fail in CI and on others computers.

--- a/Tests iOS/ShareAnItemTests.swift
+++ b/Tests iOS/ShareAnItemTests.swift
@@ -53,7 +53,7 @@ class ShareAnItemTests: XCTestCase {
 
         app
             .saves
-            .itemView(matching: "Item 2")
+            .itemView(matching: "Item 1")
             .wait()
             .tap()
 
@@ -72,7 +72,7 @@ class ShareAnItemTests: XCTestCase {
         await snowplowMicro.assertBaselineSnowplowExpectation()
         let overflowEvent = await snowplowMicro.getFirstEvent(with: "reader.toolbar.share")
         overflowEvent!.getUIContext()!.assertHas(type: "button")
-        overflowEvent!.getContentContext()!.assertHas(url: "https://example.com/item-2")
+        overflowEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
     func test_shareFromHome_sharingARecommendation_sharingFromSlate() {

--- a/Tests iOS/Support/Elements/ReaderElement.swift
+++ b/Tests iOS/Support/Elements/ReaderElement.swift
@@ -73,11 +73,11 @@ struct ReaderElement: PocketUIElement {
     }
 
     var fontStepperIncreaseButton: XCUIElement {
-        element.collectionViews.steppers["Font Size"].buttons["Increment"]
+        element.collectionViews.buttons["reader-settings-stepper-Increment"]
     }
 
     var fontStepperDecreaseButton: XCUIElement {
-        element.collectionViews.steppers["Font Size"].buttons["Decrement"]
+        element.collectionViews.buttons["reader-settings-stepper-Decrement"]
     }
 
     var safariButton: XCUIElement {


### PR DESCRIPTION
## Summary
Fixes the follow UI tests:
* `ReaderTests`
* `ShareAnItemTests`

## References 
MOSOIOS-74, MOSOIOS-76 

## Implementation Details
* Update `ShareAnItemTests` to use an existing item in the corpusSlate.json as opposed to the old slates.json
* Update `ReaderTests` to rely on identifier instead of stepper button string and update tests to use existing item from corpus items

## Test Steps
Verify that the tests above passes and confirm that the other tests that were fixed are not broken:
* PullToRefreshTests
* HomeWebViewTests
* ReportARecommendationTests

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
<img width="368" alt="image" src="https://github.com/Pocket/pocket-ios/assets/6743397/54739fb8-5006-4281-ab40-1b3a3c258a4d">

<img width="366" alt="image" src="https://github.com/Pocket/pocket-ios/assets/6743397/884c37bb-8403-47a3-a0ec-97498a9b635c">