### PR TITLE
Highlights - Fix crash on highlighting a list item

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -437,8 +437,24 @@ extension SavedItemViewModel {
             Log.capture(message: "Unable to find a substring to highlight")
             return
         }
-
-        let proposedQuote = String(content[stringRange])
+        // make sure the range does not exceed the bounds of the content. This can happen because markdown can
+        // differ from the string extracted from the attributed text. In these cases, proposedQuote would be
+        // discarded in favor of using DiffMatchPatch to find the actual quote.
+        let safeRange = Range(
+            uncheckedBounds: (
+                max(
+                    content.startIndex,
+                    stringRange.lowerBound
+                ),
+                min(
+                    content.index(
+                        before: content.endIndex
+                    ),
+                    stringRange.upperBound
+                )
+            )
+        )
+        let proposedQuote = String(content[safeRange])
 
         // merge the new patch with the new patch
         guard let mergedContent = mergeHighlights(


### PR DESCRIPTION
## Summary
* This PR fixes a crash when highlighting a list in certain conditions

## References 
* Branch name

## Implementation Details
* Update `SavedItemViewModel.saveHighlight(_:, _:, _:, _:)`, add safeguard to range bounds when calculating `proposedQuote`

## Test Steps
* Save an article with a list, for example https://pocket.co/xhC67H?utm_source=pocket_reader
* Highlight a numbered list and make sure the highlight works and the app does not crash

> [!NOTE]
> because of how `MArticle` and the current patching system work, it can happen that, if you highlight an entire numbered list, including the numbers themselves, the resulting highlight won't include the first number, basically because the patched markdown does not contain the numbers and there's virtually no difference between highlighting before or after the number.
This can be of course revisited but should be addressed in a separate PR, this one is to address the crash specifically.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
