### PR TITLE
Premium Settings - Reset to defaults for free users and premium upsell subtitle

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -203,6 +203,7 @@
 "reader.settings.alignmentLabel" = "Alignment";
 "reader.settings.resetToDefaultsLabel" = "Reset to defaults";
 "reader.settings.premiumUpsellLabel" = "Unlock more options";
+"reader.settings.premiumUpselSubtitle" = "Premium fonts, text formatting and more.";
 "reader.settings.alignmentNatural" = "Default";
 "reader.settings.alignmentJustified" = "Justified";
 

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -203,7 +203,7 @@
 "reader.settings.alignmentLabel" = "Alignment";
 "reader.settings.resetToDefaultsLabel" = "Reset to defaults";
 "reader.settings.premiumUpsellLabel" = "Unlock more options";
-"reader.settings.premiumUpselSubtitle" = "Premium fonts, text formatting and more.";
+"reader.settings.premiumUpsellSubtitle" = "Premium fonts, text formatting and more.";
 "reader.settings.alignmentNatural" = "Default";
 "reader.settings.alignmentJustified" = "Justified";
 

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -393,6 +393,8 @@ public enum Localization {
       public static let marginsLabel = Localization.tr("Localizable", "reader.settings.marginsLabel", fallback: "Margins")
       /// Unlock more options
       public static let premiumUpsellLabel = Localization.tr("Localizable", "reader.settings.premiumUpsellLabel", fallback: "Unlock more options")
+      /// Premium fonts, text formatting and more.
+      public static let premiumUpselSubtitle = Localization.tr("Localizable", "reader.settings.premiumUpselSubtitle", fallback: "Premium fonts, text formatting and more.")
       /// Reset to defaults
       public static let resetToDefaultsLabel = Localization.tr("Localizable", "reader.settings.resetToDefaultsLabel", fallback: "Reset to defaults")
       /// Display settings

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -394,7 +394,7 @@ public enum Localization {
       /// Unlock more options
       public static let premiumUpsellLabel = Localization.tr("Localizable", "reader.settings.premiumUpsellLabel", fallback: "Unlock more options")
       /// Premium fonts, text formatting and more.
-      public static let premiumUpselSubtitle = Localization.tr("Localizable", "reader.settings.premiumUpselSubtitle", fallback: "Premium fonts, text formatting and more.")
+      public static let premiumUpsellSubtitle = Localization.tr("Localizable", "reader.settings.premiumUpsellSubtitle", fallback: "Premium fonts, text formatting and more.")
       /// Reset to defaults
       public static let resetToDefaultsLabel = Localization.tr("Localizable", "reader.settings.resetToDefaultsLabel", fallback: "Reset to defaults")
       /// Display settings

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -57,13 +57,25 @@ struct ReaderSettingsView: View {
                         .navigationBarTitleDisplayMode(.inline)
                     }
                 } else {
-                    SettingsRowButton(
-                        title: Localization.Reader.Settings.premiumUpsellLabel,
-                        titleStyle: .settings.row.active,
-                        leadingImageAsset: .premiumIcon,
-                        leadingTintColor: Color(.ui.teal2)
-                    ) {
+                    Button {
                         settings.presentPremiumUpgrade()
+                    } label: {
+                        HStack(alignment: .top, spacing: 0) {
+                            VStack {
+                                Image(uiImage: UIImage(asset: .premiumIcon))
+                                    .renderingMode(.template)
+                                    .foregroundColor(Color(.ui.teal2))
+                                Spacer()
+                            }
+                            .padding(.trailing)
+                            VStack(alignment: .leading) {
+                                Text(Localization.Reader.Settings.premiumUpsellLabel)
+                                    .style(.settings.row.active)
+                                Text("Premium fonts, text formatting and more.")
+                                    .style(.settings.row.subtitle)
+                            }
+                        }
+                        .padding(.top)
                     }
                     .sheet(
                         isPresented: $settings.isPresentingPremiumUpgrade,
@@ -84,21 +96,19 @@ struct ReaderSettingsView: View {
             .sheet(isPresented: $settings.isPresentingHooray) {
                 PremiumUpgradeSuccessView()
             }
-            if settings.isPremium {
-                Section {
-                    Button {
-                        settings.reset()
-                    } label: {
-                        HStack {
-                            Text(Localization.Reader.Settings.resetToDefaultsLabel)
-                            Spacer()
-                            if settings.isUsingDefaults {
-                                Image(systemName: "checkmark")
-                            }
+            Section {
+                Button {
+                    settings.reset()
+                } label: {
+                    HStack {
+                        Text(Localization.Reader.Settings.resetToDefaultsLabel)
+                        Spacer()
+                        if settings.isUsingDefaults {
+                            Image(systemName: "checkmark")
                         }
                     }
-                    .foregroundColor(Color(.ui.black1))
                 }
+                .foregroundColor(Color(.ui.black1))
             }
         }
     }

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -68,10 +68,10 @@ struct ReaderSettingsView: View {
                                 Spacer()
                             }
                             .padding(.trailing)
-                            VStack(alignment: .leading) {
+                            VStack(alignment: .leading, spacing: 6) {
                                 Text(Localization.Reader.Settings.premiumUpsellLabel)
                                     .style(.settings.row.active)
-                                Text("Premium fonts, text formatting and more.")
+                                Text(Localization.Reader.Settings.premiumUpselSubtitle)
                                     .style(.settings.row.subtitle)
                             }
                         }

--- a/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
+++ b/PocketKit/Sources/PocketKit/ReaderSettings/ReaderSettingsView.swift
@@ -71,7 +71,7 @@ struct ReaderSettingsView: View {
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(Localization.Reader.Settings.premiumUpsellLabel)
                                     .style(.settings.row.active)
-                                Text(Localization.Reader.Settings.premiumUpselSubtitle)
+                                Text(Localization.Reader.Settings.premiumUpsellSubtitle)
                                     .style(.settings.row.subtitle)
                             }
                         }

--- a/PocketKit/Sources/PocketKit/Settings/Style+Settings.swift
+++ b/PocketKit/Sources/PocketKit/Settings/Style+Settings.swift
@@ -10,6 +10,7 @@ extension Style {
 
         struct Row {
             let `default`: Style = Style.header.sansSerif.p3.with(color: .ui.black1)
+            let subtitle = Style.header.sansSerif.p4.with(color: .ui.grey3)
             let header: Style = Style.header.sansSerif.p5.with(weight: .medium).with(color: .ui.black1)
             let deactivated: Style = Style.header.sansSerif.p3.with(color: .ui.grey4)
             let active: Style = Style.header.sansSerif.p3.with(color: .ui.teal2)


### PR DESCRIPTION
## Summary
* This PR:
    - extends the "Reset to defaults" feature to free users
    - Adds a subtitle to the premium upsell button

## References 
* NA

## Implementation Details
* Update `ReaderSettingsView` with the changes described in the summary

## Test Steps
* Checkout this branch and login as a free users
* Tap a saved article then overflow menu then reader settings
* Make sure you see the "Reset to defaults" and that, if you change font and/or size and then tap it, defaults are restored
* Make sure the premium upsell looks and works as expected

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

iPhone | iPad
-- | --
<img height=400 src=https://github.com/Pocket/pocket-ios/assets/34376330/b934c090-fdd2-4adf-a1ef-2eefc871713a> | <img height=400 src=https://github.com/Pocket/pocket-ios/assets/34376330/2d09d1f1-7583-4e51-a1c5-ba9e31460709>

