### PR TITLE
Show premium upsell if free users try to add more than three highlights

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -95,17 +95,15 @@ class ReadableViewController: UIViewController {
                 .$isPresentingHighlights
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] isPresenting in
-                    guard let self else {
+                    guard let self, isPresenting else {
                         return
                     }
-                    if isPresenting {
-                        let controller =
-                        HighlightsViewController(
-                            highlights: highlightedQuotes.sorted { $0.index < $1.index },
-                            viewModel: viewModel
-                        )
-                        present(controller, animated: true)
-                    }
+                    let controller =
+                    HighlightsViewController(
+                        highlights: highlightedQuotes.sorted { $0.index < $1.index },
+                        viewModel: viewModel
+                    )
+                    present(controller, animated: true)
                 }
                 .store(in: &subscriptions)
             viewModel
@@ -116,6 +114,26 @@ class ReadableViewController: UIViewController {
                         return
                     }
                     collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredVertically)
+                }
+                .store(in: &subscriptions)
+
+            viewModel.$isPresentingPremiumUpsell
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isPresenting in
+                    guard let self, isPresenting else {
+                        return
+                    }
+                    self.present(viewModel.makePremiumUpgradeViewController(), animated: true)
+                }
+                .store(in: &subscriptions)
+
+            viewModel.$isPresentingHooray
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isPresenting in
+                    guard let self, isPresenting else {
+                        return
+                    }
+                    self.present(viewModel.makeHoorayViewController(), animated: true)
                 }
                 .store(in: &subscriptions)
         }

--- a/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
+++ b/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
@@ -8,4 +8,5 @@ public enum PremiumUpgradeSource: String {
     case settings
     case tags
     case premiumFonts
+    case highlights
 }


### PR DESCRIPTION
## Summary
* Show `PremiumUpgradeView` when free users tap the Highlight button in the selection context menu and they already have three highlights

## References 
* Branch name
## Implementation Details
* Update `SavedItemViewModel`, add logic to display premium upsell

## Test Steps
* Login as a free user, add three highlights, add another one and make sure you see the premium upsell screen
* Optional: login as a sandbox user and complete the purchase process, and make sure the Hooray screen appears

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
