### PR TITLE
chore(deps): updating snowplow to 5.6.0

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "599b162c3acb367f839d620eefb6342799145c5c",
-        "version" : "5.4.1"
+        "revision" : "cc136256383ed50c754219895e34d25c48650314",
+        "version" : "5.6.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "54c85cb26308b89846d4671f23954dce088da2b0",
-        "version" : "2.60.0"
+        "revision" : "853522d90871b4b63262843196685795b5008c46",
+        "version" : "2.61.1"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "7f9fb5d43ecd4aa714c00746f54873f354403438",
-        "version" : "5.15.8"
+        "revision" : "fd1950de05a5ad77cb252fd88576c1e1809ee50d",
+        "version" : "5.18.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "599b162c3acb367f839d620eefb6342799145c5c",
-        "version" : "5.4.1"
+        "revision" : "cc136256383ed50c754219895e34d25c48650314",
+        "version" : "5.6.0"
       }
     },
     {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.7.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.7.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.7.3"),
-        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.4.1"),
+        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.2.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.5.0"),


### PR DESCRIPTION
## Summary
* Updating snowplow to [5.6.0](https://github.com/snowplow/snowplow-ios-tracker/releases/tag/5.6.0)