### PR TITLE
fix(tests): fix sign out and search tests

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -174,7 +174,7 @@ extension SettingsForm {
                         Button(Localization.Settings.logout, role: .destructive) {
                             model.trackLogoutConfirmTapped()
                             model.signOut()
-                        }
+                        }.accessibilityIdentifier("alert-log-out-button")
                     }, message: {
                         Text(Localization.Settings.Logout.areYouSureMessage)
                     }

--- a/Tests iOS/Fixtures/saves-loading-page-1.json
+++ b/Tests iOS/Fixtures/saves-loading-page-1.json
@@ -64,6 +64,7 @@
               "isArchived": false,
               "isFavorite": false,
               "tags": [],
+              "corpusItem": null,
               "item": {
                 "__typename": "Item",
                 "remoteID": "item-2",

--- a/Tests iOS/Fixtures/search-list-all.json
+++ b/Tests iOS/Fixtures/search-list-all.json
@@ -26,6 +26,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-1",
@@ -98,6 +99,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-2",
@@ -170,6 +172,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-3",
@@ -229,7 +232,7 @@
           "hasPreviousPage": false,
           "startCursor": null
         },
-        "totalCount": 2
+        "totalCount": 3
       }
     }
   }

--- a/Tests iOS/Fixtures/search-list-archive.json
+++ b/Tests iOS/Fixtures/search-list-archive.json
@@ -26,6 +26,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-3",
@@ -85,7 +86,7 @@
           "hasPreviousPage": false,
           "startCursor": null
         },
-        "totalCount": 2
+        "totalCount": 1
       }
     }
   }

--- a/Tests iOS/Fixtures/search-list-page-1.json
+++ b/Tests iOS/Fixtures/search-list-page-1.json
@@ -26,6 +26,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-1",
@@ -98,6 +99,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-2",
@@ -170,6 +172,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-3",
@@ -242,6 +245,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-4",
@@ -314,6 +318,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-5",
@@ -386,6 +391,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-6",
@@ -458,6 +464,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-7",
@@ -530,6 +537,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-8",
@@ -602,6 +610,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-9",
@@ -674,6 +683,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-10",
@@ -746,6 +756,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-11",
@@ -818,6 +829,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-12",
@@ -890,6 +902,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-13",
@@ -962,6 +975,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-14",
@@ -1034,6 +1048,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-15",
@@ -1106,6 +1121,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-16",
@@ -1178,6 +1194,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-17",
@@ -1250,6 +1267,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-18",
@@ -1322,6 +1340,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-19",
@@ -1394,6 +1413,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-20",
@@ -1466,6 +1486,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-21",
@@ -1538,6 +1559,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-22",
@@ -1610,6 +1632,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-23",
@@ -1682,6 +1705,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-24",
@@ -1754,6 +1778,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-25",
@@ -1826,6 +1851,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-26",
@@ -1898,6 +1924,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-27",
@@ -1970,6 +1997,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-28",
@@ -2042,6 +2070,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-29",
@@ -2114,6 +2143,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-30",

--- a/Tests iOS/Fixtures/search-list-page-2.json
+++ b/Tests iOS/Fixtures/search-list-page-2.json
@@ -26,6 +26,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-31",
@@ -98,6 +99,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-32",
@@ -170,6 +172,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-33",
@@ -242,6 +245,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-34",
@@ -314,6 +318,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-35",
@@ -386,6 +391,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-36",
@@ -458,6 +464,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-37",
@@ -530,6 +537,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-38",
@@ -602,6 +610,7 @@
                     "name": "tag 0"
                   }
                 ],
+                "corpusItem": null,
                 "item": {
                   "__typename": "Item",
                   "remoteID": "item-39",

--- a/Tests iOS/Fixtures/search-list.json
+++ b/Tests iOS/Fixtures/search-list.json
@@ -26,6 +26,7 @@
                                         "name": "tag 0"
                                     }
                                 ],
+                                "corpusItem": null,
                                 "item": {
                                     "__typename": "Item",
                                     "remoteID": "item-1",
@@ -98,6 +99,7 @@
                                         "name": "tag 0"
                                     }
                                 ],
+                                "corpusItem": null,
                                 "item": {
                                     "__typename": "Item",
                                     "remoteID": "item-2",

--- a/Tests iOS/SignOutTests.swift
+++ b/Tests iOS/SignOutTests.swift
@@ -41,8 +41,7 @@ class SignOutTests: XCTestCase {
         let logoutRowTappedEvent = await snowplowMicro.getFirstEvent(with: "global-nav.settings.logout")
         XCTAssertNotNil(logoutRowTappedEvent)
 
-        let account = XCUIApplication()
-        account.alerts["Are you sure?"].scrollViews.otherElements.buttons["Log Out"].wait().tap()
+        app.alert.element.buttons["alert-log-out-button"].tap()
         app.loggedOutView.wait()
 
         let logoutConfirmedEvent = await snowplowMicro.getFirstEvent(with: "global-nav.settings.logout-confirmed")


### PR DESCRIPTION
## Summary
Fixes the follow UI tests:
* `SearchTests`
* `SignOutTests`

## References 
MOSOIOS-75, MOSOIOS-77

## Implementation Details
* Update `SignOutTests` to rely on identifier for alert view log out button instead of using string
* Update `SearchTests` to include `corpusItem` field

## Test Steps
Verify that the tests above passes and confirm that the other tests that were fixed are not broken:
* PullToRefreshTests
* HomeWebViewTests
* ReportARecommendationTests
* ReaderTests
* ShareAnItemTests

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
| Sign Out | Search |
| --- | --- |
| ![image](https://github.com/Pocket/pocket-ios/assets/6743397/9ea87f54-613b-4fcc-a1e4-f571953d3339) | 
![image](https://github.com/Pocket/pocket-ios/assets/6743397/d06ced97-e6d8-4b68-995a-22f6f634ec5f) |
