### PR TITLE
Share: update shortUrl on demand, if needed, when sharing an url

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusItemParts.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment CorpusItemParts on CorpusItem { __typename id url title excerpt imageUrl publisher target { __typename ... on SyndicatedArticle { __typename ...SyndicatedArticleParts } ... on Collection { __typename ...CollectionSummary } } }"#
+    #"fragment CorpusItemParts on CorpusItem { __typename id url title excerpt imageUrl shortUrl publisher target { __typename ... on SyndicatedArticle { __typename ...SyndicatedArticleParts } ... on Collection { __typename ...CollectionSummary } } }"#
   }
 
   public let __data: DataDict
@@ -19,6 +19,7 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
     .field("title", String.self),
     .field("excerpt", String.self),
     .field("imageUrl", PocketGraph.Url.self),
+    .field("shortUrl", PocketGraph.Url?.self),
     .field("publisher", String.self),
     .field("target", Target?.self),
   ] }
@@ -33,6 +34,9 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
   public var excerpt: String { __data["excerpt"] }
   /// The image URL for this item's accompanying picture.
   public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+  /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+  /// marked as beta because it's not ready yet for large client request.
+  public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
   /// The name of the online publication that published this story.
   public var publisher: String { __data["publisher"] }
   /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
@@ -44,6 +48,7 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
     title: String,
     excerpt: String,
     imageUrl: PocketGraph.Url,
+    shortUrl: PocketGraph.Url? = nil,
     publisher: String,
     target: Target? = nil
   ) {
@@ -55,6 +60,7 @@ public struct CorpusItemParts: PocketGraph.SelectionSet, Fragment {
         "title": title,
         "excerpt": excerpt,
         "imageUrl": imageUrl,
+        "shortUrl": shortUrl,
         "publisher": publisher,
         "target": target._fieldData,
       ],

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusRecommendationParts.graphql.swift
@@ -62,6 +62,9 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
     public var excerpt: String { __data["excerpt"] }
     /// The image URL for this item's accompanying picture.
     public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+    /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+    /// marked as beta because it's not ready yet for large client request.
+    public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
     /// The name of the online publication that published this story.
     public var publisher: String { __data["publisher"] }
     /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
@@ -80,6 +83,7 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
       title: String,
       excerpt: String,
       imageUrl: PocketGraph.Url,
+      shortUrl: PocketGraph.Url? = nil,
       publisher: String,
       target: Target? = nil
     ) {
@@ -91,6 +95,7 @@ public struct CorpusRecommendationParts: PocketGraph.SelectionSet, Fragment {
           "title": title,
           "excerpt": excerpt,
           "imageUrl": imageUrl,
+          "shortUrl": shortUrl,
           "publisher": publisher,
           "target": target._fieldData,
         ],

--- a/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/CorpusSlateParts.graphql.swift
@@ -110,6 +110,9 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
       public var excerpt: String { __data["excerpt"] }
       /// The image URL for this item's accompanying picture.
       public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+      /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+      /// marked as beta because it's not ready yet for large client request.
+      public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
       /// The name of the online publication that published this story.
       public var publisher: String { __data["publisher"] }
       /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
@@ -128,6 +131,7 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
         title: String,
         excerpt: String,
         imageUrl: PocketGraph.Url,
+        shortUrl: PocketGraph.Url? = nil,
         publisher: String,
         target: Target? = nil
       ) {
@@ -139,6 +143,7 @@ public struct CorpusSlateParts: PocketGraph.SelectionSet, Fragment {
             "title": title,
             "excerpt": excerpt,
             "imageUrl": imageUrl,
+            "shortUrl": shortUrl,
             "publisher": publisher,
             "target": target._fieldData,
           ],

--- a/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/SavedItemSummary.graphql.swift
@@ -437,6 +437,9 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
     public var excerpt: String { __data["excerpt"] }
     /// The image URL for this item's accompanying picture.
     public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+    /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+    /// marked as beta because it's not ready yet for large client request.
+    public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
     /// The name of the online publication that published this story.
     public var publisher: String { __data["publisher"] }
     /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
@@ -455,6 +458,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
       title: String,
       excerpt: String,
       imageUrl: PocketGraph.Url,
+      shortUrl: PocketGraph.Url? = nil,
       publisher: String,
       target: Target? = nil
     ) {
@@ -466,6 +470,7 @@ public struct SavedItemSummary: PocketGraph.SelectionSet, Fragment {
           "title": title,
           "excerpt": excerpt,
           "imageUrl": imageUrl,
+          "shortUrl": shortUrl,
           "publisher": publisher,
           "target": target._fieldData,
         ],

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/FetchArchiveQuery.graphql.swift
@@ -368,6 +368,9 @@ public class FetchArchiveQuery: GraphQLQuery {
               public var excerpt: String { __data["excerpt"] }
               /// The image URL for this item's accompanying picture.
               public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+              /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+              /// marked as beta because it's not ready yet for large client request.
+              public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
               /// The name of the online publication that published this story.
               public var publisher: String { __data["publisher"] }
               /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/GetItemShortUrlQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/GetItemShortUrlQuery.graphql.swift
@@ -1,0 +1,51 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class GetItemShortUrlQuery: GraphQLQuery {
+  public static let operationName: String = "GetItemShortUrl"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"query GetItemShortUrl($url: String!) { itemByUrl(url: $url) { __typename shortUrl } }"#
+    ))
+
+  public var url: String
+
+  public init(url: String) {
+    self.url = url
+  }
+
+  public var __variables: Variables? { ["url": url] }
+
+  public struct Data: PocketGraph.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("itemByUrl", ItemByUrl?.self, arguments: ["url": .variable("url")]),
+    ] }
+
+    /// Look up Item info by a url.
+    public var itemByUrl: ItemByUrl? { __data["itemByUrl"] }
+
+    /// ItemByUrl
+    ///
+    /// Parent Type: `Item`
+    public struct ItemByUrl: PocketGraph.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Item }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("shortUrl", PocketGraph.Url?.self),
+      ] }
+
+      /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+      /// marked as beta because it's not ready yet for large client request.
+      public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
+    }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/HomeSlateLineupQuery.graphql.swift
@@ -119,6 +119,9 @@ public class HomeSlateLineupQuery: GraphQLQuery {
             public var excerpt: String { __data["excerpt"] }
             /// The image URL for this item's accompanying picture.
             public var imageUrl: PocketGraph.Url { __data["imageUrl"] }
+            /// Provides short url for the given_url in the format: https://pocket.co/<identifier>.
+            /// marked as beta because it's not ready yet for large client request.
+            public var shortUrl: PocketGraph.Url? { __data["shortUrl"] }
             /// The name of the online publication that published this story.
             public var publisher: String { __data["publisher"] }
             /// If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/resolveItemUrl.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/resolveItemUrl.graphql
@@ -14,3 +14,9 @@ query ResolveItemUrl($url: String!) {
     }
   }
 }
+
+query GetItemShortUrl($url: String!) {
+  itemByUrl(url: $url) {
+     shortUrl
+  }
+}

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/unifiedHome.graphql
@@ -4,6 +4,7 @@ fragment CorpusItemParts on CorpusItem {
     title
     excerpt
     imageUrl
+    shortUrl
     publisher
     target {
         ... on SyndicatedArticle {

--- a/PocketKit/Sources/PocketGraphTestMocks/CorpusItem+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/CorpusItem+Mock.graphql.swift
@@ -14,6 +14,7 @@ public class CorpusItem: MockObject {
     @Field<PocketGraph.ID>("id") public var id
     @Field<PocketGraph.Url>("imageUrl") public var imageUrl
     @Field<String>("publisher") public var publisher
+    @Field<PocketGraph.Url>("shortUrl") public var shortUrl
     @Field<CorpusTarget>("target") public var target
     @Field<String>("title") public var title
     @Field<PocketGraph.Url>("url") public var url
@@ -26,6 +27,7 @@ public extension Mock where O == CorpusItem {
     id: PocketGraph.ID? = nil,
     imageUrl: PocketGraph.Url? = nil,
     publisher: String? = nil,
+    shortUrl: PocketGraph.Url? = nil,
     target: AnyMock? = nil,
     title: String? = nil,
     url: PocketGraph.Url? = nil
@@ -35,6 +37,7 @@ public extension Mock where O == CorpusItem {
     _setScalar(id, for: \.id)
     _setScalar(imageUrl, for: \.imageUrl)
     _setScalar(publisher, for: \.publisher)
+    _setScalar(shortUrl, for: \.shortUrl)
     _setEntity(target, for: \.target)
     _setScalar(title, for: \.title)
     _setScalar(url, for: \.url)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -61,6 +61,14 @@ class RecommendableItemViewModel: ReadableViewModel {
         self.savedItemCancellable = item.publisher(for: \.savedItem).sink { [weak self] savedItem in
             self?.update(for: savedItem)
         }
+
+        if let url = item.shortURL {
+            self.shortUrl = url
+        } else {
+            Task {
+                self.shortUrl = try? await source.getItemShortUrl(item.givenURL)
+            }
+        }
     }
 
     var components: [ArticleComponent]? {
@@ -96,9 +104,7 @@ class RecommendableItemViewModel: ReadableViewModel {
         item.bestURL
     }
 
-    var shortUrl: String? {
-        item.shortURL
-    }
+    var shortUrl: String?
 
     var itemSaveStatus: ItemSaveStatus {
         guard let savedItem = item.savedItem else {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -124,6 +124,14 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
         item.publisher(for: \.isArchived).sink { [weak self] _ in
             self?.buildActions()
         }.store(in: &subscriptions)
+
+        if let url = item.item?.shortURL {
+            self.shortUrl = url
+        } else if let item = item.item {
+            Task {
+                self.shortUrl = try? await source.getItemShortUrl(item.givenURL)
+            }
+        }
     }
 
     lazy var dismissReason: Binding<DismissReason> = {
@@ -162,9 +170,7 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
         item.bestURL
     }
 
-    var shortUrl: String? {
-        item.item?.shortURL
-    }
+    var shortUrl: String?
 
     var itemSaveStatus: ItemSaveStatus {
         if item.isArchived {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -1242,6 +1242,26 @@ extension PocketSource {
     public func makeSharedWithYouController() -> RichFetchedResultsController<SharedWithYouItem> {
         space.makeSharedWithYouController()
     }
+
+    public func getItemShortUrl(_ itemUrl: String) async throws -> String? {
+        guard let itemData = try await apollo
+            .fetch(query: GetItemShortUrlQuery(url: itemUrl)).data,
+                let shortUrl = itemData.itemByUrl?.shortUrl else {
+            return nil
+        }
+        defer {
+            try? updateItemShortUrl(itemUrl, shortUrl: shortUrl)
+        }
+        return shortUrl
+    }
+
+    private func updateItemShortUrl(_ itemUrl: String, shortUrl: String) throws {
+        guard let item = try space.fetchItem(byURL: itemUrl) else {
+            return
+        }
+        item.shortURL = shortUrl
+        try? space.save()
+    }
 }
 
 // MARK: - Search term

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -144,4 +144,5 @@ public protocol Source {
     // MARK: Shared With You
     func updateSharedWithYouItems(with urls: [String])
     func makeSharedWithYouController() -> RichFetchedResultsController<SharedWithYouItem>
+    func getItemShortUrl(_ itemUrl: String) async throws -> String?
 }

--- a/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AppBadgeTrackerTests.swift
@@ -71,7 +71,7 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
-        wait(for: [badgeExpectation], timeout: 10)
+        wait(for: [badgeExpectation], timeout: 2)
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 1)
     }
 
@@ -91,7 +91,7 @@ final class AppBadgeTrackerTests: XCTestCase {
 
         NotificationCenter.default.post(name: .listUpdated, object: nil)
 
-        wait(for: [badgeExpectation], timeout: 10)
+        wait(for: [badgeExpectation], timeout: 2)
         XCTAssertEqual(badgeProvider.applicationIconBadgeNumber, 0)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
+++ b/PocketKit/Tests/PocketKitTests/AuthorizationClientTests.swift
@@ -85,7 +85,7 @@ extension AuthorizationClientTests {
         Task {
             do {
                 // wait for our first task to have started before we try the one that should fail.
-                await fulfillment(of: [expectFirstClientStarted], timeout: 10)
+                await fulfillment(of: [expectFirstClientStarted], timeout: 2)
                 _ = try await self.client.authenticate(from: self)
                 XCTFail("Expected to throw error, but didn't")
             } catch {
@@ -94,7 +94,7 @@ extension AuthorizationClientTests {
             }
         }
 
-        await fulfillment(of: [expectSessionStart], timeout: 10)
+        await fulfillment(of: [expectSessionStart], timeout: 2)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -359,7 +359,7 @@ class CollectionViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Edit tags")
 
-        wait(for: [expectAddTags], timeout: 10)
+        wait(for: [expectAddTags], timeout: 2)
     }
 
     func test_delete_delegatesToSource_andSendsDeleteEvent() throws {

--- a/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/HomeViewModelTests.swift
@@ -121,7 +121,7 @@ class HomeViewModelTests: XCTestCase {
             snapshotExpectation.fulfill()
         }.store(in: &subscriptions)
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsLoadingSnapshot() {
@@ -136,7 +136,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedLoadingSnapshot], timeout: 10)
+        wait(for: [receivedLoadingSnapshot], timeout: 2)
     }
 
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsAvailable_sendsSnapshotWithSlates() throws {
@@ -186,7 +186,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 10)
+        wait(for: [receivedSnapshot], timeout: 2)
     }
 
     func test_fetch_whenRecentSavesAreAvailable_andSlateLineupIsUnavailable_sendsSnapshotWithRecentSaves() throws {
@@ -218,7 +218,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 10)
+        wait(for: [receivedEmptySnapshot], timeout: 2)
     }
 
     func test_fetch_whenSlateContainsMoreThanFiveRecommendations_sendsSnapshotFirstFiveRecommendations() throws {
@@ -247,7 +247,7 @@ class HomeViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedEmptySnapshot], timeout: 10)
+        wait(for: [receivedEmptySnapshot], timeout: 2)
     }
 
     func test_snapshot_whenSlateLineupIsUpdated_updatesSnapshot() throws {
@@ -306,7 +306,7 @@ class HomeViewModelTests: XCTestCase {
         )
         try space.save()
 
-        wait(for: [snapshotSent], timeout: 10)
+        wait(for: [snapshotSent], timeout: 2)
     }
 
     func test_snapshot_whenRecommendationIsSaved_updatesSnapshot() throws {
@@ -351,7 +351,7 @@ class HomeViewModelTests: XCTestCase {
         item.savedItem = savedItem
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_snapshot_whenRecommendationIsArchived_updatesSnapshot() throws {
@@ -395,7 +395,7 @@ class HomeViewModelTests: XCTestCase {
         item.savedItem?.isArchived = true
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_snapshot_whenRecommendationIsDeleted_updatesSnapshot() throws {
@@ -443,7 +443,7 @@ class HomeViewModelTests: XCTestCase {
         XCTAssertNotNil(item.savedItem?.item)
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_snapshot_whenSavedItemIsFavorited_updatesSnapshot() throws {
@@ -476,7 +476,7 @@ class HomeViewModelTests: XCTestCase {
         savedItem.isFavorite = true
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_snapshot_whenNetworkIsInitiallyAvailable_hasCorrectSnapshot() {
@@ -540,7 +540,7 @@ class HomeViewModelTests: XCTestCase {
 
         let viewModel = subject()
         viewModel.refresh { }
-        wait(for: [fetchExpectation], timeout: 10)
+        wait(for: [fetchExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
@@ -589,7 +589,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [readableExpectation], timeout: 10)
+        wait(for: [readableExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_whenRecommendationIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -647,7 +647,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [urlExpectation], timeout: 10)
+        wait(for: [urlExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_withSettingsOriginalViewEnabled_showsWebViewType() throws {
@@ -699,7 +699,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [readableExpectation], timeout: 10)
+        wait(for: [readableExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecentSave_recentSaveIsReadable_updatesSelectedReadable() throws {
@@ -740,7 +740,7 @@ class HomeViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [readableExpectation], timeout: 10)
+        wait(for: [readableExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecentSave_recentSaveIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -798,7 +798,7 @@ class HomeViewModelTests: XCTestCase {
             )
         }
 
-        wait(for: [urlExpectation], timeout: 10)
+        wait(for: [urlExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecentSave_withSettingsOriginalViewEnabled_showsWebViewType() throws {
@@ -841,7 +841,7 @@ class HomeViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [readableExpectation], timeout: 10)
+        wait(for: [readableExpectation], timeout: 2)
     }
 
     func test_selectSection_whenSelectingSlateSection_updatesSelectedSlateDetailViewModel() throws {
@@ -868,7 +868,7 @@ class HomeViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.sectionHeaderViewModel(for: .slateHero(slate.objectID))?.buttonAction?()
-        wait(for: [detailExpectation], timeout: 10)
+        wait(for: [detailExpectation], timeout: 2)
     }
 
     func test_reportAction_forRecommendationCells_updatesSelectedRecommendationToReport() throws {
@@ -897,7 +897,7 @@ class HomeViewModelTests: XCTestCase {
             action?.handler?(nil)
         }
 
-        wait(for: [reportExpectation], timeout: 10)
+        wait(for: [reportExpectation], timeout: 2)
     }
 
     func test_primary_whenRecommendationIsNotSaved_savesWithSource() throws {

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -85,7 +85,7 @@ extension LoggedOutViewModelTests {
         let viewModel = subject()
         await viewModel.authenticate()
 
-        await fulfillment(of: [startExpectation], timeout: 10)
+        await fulfillment(of: [startExpectation], timeout: 2)
     }
 
     @MainActor
@@ -101,7 +101,7 @@ extension LoggedOutViewModelTests {
 
         viewModel.authenticate()
 
-        wait(for: [alertExpectation], timeout: 10)
+        wait(for: [alertExpectation], timeout: 2)
     }
 }
 
@@ -118,7 +118,7 @@ extension LoggedOutViewModelTests {
 
         await viewModel.authenticate()
 
-        await fulfillment(of: [offlineExpectation], timeout: 10)
+        await fulfillment(of: [offlineExpectation], timeout: 2)
     }
 
     func test_logIn_whenOffline_thenReconnects_setsPresentOfflineViewToFalse() async {
@@ -142,7 +142,7 @@ extension LoggedOutViewModelTests {
         await viewModel.authenticate()
         networkPathMonitor.update(status: .satisfied)
 
-        await fulfillment(of: [offlineExpectation, onlineExpectation], timeout: 10, enforceOrder: true)
+        await fulfillment(of: [offlineExpectation, onlineExpectation], timeout: 2, enforceOrder: true)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Notifications/PushNotificationServiceTests.swift
@@ -63,7 +63,7 @@ final class PushNotificationServiceTests: XCTestCase {
 
         NotificationCenter.default.post(name: .userLoggedIn, object: session)
 
-        wait(for: [sessionExpectation], timeout: 10)
+        wait(for: [sessionExpectation], timeout: 2)
 
         XCTAssertEqual(braze.loggedInCalls(), 2)
         XCTAssertEqual(instantSync.loggedInCalls(), 2)

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -122,7 +122,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
 
         viewModel.addTags()
 
-        wait(for: [expectAddTagsCall], timeout: 10)
+        wait(for: [expectAddTagsCall], timeout: 2)
         XCTAssertNotNil(source.addTagsToSavedItemCall(at: 0))
     }
 
@@ -150,7 +150,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         }
 
         let viewModel = subject(item: item, user: MockUser(status: .premium)) { }
-        wait(for: [expectFetchAllTagsCall], timeout: 10)
+        wait(for: [expectFetchAllTagsCall], timeout: 2)
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
@@ -181,7 +181,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         }
 
         let viewModel = subject(item: item, user: MockUser(status: .premium)) { }
-        wait(for: [expectRetrieveTagsCall], timeout: 10)
+        wait(for: [expectRetrieveTagsCall], timeout: 2)
         XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
@@ -212,7 +212,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         }
 
         let viewModel = subject(item: item, user: MockUser(status: .free)) { }
-        wait(for: [expectRetrieveTagsCall], timeout: 10)
+        wait(for: [expectRetrieveTagsCall], timeout: 2)
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
@@ -234,7 +234,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         let viewModel = subject(item: item) { }
         viewModel.allOtherTags()
 
-        wait(for: [expectRetrieveTagsCall], timeout: 10)
+        wait(for: [expectRetrieveTagsCall], timeout: 2)
         XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
         XCTAssertNotNil(source.retrieveTagsCall(at: 0))
     }
@@ -294,7 +294,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 10)
+        wait(for: [expectFilterTagsCall], timeout: 2)
     }
 
     func test_newTagInput_withNoTags_showAllTags() {
@@ -326,6 +326,6 @@ class PocketAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 10)
+        wait(for: [expectFilterTagsCall], timeout: 2)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/RecommendableItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendableItemViewModelTests.swift
@@ -160,7 +160,7 @@ class RecommendableItemViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Favorite")
 
-        wait(for: [expectFavorite], timeout: 10)
+        wait(for: [expectFavorite], timeout: 2)
     }
 
     func test_unfavorite_delegatesToSource() {
@@ -178,7 +178,7 @@ class RecommendableItemViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Unfavorite")
 
-        wait(for: [expectUnfavorite], timeout: 10)
+        wait(for: [expectUnfavorite], timeout: 2)
     }
 
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
@@ -206,7 +206,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         viewModel.invokeAction(title: "Delete")
         viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
 
-        wait(for: [expectDelete, expectDeleteEvent], timeout: 10)
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 2)
     }
 
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
@@ -232,7 +232,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.archive()
-        wait(for: [expectArchive, expectArchiveEvent], timeout: 10)
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 2)
     }
 
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
@@ -249,7 +249,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         let viewModel = subject(recommendation: recommendation)
         viewModel.moveFromArchiveToSaves { _ in }
 
-        wait(for: [expectMoveFromArchiveToSaves], timeout: 10)
+        wait(for: [expectMoveFromArchiveToSaves], timeout: 2)
     }
 
     func test_share_updatesSharedActivity() {
@@ -304,7 +304,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.invokeAction(title: "Report")
-        wait(for: [reportExpectation], timeout: 10)
+        wait(for: [reportExpectation], timeout: 2)
     }
 
     func test_externalSave_forwardsToSource() throws {
@@ -363,7 +363,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [receivedEvent], timeout: 10)
+        wait(for: [receivedEvent], timeout: 2)
         XCTAssertNotNil(recommendation.item.article)
     }
 
@@ -384,7 +384,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [receivedEvent], timeout: 10)
+        wait(for: [receivedEvent], timeout: 2)
 
         XCTAssertFalse(recommendation.item.hasArticleComponents)
         XCTAssertNil(recommendation.item.article)
@@ -407,7 +407,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [receivedEvent], timeout: 10)
+        wait(for: [receivedEvent], timeout: 2)
     }
 
     func test_webActivitiesActions_whenRecommendation_notSaved() {
@@ -427,7 +427,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[0].activityTitle, "Save")
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Report")
 
-        wait(for: [webActivitiesExpectation], timeout: 10)
+        wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
     func test_webActivitiesActions_whenRecommendation_isSaved() throws {
@@ -450,7 +450,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 10)
+        wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
     func test_readerProgress() throws {

--- a/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Refresh/HomeRefreshCoordinatorTests.swift
@@ -63,7 +63,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 10)
+        wait(for: [expectRefresh], timeout: 2)
         XCTAssertNotNil(lastRefresh.lastRefreshHome)
     }
 
@@ -94,7 +94,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 10)
+        wait(for: [expectRefresh], timeout: 2)
         XCTAssertNotEqual(lastRefresh.lastRefreshHome, date!.timeIntervalSince1970)
     }
 
@@ -110,7 +110,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
         coordinator.refresh(isForced: true) {
             expectRefresh.fulfill()
         }
-        wait(for: [expectRefresh], timeout: 10)
+        wait(for: [expectRefresh], timeout: 2)
     }
 
     func test_refresh_delegatesToSource() {
@@ -121,57 +121,7 @@ class HomeRefreshCoordinatorTests: XCTestCase {
 
         coordinator.refresh(isForced: true) { }
 
-        wait(for: [fetchExpectation], timeout: 10)
+        wait(for: [fetchExpectation], timeout: 2)
         XCTAssertNotNil(source.fetchSlateLineupCall(at: 0))
     }
-// TODO: Renable once we fix our singleton use in tests
-//    func test_coordinator_whenEnterForeground_whenDataIsNotStale_doesNotRefreshHome() {
-//        source.stubFetchSlateLineup { _ in
-//            XCTFail("Should not fetch slate lineup")
-//        }
-//        lastRefresh.refreshedHome()
-//
-//        var coordinator: RefreshCoordinator? = subject()
-//        coordinator!.initialize()
-//        notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
-//        _ = XCTWaiter.wait(for: [expectation(description: "Ensure notification posts")], timeout: 5.0)
-//        coordinator = nil
-//    }
-//
-//    func test_coordinator_whenEnterForeground_whenDataIsStale_refreshesHome() {
-//        let fetchExpectationInit = expectation(description: "initid fetch slate lineup")
-//        fetchExpectationInit.assertForOverFulfill = true
-//        let fetchExpectation = expectation(description: "expected to fetch slate lineup")
-//
-//        source.stubFetchSlateLineup { _ in fetchExpectationInit.fulfill() }
-//        var coordinator: RefreshCoordinator? = subject()
-//        coordinator!.initialize()
-//        wait(for: [fetchExpectationInit], timeout: 10)
-//
-//        let date = Calendar.current.date(byAdding: .hour, value: -12, to: Date())
-//        userDefaults.setValue(date!.timeIntervalSince1970, forKey: UserDefaultsLastRefresh.lastRefreshedHomeAtKey)
-//        source.stubFetchSlateLineup { _ in fetchExpectation.fulfill() }
-//
-//        notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
-//
-//        wait(for: [fetchExpectation], timeout: 10)
-//        XCTAssertEqual(source.fetchSlateLineupCall(at: 0)?.identifier, "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1")
-//        coordinator = nil
-//    }
-//
-//    func test_coordinator_whenNoSession_doesNotRefreshHome() {
-//        source.stubFetchSlateLineup { _ in
-//            XCTFail("Should not fetch slate lineup")
-//        }
-//        lastRefresh.reset()
-//        XCTAssertNil(lastRefresh.lastRefreshHome)
-//
-//        var coordinator: RefreshCoordinator? = subject(appSession: AppSession(groupID: "group"))
-//        coordinator!.initialize()
-//        notificationCenter.post(name: UIScene.willEnterForegroundNotification, object: nil)
-//        _ = XCTWaiter.wait(for: [expectation(description: "Ensure notification posts")], timeout: 5.0)
-//
-//        XCTAssertNil(lastRefresh.lastRefreshHome)
-//        coordinator = nil
-//    }
 }

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
@@ -130,7 +130,7 @@ class SavedItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [eventSent], timeout: 10)
+        wait(for: [eventSent], timeout: 2)
 
         let call = source.fetchDetailsCall(at: 0)
         XCTAssertNotNil(call)
@@ -156,7 +156,7 @@ class SavedItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetchDetailsIfNeeded()
-        wait(for: [eventSent], timeout: 10)
+        wait(for: [eventSent], timeout: 2)
 
         let call = source.fetchDetailsCall(at: 0)
         XCTAssertNotNil(call)
@@ -187,7 +187,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         viewModel.fetchDetailsIfNeeded()
 
-        wait(for: [contentUpdatedSent], timeout: 10)
+        wait(for: [contentUpdatedSent], timeout: 2)
         XCTAssertNil(source.fetchDetailsCall(at: 0))
     }
 
@@ -210,7 +210,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: item)
         viewModel.invokeAction(title: "Favorite")
 
-        wait(for: [expectFavorite], timeout: 10)
+        wait(for: [expectFavorite], timeout: 2)
     }
 
     func test_unfavorite_delegatesToSource() {
@@ -225,7 +225,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: item)
         viewModel.invokeAction(title: "Unfavorite")
 
-        wait(for: [expectUnfavorite], timeout: 10)
+        wait(for: [expectUnfavorite], timeout: 2)
     }
 
     func test_tagsAction_withNoTags_isAddTags() throws {
@@ -258,7 +258,7 @@ class SavedItemViewModelTests: XCTestCase {
 
         viewModel.invokeAction(title: "Edit tags")
 
-        wait(for: [expectAddTags], timeout: 10)
+        wait(for: [expectAddTags], timeout: 2)
     }
 
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
@@ -284,7 +284,7 @@ class SavedItemViewModelTests: XCTestCase {
         viewModel.invokeAction(title: "Delete")
         viewModel.presentedAlert?.actions.first { $0.title == "Yes" }?.invoke()
 
-        wait(for: [expectDelete, expectDeleteEvent], timeout: 10)
+        wait(for: [expectDelete, expectDeleteEvent], timeout: 2)
     }
 
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
@@ -309,7 +309,7 @@ class SavedItemViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.archive()
-        wait(for: [expectArchive, expectArchiveEvent], timeout: 10)
+        wait(for: [expectArchive, expectArchiveEvent], timeout: 2)
     }
 
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
@@ -325,7 +325,7 @@ class SavedItemViewModelTests: XCTestCase {
         let viewModel = subject(item: savedItem)
         viewModel.moveFromArchiveToSaves { _ in }
 
-        wait(for: [expectMoveFromArchiveToSaves], timeout: 10)
+        wait(for: [expectMoveFromArchiveToSaves], timeout: 2)
     }
 
     func test_share_updatesSharedActivity() {
@@ -392,7 +392,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 10)
+        wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
     func test_webActivitiesActions_whenItemIsArchive_canMoveToSaves() throws {
@@ -412,7 +412,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(webViewActivityList[1].activityTitle, "Delete")
         XCTAssertEqual(webViewActivityList[2].activityTitle, "Favorite")
 
-        wait(for: [webActivitiesExpectation], timeout: 10)
+        wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
     func test_readerProgress() throws {

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemsListViewModelTests.swift
@@ -133,7 +133,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         listOptions.selectedSortOption = .oldest
 
-        wait(for: [snapshotSent], timeout: 10)
+        wait(for: [snapshotSent], timeout: 2)
     }
 
     func test_shouldSelectCell_whenItemIsPending_returnsFalse() throws {
@@ -229,7 +229,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = nil
-        wait(for: [eventSent], timeout: 10)
+        wait(for: [eventSent], timeout: 2)
     }
 
     func test_selectedItem_whenReaderView_doesNotSendSelectionCleared() {
@@ -243,7 +243,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = .readable(nil)
-        wait(for: [eventSent], timeout: 10)
+        wait(for: [eventSent], timeout: 2)
     }
 
     func test_selectedItem_whenWebView_doesNotSendSelectionCleared() {
@@ -257,7 +257,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.selectedItem = .webView(nil)
-        wait(for: [eventSent], timeout: 10)
+        wait(for: [eventSent], timeout: 2)
     }
 
     func test_sourceEvents_whenEventIsSavedItemCreated_sendsSnapshotWithNewItem() {
@@ -275,7 +275,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         try? space.save()
         source._events.send(.savedItemCreated)
 
-        wait(for: [snapshotSent], timeout: 10)
+        wait(for: [snapshotSent], timeout: 2)
     }
 
     func test_sourceEvents_whenEventIsSavedItemUpdated_sendsSnapshotWithUpdatedItem() {
@@ -292,7 +292,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         source._events.send(.savedItemsUpdated([savedItem]))
 
-        wait(for: [snapshotSent], timeout: 10)
+        wait(for: [snapshotSent], timeout: 2)
     }
 
     func test_receivedSnapshots_withNoItems_includesSavesEmptyState() {
@@ -310,7 +310,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_receivedSnapshots_withNoItems_includesFavoritesEmptyState() {
@@ -329,7 +329,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_receivedSnapshots_withNoItems_includesTagsEmptyState() {
@@ -351,7 +351,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_receivedSnapshots_withItems_doesNotIncludeSavesEmptyState() {
@@ -370,7 +370,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_receivedSnapshots_withItems_doesNotIncludeFavoritesEmptyState() {
@@ -391,7 +391,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         try? itemsController.performFetch()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_refreshSaves_callsRetryImmediatelyOnSource() {
@@ -423,7 +423,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         source.initialSavesDownloadState.send(.paginating(totalCount: 2, currentPercentProgress: 0))
         try? itemsController.performFetch()
 
-        wait(for: [receivedSnapshot], timeout: 10)
+        wait(for: [receivedSnapshot], timeout: 2)
     }
 
     func test_receivedSnapshots_whenSavesInitialDownloadIsStarted_insertsPlaceholderCells() throws {
@@ -442,7 +442,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 10)
+        wait(for: [receivedSnapshot], timeout: 2)
     }
 
     func test_receivedSnapshots_whenArchiveInitialDownloadIsStarted_insertsPlaceholderCells() throws {
@@ -461,7 +461,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedSnapshot], timeout: 10)
+        wait(for: [receivedSnapshot], timeout: 2)
     }
 }
 
@@ -525,7 +525,7 @@ extension SavedItemsListViewModelTests {
             .first { $0.title == "Edit tags" }?
             .handler?(nil)
 
-        wait(for: [expectAddTags], timeout: 10)
+        wait(for: [expectAddTags], timeout: 2)
     }
 
     func test_fetch_whenTaggedSelected_sendsTagsFilterViewModel() throws {
@@ -542,7 +542,7 @@ extension SavedItemsListViewModelTests {
 
         viewModel.selectCell(with: .filterButton(.tagged))
 
-        wait(for: [expectTagFiltersCall], timeout: 10)
+        wait(for: [expectTagFiltersCall], timeout: 2)
     }
 
     func test_tagModel_calculatesTagHeightAndWidth() {

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -200,7 +200,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     func test_updateScope_forFreeUser_withAllAndTerm_showsGetPremiumEmptyState() async {
@@ -240,7 +240,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     func test_updateScope_forPremiumUser_withArchiveAndTerm_showsResults() async {
@@ -264,7 +264,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     func test_updateScope_forPremiumUser_withAllAndTerm_showsResults() async {
@@ -288,7 +288,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     // MARK: - Update Search Results
@@ -358,7 +358,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         searchService.stubSearch { _, _ in }
         searchService._results = []
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     func test_updateSearchResults_forPremiumUser_withItems_showsResults() async {
@@ -383,7 +383,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     // MARK: - Offline States
@@ -600,11 +600,11 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchResultsExpectation], timeout: 10.0, enforceOrder: false)
+        await fulfillment(of: [searchResultsExpectation], timeout: 2.0, enforceOrder: false)
 
         viewModel.clear()
 
-        await fulfillment(of: [recentSearchesExpectation], timeout: 10.0, enforceOrder: false)
+        await fulfillment(of: [recentSearchesExpectation], timeout: 2.0, enforceOrder: false)
     }
 
     func test_search_whenDeviceRegainsInternetConnection_submitsSearch() async {
@@ -644,7 +644,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         await setupOnlineSearch(with: "search-term")
 
-        await fulfillment(of: [offlineExpectation, onlineExpectation], timeout: 10, enforceOrder: true)
+        await fulfillment(of: [offlineExpectation, onlineExpectation], timeout: 2, enforceOrder: true)
     }
 
     // MARK: - Error Handling
@@ -673,7 +673,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .saves, searchTerm: "saved")
 
-        await fulfillment(of: [errorExpectation, localSavesExpectation], timeout: 10)
+        await fulfillment(of: [errorExpectation, localSavesExpectation], timeout: 2)
     }
 
     func test_updateSearchResults_withInternetConnectionError_showsOfflineView() async throws {
@@ -697,7 +697,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
         viewModel.updateScope(with: .archive, searchTerm: "search-term")
 
-        await fulfillment(of: [searchErrorExpectation, errorExpectation], timeout: 10, enforceOrder: true)
+        await fulfillment(of: [searchErrorExpectation, errorExpectation], timeout: 2, enforceOrder: true)
     }
 
     // MARK: Load More Search Results (Pagination)
@@ -727,7 +727,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         viewModel.loadMoreSearchResults(with: pocketItem, at: 0)
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
     private func setupLocalSavesSearch() throws {
@@ -790,7 +790,7 @@ extension DefaultSearchViewModelTests {
 
         viewModel.updateScope(with: .premiumSearchByTitle, searchTerm: "saved")
 
-        await fulfillment(of: [errorExpectation], timeout: 10)
+        await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
     func test_updateSearchResults_forPremiumUser_inExperiment_searchingByTag_withOnlineSavesError_showsOfflineView() async throws {
@@ -820,7 +820,7 @@ extension DefaultSearchViewModelTests {
 
         viewModel.updateScope(with: .premiumSearchByTag, searchTerm: "saved")
 
-        await fulfillment(of: [errorExpectation], timeout: 10)
+        await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
     func test_updateSearchResults_forPremiumUser_inExperiment_searchingByContent_withOnlineSavesError_showsOfflineView() async throws {
@@ -846,7 +846,7 @@ extension DefaultSearchViewModelTests {
 
         viewModel.updateScope(with: .premiumSearchByContent, searchTerm: "saved")
 
-        await fulfillment(of: [errorExpectation], timeout: 10)
+        await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
     func test_search_inExperiment_whenDeviceRegainsInternetConnection_submitsSearch() async {
@@ -947,6 +947,6 @@ extension DefaultSearchViewModelTests {
 
         await setupOnlineSearch(with: term)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
@@ -81,7 +81,7 @@ class PocketItemViewModelTests: XCTestCase {
 
         _ = viewModel.favoriteAction().handler?(nil)
 
-        wait(for: [expectFavoriteCall, expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectFavoriteCall, expectFetchSavedItemCall], timeout: 2)
         XCTAssertEqual(source.favoriteSavedItemCall(at: 0)?.item, item)
         XCTAssertTrue(viewModel.isFavorite)
     }
@@ -105,7 +105,7 @@ class PocketItemViewModelTests: XCTestCase {
 
         _ = viewModel.favoriteAction().handler?(nil)
 
-        wait(for: [expectUnfavoriteCall, expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectUnfavoriteCall, expectFetchSavedItemCall], timeout: 2)
         XCTAssertEqual(source.unfavoriteSavedItemCall(at: 0)?.item, item)
         XCTAssertFalse(viewModel.isFavorite)
     }
@@ -135,7 +135,7 @@ class PocketItemViewModelTests: XCTestCase {
             XCTFail("Should not be nil")
             return
         }
-        wait(for: [expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectFetchSavedItemCall], timeout: 2)
         XCTAssertEqual(tagsViewModel.tags, ["tag-0"])
     }
 
@@ -156,7 +156,7 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.archive()
 
-        wait(for: [expectArchive, expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectArchive, expectFetchSavedItemCall], timeout: 2)
     }
 
     func test_unarchiveAction_delegatesToSource() {
@@ -176,7 +176,7 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.moveToSaves()
 
-        wait(for: [expectUnarchive, expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectUnarchive, expectFetchSavedItemCall], timeout: 2)
     }
 
     func test_deleteAction_delegatesToSource() {
@@ -197,7 +197,7 @@ class PocketItemViewModelTests: XCTestCase {
         let viewModel = subject(item: PocketItem(item: item))
         viewModel.delete()
 
-        wait(for: [expectDelete, expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectDelete, expectFetchSavedItemCall], timeout: 2)
     }
 
     func test_fetchSavedItem_withURLandRemoteParts_shouldMatch() {
@@ -216,7 +216,7 @@ class PocketItemViewModelTests: XCTestCase {
 
         viewModel.trackOverflowMenu()
 
-        wait(for: [expectFetchSavedItemCall], timeout: 10)
+        wait(for: [expectFetchSavedItemCall], timeout: 2)
 
         XCTAssertEqual(viewModel.item.remoteItemParts?.url, pocketItem.savedItemURL)
     }

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -88,7 +88,7 @@ class SlateDetailViewModelTests: XCTestCase {
 
         viewModel.fetch()
 
-        wait(for: [receivedLoadingSnapshot], timeout: 10)
+        wait(for: [receivedLoadingSnapshot], timeout: 2)
     }
 
     func test_fetch_sendsSnapshotWithItemForEachRecommendation() throws {
@@ -119,7 +119,7 @@ class SlateDetailViewModelTests: XCTestCase {
         }.store(in: &subscriptions)
 
         viewModel.fetch()
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_snapshot_whenRecommendationIsSaved_updatesSnapshot() throws {
@@ -153,7 +153,7 @@ class SlateDetailViewModelTests: XCTestCase {
         item.savedItem = space.buildSavedItem()
         try space.save()
 
-        wait(for: [snapshotExpectation], timeout: 10)
+        wait(for: [snapshotExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
@@ -181,7 +181,7 @@ class SlateDetailViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [readableExpectation], timeout: 10)
+        wait(for: [readableExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() throws {
@@ -229,7 +229,7 @@ class SlateDetailViewModelTests: XCTestCase {
             viewModel.select(cell: cell, at: IndexPath(item: 0, section: 0))
         }
 
-        wait(for: [urlExpectation], timeout: 10)
+        wait(for: [urlExpectation], timeout: 2)
     }
 
     func test_selectCell_whenSelectingRecommendation_withSettingsOriginalViewEnabled_setsWebViewURL() throws {
@@ -258,7 +258,7 @@ class SlateDetailViewModelTests: XCTestCase {
             at: IndexPath(item: 0, section: 0)
         )
 
-        wait(for: [webViewExpectation], timeout: 10)
+        wait(for: [webViewExpectation], timeout: 2)
     }
 
     func test_reportAction_forRecommendation_updatesSelectedRecommendationToReport() throws {
@@ -281,7 +281,7 @@ class SlateDetailViewModelTests: XCTestCase {
         XCTAssertNotNil(action)
 
         action?.handler?(nil)
-        wait(for: [reportExpectation], timeout: 10)
+        wait(for: [reportExpectation], timeout: 2)
     }
 
     func test_primaryAction_whenRecommendationIsNotSaved_savesWithSource() throws {

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1331,6 +1331,29 @@ extension MockSource {
     }
 }
 
+// MARK: Fetch get short url
+extension MockSource {
+    private static let getItemShortUrl = "getItemShortUrl"
+    typealias GetItemShortUrlImpl = (String) -> String?
+
+    struct GetItemShortUrlCall {
+        let itemUrl: String
+    }
+
+    func stubGetItemShortUrl(impl: @escaping GetItemShortUrlImpl) {
+        implementations[Self.getItemShortUrl] = impl
+    }
+
+    func getItemShortUrl(_ itemUrl: String) async throws -> String? {
+        guard let impl = implementations[Self.getItemShortUrl] as? GetItemShortUrlImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        calls[Self.getItemShortUrl] = (calls[Self.getItemShortUrl] ?? []) + [GetItemShortUrlCall(itemUrl: itemUrl)]
+        return impl(itemUrl)
+    }
+}
+
 // MARK: - Fetch Items by Search
 extension MockSource {
     private static let searchTerm = "searchTerm"

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -1345,12 +1345,7 @@ extension MockSource {
     }
 
     func getItemShortUrl(_ itemUrl: String) async throws -> String? {
-        guard let impl = implementations[Self.getItemShortUrl] as? GetItemShortUrlImpl else {
-            fatalError("\(Self.self).\(#function) has not been stubbed")
-        }
-
-        calls[Self.getItemShortUrl] = (calls[Self.getItemShortUrl] ?? []) + [GetItemShortUrlCall(itemUrl: itemUrl)]
-        return impl(itemUrl)
+        return nil
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/Space+factories.swift
@@ -115,7 +115,8 @@ extension Space {
         excerpt: String? = nil,
         isArticle: Bool = true,
         article: Article? = nil,
-        syndicatedArticle: SyndicatedArticle? = nil
+        syndicatedArticle: SyndicatedArticle? = nil,
+        shortUrl: String? = nil
     ) -> Item {
         return backgroundContext.performAndWait {
             let item: Item = Item(context: backgroundContext, givenURL: givenURL, remoteID: remoteID)
@@ -127,6 +128,7 @@ extension Space {
             item.topImageURL = topImageURL
             item.excerpt = excerpt
             item.syndicatedArticle = syndicatedArticle
+            item.shortURL = shortUrl
             return item
         }
     }

--- a/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/TagsFilterViewModelTests.swift
@@ -134,7 +134,7 @@ class TagsFilterViewModelTests: XCTestCase {
         viewModel.delete(tags: ["b", "e", "q"])
 
         XCTAssertEqual(deletedTags, ["b", "e"])
-        wait(for: [expectDelete], timeout: 10)
+        wait(for: [expectDelete], timeout: 2)
     }
 
     func test_renameTag_showsNewName() {
@@ -150,7 +150,7 @@ class TagsFilterViewModelTests: XCTestCase {
         let viewModel = subject(fetchedTags: savedTags) { }
         viewModel.rename(from: "tag 1", to: "tag 0")
 
-        wait(for: [expectRename], timeout: 10)
+        wait(for: [expectRename], timeout: 2)
     }
 
     func test_renameTag_withNoOldName_doesNotRenameTag() {

--- a/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/LoggedOutViewModelTests.swift
@@ -25,6 +25,6 @@ extension LoggedOutViewModelTests {
 
         viewModel.viewWillAppear(context: context, origin: self)
 
-        await fulfillment(of: [completeRequestExpectation], timeout: 10)
+        await fulfillment(of: [completeRequestExpectation], timeout: 2)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -280,7 +280,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 10)
+        wait(for: [expectFilterTagsCall], timeout: 2)
     }
 
     func test_newTagInput_withNoTags_showAllTags() throws {
@@ -311,6 +311,6 @@ class SaveToAddTagsViewModelTests: XCTestCase {
                 XCTAssertEqual(viewModel.otherTags, [TagType.tag("tag 2"), TagType.tag("tag 3")])
             }
             .store(in: &subscriptions)
-        wait(for: [expectFilterTagsCall], timeout: 10)
+        wait(for: [expectFilterTagsCall], timeout: 2)
     }
 }

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -266,7 +266,7 @@ extension SavedItemViewModelTests {
 
         await viewModel.save(from: context)
 
-        await fulfillment(of: [completeRequestExpectation], timeout: 10)
+        await fulfillment(of: [completeRequestExpectation], timeout: 2)
     }
 
     func test_save_whenResavingExistingItem_updatesInfoViewModel() async {
@@ -300,7 +300,7 @@ extension SavedItemViewModelTests {
         context.stubCompleteRequest { _, _ in }
 
         await viewModel.save(from: context)
-        await fulfillment(of: [infoViewModelChanged], timeout: 10)
+        await fulfillment(of: [infoViewModelChanged], timeout: 2)
         subscription.cancel()
     }
 
@@ -329,7 +329,7 @@ extension SavedItemViewModelTests {
         context.stubCompleteRequest { _, _ in }
 
         await viewModel.save(from: context)
-        await fulfillment(of: [infoViewModelChanged], timeout: 10)
+        await fulfillment(of: [infoViewModelChanged], timeout: 2)
         subscription.cancel()
     }
 }
@@ -375,7 +375,7 @@ extension SavedItemViewModelTests {
 
         viewModel.showAddTagsView(from: context)
 
-        wait(for: [expectAddTags], timeout: 10)
+        wait(for: [expectAddTags], timeout: 2)
         subscription.cancel()
     }
 
@@ -397,7 +397,7 @@ extension SavedItemViewModelTests {
             do { infoViewModelChanged.fulfill() }
         }
 
-        await fulfillment(of: [infoViewModelChanged], timeout: 10)
+        await fulfillment(of: [infoViewModelChanged], timeout: 2)
         subscription.cancel()
     }
 

--- a/PocketKit/Tests/SyncTests/Fixtures/corpusSlates.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/corpusSlates.json
@@ -21,6 +21,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-1/top-image.png",
                                 "publisher":"slate-1-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "[some-type-name]",
                                     "itemId": "slate-1-rec-1-corpusItem-1-syndicated",
@@ -44,6 +45,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-2/top-image.png",
                                 "publisher":"slate-1-rec-2.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "[some-type-name]",
                                     "itemId": "slate-1-rec-2-corpusItem-2-syndicated",
@@ -75,6 +77,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-2-rec-1/top-image.png",
                                 "publisher":"slate-2-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "[some-type-name]",
                                     "itemId": "slate-2-rec-1-corpusItem-3-syndicated",

--- a/PocketKit/Tests/SyncTests/Fixtures/list-with-corpusItem.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/list-with-corpusItem.json
@@ -36,7 +36,8 @@
                                 }],
                             "corpusItem": {
                                 "__typename": "CorpusItem",
-                                "publisher":"CorpusItemPublisher-1"
+                                "publisher":"CorpusItemPublisher-1",
+                                "shortUrl": null
                             },
                             "annotations": null,
                             "item": {

--- a/PocketKit/Tests/SyncTests/Fixtures/shortUrl.json
+++ b/PocketKit/Tests/SyncTests/Fixtures/shortUrl.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "itemByUrl": {
+        "__typename": "Item",
+      "shortUrl": "https://pocket.co/example"
+    }
+  }
+}

--- a/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
+++ b/PocketKit/Tests/SyncTests/OSNotificationCenterTests.swift
@@ -24,7 +24,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [notificationWasHandled], timeout: 10)
+        wait(for: [notificationWasHandled], timeout: 2)
     }
 
     func test_register_whenAlreadyRegistered_addsBothObservers() {
@@ -41,7 +41,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [notificationWasHandled, notificationWasHandled2], timeout: 10)
+        wait(for: [notificationWasHandled, notificationWasHandled2], timeout: 2)
     }
 
     func test_remove_removesGivenObserverForGivenNotification() {
@@ -60,7 +60,7 @@ class OSNotificationCenterTests: XCTestCase {
         center.remove(observer: observers[0], name: .testNotification)
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [observer2HandledNotification], timeout: 10)
+        wait(for: [observer2HandledNotification], timeout: 2)
     }
 
     func test_remove_whenObservingWithMultipleHandlers_removesAllHandlers() {
@@ -82,7 +82,7 @@ class OSNotificationCenterTests: XCTestCase {
         DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 1) {
             pause.fulfill()
         }
-        wait(for: [pause], timeout: 10)
+        wait(for: [pause], timeout: 2)
     }
 
     func test_remove_doesNotRemoveHandlerForOtherNotifications() {
@@ -102,7 +102,7 @@ class OSNotificationCenterTests: XCTestCase {
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
         CFNotificationCenterPostNotification(cfCenter, .anotherTestNotification, nil, nil, true)
 
-        wait(for: [wasNotifiedOfAnotherTestNotification], timeout: 10)
+        wait(for: [wasNotifiedOfAnotherTestNotification], timeout: 2)
     }
 
     func test_remove_doesNotRetainObservers() {
@@ -140,7 +140,7 @@ class OSNotificationCenterTests: XCTestCase {
         }
 
         CFNotificationCenterPostNotification(cfCenter, .testNotification, nil, nil, true)
-        wait(for: [receivedNotification], timeout: 10)
+        wait(for: [receivedNotification], timeout: 2)
     }
 }
 

--- a/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
+++ b/PocketKit/Tests/SyncTests/Operations/RetriableOperationTests.swift
@@ -73,7 +73,7 @@ class RetriableOperationTests: XCTestCase {
         let queue = OperationQueue()
         queue.addOperation(executor)
 
-        wait(for: [firstAttempt], timeout: 10)
+        wait(for: [firstAttempt], timeout: 2)
         // NOTE: We need to await after the firstAttempt because it takes a few ms for the
         // retrySubscritpion to get setup after firstAttempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
@@ -112,7 +112,7 @@ class RetriableOperationTests: XCTestCase {
         queue.addOperation(executor)
 
         expectations.forEach {
-            wait(for: [$0], timeout: 10)
+            wait(for: [$0], timeout: 2)
             // NOTE: We need to await after each attempt because it takes a few ms for the
             // retrySubscritpion to get setup after the attempt is fullfilled.
             // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
@@ -120,7 +120,7 @@ class RetriableOperationTests: XCTestCase {
             retrySignal.send()
         }
 
-        wait(for: [completed], timeout: 10, enforceOrder: true)
+        wait(for: [completed], timeout: 2, enforceOrder: true)
         XCTAssertEqual(try space.fetchPersistentSyncTasks().count, 0)
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSaveServiceTests.swift
@@ -64,7 +64,7 @@ class PocketSaveServiceTests: XCTestCase {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 10)
+        wait(for: [performCalled], timeout: 2)
         let performCall: MockApolloClient.PerformCall<SaveItemMutation>? = client.performCall(at: 0)
         XCTAssertEqual(performCall?.mutation.input.url, "https://getpocket.com")
     }
@@ -86,7 +86,7 @@ class PocketSaveServiceTests: XCTestCase {
             XCTFail("Expected existingItem, but was \(result)")
             return
         }
-        wait(for: [savedItemUpdated], timeout: 10)
+        wait(for: [savedItemUpdated], timeout: 2)
 
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications?.isEmpty, false)
@@ -121,14 +121,14 @@ class PocketSaveServiceTests: XCTestCase {
         _ = service.save(url: url)
 
         do {
-            wait(for: [performMutationWasCalled], timeout: 10)
+            wait(for: [performMutationWasCalled], timeout: 2)
             let savedItem = try space.fetchSavedItem(byURL: url)
             XCTAssertNotNil(savedItem)
             XCTAssertFalse(savedItem!.hasChanges)
         }
 
         do {
-            wait(for: [performMutationCompleted], timeout: 10)
+            wait(for: [performMutationCompleted], timeout: 2)
             let savedItem = try space.fetchSavedItem(byURL: url)
             XCTAssertNotNil(savedItem?.item)
         }
@@ -157,7 +157,7 @@ class PocketSaveServiceTests: XCTestCase {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 2)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.url, url)
@@ -187,7 +187,7 @@ class PocketSaveServiceTests: XCTestCase {
             finishedActivity.fulfill()
         }
 
-        wait(for: [performMutationCalled], timeout: 10)
+        wait(for: [performMutationCalled], timeout: 2)
 
         let finishedCancellingActivity = expectation(description: "finished cancelling the activity")
         queue.async {
@@ -196,7 +196,7 @@ class PocketSaveServiceTests: XCTestCase {
             finishedCancellingActivity.fulfill()
         }
 
-        wait(for: [finishedActivity, finishedCancellingActivity], timeout: 10)
+        wait(for: [finishedActivity, finishedCancellingActivity], timeout: 2)
     }
 
     func test_cancellationOfExpiringActivity_setsSkeletonItemAsUnresolved_andPostsNotification() throws {
@@ -223,12 +223,12 @@ class PocketSaveServiceTests: XCTestCase {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled], timeout: 10)
+        wait(for: [performMutationCalled], timeout: 2)
 
         DispatchQueue(label: "cancel task").async {
             expiringActivity?(true)
         }
-        wait(for: [notificationReceived], timeout: 10)
+        wait(for: [notificationReceived], timeout: 2)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.url, url)
@@ -263,13 +263,13 @@ class PocketSaveServiceTests: XCTestCase {
 
         let service = subject()
         _ = service.save(url: "https://getpocket.com")
-        wait(for: [performCalled, savedItemCreated], timeout: 10)
+        wait(for: [performCalled, savedItemCreated], timeout: 2)
 
         DispatchQueue.main.async {
             mutationCompletion?(.success(Fixture.load(name: "save-item").asGraphQLResult(from: mutation!)))
         }
 
-        wait(for: [savedItemUpdated], timeout: 10)
+        wait(for: [savedItemUpdated], timeout: 2)
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications?.isEmpty, false)
     }
@@ -299,7 +299,7 @@ extension PocketSaveServiceTests {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 10)
+        wait(for: [performCalled], timeout: 2)
         let performCall: MockApolloClient.PerformCall<SavedItemTagMutation>? = client.performCall(at: 0)
         XCTAssertEqual(performCall?.mutation.input.tagNames, ["tag 1", "tag 2"])
     }
@@ -326,7 +326,7 @@ extension PocketSaveServiceTests {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 2)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"] )
@@ -355,7 +355,7 @@ extension PocketSaveServiceTests {
         }
         XCTAssertNotNil(backgroundActivityPerformer.performCall(at: 0))
 
-        wait(for: [performCalled], timeout: 10)
+        wait(for: [performCalled], timeout: 2)
         let performCall: MockApolloClient.PerformCall<UpdateSavedItemRemoveTagsMutation>? = client.performCall(at: 0)
         XCTAssertNotNil(performCall?.mutation.savedItemId)
     }
@@ -382,7 +382,7 @@ extension PocketSaveServiceTests {
         DispatchQueue(label: "start task").async {
             expiringActivity?(false)
         }
-        wait(for: [performMutationCalled, notificationReceived], timeout: 10)
+        wait(for: [performMutationCalled, notificationReceived], timeout: 2)
 
         let unresolved = try space.fetchUnresolvedSavedItems()
         XCTAssertEqual(unresolved[0].savedItem?.tags?.compactMap { ($0 as? Tag)?.name }, [] )

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+networkMonitoring.swift
@@ -50,7 +50,7 @@ extension PocketSourceTests {
         source.refreshSaves()
 
         networkMonitor.update(status: .satisfied)
-        wait(for: [expectSaveItem, expectFetchList], timeout: 10)
+        wait(for: [expectSaveItem, expectFetchList], timeout: 2)
     }
 
     func test_whenNetworkBecomesSatisified_retriesOperationsThatAreWaitingForSignal() throws {
@@ -80,11 +80,11 @@ extension PocketSourceTests {
         let source = subject()
         try source.archive(item: space.createSavedItem())
         _ = XCTWaiter.wait(for: [expectation(description: "wait for last refresh to be avoid its 5.0 second wait")], timeout: 1.0)
-        wait(for: [firstAttempt], timeout: 10)
+        wait(for: [firstAttempt], timeout: 2)
 
         networkMonitor.update(status: .unsatisfied)
         networkMonitor.update(status: .satisfied)
-        wait(for: [retrySignalSent], timeout: 10)
+        wait(for: [retrySignalSent], timeout: 2)
     }
 
     func test_whenAnActionIsTaken_andNetworkPathIsSatisified_retriesOperationsThatAreWaitingForSignal() throws {
@@ -122,13 +122,13 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 10)
+        wait(for: [firstAttempt], timeout: 2)
         // NOTE: We need to await after each attempt because it takes a few ms for the
         // retrySubscritpion to get setup after the attempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
         _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
         source.favorite(item: item)
-        wait(for: [retrySignalSent, attemptFavorite], timeout: 10, enforceOrder: true)
+        wait(for: [retrySignalSent, attemptFavorite], timeout: 2, enforceOrder: true)
     }
 
     func test_whenAnActionIsTaken_andNetworkPathIsNotSatisified_doesNotRetryOperationsThatAreWaitingForSignal() throws {
@@ -157,7 +157,7 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 10)
+        wait(for: [firstAttempt], timeout: 2)
 
         networkMonitor.update(status: .unsatisfied)
         source.favorite(item: item)
@@ -193,12 +193,12 @@ extension PocketSourceTests {
         let item = try space.createSavedItem()
         let source = subject()
         source.archive(item: item)
-        wait(for: [firstAttempt], timeout: 10)
+        wait(for: [firstAttempt], timeout: 2)
         // NOTE: We need to await after each attempt because it takes a few ms for the
         // retrySubscritpion to get setup after the attempt is fullfilled.
         // TODO: Refactor retrySignal to keep track of its number of subscribers and instead wait for that to become 1 instead of this random wait.
         _ = XCTWaiter.wait(for: [expectation(description: "wait for subscriber")], timeout: 1)
         source.retryImmediately()
-        wait(for: [retrySignalSent], timeout: 10)
+        wait(for: [retrySignalSent], timeout: 2)
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests+savedItemEvents.swift
@@ -21,7 +21,7 @@ extension PocketSourceTests {
         }.store(in: &subscriptions)
 
         osNotificationCenter.post(name: .savedItemCreated)
-        wait(for: [receivedNotification], timeout: 10)
+        wait(for: [receivedNotification], timeout: 2)
     }
 
     func test_events_whenOSNotificationCenterPostsSavedItemUpdatedNotification_publishesAnEvent_andDeletesNotificationRecords() {
@@ -44,7 +44,7 @@ extension PocketSourceTests {
         try! space.save()
 
         osNotificationCenter.post(name: .savedItemUpdated)
-        wait(for: [receivedNotification], timeout: 10)
+        wait(for: [receivedNotification], timeout: 2)
 
         let notifications = try? space.fetchSavedItemUpdatedNotifications()
         XCTAssertEqual(notifications, [])
@@ -68,7 +68,7 @@ extension PocketSourceTests {
 
         osNotificationCenter.post(name: .unresolvedSavedItemCreated)
 
-        wait(for: [operationStarted], timeout: 10)
+        wait(for: [operationStarted], timeout: 2)
 
         try XCTAssertEqual(space.fetchUnresolvedSavedItems(), [])
 
@@ -104,7 +104,7 @@ extension PocketSourceTests {
 
         osNotificationCenter.post(name: .savedItemUpdated)
 
-        wait(for: [expectEvent], timeout: 10)
+        wait(for: [expectEvent], timeout: 2)
         sub.cancel()
     }
 }

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -118,7 +118,7 @@ class PocketSourceTests: XCTestCase {
             }
         }
 
-        await fulfillment(of: [expectationToFetchSaves, expectationToFetchArchive], timeout: 10)
+        await fulfillment(of: [expectationToFetchSaves, expectationToFetchArchive], timeout: 2)
     }
 
     func test_refresh_addsFetchSavesOperationToQueue() {
@@ -150,7 +150,7 @@ class PocketSourceTests: XCTestCase {
             expectationToRunOperation.fulfill()
         }
 
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_refresh_whenTokenIsNil_callsCompletion() {
@@ -166,7 +166,7 @@ class PocketSourceTests: XCTestCase {
             expectationToRunOperation.fulfill()
         }
 
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_favorite_togglesIsFavorite_andExecutesFavoriteMutation() throws {
@@ -216,7 +216,7 @@ class PocketSourceTests: XCTestCase {
         let fetchedItem = try space.fetchSavedItem(byURL: "https://mozilla.com/delete")
         XCTAssertNil(fetchedItem)
         XCTAssertFalse(item.hasChanges)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_delete_ifSavedItemItemHasRecommendation_doesNotDeleteSavedItemItem() throws {
@@ -269,7 +269,7 @@ class PocketSourceTests: XCTestCase {
         XCTAssertTrue(item.isArchived)
         XCTAssertFalse(item.hasChanges)
         XCTAssertNotNil(item.archivedAt)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_unarchive_executesSaveItemMutation_andUpdatesCreatedAtField() throws {
@@ -288,7 +288,7 @@ class PocketSourceTests: XCTestCase {
 
         XCTAssertFalse(item.isArchived)
         XCTAssertNotNil(item.createdAt)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_fetchSlateLineup_forwardsToSlateService() async throws {
@@ -327,7 +327,7 @@ class PocketSourceTests: XCTestCase {
         try space.save()
         try savesResultsController.performFetch()
 
-        wait(for: [expectationForUpdatedItems], timeout: 10)
+        wait(for: [expectationForUpdatedItems], timeout: 2)
         XCTAssertEqual(savesResultsController.fetchedObjects?.compactMap({ $0.objectID }), [item1.objectID, item2.objectID])
     }
 
@@ -348,7 +348,7 @@ class PocketSourceTests: XCTestCase {
 
         source.resolveUnresolvedSavedItems(completion: nil)
 
-        wait(for: [operationStarted], timeout: 10)
+        wait(for: [operationStarted], timeout: 2)
         try XCTAssertEqual(space.fetchUnresolvedSavedItems(), [])
     }
 
@@ -366,7 +366,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -392,7 +392,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -417,7 +417,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.archive(recommendation: recommendation)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let archivedItems = try space.fetchArchivedItems()
         XCTAssertEqual(archivedItems.count, 1)
@@ -488,7 +488,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.first?.url, url)
@@ -510,7 +510,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -532,7 +532,7 @@ class PocketSourceTests: XCTestCase {
 
         let source = subject()
         source.save(url: url)
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
 
         let savedItems = try space.fetchSavedItems()
         XCTAssertEqual(savedItems.count, 1)
@@ -611,7 +611,7 @@ extension PocketSourceTests {
         source.deleteTag(tag: tag)
 
         try XCTAssertEqual(space.fetchAllTags(), [])
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     func test_renameTag_executesUpdateTagMutation() throws {
@@ -631,7 +631,7 @@ extension PocketSourceTests {
         source.renameTag(from: tag1, to: "tag 3")
 
         try XCTAssertEqual(space.fetchAllTags().compactMap { $0.name }, ["tag 3"])
-        wait(for: [expectationToRunOperation], timeout: 10)
+        wait(for: [expectationToRunOperation], timeout: 2)
     }
 
     private func createItemsWithTags(_ number: Int, isArchived: Bool = false) -> [SavedItem] {

--- a/PocketKit/Tests/SyncTests/PocketSourceTests.swift
+++ b/PocketKit/Tests/SyncTests/PocketSourceTests.swift
@@ -749,6 +749,19 @@ extension PocketSourceTests {
         XCTAssertEqual(savedItem?.item?.bestURL, "http://localhost:8080/hello")
     }
 
+    func testgetItemShortUrl() async throws {
+        // Given
+        let item = try space.createItem()
+        let source = subject()
+        XCTAssertNil(item.shortURL)
+        apollo.stubFetch(toReturnFixtureNamed: "shortUrl", asResultType: GetItemShortUrlQuery.self)
+        // When
+        let shortUrl = try await source.getItemShortUrl(item.givenURL)
+        // Then
+        XCTAssertEqual("https://pocket.co/example", shortUrl)
+        XCTAssertEqual(shortUrl, item.shortURL)
+    }
+
     private func setupLocalSavesSearch(with urlString: String? = nil) throws {
         var url: String?
         _ = (1...2).map {

--- a/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/FetchSavesTests.swift
@@ -437,7 +437,7 @@ class FetchSavesTests: XCTestCase {
         let service = subject()
         _ = await service.execute(syncTaskId: task.objectID)
 
-        await fulfillment(of: [receivedFirstPageEvent, receivedCompletedEvent], timeout: 10)
+        await fulfillment(of: [receivedFirstPageEvent, receivedCompletedEvent], timeout: 2)
     }
 
     func test_refresh_whenResultsAreEmpty_finishesOperationSuccessfully() async {

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -43,7 +43,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .saves)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -61,7 +61,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .archive)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -79,7 +79,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         try await service.search(for: "search-term", scope: .all)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -122,7 +122,7 @@ class PocketSearchServiceTests: XCTestCase {
         try await service.search(for: "search-term", scope: .all)
         XCTAssertEqual(self.apollo.fetchCalls(withQueryType: SearchSavedItemsQuery.self).count, 3)
 
-        await fulfillment(of: [firstPaginationExpectation, secondPaginationExpectation, thirdPaginationExpectation], timeout: 10)
+        await fulfillment(of: [firstPaginationExpectation, secondPaginationExpectation, thirdPaginationExpectation], timeout: 2)
     }
 
     // MARK: Error
@@ -151,7 +151,7 @@ extension PocketSearchServiceTests {
 
         try await service.search(for: "search-term", scope: .premiumSearchByTitle)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
@@ -169,7 +169,7 @@ extension PocketSearchServiceTests {
 
         try await service.search(for: "search term", scope: .premiumSearchByTag)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "tag:\"search term\"")
@@ -187,7 +187,7 @@ extension PocketSearchServiceTests {
 
         try await service.search(for: "#search", scope: .premiumSearchByTag)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "#search")
@@ -205,7 +205,7 @@ extension PocketSearchServiceTests {
 
         try await service.search(for: "search-term", scope: .premiumSearchByContent)
 
-        await fulfillment(of: [searchExpectation], timeout: 10)
+        await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")

--- a/Tests iOS/Fixtures/corpusSlates.json
+++ b/Tests iOS/Fixtures/corpusSlates.json
@@ -21,6 +21,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-1/top-image.png",
                                 "publisher":"slate-1-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "Collection",
                                     "slug": "slate-1-rec-1",
@@ -44,6 +45,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-2/top-image.png",
                                 "publisher":"slate-1-rec-2.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "SyndicatedArticle",
                                     "itemId": "slate-1-rec-2-corpusItem-2-syndicated",
@@ -76,6 +78,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-2-rec-1/top-image.png",
                                 "publisher":"slate-2-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "SyndicatedArticle",
                                     "itemId": "slate-2-rec-1-corpusItem-3-syndicated",
@@ -100,6 +103,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-2-rec-2/top-image.png",
                                 "publisher":"slate-2-rec-2.example.com",
+                                "shortUrl": null,
                                 "target": null
                             }
                         },

--- a/Tests iOS/Fixtures/shortUrl.json
+++ b/Tests iOS/Fixtures/shortUrl.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "itemByUrl": {
+        "__typename": "Item",
+      "shortUrl": "https://pocket.co/example"
+    }
+  }
+}

--- a/Tests iOS/Fixtures/updated-slates.json
+++ b/Tests iOS/Fixtures/updated-slates.json
@@ -21,6 +21,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-1/top-image.png",
                                 "publisher":"slate-1-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "Collection",
                                     "slug": "slate-1-rec-1",
@@ -44,6 +45,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-1-rec-2/top-image.png",
                                 "publisher":"slate-1-rec-2.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "SyndicatedArticle",
                                     "itemId": "slate-1-rec-2-corpusItem-2-syndicated",
@@ -76,6 +78,7 @@
                                 "excerpt": "Cursus Aenean Elit",
                                 "imageUrl": "http://example.com/slate-2-rec-1/top-image.png",
                                 "publisher":"slate-2-rec-1.example.com",
+                                "shortUrl": null,
                                 "target": {
                                     "__typename": "SyndicatedArticle",
                                     "itemId": "slate-2-rec-1-corpusItem-3-syndicated",

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -101,6 +101,10 @@ struct ClientAPIRequest {
         self.operationName == "ItemByURL" && contains(rec)
     }
 
+    var isForShortUrl: Bool {
+        operationName == "GetItemShortUrl"
+    }
+
     var isForReplacingSavedItemTags: Bool {
         self.operationName == "ReplaceSavedItemTags"
     }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -182,6 +182,10 @@ extension Response {
         fixture(named: "recommendation-detail-\(number)")
     }
 
+    static func shortUrl() -> Response {
+        fixture(named: "shortUrl")
+    }
+
     static func savedItemWithTag() -> Response {
         fixture(named: "list-with-tagged-item")
     }
@@ -378,6 +382,8 @@ extension Response {
             return .saveTags(apiRequest: apiRequest)
         } else if apiRequest.isForCollection {
             return .collection()
+        } else if apiRequest.isForShortUrl {
+            return .shortUrl()
         } else {
             fatalError("Unexpected request")
         }


### PR DESCRIPTION
## Summary
* This PR fetches `shortUrl` if it's nil before sharing an item, in order to ensure we share `shortUrl` every time we can
## References 
* Branch name

## Implementation Details
* Add graphQl query to fetch an `Item`'s `shortUrl`
* Use it to update `shortUrl` if nil, when sharing an item: this can happen when users migrate from previous versions to `8.5.0`
## Test Steps
* Install the production (App Store) version and perform a refresh
* Within 5 minutes, install this branch as an upgrade (do not delete the prod version)
* Put a breakpoint where the share logic happens, for example [here](https://github.com/Pocket/pocket-ios/blob/5bcff04f2fac59e8197aaa6e893701d98e30542a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift#L799)
* verify that `shortUrl` is nil
* put another breakpoint [here](https://github.com/Pocket/pocket-ios/blob/5bcff04f2fac59e8197aaa6e893701d98e30542a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift#L806) and verify that the shortUrl has been fetched and assigned to the corresponding item
* verify that share works properly, and that you are actually sharing a `pocket.co` url
* 
## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

