### PR TITLE
feat(openIn): making save extension open in app

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -60,6 +60,16 @@
 				<string>pocket</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.mozilla.pocket.saveTo</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pocketSaveTo</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SaveTo.swift
@@ -26,6 +26,18 @@ public extension Events.SaveTo {
         )
     }
 
+    /// Fired when a user taps open from the save extension
+    static func open(url: String) -> Event {
+        return Engagement(
+            .general,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "save-extension.openInPocket.tapped"
+            ),
+            extraEntities: [ContentEntity(url: url)]
+        )
+    }
+
     /// Fired when a user taps on "Add Tags" from the Save extension
     static func addTagsEngagement(url: String) -> Event {
         return Engagement(
@@ -42,6 +54,11 @@ public extension Events.SaveTo {
     /// Fired when the extension was unable to find a URL to save
     static func unableToSave() -> Event {
         return System(type: .unableToSave, source: .saveToPocketKit)
+    }
+
+    /// Fired when the extension was unable to find a URL to open
+    static func unableToOpen() -> Event {
+        return System(type: .unableToOpen, source: .saveToPocketKit)
     }
 }
 

--- a/PocketKit/Sources/Analytics/Events/System.swift
+++ b/PocketKit/Sources/Analytics/Events/System.swift
@@ -26,6 +26,8 @@ public struct System: Event, CustomStringConvertible {
             return appPermissionType.id()
         case .unableToSave:
             return "ios.\(source).unableToSave"
+        case .unableToOpen:
+            return "ios.\(source).unableToOpen"
         }
     }
 
@@ -33,9 +35,7 @@ public struct System: Event, CustomStringConvertible {
         switch type {
         case .userMigration(let userMigrationState):
             return userMigrationState.value(source)
-        case .appPermission:
-            return nil
-        case .unableToSave:
+        case .appPermission, .unableToSave, .unableToOpen:
             return nil
         }
     }
@@ -64,6 +64,7 @@ extension System {
         case userMigration(UserMigrationState)
         case appPermission(AppPermissionType)
         case unableToSave
+        case unableToOpen
     }
 
     public enum UserMigrationState {

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "back.to.pocket" = "Back to Pocket";
 
 "saveToPocket.tapToDismiss" = "Tap to dismiss";
+"saveToPocket.openInPocket" = "Open in Pocket";
 
 "itemWidgets.loggedOutMessage" = "Log in to Pocket to see your content.";
 "itemWidgets.errorMessage" = "Something went wrong.";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -426,6 +426,8 @@ public enum Localization {
     }
   }
   public enum SaveToPocket {
+    /// Open in Pocket
+    public static let openInPocket = Localization.tr("Localizable", "saveToPocket.openInPocket", fallback: "Open in Pocket")
     /// Tap to dismiss
     public static let tapToDismiss = Localization.tr("Localizable", "saveToPocket.tapToDismiss", fallback: "Tap to dismiss")
   }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -38,6 +38,7 @@ enum ReadableSource {
     case app
     case widget
     case spotlight
+    case saveTo
     case external
 }
 
@@ -437,6 +438,9 @@ extension HomeViewModel {
         case .spotlight:
             // Spot light never indexes recs.
             Log.breadcrumb(category: "spotlight", level: .warning, message: "Somehow entered slate open from Spotlight, which should not happen")
+        case .saveTo:
+            // Spot light never indexes recs.
+            Log.breadcrumb(category: "saveTo", level: .warning, message: "Somehow entered slate open from saveTo Extension, which should not happen")
         }
     }
 
@@ -488,6 +492,8 @@ extension HomeViewModel {
             tracker.track(event: Events.Widgets.recentSavesCardContentOpen(url: url))
         case .spotlight:
             tracker.track(event: Events.Spotlight.spotlightSearchContentOpen(url: url))
+        case .saveTo:
+            tracker.track(event: Events.SaveTo.open(url: url))
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -277,6 +277,7 @@ extension MainViewModel {
         let collectionRoute = CollectionRoute(action: routingAction)
         let syndicatedRoute = SyndicationRoute(action: routingAction)
         let spotlightRoute = SpotlightRoute(action: routingAction)
-        linkRouter.addRoutes([widgetRoute, collectionRoute, syndicatedRoute, spotlightRoute])
+        let saveToOpenRoute = SaveToOpenRoute(action: routingAction)
+        linkRouter.addRoutes([widgetRoute, collectionRoute, syndicatedRoute, spotlightRoute, saveToOpenRoute])
     }
 }

--- a/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
@@ -63,6 +63,26 @@ struct WidgetRoute: Route {
     }
 }
 
+struct SaveToOpenRoute: Route {
+    let scheme = "pocketSaveTo"
+    let path = "/itemURL"
+    let source: ReadableSource = .saveTo
+    let action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    func matchedUrlString(from url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              components.scheme == scheme,
+              components.path == path else {
+            return nil
+        }
+        return components.queryItems?.first(where: { $0.name == "url" })?.value
+    }
+}
+
 struct CollectionRoute: Route {
     let scheme = "https"
     let path =  "/collections/"

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewController.swift
@@ -33,6 +33,22 @@ class SavedItemViewController: UIViewController {
         return button
     }()
 
+    private lazy var openInPocketButton: UIButton = {
+        var configuration: UIButton.Configuration = .filled()
+        configuration.background.backgroundColor = UIColor(.ui.teal2).resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        configuration.background.cornerRadius = 13
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 13, leading: 0, bottom: 13, trailing: 0)
+        configuration.attributedTitle = AttributedString(viewModel.openInPocket)
+
+        let button = UIButton(
+            configuration: configuration,
+            primaryAction: nil
+        )
+
+        button.accessibilityIdentifier = "open-in-pocket-button"
+        return button
+    }()
+
     init(viewModel: SavedItemViewModel) {
         self.viewModel = viewModel
 
@@ -50,6 +66,12 @@ class SavedItemViewController: UIViewController {
             self?.viewModel.cancelDismissTimer()
             self?.viewModel.showAddTagsView(from: self?.extensionContext)
         }, for: .primaryActionTriggered)
+
+        openInPocketButton.addAction(UIAction { [weak self] _ in
+            Task { @MainActor in
+                await self?.viewModel.open(from: self?.extensionContext)
+            }
+        }, for: .primaryActionTriggered)
     }
 
     required init?(coder: NSCoder) {
@@ -65,11 +87,13 @@ class SavedItemViewController: UIViewController {
         view.addSubview(infoView)
         view.addSubview(dismissLabel)
         view.addSubview(addTagsButton)
+        view.addSubview(openInPocketButton)
 
         imageView.translatesAutoresizingMaskIntoConstraints = false
         infoView.translatesAutoresizingMaskIntoConstraints = false
         dismissLabel.translatesAutoresizingMaskIntoConstraints = false
         addTagsButton.translatesAutoresizingMaskIntoConstraints = false
+        openInPocketButton.translatesAutoresizingMaskIntoConstraints = false
 
         let capsuleTopConstraint = NSLayoutConstraint(
             item: infoView,
@@ -89,6 +113,11 @@ class SavedItemViewController: UIViewController {
             addTagsButton.bottomAnchor.constraint(equalTo: dismissLabel.topAnchor, constant: -16),
             addTagsButton.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             addTagsButton.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+
+            capsuleTopConstraint,
+            openInPocketButton.bottomAnchor.constraint(equalTo: addTagsButton.topAnchor, constant: -16),
+            openInPocketButton.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            openInPocketButton.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
 
             dismissLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             dismissLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16)

--- a/PocketKit/Sources/SharedPocketKit/ExtensionContext.swift
+++ b/PocketKit/Sources/SharedPocketKit/ExtensionContext.swift
@@ -8,11 +8,17 @@ public protocol ExtensionContext {
     var extensionItems: [ExtensionItem] { get }
 
     func completeRequest(returningItems items: [Any]?, completionHandler: ((Bool) -> Void)?)
+
+    func open(url: URL, completionHandler: ((Bool) -> Void)?)
 }
 
 extension NSExtensionContext: ExtensionContext {
     public var extensionItems: [ExtensionItem] {
         inputItems.compactMap { $0 as? ExtensionItem }
+    }
+
+    public func open(url: URL, completionHandler: ((Bool) -> Void)?) {
+        open(url, completionHandler: completionHandler)
     }
 }
 


### PR DESCRIPTION
## Summary
Allow the user the option to open a saved item from the save extension in the app.

![simulator_screenshot_26EA3B78-3858-4A36-B3C7-3B2603FC21B2](https://github.com/Pocket/pocket-ios/assets/1010384/59fc6a78-672d-46b6-b76a-08e30c2bd999)

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Overview of work that was implemented and changes made to the codebase

## Test Steps
* Write out what QA should do to verify this change works as expected and hasn't introduced regressions. Can mention specific OS versions, devices, areas of the app to test as needed.

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
