### PR TITLE
Login: merge Login and Signup buttons into Continue

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Login.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Login.swift
@@ -28,7 +28,7 @@ public extension Events.Login {
         return Engagement(
             uiEntity: UiEntity(
                 .button,
-                identifier: "login.accountdelete.banner.exitsurvey.tap"
+                identifier: "login.accountdelete.banner.exitsurvey.click"
             )
         )
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Login.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Login.swift
@@ -45,11 +45,32 @@ public extension Events.Login {
         )
     }
 
+    /// Continue button was tapped
     static func continueButtonTapped() -> Engagement {
         return Engagement(
             uiEntity: UiEntity(
                 .button,
                 identifier: "login.continue.tapped"
+            )
+        )
+    }
+
+    /// Login complete
+    static func loginComplete() -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "login.login.complete"
+            )
+        )
+    }
+
+    /// Signup complete
+    static func signupComplete() -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "login.signup.complete"
             )
         )
     }

--- a/PocketKit/Sources/Analytics/AppEvents/Login.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Login.swift
@@ -12,7 +12,7 @@ public extension Events {
 // MARK: Delete Account Events
 public extension Events.Login {
     /// Fired when a user sees the exit survey banner
-    static func DeleteAccountExitSurveyBannerImpression() -> Impression {
+    static func deleteAccountExitSurveyBannerImpression() -> Impression {
         return Impression(
             component: .ui,
             requirement: .viewable,
@@ -23,24 +23,33 @@ public extension Events.Login {
         )
     }
 
-    /// Fired when a user clicks the exit survey banner
-    static func DeleteAccountExitSurveyBannerClick() -> Engagement {
+    /// Fired when a user taps the exit survey banner
+    static func deleteAccountExitSurveyBannerTap() -> Engagement {
         return Engagement(
             uiEntity: UiEntity(
                 .button,
-                identifier: "login.accountdelete.banner.exitsurvey.click"
+                identifier: "login.accountdelete.banner.exitsurvey.tap"
             )
         )
     }
 
     /// Fired when a user sees the exit survey
-    static func DeleteAccountExitSurveyImpression() -> Impression {
+    static func deleteAccountExitSurveyImpression() -> Impression {
         return Impression(
             component: .ui,
             requirement: .viewable,
             uiEntity: UiEntity(
                 .screen,
                 identifier: "login.accountdelete.exitsurvey"
+            )
+        )
+    }
+
+    static func continueButtonTapped() -> Engagement {
+        return Engagement(
+            uiEntity: UiEntity(
+                .button,
+                identifier: "login.continue.tapped"
             )
         )
     }

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -340,6 +340,9 @@
 // Collection
 "collection.stories.count" = "%@ items";
 
+// Logged out
+"loggedOut.continue" = "Continue";
+
 // Errors
 "error.problemOccurred" = "A problem occurred";
 "error.redownloading" = "We are re-downloading your saved articles to improve your experience.";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -303,6 +303,8 @@ public enum Localization {
     public static let message = Localization.tr("Localizable", "loadingView.message", fallback: "Loading...")
   }
   public enum LoggedOut {
+    /// Continue
+    public static let `continue` = Localization.tr("Localizable", "loggedOut.continue", fallback: "Continue")
     public enum Offline {
       /// Looks like you're offline. Try checking your mobile data or wifi.
       public static let detail = Localization.tr("Localizable", "loggedOut.offline.detail", fallback: "Looks like you're offline. Try checking your mobile data or wifi.")

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -147,20 +147,13 @@ private struct LoggedOutActionsView: View {
     var body: some View {
         VStack {
             Button {
-                viewModel.signUp()
+                viewModel.authenticate()
             } label: {
-                Text(Localization.signUp).style(.header.sansSerif.h8.with(color: .ui.white))
+                Text(Localization.LoggedOut.continue).style(.header.sansSerif.h8.with(color: .ui.white))
                     .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                     .frame(maxWidth: 320)
-            }.buttonStyle(ActionsPrimaryButtonStyle())
-
-            Button {
-                viewModel.logIn()
-            } label: {
-                Text(Localization.logIn)
-                    .style(.header.sansSerif.p4)
-                    .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
             }
+            .buttonStyle(ActionsPrimaryButtonStyle())
         }
     }
 }

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -62,16 +62,17 @@ struct Services {
         lastRefresh = UserDefaultsLastRefresh(defaults: userDefaults)
         urlSession = URLSession.shared
 
+        let snowplow = PocketSnowplowTracker()
+        tracker = PocketTracker(snowplow: snowplow)
+
         appSession = AppSession(groupID: Keys.shared.groupID)
         authClient = AuthorizationClient(
             consumerKey: Keys.shared.pocketApiConsumerKey,
             adjustSignupEventToken: Keys.shared.adjustSignUpEventToken,
+            tracker: tracker,
             authenticationSessionFactory: ASWebAuthenticationSession.init
         )
         user = PocketUser(userDefaults: userDefaults)
-
-        let snowplow = PocketSnowplowTracker()
-        tracker = PocketTracker(snowplow: snowplow)
 
         source = PocketSource(
             space: persistentContainer.rootSpace,

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -13,7 +13,8 @@ class AuthorizationClientTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockAuthenticationSession = MockAuthenticationSession()
-        client = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token") { (_, _, completion) in
+        let mockTracker = MockTracker()
+        client = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token", tracker: mockTracker) { (_, _, completion) in
             self.mockAuthenticationSession.completionHandler = completion
             return self.mockAuthenticationSession
         }

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -30,7 +30,7 @@ class AuthorizationClientTests: XCTestCase {
 extension AuthorizationClientTests {
     func test_logIn_onSuccess_returnsAccessTokenAndUserIdentifier() async throws {
         mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
-        let response = try await client.logIn(from: self)
+        let response = try await client.authenticate(from: self)
         XCTAssertEqual(response.guid, "test-guid")
         XCTAssertEqual(response.accessToken, "test-access-token")
         XCTAssertEqual(response.userIdentifier, "test-id")
@@ -39,7 +39,7 @@ extension AuthorizationClientTests {
     func test_logIn_onSessionError_throwsErrorFromAuthenticationSession() async {
         mockAuthenticationSession.error = FakeError.error
         do {
-            _ = try await client.logIn(from: self)
+            _ = try await client.authenticate(from: self)
             XCTFail("Expected to throw error, but didn't")
         } catch {
             XCTAssertTrue(error is AuthorizationClient.Error)
@@ -50,7 +50,7 @@ extension AuthorizationClientTests {
     func test_logIn_onInvalidRedirect_throwsInvalidRedirectError() async {
         mockAuthenticationSession.url = URL(string: "pocket://fxa")!
         do {
-            _ = try await client.logIn(from: self)
+            _ = try await client.authenticate(from: self)
             XCTFail("Expected to throw error, but didn't")
         } catch {
             XCTAssertTrue(error is AuthorizationClient.Error)
@@ -74,7 +74,7 @@ extension AuthorizationClientTests {
         Task {
             do {
                 expectFirstClientStarted.fulfill()
-                _ = try await self.client.logIn(from: self)
+                _ = try await self.client.authenticate(from: self)
             } catch {
                 XCTFail("Should not have thrown an error \(error)")
             }
@@ -84,72 +84,7 @@ extension AuthorizationClientTests {
             do {
                 // wait for our first task to have started before we try the one that should fail.
                 await fulfillment(of: [expectFirstClientStarted], timeout: 10)
-                _ = try await self.client.logIn(from: self)
-                XCTFail("Expected to throw error, but didn't")
-            } catch {
-                XCTAssertTrue(error is AuthorizationClient.Error)
-                XCTAssertEqual(error as? AuthorizationClient.Error, .alreadyAuthenticating)
-            }
-        }
-
-        await fulfillment(of: [expectSessionStart], timeout: 10)
-    }
-}
-
-extension AuthorizationClientTests {
-    func test_signUp_onSuccess_returnsAccessTokenAndUserIdentifier() async throws {
-        mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
-        let response = try await client.signUp(from: self)
-        XCTAssertEqual(response.guid, "test-guid")
-        XCTAssertEqual(response.accessToken, "test-access-token")
-        XCTAssertEqual(response.userIdentifier, "test-id")
-    }
-
-    func test_signUp_onSessionError_throwsErrorFromAuthenticationSession() async {
-        mockAuthenticationSession.error = FakeError.error
-        do {
-            _ = try await client.signUp(from: self)
-            XCTFail("Expected to throw error, but didn't")
-        } catch {
-            XCTAssertTrue(error is AuthorizationClient.Error)
-            XCTAssertEqual(error as? AuthorizationClient.Error, .other(FakeError.error))
-        }
-    }
-
-    func test_signUp_onInvalidRedirect_throwsInvalidRedirectError() async {
-        mockAuthenticationSession.url = URL(string: "pocket://fxa")!
-        do {
-            _ = try await client.signUp(from: self)
-            XCTFail("Expected to throw error, but didn't")
-        } catch {
-            XCTAssertTrue(error is AuthorizationClient.Error)
-            XCTAssertEqual(error as? AuthorizationClient.Error, .invalidRedirect)
-        }
-    }
-
-    @MainActor
-    func test_signUp_startsOnlyOneSession() async {
-        mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
-
-        let expectSessionStart = expectation(description: "expected session start")
-        expectSessionStart.expectedFulfillmentCount = 2
-        expectSessionStart.isInverted = true
-        mockAuthenticationSession.stubStart {
-            expectSessionStart.fulfill()
-            return true
-        }
-
-        Task {
-            do {
-                _ = try await self.client.signUp(from: self)
-            } catch {
-                XCTFail("Should not have thrown an error \(error)")
-            }
-        }
-
-        Task {
-            do {
-                _ = try await self.client.signUp(from: self)
+                _ = try await self.client.authenticate(from: self)
                 XCTFail("Expected to throw error, but didn't")
             } catch {
                 XCTAssertTrue(error is AuthorizationClient.Error)

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -29,8 +29,9 @@ class AuthorizationClientTests: XCTestCase {
 
 extension AuthorizationClientTests {
     func test_logIn_onSuccess_returnsAccessTokenAndUserIdentifier() async throws {
-        mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&access_token=test-access-token&id=test-id")
+        mockAuthenticationSession.url = URL(string: "pocket://fxa?guid=test-guid&type=login&access_token=test-access-token&id=test-id")
         let response = try await client.authenticate(from: self)
+        XCTAssertEqual(response.type, "login")
         XCTAssertEqual(response.guid, "test-guid")
         XCTAssertEqual(response.accessToken, "test-access-token")
         XCTAssertEqual(response.userIdentifier, "test-id")

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -22,7 +22,8 @@ class LoggedOutViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        authorizationClient = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token") { (_, _, completion) in
+        let mockTracker = MockTracker()
+        authorizationClient = AuthorizationClient(consumerKey: "the-consumer-key", adjustSignupEventToken: "token", tracker: mockTracker) { (_, _, completion) in
             self.mockAuthenticationSession.completionHandler = completion
             return self.mockAuthenticationSession
         }

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -235,7 +235,7 @@ class SettingsTest: XCTestCase {
         let surveyButton = app.surveyBannerButton.wait()
         surveyButton.tap()
         app.webView.wait()
-        let events =  await [snowplowMicro.getFirstEvent(with: "login.accountdelete.banner.exitsurvey.click"), snowplowMicro.getFirstEvent(with: "login.accountdelete.exitsurvey")]
+        let events =  await [snowplowMicro.getFirstEvent(with: "login.accountdelete.banner.exitsurvey.tap"), snowplowMicro.getFirstEvent(with: "login.accountdelete.exitsurvey")]
         XCTAssertNotNil(events[0])
         XCTAssertNotNil(events[1])
     }

--- a/Tests iOS/SettingsTests.swift
+++ b/Tests iOS/SettingsTests.swift
@@ -235,7 +235,7 @@ class SettingsTest: XCTestCase {
         let surveyButton = app.surveyBannerButton.wait()
         surveyButton.tap()
         app.webView.wait()
-        let events =  await [snowplowMicro.getFirstEvent(with: "login.accountdelete.banner.exitsurvey.tap"), snowplowMicro.getFirstEvent(with: "login.accountdelete.exitsurvey")]
+        let events =  await [snowplowMicro.getFirstEvent(with: "login.accountdelete.banner.exitsurvey.click"), snowplowMicro.getFirstEvent(with: "login.accountdelete.exitsurvey")]
         XCTAssertNotNil(events[0])
         XCTAssertNotNil(events[1])
     }


### PR DESCRIPTION
## Summary
* This PR replaces Signup and Login with a single Continue button. Login and signup are then handled in the related landing page
*
## References 
* Branch tag

## Implementation Details
* Remove the `Login` button and rename `Signup` to `Continue`. Also handle analytics to properly capture login and signup

## Test Steps
* Build/run logout if needed and make sure you can both login with an existing account and signup with a new one

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
