### PR TITLE
feat(upgrades): adding in upgrade handling logic

### DIFF
--- a/PocketKit/Sources/SharedPocketKit/Bundle+Extensions.swift
+++ b/PocketKit/Sources/SharedPocketKit/Bundle+Extensions.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+extension Bundle {
+    public var appName: String { getInfo("CFBundleName") ?? "Unknown" }
+    public var displayName: String { getInfo("CFBundleDisplayName") ?? "Unknown"  }
+    public var language: String { getInfo("CFBundleDevelopmentRegion") ?? "Unknown"  }
+    public var identifier: String { getInfo("CFBundleIdentifier") ?? "Unknown"  }
+    public var copyright: String { (getInfo("NSHumanReadableCopyright") ?? "Unknown").replacingOccurrences(of: "\\\\n", with: "\n") }
+
+    public var appBuild: String { getInfo("CFBundleVersion") ?? "1"  }
+    public var appVersion: Version { Version(getInfo("CFBundleShortVersionString") ?? "1.0.0") }
+
+    fileprivate func getInfo(_ str: String) -> String? { infoDictionary?[str] as? String }
+}

--- a/PocketKit/Sources/SharedPocketKit/LastLaunch.swift
+++ b/PocketKit/Sources/SharedPocketKit/LastLaunch.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public protocol LastLaunchedAppVersion {
+    var lastLaunch: LastLaunchedAppVersionData? { get }
+    func launched()
+    func reset()
+}
+
+public struct LastLaunchedAppVersionData: Codable {
+    public var appBuild: String
+    public var appVersion: Version
+    public var date: Date
+
+    public static func current() -> LastLaunchedAppVersionData {
+        return LastLaunchedAppVersionData(
+            appBuild: Bundle.main.appBuild,
+            appVersion: Bundle.main.appVersion,
+            date: Date()
+        )
+    }
+}
+
+public struct UserDefaultsLastLaunchedAppVersion: LastLaunchedAppVersion {
+    public static let lastLaunchedAppVersionKey = UserDefaults.Key.lastLaunchedAppVersion
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    public func reset() {
+        defaults.set(nil, forKey: Self.lastLaunchedAppVersionKey)
+    }
+
+    /**
+     Called when the app has finished all launch tasks to register that the current app version, is now the last launched version
+     */
+    public func launched() {
+       do {
+        defaults.set(try JSONEncoder().encode(LastLaunchedAppVersionData.current()), forKey: Self.lastLaunchedAppVersionKey)
+       } catch {
+           Log.breadcrumb(category: "last-launch", level: .info, message: "Could not encode app version for user defaults")
+           Log.capture(error: error)
+       }
+    }
+
+    /**
+    Gets the lasted launched data object from user defaults, otherwise return the current version of the app as last launched
+     */
+    public var lastLaunch: LastLaunchedAppVersionData? {
+        guard let encodedData = defaults.value(forKey: Self.lastLaunchedAppVersionKey) else {
+            return nil
+        }
+
+        do {
+            return try JSONDecoder().decode(LastLaunchedAppVersionData.self, from: encodedData as! Data)
+        } catch {
+            Log.breadcrumb(category: "last-launch", level: .info, message: "Could not decode app version from user defaults")
+            Log.capture(error: error)
+            return nil
+        }
+    }
+}

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -40,6 +40,7 @@ public extension UserDefaults {
         case recentSavesWidget = "RecentSavesWidgetKey"
         case recommendationsWidget = "RecommendationsWidgetKey"
         case forceRefreshFromExtension = "ForceRefreshFromExtentionKey"
+        case lastLaunchedAppVersion = "LastLaunchedAppVersion"
 
         var isRemovable: Bool {
             switch self {

--- a/PocketKit/Sources/SharedPocketKit/Version.swift
+++ b/PocketKit/Sources/SharedPocketKit/Version.swift
@@ -8,28 +8,23 @@ import Foundation
  Helper struct for comparing app versions
  */
 public struct Version: Comparable, Codable {
-    let major: Int
-    let minor: Int
-    let patch: Int
+    var _version: String
 
     public init(_ versionString: String) {
-        let components = versionString.components(separatedBy: ".").compactMap { Int($0) }
-        major = components[safe: 0] ?? 0
-        minor = components[safe: 1] ?? 0
-        patch = components[safe: 2] ?? 0
+        _version = versionString
     }
 
     public static func < (lhs: Version, rhs: Version) -> Bool {
-        if lhs.major != rhs.major {
-            return lhs.major < rhs.major
-        } else if lhs.minor != rhs.minor {
-            return lhs.minor < rhs.minor
-        } else {
-            return lhs.patch < rhs.patch
+        let result = lhs._version.compare(rhs._version, options: .numeric)
+        if result == .orderedAscending {
+            return true
+        } else if result == .orderedDescending {
+            return false
         }
+        return false
     }
 
     public static func == (lhs: Version, rhs: Version) -> Bool {
-        return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
+        return lhs._version.compare(rhs._version, options: .numeric) == .orderedSame
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/Version.swift
+++ b/PocketKit/Sources/SharedPocketKit/Version.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/**
+ Helper struct for comparing app versions
+ */
+public struct Version: Comparable, Codable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    public init(_ versionString: String) {
+        let components = versionString.components(separatedBy: ".").compactMap { Int($0) }
+        major = components[safe: 0] ?? 0
+        minor = components[safe: 1] ?? 0
+        patch = components[safe: 2] ?? 0
+    }
+
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        } else if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        } else {
+            return lhs.patch < rhs.patch
+        }
+    }
+
+    public static func == (lhs: Version, rhs: Version) -> Bool {
+        return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
+    }
+}


### PR DESCRIPTION
## Summary

Enable saving off the last app launch version and let us perform upgrades as needed in the codebase to support new app versions.

In particular users that launch 8.4.0 from a previous app version will need to re-download their list metadata so that we can show them their highlights.

## References 
* POCKET-9551



## Test Steps
* Switch to the 8.2.0 (or a few commits above) tag 6d0d6dce14a584171d794c4c44fd5f286a82c82d is nice because it has a codesign fix, but is before any highlights code is added
* Start the app fresh and login.
* Wait for the list to finish downloading
* Switch to 8.4.0 release candidate
* Once launched you should see your list re-downloading and articles with highlights begin to have the highlights badge

## PR Checklist:
- [ ] Added Unit / UI tests
- [ ] Self Review (review, clean up, documentation, run tests)
- [ ] Basic Self QA

## Screenshots
