### PR TITLE
feat(search): add support for premium search experiment by feature flag

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -18,6 +18,12 @@ public extension Events.Search {
             return "archive"
         case .all:
             return "all_items"
+        case .premiumExperimentTitle:
+            return "title"
+        case .premiumExperimentTags:
+            return "tags"
+        case .premiumExperimentContent:
+            return "content"
         }
     }
 

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -21,7 +21,7 @@ public extension Events.Search {
         case .premiumSearchExperimentTitle:
             return "title"
         case .premiumSearchExperimentTag:
-            return "tags"
+            return "tag"
         case .premiumSearchExperimentContent:
             return "content"
         }

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -18,11 +18,11 @@ public extension Events.Search {
             return "archive"
         case .all:
             return "all_items"
-        case .premiumSearchExperimentTitle:
+        case .premiumSearchByTitle:
             return "title"
-        case .premiumSearchExperimentTag:
+        case .premiumSearchByTag:
             return "tag"
-        case .premiumSearchExperimentContent:
+        case .premiumSearchByContent:
             return "content"
         }
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Search.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Search.swift
@@ -18,11 +18,11 @@ public extension Events.Search {
             return "archive"
         case .all:
             return "all_items"
-        case .premiumExperimentTitle:
+        case .premiumSearchExperimentTitle:
             return "title"
-        case .premiumExperimentTags:
+        case .premiumSearchExperimentTag:
             return "tags"
-        case .premiumExperimentContent:
+        case .premiumSearchExperimentContent:
             return "content"
         }
     }

--- a/PocketKit/Sources/PocketGraph/Schema/InputObjects/SearchFilterInput.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/InputObjects/SearchFilterInput.graphql.swift
@@ -12,12 +12,14 @@ public struct SearchFilterInput: InputObject {
 
   public init(
     isFavorite: GraphQLNullable<Bool> = nil,
+    onlyTitleAndURL: GraphQLNullable<Bool> = nil,
     contentType: GraphQLNullable<GraphQLEnum<SearchItemsContentType>> = nil,
     status: GraphQLNullable<GraphQLEnum<SearchItemsStatusFilter>> = nil,
     domain: GraphQLNullable<String> = nil
   ) {
     __data = InputDict([
       "isFavorite": isFavorite,
+      "onlyTitleAndURL": onlyTitleAndURL,
       "contentType": contentType,
       "status": status,
       "domain": domain
@@ -28,6 +30,13 @@ public struct SearchFilterInput: InputObject {
   public var isFavorite: GraphQLNullable<Bool> {
     get { __data["isFavorite"] }
     set { __data["isFavorite"] = newValue }
+  }
+
+  /// Optional, filter to get user items only based on title and url, ie Free Search
+  /// Note, though that if this is selected and the user is premium, they will not get search highligthing.
+  public var onlyTitleAndURL: GraphQLNullable<Bool> {
+    get { __data["onlyTitleAndURL"] }
+    set { __data["onlyTitleAndURL"] = newValue }
   }
 
   /// Optional, filter to get SavedItems based on content type

--- a/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
@@ -10,10 +10,10 @@ public class PageInfo: MockObject {
   public typealias MockValueCollectionType = Array<Mock<PageInfo>>
 
   public struct MockFields {
-    @Field<String?>("endCursor") public var endCursor
-    @Field<Bool?>("hasNextPage") public var hasNextPage
-    @Field<Bool?>("hasPreviousPage") public var hasPreviousPage
-    @Field<String?>("startCursor") public var startCursor
+    @Field<String>("endCursor") public var endCursor
+    @Field<Bool>("hasNextPage") public var hasNextPage
+    @Field<Bool>("hasPreviousPage") public var hasPreviousPage
+    @Field<String>("startCursor") public var startCursor
   }
 }
 

--- a/PocketKit/Sources/PocketGraphTestMocks/UnleashAssignment+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/UnleashAssignment+Mock.graphql.swift
@@ -12,8 +12,8 @@ public class UnleashAssignment: MockObject {
   public struct MockFields {
     @Field<Bool>("assigned") public var assigned
     @Field<String>("name") public var name
-    @Field<String?>("payload") public var payload
-    @Field<String?>("variant") public var variant
+    @Field<String>("payload") public var payload
+    @Field<String>("variant") public var variant
   }
 }
 

--- a/PocketKit/Sources/PocketKit/FeatureFlagService.swift
+++ b/PocketKit/Sources/PocketKit/FeatureFlagService.swift
@@ -88,7 +88,12 @@ class FeatureFlagService: NSObject, FeatureFlagServiceProtocol {
             // No variant value so we can't do anything
             return
         }
-        tracker.track(event: Events.FeatureFlag.FeatureFlagFelt(name: flag.rawValue, variant: variant))
+
+        // First attempt to log the feature flag via Braze; when false, log via tracker
+        let brazeLogged = braze.logFeatureFlagImpression(id: flag.rawValue)
+        if brazeLogged == false {
+            tracker.track(event: Events.FeatureFlag.FeatureFlagFelt(name: flag.rawValue, variant: variant))
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -30,7 +30,7 @@ class MainViewModel: ObservableObject {
         self.init(
             saves: SavesContainerViewModel(
                 tracker: Services.shared.tracker,
-                searchList: SearchViewModel(
+                searchList: DefaultSearchViewModel(
                     networkPathMonitor: NWPathMonitor(),
                     user: Services.shared.user,
                     userDefaults: Services.shared.userDefaults,

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -218,16 +218,21 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate, UISea
     }
 
     func updateSearchScope() {
-        let scope: SearchScope = isFromSaves ? .saves : .archive
-        searchViewModel.updateScope(with: scope)
+        guard let searchController = navigationItem.searchController else { return }
+        let searchBar = searchController.searchBar
 
         if isFromSaves {
-            navigationItem.searchController?.searchBar.selectedScopeButtonIndex = 0
+            searchBar.selectedScopeButtonIndex = 0
         } else {
-            navigationItem.searchController?.searchBar.selectedScopeButtonIndex = 1
+            searchBar.selectedScopeButtonIndex = 1
         }
-        navigationItem.searchController?.isActive = true
-        navigationItem.searchController?.searchBar.becomeFirstResponder()
+        searchController.isActive = true
+        searchController.searchBar.becomeFirstResponder()
+
+        guard let selectedScope = searchBar.scopeButtonTitles?[safe: searchBar.selectedScopeButtonIndex],
+              let scope = SearchScope(rawValue: selectedScope)
+        else { return }
+        searchViewModel.updateScope(with: scope)
     }
 
     func willPresentSearchController(_ searchController: UISearchController) {

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -62,7 +62,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
     var isFromSaves: Bool
 
     private let viewControllers: [SelectableViewController]
-    private var searchViewModel: SearchViewModel
+    private var searchViewModel: DefaultSearchViewModel
     private var model: SavesContainerViewModel
 
     private var subscriptions: [AnyCancellable] = []

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -51,7 +51,7 @@ protocol SelectableViewController: UIViewController {
     func didBecomeSelected(by parent: SavesContainerViewController)
 }
 
-class SavesContainerViewController: UIViewController, UISearchBarDelegate {
+class SavesContainerViewController: UIViewController, UISearchBarDelegate, UISearchControllerDelegate {
     var selectedIndex: Int {
         didSet {
             resetTitleView()
@@ -165,11 +165,11 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
         let searchViewController = UIHostingController(rootView: SearchView(viewModel: searchViewModel))
         searchViewController.view.backgroundColor = UIColor(.ui.white1)
         navigationItem.searchController = UISearchController(searchResultsController: searchViewController)
+        navigationItem.searchController?.delegate = self
         navigationItem.searchController?.searchBar.delegate = self
         navigationItem.searchController?.searchBar.autocapitalizationType = .none
         navigationItem.searchController?.view.accessibilityIdentifier = "search-view"
         navigationItem.searchController?.searchBar.accessibilityHint = "Search"
-        navigationItem.searchController?.searchBar.scopeButtonTitles = searchViewModel.scopeTitles
         navigationItem.searchController?.scopeBarActivation = .onSearchActivation
         navigationItem.preferredSearchBarPlacement = .stacked
         navigationItem.searchController?.showsSearchResultsController = true
@@ -228,6 +228,12 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate {
         }
         navigationItem.searchController?.isActive = true
         navigationItem.searchController?.searchBar.becomeFirstResponder()
+    }
+
+    func willPresentSearchController(_ searchController: UISearchController) {
+        // Update the scope titles, since the user may have been (un)enrolled in the premium search experiment.
+        searchViewModel.updateScopeTitles()
+        navigationItem.searchController?.searchBar.scopeButtonTitles = searchViewModel.scopeTitles
     }
 }
 

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -18,14 +18,14 @@ class SavesContainerViewModel {
     @Published var selection: Selection = .saves
 
     let tracker: Tracker
-    let searchList: SearchViewModel
+    let searchList: DefaultSearchViewModel
     let savedItemsList: SavedItemsListViewModel
     let archivedItemsList: SavedItemsListViewModel
     let addSavedItemModel: AddSavedItemViewModel
 
     init(
         tracker: Tracker,
-        searchList: SearchViewModel,
+        searchList: DefaultSearchViewModel,
         savedItemsList: SavedItemsListViewModel,
         archivedItemsList: SavedItemsListViewModel,
         addSavedItemModel: AddSavedItemViewModel

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/PremiumExperimentSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/PremiumExperimentSearch.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Sync
+import Combine
+import SharedPocketKit
+
+class PremiumExperimentSearch {
+    private let source: Source
+    private let searchService: SearchService
+    private var subscriptions: [AnyCancellable] = []
+    private var cache: [String: [PocketItem]] = [:]
+    private let scope: SearchScope
+
+    var pageNumberLoaded: Int = 0
+
+    @Published var results: Result<[PocketItem], Error>?
+
+    init(source: Source, scope: SearchScope) {
+        self.source = source
+        self.searchService = source.makeSearchService()
+        self.scope = scope
+    }
+
+    func hasCache(with term: String) -> Bool {
+        cache[term] != nil
+    }
+
+    func search(with term: String, shouldLoadMoreResults: Bool = false) {
+        guard !hasCache(with: term) || shouldLoadMoreResults else {
+            Log.debug("Load cache for search")
+            results = .success(cache[term] ?? [])
+            return
+        }
+        clear()
+        searchService.results.dropFirst().sink { [weak self] items in
+            guard let self, let items else { return }
+            let searchItems = items.compactMap { PocketItem(item: $0) }
+            self.pageNumberLoaded += 1
+            guard let currentItems = self.cache[term] else {
+                self.cache[term] = searchItems
+                self.results = .success(searchItems)
+                return
+            }
+
+            self.cache[term] = currentItems + searchItems
+            self.results = .success(currentItems + searchItems)
+        }.store(in: &subscriptions)
+
+        Task {
+            do {
+                try await searchService.search(for: term, scope: scope)
+            } catch {
+                self.results = .failure(error)
+            }
+        }
+    }
+
+    private func clear() {
+        subscriptions = []
+    }
+
+    var hasFinishedResults: Bool {
+        searchService.hasFinishedResults
+    }
+
+    var lastEndCursor: String {
+        searchService.lastEndCursor
+    }
+}

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/PremiumOnlineSearch.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/PremiumOnlineSearch.swift
@@ -6,7 +6,9 @@ import Sync
 import Combine
 import SharedPocketKit
 
-class PremiumExperimentSearch {
+/// A type that can perform a premium online-only search by searching by tag, title, or content.
+/// Currently, this is used during a premium search experiment.
+class PremiumOnlineSearch {
     private let source: Source
     private let searchService: SearchService
     private var subscriptions: [AnyCancellable] = []
@@ -27,7 +29,7 @@ class PremiumExperimentSearch {
     }
 
     func search(with term: String, scope: SearchScope, shouldLoadMoreResults: Bool = false) {
-        guard SearchScope.premiumExperimentScopes.contains(scope) else {
+        guard SearchScope.premiumScopes.contains(scope) else {
             results = .success([])
             return
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchView.swift
@@ -8,7 +8,7 @@ import Textile
 import Localization
 
 struct SearchView: View {
-    @ObservedObject var viewModel: SearchViewModel
+    @ObservedObject var viewModel: DefaultSearchViewModel
 
     var body: some View {
         Group {
@@ -44,7 +44,7 @@ struct ResultsView: View {
 
     @Environment(\.horizontalSizeClass)
     var sizeClass
-    @ObservedObject var viewModel: SearchViewModel
+    @ObservedObject var viewModel: DefaultSearchViewModel
     @State private var showingAlert = false
 
     let results: [PocketItem]
@@ -133,7 +133,7 @@ struct SearchEmptyView: View {
 
 struct GetPocketPremiumButton: View {
     @State var dismissReason: DismissReason = .swipe
-    @EnvironmentObject private var searchViewModel: SearchViewModel
+    @EnvironmentObject private var searchViewModel: DefaultSearchViewModel
     private let text: String
 
     init(text: String) {
@@ -169,7 +169,7 @@ struct GetPocketPremiumButton: View {
 
 // MARK: - Recent Searches Component
 struct RecentSearchView: View {
-    @ObservedObject var viewModel: SearchViewModel
+    @ObservedObject var viewModel: DefaultSearchViewModel
     var recentSearches: [String]
 
     var body: some View {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -149,7 +149,7 @@ class DefaultSearchViewModel: ObservableObject {
         savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
         archiveOnlineSearch = OnlineSearch(source: source, scope: .archive)
         allOnlineSearch = OnlineSearch(source: source, scope: .all)
-        premiumExperimentSearch = PremiumExperimentSearch(source: source, scope: .all)
+        premiumExperimentSearch = PremiumExperimentSearch(source: source)
 
         searchState = defaultState
         itemsController.delegate = self
@@ -234,7 +234,7 @@ class DefaultSearchViewModel: ObservableObject {
         savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
         archiveOnlineSearch = OnlineSearch(source: source, scope: .archive)
         allOnlineSearch = OnlineSearch(source: source, scope: .all)
-        premiumExperimentSearch = PremiumExperimentSearch(source: source, scope: .all)
+        premiumExperimentSearch = PremiumExperimentSearch(source: source)
     }
 
     /// Resets the search objects if it does not have a cache before each search
@@ -254,8 +254,8 @@ class DefaultSearchViewModel: ObservableObject {
             allOnlineSearch = OnlineSearch(source: source, scope: .all)
         }
 
-        if !premiumExperimentSearch.hasCache(with: term) {
-            premiumExperimentSearch = PremiumExperimentSearch(source: source, scope: .all)
+        if !premiumExperimentSearch.hasCache(with: term, scope: selectedScope) {
+            premiumExperimentSearch = PremiumExperimentSearch(source: source)
         }
     }
 
@@ -278,7 +278,7 @@ class DefaultSearchViewModel: ObservableObject {
             allOnlineSearch.search(with: term, and: true)
         case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
             guard !premiumExperimentSearch.hasFinishedResults else { return }
-            premiumExperimentSearch.search(with: term, shouldLoadMoreResults: true)
+            premiumExperimentSearch.search(with: term, scope: selectedScope, shouldLoadMoreResults: true)
             return // TODO: Update for premium search experiment
         }
     }
@@ -311,8 +311,8 @@ class DefaultSearchViewModel: ObservableObject {
             allOnlineSearch.search(with: term)
             listenForResults(with: term, onlineSearch: allOnlineSearch, scope: .all)
         case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
-            premiumExperimentSearch.search(with: term)
-            listenForResults(with: term, premiumExperimentSearch: premiumExperimentSearch, scope: .all)
+            premiumExperimentSearch.search(with: term, scope: selectedScope)
+            listenForResults(with: term, premiumExperimentSearch: premiumExperimentSearch, scope: selectedScope)
         }
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -35,7 +35,7 @@ protocol SearchResultActionDelegate: AnyObject {
 }
 
 /// View model that holds business logic for the SearchView
-class SearchViewModel: ObservableObject {
+class DefaultSearchViewModel: ObservableObject {
     static let recentSearchesKey = UserDefaults.Key.recentSearches
 
     private var subscriptions: [AnyCancellable] = []
@@ -120,10 +120,10 @@ class SearchViewModel: ObservableObject {
 
     private var recentSearches: [String] {
         get {
-            userDefaults.stringArray(forKey: SearchViewModel.recentSearchesKey) ?? []
+            userDefaults.stringArray(forKey: DefaultSearchViewModel.recentSearchesKey) ?? []
         }
         set {
-            userDefaults.set(newValue, forKey: SearchViewModel.recentSearchesKey)
+            userDefaults.set(newValue, forKey: DefaultSearchViewModel.recentSearchesKey)
         }
     }
 
@@ -427,7 +427,7 @@ class SearchViewModel: ObservableObject {
     }
 }
 
-extension SearchViewModel: SearchResultActionDelegate {
+extension DefaultSearchViewModel: SearchResultActionDelegate {
     func itemViewModel(_ searchItem: PocketItem, index: Int) -> PocketItemViewModel {
         return PocketItemViewModel(
             item: searchItem,
@@ -549,7 +549,7 @@ extension SearchViewModel: SearchResultActionDelegate {
 }
 
 // MARK: Analytics
-extension SearchViewModel {
+extension DefaultSearchViewModel {
     /// Tracks when user opens search (magnifying glass or pull down)
     func trackOpenSearch() {
         tracker.track(event: Events.Search.openSearch(scope: selectedScope))
@@ -605,7 +605,7 @@ extension SearchViewModel {
     }
 }
 
-extension SearchViewModel: SavedItemsControllerDelegate {
+extension DefaultSearchViewModel: SavedItemsControllerDelegate {
     func controller(
         _ controller: SavedItemsController,
         didChange savedItem: SavedItem,
@@ -637,7 +637,7 @@ extension SearchViewModel: SavedItemsControllerDelegate {
 }
 
 // MARK: Premium upgrades
-extension SearchViewModel {
+extension DefaultSearchViewModel {
     @MainActor
     func makePremiumUpgradeViewModel() -> PremiumUpgradeViewModel {
         premiumUpgradeViewModelFactory(.search)
@@ -650,7 +650,7 @@ extension SearchViewModel {
 }
 
 // MARK: Sentry User Feedback Reporting
-extension SearchViewModel {
+extension DefaultSearchViewModel {
     var userEmail: String {
         user.email
     }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -470,8 +470,15 @@ class DefaultSearchViewModel: ObservableObject {
         let currentPathStatus = path?.status
 
         if lastPathStatus == .unsatisfied, currentPathStatus == .satisfied {
-            guard let currentSearchTerm, !currentSearchTerm.isEmpty, selectedScope == .archive || selectedScope == .all else { return }
-            updateSearchResults(with: currentSearchTerm)
+            guard let currentSearchTerm, !currentSearchTerm.isEmpty else { return }
+            switch selectedScope {
+            case .saves:
+                return
+            case .archive, .all:
+                updateSearchResults(with: currentSearchTerm)
+            case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+                updateSearchResults(with: currentSearchTerm)
+            }
         }
 
         lastPathStatus = currentPathStatus

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -276,7 +276,7 @@ class DefaultSearchViewModel: ObservableObject {
         case .all:
             guard !allOnlineSearch.hasFinishedResults else { return }
             allOnlineSearch.search(with: term, and: true)
-        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
             guard !premiumExperimentSearch.hasFinishedResults else { return }
             premiumExperimentSearch.search(with: term, scope: selectedScope, shouldLoadMoreResults: true)
             return // TODO: Update for premium search experiment
@@ -310,7 +310,7 @@ class DefaultSearchViewModel: ObservableObject {
         case .all:
             allOnlineSearch.search(with: term)
             listenForResults(with: term, onlineSearch: allOnlineSearch, scope: .all)
-        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
             premiumExperimentSearch.search(with: term, scope: selectedScope)
             listenForResults(with: term, premiumExperimentSearch: premiumExperimentSearch, scope: selectedScope)
         }
@@ -427,7 +427,7 @@ class DefaultSearchViewModel: ObservableObject {
             return NoResultsEmptyState()
         case .archive, .all:
             return isOffline ? OfflineEmptyState(type: selectedScope) : NoResultsEmptyState()
-        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
             return isOffline ? OfflineEmptyState(type: selectedScope) : NoResultsEmptyState() // TODO: Update for premium search experiment
         }
     }
@@ -443,7 +443,7 @@ class DefaultSearchViewModel: ObservableObject {
             return isOffline ? OfflineEmptyState(type: .archive) : SearchEmptyState()
         case .all:
             return GetPremiumEmptyState()
-        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
             return isOffline ? OfflineEmptyState(type: .archive) : SearchEmptyState() // TODO: Update for premium search experiment
         }
     }
@@ -476,7 +476,7 @@ class DefaultSearchViewModel: ObservableObject {
                 return
             case .archive, .all:
                 updateSearchResults(with: currentSearchTerm)
-            case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+            case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
                 updateSearchResults(with: currentSearchTerm)
             }
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -176,6 +176,7 @@ class DefaultSearchViewModel: ObservableObject {
     func updateScopeTitles() {
         if featureFlags.isAssigned(flag: .premiumSearchScopesExperiment, variant: nil) {
             scopeTitles = SearchScope.premiumExperimentScopes.map { $0.rawValue }
+            featureFlags.trackFeatureFlagFelt(flag: .premiumSearchScopesExperiment, variant: nil)
         } else {
             scopeTitles = SearchScope.defaultScopes.map { $0.rawValue }
         }

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -189,7 +189,7 @@ struct Services {
             source: source
         )
 
-        featureFlagService = FeatureFlagService(source: source, tracker: tracker, userDefaults: userDefaults)
+        featureFlagService = FeatureFlagService(source: source, tracker: tracker, userDefaults: userDefaults, braze: braze)
 
         listen = Listen(
             appSession: appSession,

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -7,15 +7,15 @@ public enum SearchScope: String, CaseIterable, Codable {
     case archive = "Archive"
     case all = "All items"
     // Premium Experiment
-    case premiumSearchExperimentTitle = "Title"
-    case premiumSearchExperimentTag = "Tag"
-    case premiumSearchExperimentContent = "Content"
+    case premiumSearchByTitle = "Title"
+    case premiumSearchByTag = "Tag"
+    case premiumSearchByContent = "Content"
 
     public static var defaultScopes: [SearchScope] {
         return [.saves, .archive, .all]
     }
 
-    public static var premiumExperimentScopes: [SearchScope] {
-        return [.premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent]
+    public static var premiumScopes: [SearchScope] {
+        return [.premiumSearchByTitle, .premiumSearchByTag, .premiumSearchByContent]
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -7,15 +7,15 @@ public enum SearchScope: String, CaseIterable, Codable {
     case archive = "Archive"
     case all = "All items"
     // Premium Experiment
-    case premiumExperimentTitle = "Title"
-    case premiumExperimentTags = "Tag"
-    case premiumExperimentContent = "Content"
+    case premiumSearchExperimentTitle = "Title"
+    case premiumSearchExperimentTag = "Tag"
+    case premiumSearchExperimentContent = "Content"
 
     public static var defaultScopes: [SearchScope] {
         return [.saves, .archive, .all]
     }
 
     public static var premiumExperimentScopes: [SearchScope] {
-        return [.premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent]
+        return [.premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent]
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -6,4 +6,16 @@ public enum SearchScope: String, CaseIterable, Codable {
     case saves = "Saves"
     case archive = "Archive"
     case all = "All items"
+    // Premium Experiment
+    case premiumExperimentTitle = "Title"
+    case premiumExperimentTags = "Tags"
+    case premiumExperimentContent = "Content"
+
+    public static var defaultScopes: [SearchScope] {
+        return [.saves, .archive, .all]
+    }
+
+    public static var premiumExperimentScopes: [SearchScope] {
+        return [.premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent]
+    }
 }

--- a/PocketKit/Sources/SharedPocketKit/SearchScope.swift
+++ b/PocketKit/Sources/SharedPocketKit/SearchScope.swift
@@ -8,7 +8,7 @@ public enum SearchScope: String, CaseIterable, Codable {
     case all = "All items"
     // Premium Experiment
     case premiumExperimentTitle = "Title"
-    case premiumExperimentTags = "Tags"
+    case premiumExperimentTags = "Tag"
     case premiumExperimentContent = "Content"
 
     public static var defaultScopes: [SearchScope] {

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -117,11 +117,11 @@ public class PocketSearchService: SearchService {
             return SearchFilterInput(status: .init(.archived))
         case .all:
             return SearchFilterInput()
-        case .premiumExperimentTitle:
+        case .premiumSearchExperimentTitle:
             return SearchFilterInput(onlyTitleAndURL: true)
-        case .premiumExperimentTags:
+        case .premiumSearchExperimentTag:
             return SearchFilterInput()
-        case .premiumExperimentContent:
+        case .premiumSearchExperimentContent:
             return SearchFilterInput()
         }
     }
@@ -132,10 +132,10 @@ public class PocketSearchService: SearchService {
 
     func getTerm(_ term: String, for scope: SearchScope) -> String {
         switch scope {
-        case .all, .saves, .archive, .premiumExperimentTitle, .premiumExperimentContent: return term
+        case .all, .saves, .archive, .premiumSearchExperimentTitle, .premiumSearchExperimentContent: return term
         // For now, assume that tags uses the search bar text as a single tag term.
         // Support for multiple tags may come later.
-        case .premiumExperimentTags:
+        case .premiumSearchExperimentTag:
             // Searching by tag uses custom operators:
             // https://support.mozilla.org/en-US/kb/searching-for-tags-with-pocket-premium
             // So, if the user has already prefixed their search term appropriately,

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -117,6 +117,8 @@ public class PocketSearchService: SearchService {
             return SearchFilterInput(status: .init(.archived))
         case .all:
             return SearchFilterInput()
+        default:
+            return SearchFilterInput() // TODO: Update for premium search experiment
         }
     }
 

--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -117,11 +117,11 @@ public class PocketSearchService: SearchService {
             return SearchFilterInput(status: .init(.archived))
         case .all:
             return SearchFilterInput()
-        case .premiumSearchExperimentTitle:
+        case .premiumSearchByTitle:
             return SearchFilterInput(onlyTitleAndURL: true)
-        case .premiumSearchExperimentTag:
+        case .premiumSearchByTag:
             return SearchFilterInput()
-        case .premiumSearchExperimentContent:
+        case .premiumSearchByContent:
             return SearchFilterInput()
         }
     }
@@ -132,10 +132,10 @@ public class PocketSearchService: SearchService {
 
     func getTerm(_ term: String, for scope: SearchScope) -> String {
         switch scope {
-        case .all, .saves, .archive, .premiumSearchExperimentTitle, .premiumSearchExperimentContent: return term
+        case .all, .saves, .archive, .premiumSearchByTitle, .premiumSearchByContent: return term
         // For now, assume that tags uses the search bar text as a single tag term.
         // Support for multiple tags may come later.
-        case .premiumSearchExperimentTag:
+        case .premiumSearchByTag:
             // Searching by tag uses custom operators:
             // https://support.mozilla.org/en-US/kb/searching-for-tags-with-pocket-premium
             // So, if the user has already prefixed their search term appropriately,

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -788,7 +788,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchByTitle, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -818,7 +818,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumSearchExperimentTag, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchByTag, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -844,7 +844,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumSearchExperimentContent, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchByContent, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -886,7 +886,7 @@ extension DefaultSearchViewModelTests {
 
         // Since the logic is the same for title, tag, and content (aside from which query filter is used),
         // we will assume that this single scope test will act the same for the others.
-        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "search-term")
+        viewModel.updateScope(with: .premiumSearchByTitle, searchTerm: "search-term")
 
         networkPathMonitor.update(status: .satisfied)
 
@@ -912,7 +912,7 @@ extension DefaultSearchViewModelTests {
         }
         XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
 
-        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "search-term")
+        viewModel.updateScope(with: .premiumSearchByTitle, searchTerm: "search-term")
         guard case .emptyState(let emptyStateViewModel) = viewModel.searchState else {
             XCTFail("Should not have failed")
             return
@@ -943,7 +943,7 @@ extension DefaultSearchViewModelTests {
             searchExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: term)
+        viewModel.updateScope(with: .premiumSearchByTitle, searchTerm: term)
 
         await setupOnlineSearch(with: term)
 

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -767,7 +767,7 @@ extension DefaultSearchViewModelTests {
         featureFlags.stubIsAssigned { _, _ in
             return true
         }
-        
+
         let errorExpectation = expectation(description: "should throw an error")
         searchService.stubSearch { _, _ in
             errorExpectation.fulfill()
@@ -788,7 +788,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumExperimentTitle, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -797,7 +797,7 @@ extension DefaultSearchViewModelTests {
         featureFlags.stubIsAssigned { _, _ in
             return true
         }
-        
+
         let errorExpectation = expectation(description: "should throw an error")
         searchService.stubSearch { _, _ in
             errorExpectation.fulfill()
@@ -818,7 +818,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumExperimentTags, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchExperimentTag, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -844,7 +844,7 @@ extension DefaultSearchViewModelTests {
             errorExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumExperimentContent, searchTerm: "saved")
+        viewModel.updateScope(with: .premiumSearchExperimentContent, searchTerm: "saved")
 
         await fulfillment(of: [errorExpectation], timeout: 10)
     }
@@ -886,7 +886,7 @@ extension DefaultSearchViewModelTests {
 
         // Since the logic is the same for title, tag, and content (aside from which query filter is used),
         // we will assume that this single scope test will act the same for the others.
-        viewModel.updateScope(with: .premiumExperimentTitle, searchTerm: "search-term")
+        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "search-term")
 
         networkPathMonitor.update(status: .satisfied)
 
@@ -899,7 +899,7 @@ extension DefaultSearchViewModelTests {
         featureFlags.stubIsAssigned { _, _ in
             return true
         }
-        
+
         await setupOnlineSearch(with: "search-term")
 
         let viewModel = await subject(user: MockUser(status: .premium))
@@ -912,7 +912,7 @@ extension DefaultSearchViewModelTests {
         }
         XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
 
-        viewModel.updateScope(with: .premiumExperimentTitle, searchTerm: "search-term")
+        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: "search-term")
         guard case .emptyState(let emptyStateViewModel) = viewModel.searchState else {
             XCTFail("Should not have failed")
             return
@@ -926,7 +926,7 @@ extension DefaultSearchViewModelTests {
         featureFlags.stubIsAssigned { _, _ in
             return true
         }
-        
+
         let term = "search-term"
         await setupOnlineSearch(with: term)
 
@@ -943,7 +943,7 @@ extension DefaultSearchViewModelTests {
             searchExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        viewModel.updateScope(with: .premiumExperimentTitle, searchTerm: term)
+        viewModel.updateScope(with: .premiumSearchExperimentTitle, searchTerm: term)
 
         await setupOnlineSearch(with: term)
 

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -12,7 +12,7 @@ import Apollo
 @testable import Sync
 @testable import PocketKit
 
-class SearchViewModelTests: XCTestCase {
+class DefaultSearchViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var userDefaults: UserDefaults!
     private var source: MockSource!
@@ -67,14 +67,14 @@ class SearchViewModelTests: XCTestCase {
         source: Source? = nil,
         tracker: Tracker? = nil,
         notificationCenter: NotificationCenter? = nil
-    ) async -> SearchViewModel {
+    ) async -> DefaultSearchViewModel {
         let premiumViewModel = PremiumUpgradeViewModel(
             store: subscriptionStore,
             tracker: MockTracker(),
             source: .search,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor
         )
-        return SearchViewModel(
+        return DefaultSearchViewModel(
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             user: user,
             userDefaults: userDefaults ?? self.userDefaults,

--- a/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
@@ -6,7 +6,9 @@ import Foundation
 import UserNotifications
 @testable import PocketKit
 
-class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol { }
+class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol {
+    func logFeatureFlagImpression(id: String) -> Bool { return false }
+}
 
 extension MockPocketBraze {
     private static let isFeatureFlagEnabled = "isFeatureFlagEnabled"

--- a/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
@@ -6,9 +6,7 @@ import Foundation
 import UserNotifications
 @testable import PocketKit
 
-class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol {
-
-}
+class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol { }
 
 extension MockPocketBraze {
     private static let isFeatureFlagEnabled = "isFeatureFlagEnabled"

--- a/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockPocketBraze.swift
@@ -6,7 +6,39 @@ import Foundation
 import UserNotifications
 @testable import PocketKit
 
-class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol { }
+class MockPocketBraze: MockPushNotificationProtocol, BrazeSDKProtocol {
+
+}
+
+extension MockPocketBraze {
+    private static let isFeatureFlagEnabled = "isFeatureFlagEnabled"
+    typealias IsFeatureFlagEnabledImpl = (String) -> Bool
+    struct IsFeatureFlagEnabledCall {
+        let id: String
+    }
+
+    func stubIsFeatureFlagEnabled(impl: @escaping IsFeatureFlagEnabledImpl) {
+        implementations[Self.isFeatureFlagEnabled] = impl
+    }
+
+    func isFeatureFlagEnabled(id: String) -> Bool {
+        guard let impl = implementations[Self.isFeatureFlagEnabled] as? IsFeatureFlagEnabledImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.isFeatureFlagEnabled] = (calls[Self.isFeatureFlagEnabled] ?? []) + [IsFeatureFlagEnabledCall(id: id)]
+
+        return impl(id)
+    }
+
+    func isFeatureFlagCall(at index: Int) -> IsFeatureFlagEnabledCall? {
+        guard let calls = calls[Self.isFeatureFlagEnabled] else {
+            return nil
+        }
+
+        return calls[safe: index] as? IsFeatureFlagEnabledCall
+    }
+}
 
 // MARK: Did Receive User Notification
 extension MockPocketBraze {

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-1.json
@@ -5,7 +5,7 @@
       "isPremium": true,
       "savedItems": {
         "__typename": "[type-name-here]",
-        "totalCount": 1001,
+        "totalCount": 10001,
         "pageInfo": {
           "__typename": "[type-name-here]",
           "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-2.json
@@ -5,7 +5,7 @@
       "isPremium": true,
       "savedItems": {
         "__typename": "[type-name-here]",
-        "totalCount": 1001,
+        "totalCount": 10001,
         "pageInfo": {
           "__typename": "[type-name-here]",
           "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/large-list-3.json
@@ -5,7 +5,7 @@
       "isPremium": true,
       "savedItems": {
         "__typename": "[type-name-here]",
-        "totalCount": 1001,
+        "totalCount": 10001,
         "pageInfo": {
           "__typename": "[type-name-here]",
           "hasNextPage": true,

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -149,7 +149,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search-term", scope: .premiumSearchExperimentTitle)
+        try await service.search(for: "search-term", scope: .premiumSearchByTitle)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -167,7 +167,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search term", scope: .premiumSearchExperimentTag)
+        try await service.search(for: "search term", scope: .premiumSearchByTag)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -185,7 +185,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "#search", scope: .premiumSearchExperimentTag)
+        try await service.search(for: "#search", scope: .premiumSearchByTag)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -203,7 +203,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search-term", scope: .premiumSearchExperimentContent)
+        try await service.search(for: "search-term", scope: .premiumSearchByContent)
 
         wait(for: [searchExpectation], timeout: 10)
 

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -149,7 +149,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search-term", scope: .premiumExperimentTitle)
+        try await service.search(for: "search-term", scope: .premiumSearchExperimentTitle)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -167,7 +167,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search term", scope: .premiumExperimentTags)
+        try await service.search(for: "search term", scope: .premiumSearchExperimentTag)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -185,7 +185,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "#search", scope: .premiumExperimentTags)
+        try await service.search(for: "#search", scope: .premiumSearchExperimentTag)
 
         wait(for: [searchExpectation], timeout: 10)
 
@@ -203,7 +203,7 @@ extension PocketSearchServiceTests {
             searchExpectation.fulfill()
         }.store(in: &cancellables)
 
-        try await service.search(for: "search-term", scope: .premiumExperimentContent)
+        try await service.search(for: "search-term", scope: .premiumSearchExperimentContent)
 
         wait(for: [searchExpectation], timeout: 10)
 

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -133,6 +133,12 @@ struct ClientAPIRequest {
             return self.operationName == "SearchSavedItems" && contains("filter\":{\"status\":\"ARCHIVED\"}")
         case .all:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}")
+        case .premiumExperimentTitle:
+            return self.operationName == "SearchSavedItems" && contains("filter\":{\"onlyTitleAndURL\"}")
+        case .premiumExperimentTags:
+            return self.operationName == "SearchSavedItems" && contains("filter\":{}") && contains("tag:")
+        case .premiumExperimentContent:
+            return self.operationName == "SearchSavedItems" && contains("filter\":{}")
         }
     }
 

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -133,11 +133,11 @@ struct ClientAPIRequest {
             return self.operationName == "SearchSavedItems" && contains("filter\":{\"status\":\"ARCHIVED\"}")
         case .all:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}")
-        case .premiumSearchExperimentTitle:
+        case .premiumSearchByTitle:
             return self.operationName == "SearchSavedItems" && contains("filter\":{\"onlyTitleAndURL\"}")
-        case .premiumSearchExperimentTag:
+        case .premiumSearchByTag:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}") && contains("tag:")
-        case .premiumSearchExperimentContent:
+        case .premiumSearchByContent:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}")
         }
     }

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -133,11 +133,11 @@ struct ClientAPIRequest {
             return self.operationName == "SearchSavedItems" && contains("filter\":{\"status\":\"ARCHIVED\"}")
         case .all:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}")
-        case .premiumExperimentTitle:
+        case .premiumSearchExperimentTitle:
             return self.operationName == "SearchSavedItems" && contains("filter\":{\"onlyTitleAndURL\"}")
-        case .premiumExperimentTags:
+        case .premiumSearchExperimentTag:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}") && contains("tag:")
-        case .premiumExperimentContent:
+        case .premiumSearchExperimentContent:
             return self.operationName == "SearchSavedItems" && contains("filter\":{}")
         }
     }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -256,7 +256,7 @@ extension Response {
             fixtureName = "search-list-archive"
         case .all:
             fixtureName = "search-list-all"
-        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
+        case .premiumSearchByTitle, .premiumSearchByTag, .premiumSearchByContent:
             fixtureName = "search-list-all"
         }
 

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -256,6 +256,8 @@ extension Response {
             fixtureName = "search-list-archive"
         case .all:
             fixtureName = "search-list-all"
+        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+            fixtureName = "search-list-all"
         }
 
         return Response {

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -256,7 +256,7 @@ extension Response {
             fixtureName = "search-list-archive"
         case .all:
             fixtureName = "search-list-all"
-        case .premiumExperimentTitle, .premiumExperimentTags, .premiumExperimentContent:
+        case .premiumSearchExperimentTitle, .premiumSearchExperimentTag, .premiumSearchExperimentContent:
             fixtureName = "search-list-all"
         }
 


### PR DESCRIPTION
## Summary

Adds support for a premium search experiment by feature flag. This experiment updates the scopes to online-only by title, tag, or content.

This also fixes a Sync test that was failing after updating the max download count for Saves and Archive.

If the time comes to remove this experiment, I'd suggest removing the three added scopes and resolving any build errors.

## Implementation Details

- Update feature flags to check via Unleash _or_ Braze
- Add three premium experiment scopes to existing `SearchScope`
- Dynamically update titles based on feature flag when search is first opened
- Piggyback off of existing online-only logic to add online-only support, ensuring it only occurs if the scope is a premium experiment scope
- Add `PremiumExperimentSearch` to handle updated query filter
  - Added as a separate file just to keep the logic for experiment search separate from default online search
 
I initially had an idea to turn `SearchViewModel` into a protocol and have two conforming types (default, and experiment), but the refactor for that would've been too great, so I deferred to a simpler solution that utilized the existing view model.

## Test Steps

- [ ] Add yourself to the premium search experiment via Braze feature flag
- [ ] Launch the app
- [ ] When opening Search, you should see "Title", "Tag", and "Content"
- [ ] When searching by "Title", you should see only results that contain that word in the title
- [ ] When searching by Tag, you should see only the items tagged by your search term (single tag only)
- [ ] When searching by Content, you should see the equivalent of performing "All" outside of the experiment
---
- [ ] Remove yourself to the premium search experiment via Braze feature flag
- [ ] Launch the app
- [ ] When opening Search, you should see "Saves", "Archive", and "All"
- [ ] Regression test on the prior search experience

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
