### PR TITLE
Highlights - Extend feature flag and use amber color for quotes

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
@@ -50,4 +50,3 @@ struct HighlightRow: View {
         }
     }
 }
-

--- a/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
@@ -15,7 +15,7 @@ struct HighlightRow: View {
             HStack {
                 Divider()
                     .frame(width: 4)
-                    .overlay(Appearance.dividerColor)
+                    .overlay(Color(.branding.amber3))
                     .clipShape(.rect(cornerRadius: 2))
                 Text(highlightedQuote.quote)
             }
@@ -51,8 +51,3 @@ struct HighlightRow: View {
     }
 }
 
-private extension HighlightRow {
-    enum Appearance {
-        static let dividerColor = Color(uiColor: UIColor(red: 144/255, green: 19/255, blue: 36/255, alpha: 1))
-    }
-}

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -249,7 +249,7 @@ extension SavedItemViewModel {
             .delete { [weak self] _ in self?.confirmDelete() },
             .share { [weak self] _ in self?.share() }
         ]
-        if let highlights, !highlights.isEmpty {
+        if let highlights, !highlights.isEmpty, featureFlagService.isAssigned(flag: .marticleHighlights) {
             _actions.insert(highlightsAction(), at: 2)
         }
     }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -84,7 +84,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     private var subscriptions: [AnyCancellable] = []
     private var store: SubscriptionStore
     private var networkPathMonitor: NetworkPathMonitor
-    private var featureFlags: FeatureFlagServiceProtocol
+    let featureFlags: FeatureFlagServiceProtocol
 
     private var selectedFilters: Set<ItemsListFilter>
     private let availableFilters: [ItemsListFilter]
@@ -488,7 +488,11 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         let sections: [ItemsListSection] = [.filters]
         snapshot.appendSections(sections)
 
-        var cases = ItemsListFilter.allCases
+        let cases: [ItemsListFilter] =
+        featureFlags.isAssigned(flag: .marticleHighlights) ?
+        ItemsListFilter.allCases :
+        [.all, .listen, .tagged, .favorites, .sortAndFilter]
+
         snapshot.appendItems(
             cases.map { ItemsListCell<ItemIdentifier>.filterButton($0) },
             toSection: .filters


### PR DESCRIPTION
## Summary
* Add highlights feature flag to highlights list and filter
* Replace custom quote color with `amber3` in highlights list


## Implementation Details
* See summary

## Test Steps
* Login with an account that is not in the allowed list of the `marticleHighlights` feature flag, and make sure highlights filter and list do not show
* Login with an account that is in the allowed list, select an article with highlights, select the list in the overflow menu and make sure the quote color is amber
## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
