### PR TITLE
fix(tags): updating tags pageinfo mock

### DIFF
--- a/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
@@ -10,10 +10,10 @@ public class PageInfo: MockObject {
   public typealias MockValueCollectionType = Array<Mock<PageInfo>>
 
   public struct MockFields {
-    @Field<String>("endCursor") public var endCursor
-    @Field<Bool>("hasNextPage") public var hasNextPage
-    @Field<Bool>("hasPreviousPage") public var hasPreviousPage
-    @Field<String>("startCursor") public var startCursor
+    @Field<String?>("endCursor") public var endCursor
+    @Field<Bool?>("hasNextPage") public var hasNextPage
+    @Field<Bool?>("hasPreviousPage") public var hasPreviousPage
+    @Field<String?>("startCursor") public var startCursor
   }
 }
 


### PR DESCRIPTION
## Summary
* Make fields optional when building a graphql request

See https://github.com/apollographql/apollo-ios/issues/2977

https://github.com/Pocket/pocket-ios/pull/645