### PR TITLE
fix(auth): updating auth race condition test

### DIFF
--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -68,9 +68,12 @@ extension AuthorizationClientTests {
             expectSessionStart.fulfill()
             return true
         }
+        let expectFirstClientStarted = expectation(description: "started client login")
+        expectFirstClientStarted.expectedFulfillmentCount = 1
 
         Task {
             do {
+                expectFirstClientStarted.fulfill()
                 _ = try await self.client.logIn(from: self)
             } catch {
                 XCTFail("Should not have thrown an error \(error)")
@@ -79,6 +82,8 @@ extension AuthorizationClientTests {
 
         Task {
             do {
+                // wait for our first task to have started before we try the one that should fail.
+                await fulfillment(of: [expectFirstClientStarted], timeout: 10)
                 _ = try await self.client.logIn(from: self)
                 XCTFail("Expected to throw error, but didn't")
             } catch {


### PR DESCRIPTION
## Summary

Fix one of our unit tests that runs asynchronous by waiting for a test expectation in the second test so that it starts only after the first one begins.