### PR TITLE
Fix erroneous alert in premium status view

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/PremiumStatus/View/PremiumStatusView.swift
@@ -35,8 +35,10 @@ struct PremiumStatusView: View {
         .manageSubscriptionsSheet(isPresented: $presentManageSubscriptions)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("premium-status-view")
-        .task {
-            await viewModel.getInfo()
+        .onAppear {
+            Task {
+                await viewModel.getInfo()
+            }
         }
         .padding([.leading, .trailing], Constants.verticalPadding)
         .alert(

--- a/PocketKit/Sources/Sync/V3/V3Client.swift
+++ b/PocketKit/Sources/Sync/V3/V3Client.swift
@@ -96,12 +96,7 @@ public class V3Client: NSObject, V3ClientProtocol {
         request: URLRequest,
         decodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase
     )  async throws -> T  where T: Decodable {
-        let (data, response): (Data, URLResponse)
-        do {
-            (data, response) = try await urlSession.data(for: request, delegate: nil)
-        } catch {
-            throw Error.generic(error)
-        }
+        let (data, response) = try await urlSession.data(for: request, delegate: nil)
         let httpResponse = try response.httpUrlResponse()
 
         // TODO: V3 almost always returns a 200 even when errors, so we will need to check the x-status-code header in the future

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -150,6 +150,7 @@ class SettingsTest: XCTestCase {
     @MainActor
     func test_premiumStatus_success() async {
         let saveRequestExpectation = expectation(description: "A save mutation request")
+        saveRequestExpectation.assertForOverFulfill = false
         server.routes.post("/graphql") { request, _ -> Response in
             let apiRequest = ClientAPIRequest(request)
             if apiRequest.isForUserDetails {


### PR DESCRIPTION
## Summary
This PR fix an erroneous alert when displaying premium status

## References 
* branch name

## Implementation Details
*Update `PemiumStatusView`, switch from `.task` to `.onAppear` because the former seems to be cancelled by SwiftUI in certain conditions

## Test Steps
* Build/run this branch and login with a premium account
* Tap settings/premium subscriptions and make sure the info appears and no error is shown

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
