### PR TITLE
feat(listen): add support for dark mode

### DIFF
--- a/PocketKit/Sources/PocketKit/Listen/Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/Listen.swift
@@ -13,7 +13,7 @@ import Network
 class Listen: NSObject {
     private var subscriptions: Set<AnyCancellable> = []
 
-    static let colors = PKTListenAppTheme()
+    static let colors = ListenTheme()
 
     /// Analytics tracker
     private let tracker: Tracker

--- a/PocketKit/Sources/PocketKit/Listen/ListenTheme.swift
+++ b/PocketKit/Sources/PocketKit/Listen/ListenTheme.swift
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import PKTListen
+import Textile
+
+class ListenTheme: NSObject, PKTUITheme {
+    func white() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.gray1)
+        }
+
+        return UIColor(.listen.white)
+    }
+
+    func amber() -> UIColor! {
+        return UIColor(.listen.amber)
+    }
+
+    func amberTouch() -> UIColor! {
+        return UIColor(.listen.amberTouch)
+    }
+
+    func blue() -> UIColor! {
+        return UIColor(.listen.blue)
+    }
+
+    func blueTouch() -> UIColor! {
+        return UIColor(.listen.blueTouch)
+    }
+
+    func teal() -> UIColor! {
+        return UIColor(.listen.teal)
+    }
+
+    func tealLight() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.darkTeal)
+        }
+
+        return UIColor(.listen.tealLight)
+    }
+
+    func darkTeal() -> UIColor! {
+        return UIColor(.listen.darkTeal)
+    }
+
+    func mintGreen() -> UIColor! {
+        return UIColor(.listen.mintGreen)
+    }
+
+    func coral() -> UIColor! {
+        return UIColor(.listen.coral)
+    }
+
+    func coralTouch() -> UIColor! {
+        return UIColor(.listen.coralTouch)
+    }
+
+    func coralLight() -> UIColor! {
+        return UIColor(.listen.coralLight)
+    }
+
+    func darkTealSelection() -> UIColor! {
+        return UIColor(.listen.darkTealSelection)
+    }
+
+    func purle() -> UIColor! {
+        return UIColor(.listen.purple)
+    }
+
+    func gray1() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.white)
+        }
+
+        return UIColor(.listen.gray1)
+    }
+
+    func gray2() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.gray3)
+        }
+
+        return UIColor(.listen.gray2)
+    }
+
+    func gray3() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.gray4)
+        }
+
+        return UIColor(.listen.gray3)
+    }
+
+    func gray4() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.gray5)
+        }
+
+        return UIColor(.listen.gray4)
+    }
+
+    func gray5() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.gray2)
+        }
+
+        return UIColor(.listen.gray5)
+    }
+
+    func gray6() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return UIColor(.listen.black)
+        }
+
+        return UIColor(.listen.gray6)
+    }
+
+    func tileStartFadeColor() -> UIColor! {
+        let alphaComponent = UITraitCollection.current.userInterfaceStyle == .dark ? 0.5 : 0.05
+        return .black.withAlphaComponent(alphaComponent)
+    }
+
+    func tileEndFadeColor() -> UIColor! {
+        return .black.withAlphaComponent(0)
+    }
+
+    func highlightTextColor() -> UIColor! {
+        // Legacy light mode and dark mode both use the light mode color
+        return UIColor(.listen.gray1).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+    }
+
+    func highlightBackgroundColor() -> UIColor! {
+        // Legacy light mode and dark mode both use the light mode color
+        return UIColor(.listen.amberTouch).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+    }
+
+    func disabledTextColor() -> UIColor! {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            // Legacy dark mode uses the light mode color
+            return UIColor(.listen.gray3).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        }
+
+        return UIColor(.listen.gray4)
+    }
+
+    func tagSelectedBackgroundColor() -> UIColor! {
+        return UIColor(.ui.grey7)
+    }
+
+    func inListBigDiamond() -> UIImage! {
+        return UIImage(asset: .diamond)
+    }
+
+    func statusBarStyle() -> UIStatusBarStyle {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return .lightContent
+        }
+
+        return .darkContent
+    }
+
+    func scrollViewIndicatorStyle() -> UIScrollView.IndicatorStyle {
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            return .white
+        }
+
+        return .black
+    }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/ColorAsset.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/ColorAsset.swift
@@ -16,4 +16,8 @@ public struct ColorAsset {
     static func branding(_ name: String) -> Self {
         Self(name: "Branding/\(name)")
     }
+
+    static func listen(_ name: String) -> Self {
+        Self(name: "Listen/\(name)")
+    }
 }

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/amber.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/amber.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x42",
+          "green" : "0xB5",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x43",
+          "green" : "0xB6",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/amberTouch.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/amberTouch.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD0",
+          "green" : "0xEC",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3A",
+          "green" : "0x74",
+          "red" : "0x96"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/black.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.790",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/blue.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/blue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xAA",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xAB",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/blueTouch.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/blueTouch.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xD4",
+          "red" : "0x8F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x95",
+          "green" : "0x6E",
+          "red" : "0x28"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coral.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coral.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x3E",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x40",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coralLight.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coralLight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coralTouch.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/coralTouch.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD4",
+          "green" : "0xCF",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x44",
+          "green" : "0x39",
+          "red" : "0x91"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/darkTeal.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/darkTeal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x71",
+          "green" : "0x79",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x73",
+          "green" : "0x79",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/darkTealSelection.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/darkTealSelection.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x28",
+          "red" : "0x15"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray1.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray2.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4F",
+          "green" : "0x4F",
+          "red" : "0x4F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3E",
+          "green" : "0x3E",
+          "red" : "0x3E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray3.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x82",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x82",
+          "green" : "0x82",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray4.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBB",
+          "green" : "0xBB",
+          "red" : "0xBB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xBC",
+          "red" : "0xBC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray5.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDF",
+          "green" : "0xDF",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDF",
+          "green" : "0xDF",
+          "red" : "0xDF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray6.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xF1",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray7.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/gray7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD2",
+          "green" : "0xD2",
+          "red" : "0xD2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/mintGreen.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/mintGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB7",
+          "green" : "0xEC",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0xEC",
+          "red" : "0x83"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/purple.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/purple.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEE",
+          "green" : "0x3E",
+          "red" : "0xA2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEE",
+          "green" : "0x40",
+          "red" : "0xA1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/teal.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/teal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0xB0",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0xAF",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/tealLight.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/tealLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF7",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/white.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Listen/white.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -75,7 +75,34 @@ public struct BrandingPalette {
     public let mint5 = ColorAsset.branding("mint5")
 }
 
+public struct ListenPalette {
+    public let black = ColorAsset.listen("black")
+    public let white = ColorAsset.listen("white")
+    public let amber = ColorAsset.listen("amber")
+    public let amberTouch = ColorAsset.listen("amberTouch")
+    public let blue = ColorAsset.listen("blue")
+    public let blueTouch = ColorAsset.listen("blueTouch")
+    public let teal = ColorAsset.listen("teal")
+    public let tealLight = ColorAsset.listen("tealLight")
+    public let darkTeal = ColorAsset.listen("darkTeal")
+    public let mintGreen = ColorAsset.listen("mintGreen")
+    public let coral = ColorAsset.listen("coral")
+    public let coralTouch = ColorAsset.listen("coralTouch")
+    public let coralLight = ColorAsset.listen("coralLight")
+    public let darkTealSelection = ColorAsset.listen("darkTealSelection")
+    public let purple = ColorAsset.listen("purple")
+
+    public let gray1 = ColorAsset.listen("gray1")
+    public let gray2 = ColorAsset.listen("gray2")
+    public let gray3 = ColorAsset.listen("gray3")
+    public let gray4 = ColorAsset.listen("gray4")
+    public let gray5 = ColorAsset.listen("gray5")
+    public let gray6 = ColorAsset.listen("gray6")
+    public let gray7 = ColorAsset.listen("gray7")
+}
+
 extension ColorAsset {
     public static let ui = UIPalette()
     public static let branding = BrandingPalette()
+    public static let listen = ListenPalette()
 }


### PR DESCRIPTION
## Summary

Adds support for dark mode in Listen by mimicking the light and dark themes from the legacy app.

## Implementation Details

From the legacy codebase, the correct color assets were added for colors defined in both `PKTTheme` (light mode) and `PKTDarkTheme` (dark mode). Then, a custom theme was added to the Pocket 8 codebase that supports both light and dark mode. Some colors in legacy dark mode used the light mode colors, so some colors are forced to be the light mode versions.

## Test Steps

- [ ] In light mode, open Listen. Light mode should be visible, and all UI elements should be visible
- [ ] In dark mode, open Listen. Dark mode should be visible, and all UI elements should be visible

## PR Checklist:

- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

### Light Mode
![image](https://github.com/Pocket/pocket-ios/assets/1158092/3bdee8f8-e7aa-4b13-939b-c1c1295d19ec)

### Dark Mode
![image](https://github.com/Pocket/pocket-ios/assets/1158092/ad8f521f-18d8-4be0-9fbf-d34ec5dd7f1d)
