### PR TITLE
feat(listen): add listen support to an individual item [INXT-1362]

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -24,6 +24,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var presentedWebReaderURL: URL? { get set }
     var isPresentingReaderSettings: Bool? { get set }
 
+    var isListenSupported: Bool { get }
     var actions: Published<[ItemAction]>.Publisher { get }
     var events: EventPublisher { get }
 
@@ -59,6 +60,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     func beginBulkEdit()
     func trackReadingProgress(index: IndexPath)
     func readingProgress() -> IndexPath?
+    func listen()
 }
 
 // MARK: - ReadableViewControllerDelegate

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -11,8 +11,18 @@ import Analytics
 import Localization
 import SharedPocketKit
 
+protocol ReadableViewModelDelegate: AnyObject {
+    /// Called when a ReadableViewModel requests that Listen be presented with a given view model.
+    /// - Parameters:
+    ///   - readableViewModel: The view model requesting that Listen be presented.
+    ///   - viewModel: The view model to use when presenting Listen.
+    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen viewModel: ListenViewModel)
+}
+
 protocol ReadableViewModel: ReadableViewControllerDelegate {
     typealias EventPublisher = AnyPublisher<ReadableEvent, Never>
+
+    var delegate: ReadableViewModelDelegate? { get set }
 
     var tracker: Tracker { get }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -11,6 +11,8 @@ import Analytics
 import SharedPocketKit
 
 class RecommendationViewModel: ReadableViewModel {
+    weak var delegate: ReadableViewModelDelegate?
+
     @Published private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendationViewModel.swift
@@ -103,6 +103,10 @@ class RecommendationViewModel: ReadableViewModel {
         pocketPremiumURL(url, user: user)
     }
 
+    var isListenSupported: Bool {
+        false
+    }
+
     func moveToSaves() {
         guard let savedItem = recommendation.item.savedItem else {
             return
@@ -221,6 +225,8 @@ class RecommendationViewModel: ReadableViewModel {
             return webViewActivityItems(for: savedItem)
         }
     }
+
+    func listen() { }
 }
 
 extension RecommendationViewModel {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -61,6 +61,8 @@ class SavedItemViewModel: ReadableViewModel {
 
     @Published var isPresentingReaderSettings: Bool?
 
+    @Published var presentedListenViewModel: ListenViewModel?
+
     private let item: SavedItem
     private let source: Source
     private let pasteboard: Pasteboard
@@ -156,6 +158,10 @@ class SavedItemViewModel: ReadableViewModel {
         pocketPremiumURL(url, user: user)
     }
 
+    var isListenSupported: Bool {
+        item.isEligibleForListen
+    }
+
     func moveToSaves() {
         source.unarchive(item: item)
     }
@@ -207,6 +213,13 @@ class SavedItemViewModel: ReadableViewModel {
         }
 
         return webViewActivityItems(for: savedItem)
+    }
+
+    func listen() {
+        presentedListenViewModel = ListenViewModel.source(
+            savedItems: [item],
+            title: item.isArchived ? Localization.archive : "Saves"
+        )
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -41,6 +41,8 @@ class SavedItemViewModel: ReadableViewModel {
         "readingProgress.\(url)."
     }
 
+    weak var delegate: ReadableViewModelDelegate?
+
     let readableSource: ReadableSource
 
     let tracker: Tracker
@@ -60,8 +62,6 @@ class SavedItemViewModel: ReadableViewModel {
     @Published var sharedActivity: PocketActivity?
 
     @Published var isPresentingReaderSettings: Bool?
-
-    @Published var presentedListenViewModel: ListenViewModel?
 
     private let item: SavedItem
     private let source: Source
@@ -216,10 +216,12 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     func listen() {
-        presentedListenViewModel = ListenViewModel.source(
+        let listen = ListenViewModel.source(
             savedItems: [item],
             title: item.isArchived ? Localization.archive : "Saves"
         )
+
+        delegate?.viewModel(self, didRequestListen: listen)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -408,6 +408,8 @@ extension HomeViewController {
             animated: true
         )
 
+        // TODO: Listen
+
         recommendation.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readerSubscriptions)
@@ -446,6 +448,8 @@ extension HomeViewController {
             ReadableHostViewController(readableViewModel: savedItem),
             animated: true
         )
+
+        // TODO: Listen
 
         savedItem.$presentedAlert.receive(on: DispatchQueue.main).sink { [weak self] alert in
             self?.present(alert: alert)

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -50,6 +50,14 @@ class ReadableHostViewController: UIViewController {
         navigationItem.largeTitleDisplayMode = .never
         hidesBottomBarWhenPushed = true
 
+        let listenButtonItem = UIBarButtonItem(
+            image: UIImage(asset: .listen),
+            style: .plain,
+            target: self,
+            action: #selector(listen)
+        )
+        listenButtonItem.isEnabled = readableViewModel.isListenSupported
+
         navigationItem.rightBarButtonItems = [
             moreButtonItem,
             UIBarButtonItem(
@@ -58,7 +66,8 @@ class ReadableHostViewController: UIViewController {
                 target: self,
                 action: #selector(showWebView)
             ),
-            readableViewModel.isArchived ? getMoveFromArchiveToSavesButton : getArchiveButton
+            readableViewModel.isArchived ? getMoveFromArchiveToSavesButton : getArchiveButton,
+            listenButtonItem
         ]
 
         readableViewModel.actions.receive(on: DispatchQueue.main).sink { [weak self] actions in
@@ -150,6 +159,11 @@ class ReadableHostViewController: UIViewController {
                 self?.navigationItem.rightBarButtonItems?[index] = archiveButton
             }
         }
+    }
+
+    @objc
+    private func listen() {
+        readableViewModel.listen()
     }
 
     var popoverAnchor: UIBarButtonItem? {

--- a/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/SavedItem+Listen.swift
@@ -8,6 +8,26 @@ import PKTListen
 import SharedPocketKit
 
 extension SavedItem: PKTListenItem {
+    public var isEligibleForListen: Bool {
+        if remoteID == nil {
+            return false
+        }
+
+        if estimatedAlbumDuration <= 60 {
+            return false
+        }
+
+        guard let language = albumLanguage else {
+            return false
+        }
+
+        if !(PKTListen.supportedLanguages ?? []).contains(language) {
+            return false
+        }
+
+        return item?.isArticle ?? false
+    }
+
     public var albumID: String? {
         self.remoteID
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -100,9 +100,15 @@ enum ItemsListEvent<ItemIdentifier: Hashable> {
     case networkStatusUpdated
 }
 
+protocol ItemsListViewModelDelegate: AnyObject {
+    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen: ListenViewModel)
+}
+
 protocol ItemsListViewModel: AnyObject {
     associatedtype ItemIdentifier: Hashable
     typealias Snapshot = NSDiffableDataSourceSnapshot<ItemsListSection, ItemsListCell<ItemIdentifier>>
+
+    var delegate: ItemsListViewModelDelegate? { get set }
 
     var events: AnyPublisher<ItemsListEvent<ItemIdentifier>, Never> { get }
     var selectionItem: SelectionItem { get }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -21,6 +21,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     typealias ItemIdentifier = NSManagedObjectID
     typealias Snapshot = NSDiffableDataSourceSnapshot<ItemsListSection, ItemsListCell<ItemIdentifier>>
 
+    weak var delegate: ItemsListViewModelDelegate?
+
     private let _events: PassthroughSubject<ItemsListEvent<ItemIdentifier>, Never> = .init()
     var events: AnyPublisher<ItemsListEvent<ItemIdentifier>, Never> { _events.eraseToAnyPublisher() }
 
@@ -47,8 +49,6 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     @Published var sharedActivity: PocketActivity?
 
     @Published var presentedSortFilterViewModel: SortMenuViewModel?
-
-    @Published var presentedListenViewModel: ListenViewModel?
 
     @Published private var _initialDownloadState: InitialDownloadState
     var initialDownloadState: Published<InitialDownloadState>.Publisher { $_initialDownloadState }
@@ -678,7 +678,10 @@ extension SavedItemsListViewModel {
                 case .notTagged: break
                 }
             }
-            presentedListenViewModel = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects, title: title)
+
+            let listen = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects, title: title)
+            delegate?.viewModel(self, didRequestListen: listen)
+
             selectedFilters.remove(.listen)
         case .all:
             selectedFilters.removeAll()

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -257,6 +257,14 @@ extension SavesContainerViewController {
             self?.showListen(listenViewModel: listenViewModel)
         }.store(in: &subscriptions)
 
+        model.savedItemsList.$presentedListenViewModel
+            .filter { $0 != nil }
+            .sink { [weak self] listenViewModel in
+                guard let listenViewModel else { return }
+                self?.showListen(listenViewModel: listenViewModel)
+                self?.model.savedItemsList.presentedListenViewModel = nil
+            }.store(in: &subscriptions)
+
         model.savedItemsList.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
         }.store(in: &subscriptions)
@@ -284,12 +292,13 @@ extension SavesContainerViewController {
             self?.navigate(selectedItem: selectedArchivedItem)
         }.store(in: &subscriptions)
 
-        model.archivedItemsList.$presentedListenViewModel.sink { [weak self] listenViewModel in
-            guard let listenViewModel else {
-                return
-            }
-            self?.showListen(listenViewModel: listenViewModel)
-        }.store(in: &subscriptions)
+        model.archivedItemsList.$presentedListenViewModel
+            .filter { $0 != nil }
+            .sink { [weak self] listenViewModel in
+                guard let listenViewModel else { return }
+                self?.showListen(listenViewModel: listenViewModel)
+                self?.model.archivedItemsList.presentedListenViewModel = nil
+            }.store(in: &subscriptions)
 
         model.archivedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
@@ -368,6 +377,14 @@ extension SavesContainerViewController {
         readable.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
         }.store(in: &readableSubscriptions)
+
+        readable.$presentedListenViewModel
+            .filter { $0 != nil }
+            .sink { [weak self] listenViewModel in
+                guard let listenViewModel else { return }
+                self?.showListen(listenViewModel: listenViewModel)
+                readable.presentedListenViewModel = nil
+            }.store(in: &subscriptions)
 
         readable.events.sink { [weak self] event in
             switch event {

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -245,25 +245,12 @@ extension SavesContainerViewController {
             }
         }.store(in: &subscriptions)
 
+        model.savedItemsList.delegate = self
+
         // Saves navigation
         model.savedItemsList.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &subscriptions)
-
-        model.savedItemsList.$presentedListenViewModel.sink { [weak self] listenViewModel in
-            guard let listenViewModel else {
-                return
-            }
-            self?.showListen(listenViewModel: listenViewModel)
-        }.store(in: &subscriptions)
-
-        model.savedItemsList.$presentedListenViewModel
-            .filter { $0 != nil }
-            .sink { [weak self] listenViewModel in
-                guard let listenViewModel else { return }
-                self?.showListen(listenViewModel: listenViewModel)
-                self?.model.savedItemsList.presentedListenViewModel = nil
-            }.store(in: &subscriptions)
 
         model.savedItemsList.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
@@ -286,19 +273,13 @@ extension SavesContainerViewController {
             self?.presentSortMenu(presentedSortFilterViewModel: presentedSortFilterViewModel)
         }.store(in: &subscriptions)
 
+        model.archivedItemsList.delegate = self
+
         // Archive navigation
         model.archivedItemsList.$selectedItem.sink { [weak self] selectedArchivedItem in
             guard let selectedArchivedItem = selectedArchivedItem else { return }
             self?.navigate(selectedItem: selectedArchivedItem)
         }.store(in: &subscriptions)
-
-        model.archivedItemsList.$presentedListenViewModel
-            .filter { $0 != nil }
-            .sink { [weak self] listenViewModel in
-                guard let listenViewModel else { return }
-                self?.showListen(listenViewModel: listenViewModel)
-                self?.model.archivedItemsList.presentedListenViewModel = nil
-            }.store(in: &subscriptions)
 
         model.archivedItemsList.$sharedActivity.sink { [weak self] activity in
             self?.present(activity: activity)
@@ -358,6 +339,8 @@ extension SavesContainerViewController {
             return
         }
 
+        readable.delegate = self
+
         readable.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
@@ -377,14 +360,6 @@ extension SavesContainerViewController {
         readable.$presentedAddTags.sink { [weak self] addTagsViewModel in
             self?.present(viewModel: addTagsViewModel)
         }.store(in: &readableSubscriptions)
-
-        readable.$presentedListenViewModel
-            .filter { $0 != nil }
-            .sink { [weak self] listenViewModel in
-                guard let listenViewModel else { return }
-                self?.showListen(listenViewModel: listenViewModel)
-                readable.presentedListenViewModel = nil
-            }.store(in: &subscriptions)
 
         readable.events.sink { [weak self] event in
             switch event {
@@ -641,5 +616,17 @@ extension SavesContainerViewController {
         let listen =  PKTListenContainerViewController(configuration: appConfig)
         listen.title = listenViewModel.title
         self.present(listen, animated: true)
+    }
+}
+
+extension SavesContainerViewController: ReadableViewModelDelegate {
+    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen viewModel: ListenViewModel) {
+        showListen(listenViewModel: viewModel)
+    }
+}
+
+extension SavesContainerViewController: ItemsListViewModelDelegate {
+    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen viewModel: ListenViewModel) {
+        showListen(listenViewModel: viewModel)
     }
 }


### PR DESCRIPTION
## Summary

Adds a Listen button when viewing an individual item in the reader view.

## Implementation Details

- Adds a `UIBarButtonItem` to `ReadableHostViewController` that uses its view model to determine listen support for the presented item
- Item support / eligibility has been extracted to a convenience getter, which is reused when building the Listen view model from the main list, as well as determining single-item support

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
![image](https://github.com/Pocket/pocket-ios/assets/1158092/5cd1849c-1156-4913-b9b0-a4fd1bfd01ee)
