### PR TITLE
feat(listen): use offline delegation for offline tts

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .binaryTarget(
             name: "PKTListen",
             url: "https://github.com/Pocket/pocket-ios/releases/download/release%2Fv8.2.0-offline-tts/PKTListen.xcframework.zip",
-            checksum: "ba4126d5730601d6fce5c65471dd7173eb8d70e017108537f64a2ea5606dd1c4"
+            checksum: "b1f1a7a6c342123cef4d725b9b9c43247afe6576f67963f993959084dbaa8864"
         ),
         .target(
             name: "ItemWidgetsKit",

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .binaryTarget(
             name: "PKTListen",
             url: "https://github.com/Pocket/pocket-ios/releases/download/release%2Fv8.2.0-offline-tts/PKTListen.xcframework.zip",
-            checksum: "802bed71bd9a924ecd849f8c052427d743579e41dc03bc342a7f84de3832d70e"
+            checksum: "ba4126d5730601d6fce5c65471dd7173eb8d70e017108537f64a2ea5606dd1c4"
         ),
         .target(
             name: "ItemWidgetsKit",

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "PKTListen",
-            url: "https://github.com/Pocket/pocket-ios/releases/download/release%2Fv8.0.1.24700/PKTListen.xcframework.zip",
-            checksum: "0e21242b5cdadf2da674de811476910a89b7046bd2f1282d23193695d9e61a05"
+            url: "https://github.com/Pocket/pocket-ios/releases/download/release%2Fv8.2.0-offline-tts/PKTListen.xcframework.zip",
+            checksum: "802bed71bd9a924ecd849f8c052427d743579e41dc03bc342a7f84de3832d70e"
         ),
         .target(
             name: "ItemWidgetsKit",

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -16,7 +16,7 @@ protocol ReadableViewModelDelegate: AnyObject {
     /// - Parameters:
     ///   - readableViewModel: The view model requesting that Listen be presented.
     ///   - viewModel: The view model to use when presenting Listen.
-    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen viewModel: ListenViewModel)
+    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen configuration: ListenConfiguration)
 }
 
 protocol ReadableViewModel: ReadableViewControllerDelegate {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -216,12 +216,13 @@ class SavedItemViewModel: ReadableViewModel {
     }
 
     func listen() {
-        let listen = ListenViewModel.source(
-            savedItems: [item],
-            title: item.isArchived ? Localization.archive : "Saves"
+        delegate?.viewModel(
+            self,
+            didRequestListen: ListenConfiguration(
+                title: item.isArchived ? Localization.archive : "Saves",
+                savedItems: [item]
+            )
         )
-
-        delegate?.viewModel(self, didRequestListen: listen)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -68,10 +68,10 @@ class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenOfflineTTSDel
         return article.components.compactMap { c in
             switch c {
             // Utilize the NSAttributedString(markdown:) initializer to "strip out" the characters used for styling
-            case .text(let textComponent): return try? NSAttributedString(markdown: textComponent.content).string
+            case .text(let textComponent): return try? NSAttributedString(markdown: textComponent.content)
             default: return nil
             }
-        }.map { ListenTextUnit(stringValue: $0) }
+        }.map { ListenTextUnit(attributedString: $0) }
     }
 
     func isKusariAvailable(forOfflineTTS kusari: PKTKusari<PKTListenItem>) -> Bool {
@@ -82,11 +82,13 @@ class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenOfflineTTSDel
 private class ListenTextUnit: NSObject, PKTTextUnit {
     var type: PKTTagMatchType = .text
 
+    var attributedStringValue: NSAttributedString?
     var stringValue: String?
 
     var tagValue: String?
 
-    init(stringValue: String) {
-        self.stringValue = stringValue
+    init(attributedString: NSAttributedString) {
+        self.attributedStringValue = attributedString
+        self.stringValue = attributedString.string
     }
 }

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -7,10 +7,52 @@ import Sync
 import PKTListen
 import SharedPocketKit
 
-class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
-    public var title: String = "Unknown"
+class ListenConfiguration: NSObject, PKTListenOfflineTTSDelegate {
+    let title: String
+    private let savedItems: [SavedItem]?
 
-    static func source(savedItems: [SavedItem]?, title: String) -> ListenViewModel {
+    init(title: String, savedItems: [SavedItem]?) {
+        self.title = title
+        self.savedItems = savedItems
+    }
+
+    func toAppConfiguration() -> PKTListenAppConfiguration {
+        let config = PKTListenAppConfiguration(source: createSource())
+        config.offlineTTSDelegate = self
+        return config
+    }
+
+    private func createSource() -> ListenSource {
+        return ListenSource.source(savedItems: savedItems)
+    }
+
+    func textUnits(for kusari: PKTKusari<PKTListenItem>) -> [PKTTextUnit] {
+        // When returning the text components for offline TTS,
+        // fetch the saved item with the given URL of the item staged for playing, ensuring it has an article
+        guard let givenURL = kusari.album?.givenURL,
+              let savedItem = savedItems?.first(where: { $0.givenURL == givenURL }),
+              let article = savedItem.item?.article
+        else {
+            return []
+        }
+
+        // For offline TTS, filter out only the text components, returning the appropriate types
+        return article.components.compactMap { c in
+            switch c {
+            // Utilize the NSAttributedString(markdown:) initializer to "strip out" the characters used for styling
+            case .text(let textComponent): return try? NSAttributedString(markdown: textComponent.content).string
+            default: return nil
+            }
+        }.map { ListenTextUnit(stringValue: $0) }
+    }
+
+    func isKusariAvailable(forOfflineTTS kusari: PKTKusari<PKTListenItem>) -> Bool {
+        return textUnits(for: kusari).isEmpty == false
+    }
+}
+
+class ListenSource: PKTListenDataSource<PKTListDiffable> {
+    static func source(savedItems: [SavedItem]?) -> ListenSource {
         let config = PKTListenAppKusariConfiguration()
 
         let listenItems: [PKTKusari<PKTListenItem>] = savedItems?
@@ -26,12 +68,22 @@ class ListenViewModel: PKTListenDataSource<PKTListDiffable> {
             })
         }
 
-        let viewModel = ListenViewModel(context: ["index": NSNumber(value: 0)]) { source, context, complete in
+        return ListenSource(context: ["index": NSNumber(value: 0)]) { source, context, complete in
             source.hasMore = false
             Log.debug("Loaded Listen with \(listenItems.count) articles")
             complete(nil, ["index": NSNumber(value: listenItems.count)], listenItems)
         }
-        viewModel.title = title
-        return viewModel
+    }
+}
+
+private class ListenTextUnit: NSObject, PKTTextUnit {
+    var type: PKTTagMatchType = .text
+
+    var stringValue: String?
+
+    var tagValue: String?
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -101,7 +101,7 @@ enum ItemsListEvent<ItemIdentifier: Hashable> {
 }
 
 protocol ItemsListViewModelDelegate: AnyObject {
-    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen: ListenViewModel)
+    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen: ListenConfiguration)
 }
 
 protocol ItemsListViewModel: AnyObject {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -679,8 +679,7 @@ extension SavedItemsListViewModel {
                 }
             }
 
-            let listen = ListenViewModel.source(savedItems: self.itemsController.fetchedObjects, title: title)
-            delegate?.viewModel(self, didRequestListen: listen)
+            delegate?.viewModel(self, didRequestListen: ListenConfiguration(title: title, savedItems: self.itemsController.fetchedObjects))
 
             selectedFilters.remove(.listen)
         case .all:

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -611,22 +611,21 @@ extension SavesContainerViewController: SFSafariViewControllerDelegate {
 }
 
 extension SavesContainerViewController {
-    private func showListen(listenViewModel: ListenViewModel) {
-        let appConfig = PKTListenAppConfiguration(source: listenViewModel)
-        let listen =  PKTListenContainerViewController(configuration: appConfig)
-        listen.title = listenViewModel.title
+    private func showListen(_ configuration: ListenConfiguration) {
+        let listen =  PKTListenContainerViewController(configuration: configuration.toAppConfiguration())
+        listen.title = configuration.title
         self.present(listen, animated: true)
     }
 }
 
 extension SavesContainerViewController: ReadableViewModelDelegate {
-    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen viewModel: ListenViewModel) {
-        showListen(listenViewModel: viewModel)
+    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen configuration: ListenConfiguration) {
+        showListen(configuration)
     }
 }
 
 extension SavesContainerViewController: ItemsListViewModelDelegate {
-    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen viewModel: ListenViewModel) {
-        showListen(listenViewModel: viewModel)
+    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen configuration: ListenConfiguration) {
+        showListen(configuration)
     }
 }


### PR DESCRIPTION
## Summary

Reenables support of offline TTS via Listen via delegation through the update Listen library.

## Implementation Details

- [ ] Implement `PKTListenOfflineTTSDelegate` to create text units based on text components in offline marticle data
  - Adds a basic implementation of `PKTTextUnit` to maintain and provide text as needed

## Test Steps

- [ ] Open Listen
- [ ] Open Listen settings
- [ ] Enable always use offline
- [ ] Open Listen from the Saves
- [ ] Open Listen from an individual item
- [ ] Listen should behave as expected

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
