### PR TITLE
Shared With You - Fix missing attribution views

### DIFF
--- a/PocketKit/Sources/Localization/Resources/de-DE.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/de-DE.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ Elemente";
 
-// Shared With You
-"sharedWithYou.title" = "hat Folgendes mit dir geteilt:";
-
 // Logged out
 "loggedOut.continue" = "Weiter";
 

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%@ items";
 
-// Shared With You
-"sharedWithYou.title" = "Shared With You";
-
 // Logged out
 "loggedOut.continue" = "Continue";
 

--- a/PocketKit/Sources/Localization/Resources/es-ES.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/es-ES.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ ítems";
 
-// Shared With You
-"sharedWithYou.title" = "te ha enviado";
-
 // Logged out
 "loggedOut.continue" = "Continuar";
 

--- a/PocketKit/Sources/Localization/Resources/es-LA.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/es-LA.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ enlaces";
 
-// Shared With You
-"sharedWithYou.title" = "compartido contigo";
-
 // Logged out
 "loggedOut.continue" = "Continuar";
 

--- a/PocketKit/Sources/Localization/Resources/fr-CA.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/fr-CA.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ éléments";
 
-// Shared With You
-"sharedWithYou.title" = "partagé avec vous";
-
 // Logged out
 "loggedOut.continue" = "Continuer";
 

--- a/PocketKit/Sources/Localization/Resources/fr-FR.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/fr-FR.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ éléments";
 
-// Shared With You
-"sharedWithYou.title" = "partagé avec vous";
-
 // Logged out
 "loggedOut.continue" = "Continuer";
 

--- a/PocketKit/Sources/Localization/Resources/it-IT.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/it-IT.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ contenuti";
 
-// Shared With You
-"sharedWithYou.title" = "ha condiviso con te";
-
 // Logged out
 "loggedOut.continue" = "Continua";
 

--- a/PocketKit/Sources/Localization/Resources/ja-JP.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/ja-JP.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ 件のアイテム";
 
-// Shared With You
-"sharedWithYou.title" = "があなたと共有しました";
-
 // Logged out
 "loggedOut.continue" = "続行";
 

--- a/PocketKit/Sources/Localization/Resources/ko-KR.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/ko-KR.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@개 항목";
 
-// Shared With You
-"sharedWithYou.title" = "이(가) 공유함";
-
 // Logged out
 "loggedOut.continue" = "계속";
 

--- a/PocketKit/Sources/Localization/Resources/nl-NL.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/nl-NL.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ items";
 
-// Shared With You
-"sharedWithYou.title" = "gedeeld met jou";
-
 // Logged out
 "loggedOut.continue" = "Doorgaan";
 

--- a/PocketKit/Sources/Localization/Resources/pl-PL.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/pl-PL.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "Liczba elementów: %1$@";
 
-// Shared With You
-"sharedWithYou.title" = "udostępnione Tobie";
-
 // Logged out
 "loggedOut.continue" = "Dalej";
 

--- a/PocketKit/Sources/Localization/Resources/pt-BR.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/pt-BR.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ itens";
 
-// Shared With You
-"sharedWithYou.title" = "compartilhado com você";
-
 // Logged out
 "loggedOut.continue" = "Continuar";
 

--- a/PocketKit/Sources/Localization/Resources/pt-PT.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/pt-PT.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ itens";
 
-// Shared With You
-"sharedWithYou.title" = "partilhou contigo";
-
 // Logged out
 "loggedOut.continue" = "Continuar";
 

--- a/PocketKit/Sources/Localization/Resources/ru-RU.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/ru-RU.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ материалов";
 
-// Shared With You
-"sharedWithYou.title" = "отправлено вам";
-
 // Logged out
 "loggedOut.continue" = "Продолжить";
 

--- a/PocketKit/Sources/Localization/Resources/zh-CN.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/zh-CN.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ 个项目";
 
-// Shared With You
-"sharedWithYou.title" = "已与您分享";
-
 // Logged out
 "loggedOut.continue" = "继续";
 

--- a/PocketKit/Sources/Localization/Resources/zh-TW.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/zh-TW.lproj/Localizable.strings
@@ -345,9 +345,6 @@
 // Collection
 "collection.stories.count" = "%1$@ 個項目";
 
-// Shared With You
-"sharedWithYou.title" = "已與您分享";
-
 // Logged out
 "loggedOut.continue" = "繼續";
 

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -631,10 +631,6 @@ public enum Localization {
       public static let credits = Localization.tr("Localizable", "settings.thankyou.credits", fallback: "Thank you for using Pocket")
     }
   }
-  public enum SharedWithYou {
-    /// Shared With You
-    public static let title = Localization.tr("Localizable", "sharedWithYou.title", fallback: "Shared With You")
-  }
   public enum SortingOption {
     /// Longest to read
     public static let longestToRead = Localization.tr("Localizable", "sortingOption.longestToRead", fallback: "Longest to read")

--- a/PocketKit/Sources/PocketKit/Home/Cells/Carousel/SharedWithYouCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/Cells/Carousel/SharedWithYouCarouselCell.swift
@@ -45,16 +45,12 @@ class SharedWithYouCarouselCell: UICollectionViewCell {
 // MARK: configuration
 extension SharedWithYouCarouselCell {
     func configure(with configuration: HomeCarouselCellConfiguration) {
-        Log.capture(message: "SWH: carousel cell configuration - configuring cell")
         topView.configure(with: configuration)
 
         if let url = configuration.sharedWithYouUrlString {
-            Log.capture(message: "SWH: carousel cell configuration - found valid url: \(url)")
             Task {
                 await updateAttributionView(url)
             }
-        } else {
-            Log.capture(message: "SWH: carousel cell configuration - no url found in configuration")
         }
     }
 }
@@ -65,11 +61,9 @@ extension SharedWithYouCarouselCell {
     /// - Parameter urlString: the string representation of the url
     private func updateAttributionView(_ urlString: String) async {
         guard let url = URL(string: urlString) else {
-            Log.capture(message: "SWH: carousel cell configuration - unable to construct url from \(urlString)")
             return
         }
         do {
-            Log.capture(message: "SWH: carousel cell configuration - attempting to retrieve highlight for \(urlString)")
             let highlight = try await SWHighlightCenter().highlight(for: url)
             attributionView.highlight = highlight
         } catch {

--- a/PocketKit/Sources/PocketKit/Home/Cells/Hero/SharedWithYouItemCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/Cells/Hero/SharedWithYouItemCell.swift
@@ -44,16 +44,12 @@ class SharedWithYouItemCell: UICollectionViewCell {
 // MARK: configuration
 extension SharedWithYouItemCell {
     func configure(model: ItemCellViewModel) {
-        Log.capture(message: "SWH: item cell configuration - configuring cell")
         topView.configure(model: model)
 
         if let url = model.sharedWithYouUrlString {
-            Log.capture(message: "SWH: item cell configuration - found valid url: \(url)")
             Task {
-                await addAttributionView(url)
+                await updateAttributionView(url)
             }
-        } else {
-            Log.capture(message: "SWH: item cell configuration - no url found in configuration")
         }
     }
 }
@@ -62,13 +58,11 @@ extension SharedWithYouItemCell {
 extension SharedWithYouItemCell {
     /// Add the attribution view if a valid shared with you url is found
     /// - Parameter urlString: the string representation of the url
-    private func addAttributionView(_ urlString: String) async {
+    private func updateAttributionView(_ urlString: String) async {
         guard let url = URL(string: urlString) else {
-            Log.capture(message: "SWH: item cell configuration - unable to construct url from \(urlString)")
             return
         }
         do {
-            Log.capture(message: "SWH: item cell configuration - attempting to retrieve highlight for \(urlString)")
             let highlight = try await SWHighlightCenter().highlight(for: url)
             attributionView.highlight = highlight
         } catch {

--- a/PocketKit/Sources/PocketKit/Home/Lists/SharedWithYouListViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/SharedWithYouListViewController.swift
@@ -9,6 +9,7 @@ import Combine
 import Lottie
 import Textile
 import Localization
+import SharedWithYou
 
 class SharedWithYouListViewController: UIViewController {
     private lazy var layoutConfiguration = UICollectionViewCompositionalLayout { [weak self] index, env in
@@ -57,7 +58,7 @@ class SharedWithYouListViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         view.accessibilityIdentifier = "slate-detail"
-        navigationItem.title = Localization.SharedWithYou.title
+        navigationItem.title = SWHighlightCenter.highlightCollectionTitle
         hidesBottomBarWhenPushed = true
 
         let largeTitleTwoLineMode = "_largeTitleTwoLineMode"

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -375,15 +375,15 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
     }
     @MainActor
     func share(item: SavedItem, sender: Any?) async {
-            var shortUrl: String?
-            if let existingShortUrl = item.item?.shortURL {
-                shortUrl = existingShortUrl
-            } else {
-                shortUrl = try? await source.getItemShortUrl(item.url)
-            }
-            let shareableUrl = shortUrl ?? item.url
-            sharedActivity = PocketItemActivity.fromSaves(url: shareableUrl, sender: sender)
-            track(item: item, identifier: .itemShare)
+        var shortUrl: String?
+        if let existingShortUrl = item.item?.shortURL {
+            shortUrl = existingShortUrl
+        } else {
+            shortUrl = try? await source.getItemShortUrl(item.url)
+        }
+        let shareableUrl = shortUrl ?? item.url
+        sharedActivity = PocketItemActivity.fromSaves(url: shareableUrl, sender: sender)
+        track(item: item, identifier: .itemShare)
     }
 
     func overflowActions(for objectID: NSManagedObjectID) -> [ItemAction] {

--- a/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
+++ b/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
@@ -16,11 +16,8 @@ final class SharedWithYouStore: NSObject {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private(set) var highlights: [SWHighlight]
-
     init(highlightCenter: SWHighlightCenter? = nil, source: Source, appSession: AppSession) {
         self.highlightCenter = highlightCenter ?? SWHighlightCenter()
-        self.highlights = self.highlightCenter.highlights
         self.source = source
         self.appSession = appSession
         super.init()
@@ -35,17 +32,9 @@ final class SharedWithYouStore: NSObject {
 extension SharedWithYouStore: SWHighlightCenterDelegate {
     /// Emits changes in the shared with you list associated with the app
     func highlightCenterHighlightsDidChange(_ highlightCenter: SWHighlightCenter) {
-        Log.capture(message: "SWH: highlight center delegate triggered - existing highlight n.: \(self.highlights.count), new highlights n.: \(highlightCenter.highlights.count)")
-        // if the list is different (either by elements or sort order) replace it
-        if highlightCenter.highlights != self.highlights {
-            Log.capture(message: "SWH: sdding new highlights")
-            self.highlights = highlightCenter.highlights
-            // Update local storage with the new highlights, which will trigger a UI update
-            // via the associated RichFetchedResultController
-            source.updateSharedWithYouItems(with: highlightCenter.highlights.map { $0.url.absoluteString })
-        } else {
-            Log.capture(message: "SWH: no new highlights added")
-        }
+        // Update local storage with the new highlights, which will trigger a UI update
+        // via the associated RichFetchedResultController
+        source.updateSharedWithYouItems(with: highlightCenter.highlights.map { $0.url.absoluteString })
     }
 }
 

--- a/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
+++ b/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
@@ -52,11 +52,16 @@ extension SharedWithYouStore: SWHighlightCenterDelegate {
 // MARK: private helpers
 private extension SharedWithYouStore {
     func start() {
-        self.highlightCenter.delegate = self
+        do {
+            try source.deleteAllSharedWithYouItems()
+        } catch {
+            Log.capture(message: "SWH: starting store - error while attempting to delete existing highlights. Detail: \(error)")
+        }
+        highlightCenter.delegate = self
     }
 
     func stop() {
-        self.highlightCenter.delegate = nil
+        highlightCenter.delegate = nil
     }
 
     func listenForUserSession() {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -1262,6 +1262,10 @@ extension PocketSource {
         item.shortURL = shortUrl
         try? space.save()
     }
+
+    public func deleteAllSharedWithYouItems() throws {
+        try space.deleteSharedWithYouItems()
+    }
 }
 
 // MARK: - Search term

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -145,4 +145,5 @@ public protocol Source {
     func updateSharedWithYouItems(with urls: [String])
     func makeSharedWithYouController() -> RichFetchedResultsController<SharedWithYouItem>
     func getItemShortUrl(_ itemUrl: String) async throws -> String?
+    func deleteAllSharedWithYouItems() throws
 }

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -370,6 +370,10 @@ extension Space {
         request.fetchLimit = 1
         return try fetch(request, context: context).first
     }
+
+    func deleteSharedWithYouItems(_ context: NSManagedObjectContext? = nil) throws {
+        try deleteEntities(request: Requests.fetchAllSharedWithYouItems(), context: context ?? backgroundContext)
+    }
 }
 
 // MARK: Slate/SlateLineUp

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,6 +8,9 @@ import CoreData
 import Combine
 
 class MockSource: Source {
+    func deleteAllSharedWithYouItems() throws {
+    }
+
     func fetchShortUrlViewItem(_ url: String) async throws -> Sync.Item? {
         return nil
     }


### PR DESCRIPTION
## Summary
* This PR fixes an issue that prevented attribution views to show on Shared with You highlights in certain conditions
## References 
* na
## Implementation Details
* Delete shared with you from Core Data at launch and always keep the local list in sync with what comes from `SWHighlightCenter`
## Test Steps
* Install this branch, verify you see highlights
* Install the nightly then back to this one, etc: verify you are always able to see highlights

> [!NOTE]
> sometimes it might take a bit for highlights to load

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
