### PR TITLE
chore(deps): batch of dependency updates for 11/01/2023

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/danger/swift.git",
       "state" : {
-        "revision" : "0a4b52f4518974cbd2cc45c29d33cb54a303f81d",
-        "version" : "3.15.0"
+        "revision" : "d246105c3b08ba9e8bf7d9023df36cbf6ceab0bb",
+        "version" : "3.17.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,12 @@ import PackageDescription
 
 let package = Package(
     name: "Danger",
-    platforms: [.iOS("15"), .macOS("11")],
+    platforms: [.iOS("16"), .macOS("13")],
     products: [
         .library(name: "DangerDeps", type: .dynamic, targets: ["DangerDependencies"]), // dev
     ],
     dependencies: [
-        .package(url: "https://github.com/danger/swift.git", exact: "3.16.0"), // dev
+        .package(url: "https://github.com/danger/swift.git", exact: "3.17.1"), // dev
         .package(url: "https://github.com/f-meloni/danger-swift-coverage", exact: "1.2.1") // dev
     ],
     targets: [

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -1878,7 +1878,7 @@
 			repositoryURL = "https://github.com/adjust/ios_sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 4.33.4;
+				version = 4.35.2;
 			};
 		};
 		650EEABA29F35499004D66BD /* XCRemoteSwiftPackageReference "apollo-ios" */ = {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "9cf7d2e514af1600cc2b3c5592e2848c6c5a76d6",
-        "version" : "8.7.3"
+        "revision" : "02aa06fed7de6fbf28e74b3831f7a5bf276638eb",
+        "version" : "8.15.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "e8625b80c413457b13ea9be75d07f6e9f5830c19",
-        "version" : "7.7.0"
+        "revision" : "277f1ab2c6664b19b4a412e32b094b201e2d5757",
+        "version" : "7.10.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",
       "state" : {
-        "revision" : "6ae03883c3b7d22e72e2a5937ad5dd8765d9c31d",
-        "version" : "4.33.4"
+        "revision" : "20c2666082c372f9f2c0adf871d8cef195d011f7",
+        "version" : "4.35.2"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",
       "state" : {
-        "revision" : "d6feea26a370019b4d3a85f5984cb95a2734776f",
-        "version" : "4.2.0"
+        "revision" : "45517c3cfec9469bbdd4f86e32393c28ae9df0bc",
+        "version" : "4.3.3"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/YouTubePlayerKit.git",
       "state" : {
-        "revision" : "b2cf1e0c0b081594a51b229347d7c3b7d3aca5a1",
-        "version" : "1.5.0"
+        "revision" : "94b5739d32f0108f1820091e6955d544a0363fad",
+        "version" : "1.5.4"
       }
     }
   ],

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "e8625b80c413457b13ea9be75d07f6e9f5830c19",
-        "version" : "7.7.0"
+        "revision" : "277f1ab2c6664b19b4a412e32b094b201e2d5757",
+        "version" : "7.10.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "9cf7d2e514af1600cc2b3c5592e2848c6c5a76d6",
-        "version" : "8.7.3"
+        "revision" : "02aa06fed7de6fbf28e74b3831f7a5bf276638eb",
+        "version" : "8.15.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",
       "state" : {
-        "revision" : "6ae03883c3b7d22e72e2a5937ad5dd8765d9c31d",
-        "version" : "4.33.4"
+        "revision" : "20c2666082c372f9f2c0adf871d8cef195d011f7",
+        "version" : "4.35.2"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",
       "state" : {
-        "revision" : "d6feea26a370019b4d3a85f5984cb95a2734776f",
-        "version" : "4.2.0"
+        "revision" : "45517c3cfec9469bbdd4f86e32393c28ae9df0bc",
+        "version" : "4.3.3"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/YouTubePlayerKit.git",
       "state" : {
-        "revision" : "b2cf1e0c0b081594a51b229347d7c3b7d3aca5a1",
-        "version" : "1.5.0"
+        "revision" : "94b5739d32f0108f1820091e6955d544a0363fad",
+        "version" : "1.5.4"
       }
     }
   ],

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.7.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.7.3"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
-        .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.2.0"),
+        .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.3.3"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.5.4"),
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "7.1.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.2.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
-        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.5.0"),
+        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.5.4"),
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "7.1.0"),
         .package(url: "https://github.com/adjust/ios_sdk", exact: "4.33.4"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", exact: "5.1.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.7.0"),
-        .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.7.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.15.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.3.3"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.5.4"),
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "7.1.0"),
-        .package(url: "https://github.com/adjust/ios_sdk", exact: "4.33.4"),
+        .package(url: "https://github.com/adjust/ios_sdk", exact: "4.35.2"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", exact: "5.1.0"),
     ],
     targets: [

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.7.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.7.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.7.3"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.15.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.3.3"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),

--- a/PocketKit/Sources/Textile/Animations/LottieView.swift
+++ b/PocketKit/Sources/Textile/Animations/LottieView.swift
@@ -9,6 +9,7 @@ import UIKit
 import Lottie
 import SwiftUI
 
+//TODO: As of Lottie 4.3.0 Lottie is SwiftUI Native and we can remove this wrapper.
 public struct LottieView: UIViewRepresentable {
     public init(_ pocketAnimation: PocketAnimation, loopMode: LottieLoopMode = .loop) {
         self.pocketAnimation = pocketAnimation

--- a/PocketKit/Sources/Textile/Animations/LottieView.swift
+++ b/PocketKit/Sources/Textile/Animations/LottieView.swift
@@ -9,7 +9,7 @@ import UIKit
 import Lottie
 import SwiftUI
 
-//TODO: As of Lottie 4.3.0 Lottie is SwiftUI Native and we can remove this wrapper.
+// TODO: As of Lottie 4.3.0 Lottie is SwiftUI Native and we can remove this wrapper.
 public struct LottieView: UIViewRepresentable {
     public init(_ pocketAnimation: PocketAnimation, loopMode: LottieLoopMode = .loop) {
         self.pocketAnimation = pocketAnimation


### PR DESCRIPTION
## Summary
* YouTube PlayerKit -> 1.5.4
* AdjustSDK -> [4.35.2](https://github.com/adjust/ios_sdk/releases/tag/v4.35.2)
* Lottie -> [4.30](https://github.com/airbnb/lottie-ios/releases/tag/4.3.3)
  * Note: This adds Native SwiftUI support, but I did not update our views to use it.
* Danger -> 3.17.1
* Sentry -> [8.15.0](https://github.com/getsentry/sentry-cocoa/releases/tag/8.15.0)
   * Note: Lots of threading improvements here.
* Kingfisher -> [7.10.0](https://github.com/onevcat/Kingfisher/releases/tag/7.10.0)
   * Note: They support apples new privacy manifests for 3rd party frameworks. 
