### PR TITLE
fix(analytics): adding in a way to get mac analytics

### DIFF
--- a/PocketKit/Sources/Analytics/Entities/APIUserEntity.swift
+++ b/PocketKit/Sources/Analytics/Entities/APIUserEntity.swift
@@ -18,7 +18,11 @@ public struct APIUserEntity: Entity {
     public init(consumerKey: String) {
         let components = consumerKey.components(separatedBy: "-")
         let id: UInt
-        if let identifier = components.first, let apiID = UInt(identifier) {
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            // Hack to attribute analytics to our Mac Version of Pocket.
+            // In the future we need to do something more with ouir app id.
+            id = 8775
+        } else if let identifier = components.first, let apiID = UInt(identifier) {
             id = apiID
         } else {
             id = 1

--- a/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
@@ -45,6 +45,11 @@ public class PocketSnowplowTracker: SnowplowTracker {
             .scale
         ]
 
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            trackerConfiguration.devicePlatform = .desktop
+            trackerConfiguration.appId = "pocket-mac-next"
+        }
+
         let optionalTracker = Snowplow.createTracker(
             namespace: appID,
             network: networkConfiguration,


### PR DESCRIPTION
## Summary

Currently we have no way to segment our analytics by Mac users. This at least will let us attribute actions to mac users, even if the internal snowplow data still says its iPad.

Hopefully https://github.com/snowplow/snowplow-ios-tracker/issues/863 gets traction to give us better tracking.
