### PR TITLE
feat(listen): add support for disabling online TTS

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .binaryTarget(
             name: "PKTListen",
             url: "https://github.com/Pocket/pocket-ios/releases/download/release%2Fv8.2.0-offline-tts/PKTListen.xcframework.zip",
-            checksum: "b1f1a7a6c342123cef4d725b9b9c43247afe6576f67963f993959084dbaa8864"
+            checksum: "47a318af51ff3196d142ede33fe1da33f93b6d6c459b5834e0968bb4b02406e9"
         ),
         .target(
             name: "ItemWidgetsKit",

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -72,6 +72,7 @@ class SavedItemViewModel: ReadableViewModel {
     private var store: SubscriptionStore
     private var networkPathMonitor: NetworkPathMonitor
     private let notificationCenter: NotificationCenter
+    private let featureFlagService: FeatureFlagServiceProtocol
 
     init(
         item: SavedItem,
@@ -83,7 +84,8 @@ class SavedItemViewModel: ReadableViewModel {
         networkPathMonitor: NetworkPathMonitor,
         userDefaults: UserDefaults,
         notificationCenter: NotificationCenter,
-        readableSource: ReadableSource = .app
+        readableSource: ReadableSource = .app,
+        featureFlagService: FeatureFlagServiceProtocol
     ) {
         self.item = item
         self.source = source
@@ -95,6 +97,7 @@ class SavedItemViewModel: ReadableViewModel {
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.readableSource = readableSource
+        self.featureFlagService = featureFlagService
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()
@@ -220,7 +223,8 @@ class SavedItemViewModel: ReadableViewModel {
             self,
             didRequestListen: ListenConfiguration(
                 title: item.isArchived ? Localization.archive : "Saves",
-                savedItems: [item]
+                savedItems: [item],
+                featureFlagService: featureFlagService
             )
         )
     }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -325,7 +325,8 @@ extension CollectionViewModel {
                     store: store,
                     networkPathMonitor: networkPathMonitor,
                     userDefaults: userDefaults,
-                    notificationCenter: notificationCenter
+                    notificationCenter: notificationCenter,
+                    featureFlagService: featureFlags
                 )
             )
         // Check if item has an associated recommendation

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -116,6 +116,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case reportIssue = "perm.ios.report_issue"
     case disableReader = "perm.ios.disable_reader"
     case nativeCollections = "perm.ios.native_collections"
+    case disableOnlineListen = "perm.ios.listen.disableOnline"
 
     /// Description to use in a debug menu
     var description: String {
@@ -132,6 +133,8 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "Disable the Reader to force use of a Web view for viewing content"
         case .nativeCollections:
             return "Enable native collections instead of opening collections in web view"
+        case .disableOnlineListen:
+            return "Disable online listen support, and fall back to offline TTS"
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -422,7 +422,8 @@ extension HomeViewModel {
                 networkPathMonitor: networkPathMonitor,
                 userDefaults: userDefaults,
                 notificationCenter: notificationCenter,
-                readableSource: readableSource
+                readableSource: readableSource,
+                featureFlagService: featureFlags
             )
 
             if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {

--- a/PocketKit/Sources/PocketKit/Listen/ListenConfiguration.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenConfiguration.swift
@@ -25,7 +25,7 @@ class ListenConfiguration: NSObject {
     }
 }
 
-class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenPlayerDelegate {
+private class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenPlayerDelegate {
     private var savedItems: [SavedItem]?
 
     convenience init(savedItems: [SavedItem]?) {

--- a/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenViewModel.swift
@@ -20,12 +20,12 @@ class ListenConfiguration: NSObject {
     func toAppConfiguration() -> PKTListenAppConfiguration {
         let source = ListenSource(savedItems: savedItems)
         let config = PKTListenAppConfiguration(source: source)
-        config.offlineTTSDelegate = source
+        config.playerDelegate = source
         return config
     }
 }
 
-class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenOfflineTTSDelegate {
+class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenPlayerDelegate {
     private var savedItems: [SavedItem]?
 
     convenience init(savedItems: [SavedItem]?) {
@@ -93,6 +93,10 @@ class ListenSource: PKTListenDataSource<PKTListDiffable>, PKTListenOfflineTTSDel
 
     func isKusariAvailable(forOfflineTTS kusari: PKTKusari<PKTListenItem>) -> Bool {
         return textUnits(for: kusari).isEmpty == false
+    }
+
+    func isOnlinePlayerAvailable() -> Bool {
+        return false
     }
 
     private func string(from component: BulletedListComponent) -> String? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -249,7 +249,8 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             store: store,
             networkPathMonitor: networkPathMonitor,
             userDefaults: userDefaults,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            featureFlagService: featureFlags
         )
 
         if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
@@ -614,7 +615,8 @@ extension SavedItemsListViewModel {
             store: store,
             networkPathMonitor: networkPathMonitor,
             userDefaults: userDefaults,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            featureFlagService: featureFlags
         )
 
         if let slug = readable.collection?.slug ?? readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
@@ -679,7 +681,14 @@ extension SavedItemsListViewModel {
                 }
             }
 
-            delegate?.viewModel(self, didRequestListen: ListenConfiguration(title: title, savedItems: self.itemsController.fetchedObjects))
+            delegate?.viewModel(
+                self,
+                didRequestListen: ListenConfiguration(
+                    title: title,
+                    savedItems: self.itemsController.fetchedObjects,
+                    featureFlagService: featureFlags
+                )
+            )
 
             selectedFilters.remove(.listen)
         case .all:

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -463,7 +463,8 @@ extension SearchViewModel: SearchResultActionDelegate {
             store: store,
             networkPathMonitor: networkPathMonitor,
             userDefaults: userDefaults,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            featureFlagService: featureFlags
         )
 
         if let slug = readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
@@ -20,6 +20,7 @@ class SavedItemViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var userDefaults: UserDefaults!
     private var notificationCenter: NotificationCenter!
+    private var featureFlagService: MockFeatureFlagService!
 
     private var subscriptions: Set<AnyCancellable> = []
 
@@ -34,6 +35,7 @@ class SavedItemViewModelTests: XCTestCase {
         subscriptionStore = MockSubscriptionStore()
         userDefaults = .standard
         notificationCenter = .default
+        featureFlagService = MockFeatureFlagService()
     }
 
     override func tearDownWithError() throws {
@@ -51,7 +53,8 @@ class SavedItemViewModelTests: XCTestCase {
         pasteboard: UIPasteboard? = nil,
         user: User? = nil,
         networkPathMonitor: NetworkPathMonitor? = nil,
-        notificationCenter: NotificationCenter? = nil
+        notificationCenter: NotificationCenter? = nil,
+        featureFlagService: FeatureFlagServiceProtocol? = nil
     ) -> SavedItemViewModel {
         SavedItemViewModel(
             item: item,
@@ -62,7 +65,8 @@ class SavedItemViewModelTests: XCTestCase {
             store: subscriptionStore ?? self.subscriptionStore,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             userDefaults: userDefaults ?? self.userDefaults,
-            notificationCenter: notificationCenter ?? self.notificationCenter
+            notificationCenter: notificationCenter ?? self.notificationCenter,
+            featureFlagService: featureFlagService ?? self.featureFlagService
         )
     }
 


### PR DESCRIPTION
## Summary

Updates Listen usage to include support for updated Listen delegates which allow for disabling online TTS. Client-side, this is based on feature flag.

## Test Steps

- Enable `perm.ios.listen.disableOffline`
- Open the app
- Open Listen
- Offline TTS should be used

---

- Disable `perm.ios.listen.disableOffline`
- Open the app
- Open Listen
- TTS should be respected based on "Always use offline" setting

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
