### PR TITLE
Highlights - fix bug that could prevent applying an highlight in certain conditions

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -426,7 +426,7 @@ extension SavedItemViewModel {
         guard let component = item.item?.article?.components[safe: componentIndex],
               let content = getContent(from: component),
               // find the range to highlight
-              let stringRange = Range(range, in: content),
+              let stringRange = Range(range, in: text),
               // get the previously patched component/content
               let previousComponent = components?[safe: componentIndex],
               let previousContent = getContent(from: previousComponent) else {


### PR DESCRIPTION
## Summary
* This PR fixes a bug that prevented to apply an highlight in certain conditions

## References 
* NA

## Implementation Details
* Update `SavedItemViewModel`, fix an issue in `saveHighlight(...)` where the quote lookup happened in the original mardown instead of the text coming from the attributed string, which could cause mismatches depending on the markdown.

## Test Steps
* Highlight some text in a bulleted or numbered list and make sure it gets applied correctly

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
