### PR TITLE
chore(deps): early february dependency update

### DIFF
--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -2109,7 +2109,7 @@
 			repositoryURL = "https://github.com/apollographql/apollo-ios.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.8.0;
+				version = 1.9.0;
 			};
 		};
 		65167B6D2909904200343FA8 /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -2117,7 +2117,7 @@
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.6.0;
+				version = 8.0.0;
 			};
 		};
 		6547A0FD29F17AAF00F6FC6B /* XCRemoteSwiftPackageReference "Sails" */ = {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "5c8abdeabf8d0dc5055879a657e31bac49bc1624",
-        "version" : "8.19.0"
+        "revision" : "b847a202a517a90763e8fd0656d8028aeee7b78d",
+        "version" : "8.20.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "ff54632b8740ecfb858bae4630d822e615c7ef1c",
-        "version" : "1.8.0"
+        "revision" : "74a16c771a0a5f2cb9e069e8f96125a9288894d0",
+        "version" : "1.9.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/YouTubePlayerKit.git",
       "state" : {
-        "revision" : "fe26e1c3f24e227547f8de5abde86c36ae105b6a",
-        "version" : "1.6.0"
+        "revision" : "ca8f0cd89d63d6f5e5cb556b0dd30cd65632bc3a",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
-        "version" : "7.10.2"
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "e86d218bd88ec522f6bd120afbd1badcb8ec0f69",
-        "version" : "6.0.0"
+        "revision" : "6b50e444ce15a8e092427edb67d27a8b6cbd96ae",
+        "version" : "6.0.1"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk.git",
       "state" : {
-        "revision" : "dee5204a3f92ca48b58284327c32053c0a379460",
-        "version" : "7.6.0"
+        "revision" : "55b53a092076affa7ca212f4d117363d220e949b",
+        "version" : "8.0.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "fmdb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ccgus/fmdb",
-      "state" : {
-        "revision" : "e6e1c0eff4f115c46a850db9dc92fb41a01a8b55",
-        "version" : "2.7.8"
-      }
-    },
-    {
       "identity" : "ios_sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",
@@ -104,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "cc136256383ed50c754219895e34d25c48650314",
-        "version" : "5.6.0"
+        "revision" : "e86d218bd88ec522f6bd120afbd1badcb8ec0f69",
+        "version" : "6.0.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "fmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ccgus/fmdb",
+      "state" : {
+        "revision" : "e6e1c0eff4f115c46a850db9dc92fb41a01a8b55",
+        "version" : "2.7.8"
+      }
+    },
+    {
       "identity" : "ios_sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "ff54632b8740ecfb858bae4630d822e615c7ef1c",
-        "version" : "1.8.0"
+        "revision" : "74a16c771a0a5f2cb9e069e8f96125a9288894d0",
+        "version" : "1.9.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "fmdb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ccgus/fmdb",
-      "state" : {
-        "revision" : "e6e1c0eff4f115c46a850db9dc92fb41a01a8b55",
-        "version" : "2.7.8"
-      }
-    },
-    {
       "identity" : "ios_sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",
@@ -95,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "cc136256383ed50c754219895e34d25c48650314",
-        "version" : "5.6.0"
+        "revision" : "e86d218bd88ec522f6bd120afbd1badcb8ec0f69",
+        "version" : "6.0.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
-        "version" : "7.10.2"
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "e86d218bd88ec522f6bd120afbd1badcb8ec0f69",
-        "version" : "6.0.0"
+        "revision" : "6b50e444ce15a8e092427edb67d27a8b6cbd96ae",
+        "version" : "6.0.1"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/YouTubePlayerKit.git",
       "state" : {
-        "revision" : "fe26e1c3f24e227547f8de5abde86c36ae105b6a",
-        "version" : "1.6.0"
+        "revision" : "ca8f0cd89d63d6f5e5cb556b0dd30cd65632bc3a",
+        "version" : "1.7.0"
       }
     }
   ],

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk.git",
       "state" : {
-        "revision" : "dee5204a3f92ca48b58284327c32053c0a379460",
-        "version" : "7.6.0"
+        "revision" : "55b53a092076affa7ca212f4d117363d220e949b",
+        "version" : "8.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ccgus/fmdb",
       "state" : {
-        "revision" : "e6e1c0eff4f115c46a850db9dc92fb41a01a8b55",
-        "version" : "2.7.8"
+        "revision" : "47a2fa12a242b5a2fe13b916c22f2212e426055c",
+        "version" : "2.7.9"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "59730af512c06fb569c119d737df4c1c499e001d",
-        "version" : "5.18.10"
+        "revision" : "b11493f76481dff17ac8f45274a6b698ba0d3af5",
+        "version" : "5.18.11"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "5c8abdeabf8d0dc5055879a657e31bac49bc1624",
-        "version" : "8.19.0"
+        "revision" : "b847a202a517a90763e8fd0656d8028aeee7b78d",
+        "version" : "8.20.0"
       }
     },
     {

--- a/PocketKit/Package.resolved
+++ b/PocketKit/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "fmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ccgus/fmdb",
+      "state" : {
+        "revision" : "e6e1c0eff4f115c46a850db9dc92fb41a01a8b55",
+        "version" : "2.7.8"
+      }
+    },
+    {
       "identity" : "ios_sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adjust/ios_sdk",

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.9.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.11.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.20.0"),
-        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),
+        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.1"),
         .package(url: "https://github.com/ccgus/fmdb", from: "2.7.6"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/ccgus/fmdb", from: "2.7.6"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
-        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.6.0"),
+        .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.7.0"),
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "7.6.0"),
         .package(url: "https://github.com/adjust/ios_sdk", exact: "4.37.0"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", exact: "5.1.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "DiffMatchPatch", targets: ["DiffMatchPatch"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.8.0"),
+        .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.9.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.2"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.19.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.8.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.2"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.19.0"),
-        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "5.6.0"),
+        .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.6.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.9.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.2"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.19.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.20.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),
         .package(url: "https://github.com/ccgus/fmdb", from: "2.7.6"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.2"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.19.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),
+        .package(url: "https://github.com/ccgus/fmdb", from: "2.7.6"),
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.6.0"),
@@ -84,7 +85,9 @@ let package = Package(
                 .product(name: "YouTubePlayerKit", package: "YouTubePlayerKit"),
                 .product(name: "BrazeKit", package: "braze-swift-sdk"),
                 .product(name: "BrazeUI", package: "braze-swift-sdk"),
-                .product(name: "Adjust", package: "ios_sdk")
+                .product(name: "Adjust", package: "ios_sdk"),
+                // Used by listen, ideally we put this there, but there were some c99 compilker issues, this used to be included by snowplow but is not anymore
+                .product(name: "FMDB", package: "fmdb")
             ],
             linkerSettings: [.unsafeFlags(["-ObjC"])] // Needed to load categories in PKTListen
         ),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", exact: "1.9.0"),
-        .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.10.2"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", exact: "7.11.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.20.0"),
         .package(url: "https://github.com/snowplow/snowplow-objc-tracker", exact: "6.0.0"),
         .package(url: "https://github.com/ccgus/fmdb", from: "2.7.6"),

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/airbnb/lottie-ios.git", exact: "4.4.0"),
         .package(url: "https://github.com/johnxnguyen/Down", exact: "0.11.0"),
         .package(url: "https://github.com/SvenTiigi/YouTubePlayerKit.git", exact: "1.7.0"),
-        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "7.6.0"),
+        .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "8.0.0"),
         .package(url: "https://github.com/adjust/ios_sdk", exact: "4.37.0"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", exact: "5.1.0"),
     ],

--- a/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
@@ -63,6 +63,7 @@ public class PocketSnowplowTracker: SnowplowTracker {
         #if DEBUG || DEBUG_ALPHA_NEUE
         // We are using a debug build, emit analytics instantly for testing instead of batches
         tracker.emitter?.bufferOption = .single
+        tracker.emitter?.emitRange = 1
         #endif
 
         _ = tracker.globalContexts?.add(tag: "persistent-entities", contextGenerator: GlobalContext(generator: {  event in

--- a/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/PocketSnowplowTracker.swift
@@ -27,11 +27,12 @@ public class PocketSnowplowTracker: SnowplowTracker {
         trackerConfiguration.applicationContext = true
         trackerConfiguration.platformContext = true
         trackerConfiguration.geoLocationContext = false
-        trackerConfiguration.sessionContext = false
+        trackerConfiguration.sessionContext = true
         trackerConfiguration.screenContext = true
+        trackerConfiguration.deepLinkContext = true
         trackerConfiguration.screenViewAutotracking = true
-        trackerConfiguration.lifecycleAutotracking = false
-        trackerConfiguration.installAutotracking = false
+        trackerConfiguration.lifecycleAutotracking = true
+        trackerConfiguration.installAutotracking = true
         trackerConfiguration.exceptionAutotracking = false
         trackerConfiguration.diagnosticAutotracking = false
         trackerConfiguration.platformContextProperties = [
@@ -55,10 +56,6 @@ public class PocketSnowplowTracker: SnowplowTracker {
             network: networkConfiguration,
             configurations: [trackerConfiguration]
         )
-
-        guard let optionalTracker else {
-            fatalError("snowplow tracker did not inititalize")
-        }
 
         tracker = optionalTracker
         _ = Snowplow.setAsDefault(tracker: tracker)

--- a/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/PageInfo+Mock.graphql.swift
@@ -10,10 +10,10 @@ public class PageInfo: MockObject {
   public typealias MockValueCollectionType = Array<Mock<PageInfo>>
 
   public struct MockFields {
-    @Field<String>("endCursor") public var endCursor
-    @Field<Bool>("hasNextPage") public var hasNextPage
-    @Field<Bool>("hasPreviousPage") public var hasPreviousPage
-    @Field<String>("startCursor") public var startCursor
+    @Field<String?>("endCursor") public var endCursor
+    @Field<Bool?>("hasNextPage") public var hasNextPage
+    @Field<Bool?>("hasPreviousPage") public var hasPreviousPage
+    @Field<String?>("startCursor") public var startCursor
   }
 }
 

--- a/PocketKit/Sources/PocketGraphTestMocks/UnleashAssignment+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/UnleashAssignment+Mock.graphql.swift
@@ -12,8 +12,8 @@ public class UnleashAssignment: MockObject {
   public struct MockFields {
     @Field<Bool>("assigned") public var assigned
     @Field<String>("name") public var name
-    @Field<String>("payload") public var payload
-    @Field<String>("variant") public var variant
+    @Field<String?>("payload") public var payload
+    @Field<String?>("variant") public var variant
   }
 }
 

--- a/Tests iOS/CollectionTests.swift
+++ b/Tests iOS/CollectionTests.swift
@@ -46,7 +46,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingCollectionItem_fromSaves_showsNativeCollectionView() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
 
         let screenViewEvent = await snowplowMicro.getFirstEvent(with: "collection.screen")
         screenViewEvent!.getUIContext()!.assertHas(type: "screen")
@@ -74,7 +74,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingArchiveAndSaveNavBarButton_forSavedItem_archivesAndSavesCollection() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.archiveButton.wait().tap()
         app.saves.wait()
         app.saves.selectionSwitcher.archiveButton.tap()
@@ -97,7 +97,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingOverflowMenu_fromSavedCollection_showsOverflowOptions() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
 
         XCTAssertTrue(app.collectionView.favoriteButton.exists)
@@ -112,7 +112,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingFavoriteAndUnfavoriteFromOverflowMenu_forSavedCollection_showsShare() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
         app.collectionView.favoriteButton.wait().tap()
         app.collectionView.overflowButton.wait().tap()
@@ -131,7 +131,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingAddTagsFromOverflowMenu_forSavedCollection_showsShare() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
         app.collectionView.addTagsButton.wait().tap()
 
@@ -148,7 +148,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingDeleteNoFromOverflowMenu_dismissesDeleteConfirmation() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
         app.collectionView.deleteButton.wait().tap()
         app.collectionView.deleteNoButton.wait().tap()
@@ -167,11 +167,12 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingDeleteYesFromOverflowMenu_dismissesAndDeletesCollection() async {
-        openCollectionFromSaves()
+        let collectionCell = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
         app.collectionView.deleteButton.wait().tap()
         app.collectionView.deleteYesButton.wait().tap()
         app.saves.wait()
+        waitForDisappearance(of: collectionCell)
 
         async let overflowEvent = await snowplowMicro.getFirstEvent(with: "collection.overflow")
         async let deleteEvent = await snowplowMicro.getFirstEvent(with: "collection.overflow.delete")
@@ -186,7 +187,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingShareFromOverflowMenu_forSavedCollection_showsShare() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.overflowButton.wait().tap()
         XCTAssertTrue(app.collectionView.shareButton.exists)
         app.shareButton.wait().tap()
@@ -240,7 +241,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_tappingStory_fromCollection_opensContent() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.cell(containing: "Collection Story 1").wait().tap()
 
         let openEvent = await snowplowMicro.getFirstEvent(with: "collection.story.open")
@@ -249,7 +250,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_savingAndunsavingStory_fromCollection_opensContent() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.cell(containing: "Collection Story 1").savedButton.wait().tap()
 
         app.collectionView.cell(containing: "Collection Story 1").saveButton.wait().tap()
@@ -266,7 +267,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_sharingStory_fromCollection() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.cell(containing: "Collection Story 1").overflowButton.wait().tap()
         app.shareButton.wait().tap()
 
@@ -276,7 +277,7 @@ class CollectionTests: XCTestCase {
 
     @MainActor
     func test_reportingStory_fromCollection() async {
-        openCollectionFromSaves()
+        _ = openCollectionFromSaves()
         app.collectionView.cell(containing: "Collection Story 1").overflowButton.wait().tap()
         app.reportButton.wait().tap()
 
@@ -284,7 +285,7 @@ class CollectionTests: XCTestCase {
         openEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello")
     }
 
-    private func openCollectionFromSaves() {
+    private func openCollectionFromSaves() -> ItemRowElement {
         app.launch().tabBar.savesButton.wait().tap()
         let collectionItem = app
             .saves
@@ -292,6 +293,7 @@ class CollectionTests: XCTestCase {
             .wait()
         XCTAssertTrue(collectionItem.collectionLabel.exists)
         collectionItem.tap()
+        return collectionItem
     }
 
     private func openCollectionFromHome() {

--- a/Tests iOS/ErrorTests.swift
+++ b/Tests iOS/ErrorTests.swift
@@ -43,16 +43,14 @@ class ErrorTests: XCTestCase {
 
     func test_serverError_banner_for_throttled_user() {
         configureThrottledUser()
-        app.launch()
-
-        XCTAssert(app.saves.element.staticTexts["Our server is not responding right now. Please bear with us. It should be available within an hour."].exists)
+                app.launch()
+        app.saves.element.staticTexts["Our server is not responding right now. Please bear with us. It should be available within an hour."].wait()
     }
 
     func test_serverError_banner_for_internal_server_error() {
         configureInternalServerErrorUser()
         app.launch()
-
-        XCTAssert(app.saves.element.staticTexts["Something went wrong with your request. The Pocket team has been notified. Please try again later."].exists)
+        app.saves.element.staticTexts["Something went wrong with your request. The Pocket team has been notified. Please try again later."].wait()
     }
 
     /// Set user to throttled

--- a/Tests iOS/Fixtures/list-with-tagged-item.json
+++ b/Tests iOS/Fixtures/list-with-tagged-item.json
@@ -39,7 +39,7 @@
                         "domain": null,
                         "language": "en",
                         "timeToRead": 6,
-                    "wordCount": 500,
+                        "wordCount": 500,
                         "marticle": #MARTICLE#,
                         "excerpt": "Cursus Aenean Elit",
                         "datePublished": "2021-01-01 12:01:01",

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -43,7 +43,7 @@ class HomeTests: XCTestCase {
 
     @MainActor
     func test_navigatingToHomeTab_showsASectionForEachSlate() async {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
 
         home.sectionHeader("Slate 1").wait()
         home.element.swipeUp()
@@ -67,7 +67,7 @@ class HomeTests: XCTestCase {
 
     @MainActor
     func test_navigatingToHomeTab_showsRecentlySavedItems() async {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait()
         home.savedItemCell("Item 2").wait()
         home.savedItemCell("Item 1").swipeLeft(velocity: .fast)
@@ -77,7 +77,7 @@ class HomeTests: XCTestCase {
 
     @MainActor
     func test_tappingRecentSavesItem_showsReader() async {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait().tap()
         app.readerView.wait()
         app.readerView.cell(containing: "Commodo Consectetur Dapibus").wait()
@@ -114,7 +114,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_favoritingRecentSavesItem_shouldShowFavoriteInSaves() {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").favoriteButton.tap()
         XCTAssertTrue(home.recentSavesView(matching: "Item 1").favoriteButton.isFilled)
@@ -125,7 +125,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_unfavoritingRecentSavesItem_shouldNotAppearForFavoriteInSaves() {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 2").wait()
         XCTAssertTrue(home.recentSavesView(matching: "Item 2").favoriteButton.isFilled)
         home.recentSavesView(matching: "Item 2").favoriteButton.tap()
@@ -137,7 +137,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_archivingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.archiveButton.wait().tap()
@@ -146,7 +146,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_deletingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.deleteButton.wait().tap()
@@ -158,7 +158,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_sharingRecentSavesItem_removesItemFromRecentSaves() {
-        let home = app.launch().homeView.wait()
+        let home = app.launch().waitForHomeToLoad()
         home.savedItemCell("Item 1").wait()
         home.recentSavesView(matching: "Item 1").overflowButton.wait().tap()
         app.shareButton.wait().tap()
@@ -172,7 +172,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_tappingSlatesSeeAllButton_showsSlateDetailView() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
 
         home.sectionHeader("Slate 1").seeAllButton.wait().tap()
         app.slateDetailView.recommendationCell("Slate 1, Recommendation 1").wait()
@@ -186,7 +186,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_slateDetails_savingARecommendation_addsItemToList() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.sectionHeader("Slate 1").seeAllButton.wait().tap()
 
         let cell = app.slateDetailView
@@ -207,8 +207,7 @@ class HomeTests: XCTestCase {
                 Fixture.data(name: "hello", ext: "html")
             }
         }
-
-        app.launch()
+        app.launch().waitForHomeToLoad()
         app.homeView.element.swipeUp()
         app.homeView.recommendationCell("Slate 2, Recommendation 2").wait().tap()
         app.webReaderView
@@ -217,8 +216,9 @@ class HomeTests: XCTestCase {
     }
 
     func test_tappingRecommendationCell_whenItemIsNotSaved_andItemIsSyndicated_opensItemInReaderView() {
-        app.launch()
-            .homeView.recommendationCell("Slate 1, Recommendation 1")
+        app.launch().waitForHomeToLoad()
+
+        app.homeView.recommendationCell("Slate 1, Recommendation 1")
             .wait().element.swipeUp()
 
         app.homeView.recommendationCell("Slate 1, Recommendation 2")
@@ -229,7 +229,8 @@ class HomeTests: XCTestCase {
 
     func test_tappingRecommendationCell_whenItemIsNotSaved_andItemIsSyndicated_andUserGoesBack_SyndicationInfoStays() {
         app.launch()
-            .homeView.recommendationCell("Slate 1, Recommendation 1")
+            .waitForHomeToLoad()
+            .recommendationCell("Slate 1, Recommendation 1")
             .wait().element.swipeUp()
 
         app.homeView.recommendationCell("Slate 1, Recommendation 2")
@@ -260,7 +261,7 @@ class HomeTests: XCTestCase {
             return .fallbackResponses(apiRequest: apiRequest)
         }
 
-        let cell = app.launch().homeView.recommendationCell("Slate 1, Recommendation 1")
+        let cell = app.launch().waitForHomeToLoad().recommendationCell("Slate 1, Recommendation 1")
         cell.saveButton.tap()
         cell.savedButton.wait()
 
@@ -301,8 +302,7 @@ class HomeTests: XCTestCase {
             return .fallbackResponses(apiRequest: apiRequest)
         }
 
-        app.launch()
-            .homeView
+        app.launch().waitForHomeToLoad()
             .sectionHeader("Slate 1")
             .seeAllButton
             .wait().tap()
@@ -360,7 +360,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_returningFromSaves_maintainsHomePosition() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.overscroll()
         validateBottomMessage()
         app.tabBar.savesButton.tap()
@@ -369,7 +369,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_returningFromSettings_maintainsHomePosition() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.overscroll()
         validateBottomMessage()
         app.tabBar.settingsButton.tap()
@@ -378,7 +378,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_returningFromReader_maintainsHomePosition() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.overscroll()
         validateBottomMessage()
         home.recommendationCell("Slate 1, Recommendation 2").tap()
@@ -387,7 +387,7 @@ class HomeTests: XCTestCase {
     }
 
     func test_returningFromSeeAll_maintainsHomePosition() {
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.overscroll()
         validateBottomMessage()
         home.seeAllCollectionButton.tap()
@@ -436,7 +436,7 @@ extension HomeTests {
             }
             return .fallbackResponses(apiRequest: apiRequest)
         }
-        let home = app.launch().homeView
+        let home = app.launch().waitForHomeToLoad()
         home.recommendationCell("Slate 1, Recommendation 1").wait()
 
         home.pullToRefresh()
@@ -449,7 +449,7 @@ extension HomeTests {
     // Started failing in Xcode 13.2.1
     // Error: Failed to determine hittability of "home-overscroll" Other: Activation point invalid and no suggested hit points based on element frame
     func xtest_overscrollingHome_showsOverscrollView() {
-        let home = app.homeView
+        let home = app.launch().waitForHomeToLoad()
         let overscrollView = home.overscrollView
 
         home.sectionHeader("Slate 1").wait()
@@ -476,18 +476,18 @@ extension HomeTests {
             return .fallbackResponses(apiRequest: apiRequest)
         }
 
-        app.launch().homeView.wait()
+        let homeView = app.launch().waitForHomeToLoad()
 
         // If an item isn't initially visible (e.g "Item 3"),
         // take the first cell and swipe left so that it becomes visible.
         // This works because the fixture for "Saves" contains 3 items.
         // The first two tests for "Item 1" and "Item 2" work because
         // they are on-screen, but we have to scroll for "Item 3".
-        if !app.homeView.savedItemCell(item).exists {
-            app.homeView.savedItemCell(at: 0).swipeLeft()
+        if !homeView.savedItemCell(item).exists {
+            homeView.savedItemCell(at: 0).swipeLeft()
         }
 
-        app.homeView.savedItemCell(item).wait().tap()
+        homeView.savedItemCell(item).wait().tap()
 
         app
             .webReaderView

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -440,32 +440,6 @@ class SearchTests: XCTestCase {
         searchEvent2!.getUIContext()!.assertHas(componentDetail: "saves")
         searchEvent2!.getContentContext()!.assertHas(url: "http://localhost:8080/hello-2")
     }
-    // TODO: DISABLED FLAKEY - To be investigated: share sheet does not always appear in ui tests.
-    @MainActor
-    func xtest_sharingAnItemFromSearch_forPremiumUser_presentsShareSheet() async {
-        stubGraphQLEndpoint(isPremium: true)
-        app.launch()
-        tapSearch()
-
-        let searchField = app.navigationBar.searchFields["Search"].wait()
-        searchField.tap()
-        searchField.typeText("item\n")
-        app.saves.searchView.searchResultsView.wait()
-
-        let itemCell = app
-            .saves.searchView
-            .searchItemCell(matching: "Item 2")
-            .wait()
-
-        itemCell.shareButton.wait().tap()
-
-        app.shareSheet.wait()
-
-        let searchEvent = await snowplowMicro.getFirstEvent(with: "global-nav.search.share")
-        searchEvent!.getUIContext()!.assertHas(type: "button")
-        searchEvent!.getUIContext()!.assertHas(componentDetail: "saves")
-        searchEvent!.getContentContext()!.assertHas(url: "http://localhost:8080/hello-2")
-    }
 
     @MainActor
     func test_addTagsFromSearch_forPremiumUser_showsAddTagsView() async {

--- a/Tests iOS/MyList/SearchTests.swift
+++ b/Tests iOS/MyList/SearchTests.swift
@@ -440,9 +440,9 @@ class SearchTests: XCTestCase {
         searchEvent2!.getUIContext()!.assertHas(componentDetail: "saves")
         searchEvent2!.getContentContext()!.assertHas(url: "http://localhost:8080/hello-2")
     }
-    // TODO: FLAKEY - To be investigated: share sheet does not always appear in ui tests.
+    // TODO: DISABLED FLAKEY - To be investigated: share sheet does not always appear in ui tests.
     @MainActor
-    func test_sharingAnItemFromSearch_forPremiumUser_presentsShareSheet() async {
+    func xtest_sharingAnItemFromSearch_forPremiumUser_presentsShareSheet() async {
         stubGraphQLEndpoint(isPremium: true)
         app.launch()
         tapSearch()

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -121,8 +121,8 @@ class ReaderTests: XCTestCase {
         XCTAssertTrue(app.readerView.fontStepperIncreaseButton.exists)
         XCTAssertTrue(app.readerView.fontStepperDecreaseButton.exists)
         openFontMenu()
-        XCTAssertTrue(app.readerView.fontSelection(fontName: "Graphik LCG").exists)
-        XCTAssertTrue(app.readerView.fontSelection(fontName: "Blanco OSF").exists)
+        XCTAssertTrue(app.readerView.fontSelection(fontName: "Graphik").exists)
+        XCTAssertTrue(app.readerView.fontSelection(fontName: "Blanco").exists)
 
         let textSettingsEvent = await snowplowMicro.getFirstEvent(with: "reader.toolbar.text_settings")
         textSettingsEvent!.getUIContext()!.assertHas(type: "button")

--- a/Tests iOS/Support/Elements/PocketAppElement.swift
+++ b/Tests iOS/Support/Elements/PocketAppElement.swift
@@ -176,6 +176,13 @@ struct PocketAppElement {
         return self
     }
 
+    @discardableResult
+    func waitForHomeToLoad() -> HomeViewElement {
+        self.homeView.savedItemCell("Item 1").wait()
+        self.homeView.recommendationCell("Slate 1, Recommendation 1").wait()
+        return self.homeView
+    }
+
     func terminate() {
         app.terminate()
     }

--- a/Tests iOS/Support/Elements/PocketUIElement.swift
+++ b/Tests iOS/Support/Elements/PocketUIElement.swift
@@ -27,7 +27,7 @@ extension PocketUIElement {
 
     @discardableResult
     func wait(
-        timeout: TimeInterval = 30,
+        timeout: TimeInterval = 3,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Self {

--- a/Tests iOS/Support/Elements/PocketUIElement.swift
+++ b/Tests iOS/Support/Elements/PocketUIElement.swift
@@ -27,7 +27,7 @@ extension PocketUIElement {
 
     @discardableResult
     func wait(
-        timeout: TimeInterval = 2,
+        timeout: TimeInterval = 30,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Self {

--- a/Tests iOS/Support/Elements/SavesElement.swift
+++ b/Tests iOS/Support/Elements/SavesElement.swift
@@ -132,7 +132,7 @@ struct SavesElement: PocketUIElement {
 
     @discardableResult
     func wait(
-        timeout: TimeInterval = 3,
+        timeout: TimeInterval = 30,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Self {

--- a/Tests iOS/Support/Elements/SavesElement.swift
+++ b/Tests iOS/Support/Elements/SavesElement.swift
@@ -132,7 +132,7 @@ struct SavesElement: PocketUIElement {
 
     @discardableResult
     func wait(
-        timeout: TimeInterval = 30,
+        timeout: TimeInterval = 3,
         file: StaticString = #file,
         line: UInt = #line
     ) -> Self {

--- a/Tests iOS/Support/Elements/XCUIElement+wait.swift
+++ b/Tests iOS/Support/Elements/XCUIElement+wait.swift
@@ -7,7 +7,7 @@ import XCTest
 extension XCUIElement {
     @discardableResult
     func wait(
-        timeout: TimeInterval = 4,
+        timeout: TimeInterval = 30,
         file: StaticString = #file,
         line: UInt = #line
     ) -> XCUIElement {

--- a/Tests iOS/Support/Elements/XCUIElement+wait.swift
+++ b/Tests iOS/Support/Elements/XCUIElement+wait.swift
@@ -7,7 +7,7 @@ import XCTest
 extension XCUIElement {
     @discardableResult
     func wait(
-        timeout: TimeInterval = 30,
+        timeout: TimeInterval = 3,
         file: StaticString = #file,
         line: UInt = #line
     ) -> XCUIElement {

--- a/Tests iOS/Support/SnowplowMicro.swift
+++ b/Tests iOS/Support/SnowplowMicro.swift
@@ -207,7 +207,7 @@ class SnowplowMicro {
     internal func snowplowRequest(path: String, method: String = "GET", shouldWait: Bool = true) async -> Data {
         if shouldWait {
             // For now we wait 1 seconds for snowplow data to be available because the iOS app flushes it to the server.
-            _ = await XCTWaiter.fulfillment(of: [XCTestExpectation(description: "Wait 5 seconds for snowplow data to be available.")], timeout: 1.0)
+            _ = await XCTWaiter.fulfillment(of: [XCTestExpectation(description: "Wait 1 seconds for snowplow data to be available.")], timeout: 1.0)
         }
         let data = try! await self.client.httpData(from: URL(string: "http://localhost:9090\(path)")!, method: method)
         return data
@@ -217,7 +217,7 @@ class SnowplowMicro {
      Resets snowplow micro events and event counter
      */
     func resetSnowplowEvents() async {
-        _ = await snowplowRequest(path: "/micro/reset", method: "POST", shouldWait: false)
+        _ = await snowplowRequest(path: "/micro/reset", method: "POST", shouldWait: true)
     }
 
     /**
@@ -365,8 +365,11 @@ extension SnowplowMicro {
     internal func assertAPIUser(for event: SnowplowMicroEvent) {
         let apiUser = event.getAPIUserContext()
         XCTAssertNotNil(apiUser, "API User not found in analytics event")
-        XCTAssertEqual(apiUser!.dataDict()["api_id"] as! Int, 5512)
-        XCTAssertEqual(apiUser!.dataDict()["client_version"] as! String, "1")
+        guard let data = apiUser?.dataDict() else {
+            return
+        }
+        XCTAssertEqual(data["api_id"] as! Int, 5512)
+        XCTAssertEqual(data["client_version"] as! String, "1")
     }
 
     /**
@@ -401,8 +404,11 @@ extension SnowplowMicro {
         }
 
         XCTAssertNotNil(user, "User not found in analytics event")
-        XCTAssertEqual(user!.dataDict()["hashed_user_id"] as! String, "session-user-id")
-        XCTAssertEqual(user!.dataDict()["hashed_guid"] as! String, "session-guid")
+        guard let data = user?.dataDict() else {
+            return
+        }
+        XCTAssertEqual(data["hashed_user_id"] as! String, "session-user-id")
+        XCTAssertEqual(data["hashed_guid"] as! String, "session-guid")
     }
 }
 

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval = 3) {
+    func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval = 30) {
         let doesNotExist = NSPredicate(format: "exists == 0")
         let elementToNotExist = expectation(for: doesNotExist, evaluatedWith: element)
         wait(for: [elementToNotExist], timeout: timeout)

--- a/Tests iOS/Support/XCTestCase+extensions.swift
+++ b/Tests iOS/Support/XCTestCase+extensions.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 extension XCTestCase {
-    func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval = 30) {
+    func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval = 3) {
         let doesNotExist = NSPredicate(format: "exists == 0")
         let elementToNotExist = expectation(for: doesNotExist, evaluatedWith: element)
         wait(for: [elementToNotExist], timeout: timeout)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -218,8 +218,8 @@ workflows:
                 ## It uses the values in MICRO_IGLU_REGISTRY_URL and MICRO_IGLU_API_KEY
                 echo "Run snowplow"
                 brew install wget openjdk
-                wget https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.7.2/snowplow-micro-1.7.2.jar
-                java -jar snowplow-micro-1.7.2.jar &
+                wget https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-2.0.0/snowplow-micro-2.0.0.jar
+                java -jar snowplow-micro-2.0.0.jar &
 
   #Builds a release build that could be uploaded to App Store Connect
   release-build:


### PR DESCRIPTION
## Summary

The main purpose of this round of dependency updates was to pull in [Snowplow 6.0.0 ](https://github.com/snowplow/snowplow-ios-tracker/releases/tag/6.0.0).

This led to a few other things:
* Added in FMDB since Snowplow removed it and PKTListen needs it. (see details below)
* Enabled snowplow autotracking by default so we can compare the new events against our custom made ones.


## Implementation Details

**FMDB**
FMDB should not be here, instead it should be included in Listen and part of its fat binary. However doing that led to a bunch of C99 compile errors, so side stepping for now. 

What I would like to do, is take another pass at trying to Convert Listen to use Swift Package manager, and then move it to that long term.
