### PR TITLE
Highlights - add badges to saves/archive list

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
@@ -310,7 +310,6 @@ extension NSAttributedString {
         highlightableRanges.forEach {
             let nsRange = NSRange($0, in: highlightableString)
             mutable.addAttribute(.backgroundColor, value: HighlightConstants.highlightColor, range: nsRange)
-            mutable.addAttribute(.foregroundColor, value: HighlightConstants.highlightedTextColor, range: nsRange)
         }
 
         let tagsToRemove =
@@ -358,6 +357,5 @@ private enum HighlightConstants {
         "<pkt_tag_annotation_\(index)>"
     }
     /// colors
-    static let highlightColor = UIColor(displayP3Red: 250/255, green: 233/255, blue: 199/255, alpha: 0.8)
-    static let highlightedTextColor = UIColor.black
+    static let highlightColor = UIColor(.ui.highlight)
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Kingfisher
+import Textile
 
 class ItemsListItemCell: UICollectionViewListCell {
     var model: Model? {
@@ -125,6 +126,22 @@ class ItemsListItemCell: UICollectionViewListCell {
 
         return stack
     }()
+
+    private func makeHighlightsButton() -> UIButton {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(asset: .highlights)
+            .resized(to: CGSize(width: 13, height: 13))
+            .withTintColor(UIColor(.branding.amber7))
+        config.imagePadding = 5
+
+        config.background.cornerRadius = 4
+        config.background.backgroundColor = UIColor(.branding.amber6).withAlphaComponent(0.2)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
+
+        let button = UIButton(configuration: config, primaryAction: nil)
+        button.accessibilityIdentifier = "highlights-button"
+        return button
+    }
 
     private var tagButton: UIButton {
         var config = UIButton.Configuration.plain()
@@ -251,6 +268,9 @@ extension ItemsListItemCell {
         let filterByTagAction: UIAction?
         let trackOverflow: UIAction?
         let swiftUITrackOverflow: ItemAction?
+
+        let hasHighlights: Bool
+        let highlightsCount: Int
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -279,6 +299,17 @@ extension ItemsListItemCell {
             view.removeFromSuperview()
         }
 
+        if let number = model?.highlightsCount, number > 0 {
+            let highlightStyle: Style = .header.sansSerif.p5.with(color: .branding.amber7).with(weight: .medium).with { paragraph in
+                paragraph
+                    .with(lineBreakMode: .byTruncatingTail)
+            }
+            let button = makeHighlightsButton()
+            button.isUserInteractionEnabled = false
+            button.configuration?.attributedTitle = AttributedString(NSAttributedString(string: "\(number)", style: highlightStyle))
+            tagsStack.addArrangedSubview(button)
+        }
+
         if let attributedTags = state.model?.attributedTags {
             attributedTags.forEach { attributedTag in
                 let button = tagButton
@@ -292,6 +323,7 @@ extension ItemsListItemCell {
             countLabel.attributedText = state.model?.attributedTagCount
             tagsStack.addArrangedSubview(countLabel)
         }
+        tagsStack.addArrangedSubview(UIView())
 
         favoriteButton.accessibilityLabel = state.model?.favoriteAction?.title
         favoriteButton.accessibilityIdentifier = state.model?.favoriteAction?.accessibilityIdentifier

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
@@ -135,7 +135,7 @@ class ItemsListItemCell: UICollectionViewListCell {
         config.imagePadding = 5
 
         config.background.cornerRadius = 4
-        config.background.backgroundColor = UIColor(.branding.amber6).withAlphaComponent(0.2)
+        config.background.backgroundColor = UIColor(.branding.amber6)
         config.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
 
         let button = UIButton(configuration: config, primaryAction: nil)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/ItemsListItemCell.swift
@@ -299,14 +299,14 @@ extension ItemsListItemCell {
             view.removeFromSuperview()
         }
 
-        if let number = model?.highlightsCount, number > 0 {
+        if let highlightsCount = model?.highlightsCount, highlightsCount > 0 {
             let highlightStyle: Style = .header.sansSerif.p5.with(color: .branding.amber7).with(weight: .medium).with { paragraph in
                 paragraph
                     .with(lineBreakMode: .byTruncatingTail)
             }
             let button = makeHighlightsButton()
             button.isUserInteractionEnabled = false
-            button.configuration?.attributedTitle = AttributedString(NSAttributedString(string: "\(number)", style: highlightStyle))
+            button.configuration?.attributedTitle = AttributedString(NSAttributedString(string: "\(highlightsCount)", style: highlightStyle))
             tagsStack.addArrangedSubview(button)
         }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListItemPresenter.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListItemPresenter.swift
@@ -73,6 +73,14 @@ class ItemsListItemPresenter {
         return CDNURLBuilder().imageCacheURL(for: item.topImageURL)
     }
 
+    var hasHighlights: Bool {
+        item.hasHighlights
+    }
+
+    var highlightsCount: Int {
+        item.highlightsCount
+    }
+
     private var title: String {
         item.displayTitle
     }
@@ -87,13 +95,15 @@ class ItemsListItemPresenter {
 
     private var tags: [String]? {
         guard let names = item.tagNames else { return nil }
-        let tagsCount = min(names.count, 2)
+        let highlightAddOn = hasHighlights ? 1 : 0
+        let tagsCount = min(names.count, 2 - highlightAddOn)
         return tagsCount > 0 ? Array(names[..<tagsCount]) : nil
     }
 
     private var otherTagsCount: Int? {
         guard let count = item.tagNames?.count else { return nil }
-        return count > 2 ? count - 2 : nil
+        let highlightAddOn = hasHighlights ? 1 : 0
+        return count + highlightAddOn > 2 ? count + highlightAddOn - 2 : nil
     }
 
     private var timeToRead: String? {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -324,7 +324,9 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
                 overflowActions: [],
                 filterByTagAction: nil,
                 trackOverflow: nil,
-                swiftUITrackOverflow: nil
+                swiftUITrackOverflow: nil,
+                hasHighlights: false,
+                highlightsCount: 0
             )
 
             return
@@ -342,7 +344,9 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             overflowActions: model.overflowActions(for: objectID),
             filterByTagAction: model.filterByTagAction(),
             trackOverflow: model.trackOverflow(for: objectID),
-            swiftUITrackOverflow: model.swiftUITrackOverflow(for: objectID)
+            swiftUITrackOverflow: model.swiftUITrackOverflow(for: objectID),
+            hasHighlights: presenter.hasHighlights,
+            highlightsCount: presenter.highlightsCount
         )
     }
 

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/ItemsListItem.swift
@@ -25,6 +25,8 @@ protocol ItemsListItem {
     var cursor: String? { get }
     var isCollection: Bool { get }
     var isSyndicated: Bool { get }
+    var hasHighlights: Bool { get }
+    var highlightsCount: Int { get }
 }
 
 extension ItemsListItem {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchSavedItem+ItemsListItem.swift
@@ -114,6 +114,14 @@ extension SearchSavedItem: ItemsListItem {
     var savedItemURL: String {
         remoteItem.url
     }
+    // TODO: we might add support for highlights icon in search
+    var hasHighlights: Bool {
+        false
+    }
+
+    var highlightsCount: Int {
+        0
+    }
 }
 
 extension SavedItemParts.Item.AsItem.DomainMetadata: ItemsListItemDomainMetadata { }

--- a/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
+++ b/PocketKit/Sources/Sync/CoreDataInitializers/SavedItem+CoreDataProperties.swift
@@ -59,3 +59,14 @@ extension SavedItem {
     @objc(removeTags:)
     @NSManaged public func removeFromTags(_ values: NSOrderedSet)
 }
+
+// MARK: Convenience properties
+extension SavedItem {
+    public var hasHighlights: Bool {
+        highlightsCount > 0
+    }
+
+    public var highlightsCount: Int {
+        highlights?.count ?? 0
+    }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5E",
+          "green" : "0xD2",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x53",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE3",
-          "green" : "0xFB",
+          "blue" : "0xD1",
+          "green" : "0xF9",
           "red" : "0xFF"
         }
       },
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0x1B",
-          "red" : "0x34"
+          "green" : "0x20",
+          "red" : "0x55"
         }
       },
       "idiom" : "universal"

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber6.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x5E",
-          "green" : "0xD2",
+          "blue" : "0xE3",
+          "green" : "0xFB",
           "red" : "0xFF"
         }
       },
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0x53",
-          "red" : "0xE5"
+          "green" : "0x1B",
+          "red" : "0x34"
         }
       },
       "idiom" : "universal"

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber7.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x40",
+          "red" : "0xB2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x43",
+          "green" : "0xB6",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber7.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/Branding/amber7.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x00",
-          "green" : "0x40",
-          "red" : "0xB2"
+          "blue" : "0x05",
+          "green" : "0x46",
+          "red" : "0x98"
         }
       },
       "idiom" : "universal"

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/Highlight.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/Highlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD1",
+          "green" : "0xF9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x05",
+          "green" : "0x46",
+          "red" : "0x98"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -41,6 +41,8 @@ public struct UIPalette {
     public let black1 = ColorAsset.ui("black1")
     public let border = ColorAsset.ui("border")
     public let skeletonCellImageBackground = ColorAsset.ui("skeletonCellImageBackground")
+
+    public let highlight = ColorAsset.ui("Highlight")
 }
 
 public struct BrandingPalette {

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -49,6 +49,8 @@ public struct BrandingPalette {
     public let amber3 = ColorAsset.branding("amber3")
     public let amber4 = ColorAsset.branding("amber4")
     public let amber5 = ColorAsset.branding("amber5")
+    public let amber6 = ColorAsset.branding("amber6")
+    public let amber7 = ColorAsset.branding("amber7")
 
     public let apricot1 = ColorAsset.branding("apricot1")
     public let apricot2 = ColorAsset.branding("apricot2")

--- a/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockItemsListItem.swift
@@ -7,6 +7,14 @@ import Localization
 @testable import PocketKit
 
 struct MockItemsListItem: ItemsListItem {
+    var hasHighlights: Bool {
+        false
+    }
+
+    var highlightsCount: Int {
+        0
+    }
+
     var displayTitle: String {
         title ?? bestURL ?? ""
     }


### PR DESCRIPTION
## Summary
* This PR adds a highlight badge and count to the saves/archive list, for those items that contain highlights

> [!NOTE]
> Search items are not affected by this change


## Implementation Details
* Update `ItemsListCell`, add highlights badge using the existing tags button format
* Update color assets to add colors for the badge

## Test Steps
* Go to saves and make sure that items with highlights display the badge (see screenshots)
## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

Light | Dark
-- | --
![Simulator Screenshot - iPhone 15 - 2024-01-26 at 13 42 41](https://github.com/Pocket/pocket-ios/assets/34376330/53763ebd-19ae-4a55-9fa2-f7f511ab8e80) | ![Simulator Screenshot - iPhone 15 - 2024-01-26 at 13 42 33](https://github.com/Pocket/pocket-ios/assets/34376330/c4944864-6c66-4bfe-92f0-6d4175c026bb)









