### PR TITLE
Highlights: do not auto dismiss highlights list upon deleting an highlight, if the resulting list is not empty

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -20,6 +20,7 @@ protocol ArticleComponentTextCell: ArticleComponentTextViewDelegate {
     var delegate: ArticleComponentTextCellDelegate? { get set }
     var componentIndex: Int { get set }
     var onHighlight: ((Int, NSRange, String, String) -> Void)? { get set }
+    func highlightAll()
 }
 
 // Apply default implementations of PocketTextViewDelegate callbacks
@@ -81,6 +82,16 @@ class ArticleComponentTextView: UITextView {
     @objc
     func _share(_ sender: Any?) {
         actionDelegate?.articleComponentTextViewDidSelectShareAction(self)
+    }
+
+    func highilghtAll() {
+        let fullRange = NSMutableAttributedString(
+            attributedString: self.attributedText
+        )
+            .mutableString.range(
+                of: self.attributedText.string
+            )
+        applyHighlight(fullRange)
     }
 
     private func applyHighlight(_ range: NSRange) {

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -103,11 +103,12 @@ extension ArticleComponentTextView: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
+        guard !attributedText.isHighlighted(in: range), onHighlight != nil else {
+            return UIMenu(children: suggestedActions)
+        }
+
         let highlightAction = UIAction(title: Localization.EditAction.highlight) { [weak self] action in
             self?.applyHighlight(range)
-        }
-        guard !attributedText.isHighlighted(in: range) else {
-            return UIMenu(children: suggestedActions)
         }
 
         var newActions = suggestedActions

--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleMetadataCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleMetadataCell.swift
@@ -80,4 +80,8 @@ class ArticleMetadataCell: UICollectionViewCell, ArticleComponentTextCell, Artic
             textStack.spacing = Constants.stackSpacing
         }
     }
+
+    func highlightAll() {
+        // no op
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
@@ -69,4 +69,8 @@ class BlockquoteComponentCell: UICollectionViewCell, ArticleComponentTextCell, A
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
     }
+
+    func highlightAll() {
+        textView.highilghtAll()
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
@@ -62,4 +62,8 @@ class CodeBlockComponentCell: UICollectionViewCell, ArticleComponentTextCell, Ar
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
     }
+
+    func highlightAll() {
+        textView.highilghtAll()
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
@@ -70,4 +70,8 @@ class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, Art
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
     }
+
+    func highlightAll() {
+        textView.highilghtAll()
+    }
 }

--- a/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/HighlightRow.swift
@@ -35,7 +35,6 @@ struct HighlightRow: View {
                 .buttonStyle(BorderlessButtonStyle())
 
                 Button {
-                    modalDismiss()
                     if let ID = highlightedQuote.remoteID {
                         viewModel.deleteHighlight(ID)
                     }

--- a/PocketKit/Sources/PocketKit/Article/Highlights/HighlightsView.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/HighlightsView.swift
@@ -7,13 +7,12 @@ import SwiftUI
 import Textile
 
 class HighlightsViewController: UIHostingController<HighlightsView> {
-    convenience init(highlights: [HighlightedQuote], viewModel: SavedItemViewModel) {
-        self.init(rootView: HighlightsView(highlights: highlights, viewModel: viewModel))
+    convenience init(viewModel: SavedItemViewModel) {
+        self.init(rootView: HighlightsView(viewModel: viewModel))
     }
 }
 
 struct HighlightsView: View {
-    let highlights: [HighlightedQuote]
     @ObservedObject var viewModel: SavedItemViewModel
     @Environment(\.dismiss)
     private var dismiss
@@ -30,15 +29,19 @@ struct HighlightsView: View {
             }
             .frame(width: 36)
             VStack(alignment: .leading) {
-                Text(Localization.ItemAction.showHighlights)
-                    .font(.title3)
-                    .bold()
-                    .foregroundColor(Color(.ui.grey8))
-                    .padding(.leading)
+                HStack(alignment: .top) {
+                    Text(Localization.ItemAction.showHighlights)
+                        .font(.title3)
+                        .bold()
+                        .foregroundColor(Color(.ui.grey8))
+                        .padding(.leading)
+                    Spacer()
+                    dismissButton
+                }
                 Divider()
                     .padding(.leading)
                     .padding(.trailing)
-                List(highlights) { highlight in
+                List(viewModel.highlightedQuotes) { highlight in
                     HighlightRow(highlightedQuote: highlight, viewModel: viewModel, modalDismiss: dismiss)
                         .listRowSeparator(.hidden)
                         .onTapGesture {
@@ -51,5 +54,18 @@ struct HighlightsView: View {
             .padding(.trailing, 16)
         }
         .padding(.top)
+    }
+}
+
+extension HighlightsView {
+    private var dismissButton: some View {
+        HStack(spacing: 0) {
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Image(asset: .close).renderingMode(.template).foregroundColor(Color(.ui.grey5))
+            }
+        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/Highlights/HighlightsView.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/HighlightsView.swift
@@ -54,6 +54,11 @@ struct HighlightsView: View {
             .padding(.trailing, 16)
         }
         .padding(.top)
+        .onChange(of: viewModel.highlightedQuotes.count) { value in
+            if value == 0 {
+                dismiss()
+            }
+        }
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/BlockquoteComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/BlockquoteComponentPresenter.swift
@@ -16,8 +16,6 @@ private extension Style {
 }
 
 class BlockquoteComponentPresenter: ArticleComponentPresenter {
-    var onHighlight: ((Int, NSRange) -> Void)?
-
     var componentIndex: Int
 
     var highlightIndexes: [Int]?

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -387,28 +387,13 @@ extension ReadableViewController {
             section.contentInsetsReference = .readableContent
             return section
         default:
-            let availableItemWidth = view.readableContentGuide.layoutFrame.width
-
-            var height: CGFloat = 0
-            let subitems = presenters?.compactMap { presenter -> NSCollectionLayoutItem? in
-                let size = presenter.size(for: availableItemWidth)
-                height += size.height
-                let layoutSize = NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .estimated(size.height)
-                )
-
-                return NSCollectionLayoutItem(layoutSize: layoutSize)
+            // for image presenters, calling size will set the image size used by Kingfisher
+            if let imagePresenters = presenters?.compactMap({ $0 as? ImageComponentPresenter }) {
+                let availableItemWidth = view.readableContentGuide.layoutFrame.width
+                imagePresenters.forEach {
+                    _ = $0.size(for: availableItemWidth)
+                }
             }
-
-            let group = NSCollectionLayoutGroup.vertical(
-                layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .estimated(height)
-                ),
-                subitems: subitems ?? []
-            )
-            group.interItemSpacing = .fixed(0)
 
             var config = UICollectionLayoutListConfiguration(appearance: .plain)
             config.backgroundColor = UIColor(.ui.white1)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -410,7 +410,25 @@ extension ReadableViewController {
             )
             group.interItemSpacing = .fixed(0)
 
-            let section = NSCollectionLayoutSection(group: group)
+            var config = UICollectionLayoutListConfiguration(appearance: .plain)
+            config.trailingSwipeActionsConfigurationProvider = { [unowned self] indexPath in
+                guard let presenter = presenters?[safe: indexPath.item],
+                        let indexes = presenter.highlightIndexes, !indexes.isEmpty,
+                        let currentCell = self.collectionView.cellForItem(at: indexPath) as? ArticleComponentTextCell else {
+                    return nil
+                }
+
+                let actions: [UIContextualAction] = [
+                    UIContextualAction(style: .normal, title: "Highlight") {_, _, completion in
+                        currentCell.highlightAll()
+                        completion(true)
+                    }
+                ]
+
+                return UISwipeActionsConfiguration(actions: actions)
+            }
+
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
             // Zero out the default leading/trailing contentInsets, but preserve the default top/bottom values.
             // This ensures each section will be inset horizontally exactly to the readable content width.
             var contentInsets = section.contentInsets

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -411,21 +411,21 @@ extension ReadableViewController {
             group.interItemSpacing = .fixed(0)
 
             var config = UICollectionLayoutListConfiguration(appearance: .plain)
+            config.backgroundColor = UIColor(.ui.white1)
+            config.showsSeparators = false
             config.trailingSwipeActionsConfigurationProvider = { [unowned self] indexPath in
                 guard let presenter = presenters?[safe: indexPath.item],
-                        let indexes = presenter.highlightIndexes, !indexes.isEmpty,
+                        presenter.highlightIndexes == nil,
                         let currentCell = self.collectionView.cellForItem(at: indexPath) as? ArticleComponentTextCell else {
                     return nil
                 }
 
-                let actions: [UIContextualAction] = [
-                    UIContextualAction(style: .normal, title: "Highlight") {_, _, completion in
-                        currentCell.highlightAll()
-                        completion(true)
-                    }
-                ]
-
-                return UISwipeActionsConfiguration(actions: actions)
+                let action = UIContextualAction(style: .normal, title: "Highlight") {_, _, completion in
+                    currentCell.highlightAll()
+                    completion(true)
+                }
+                action.backgroundColor = UIColor(.ui.highlight)
+                return UISwipeActionsConfiguration(actions: [action])
             }
 
             let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -41,8 +41,6 @@ class ReadableViewController: UIViewController {
 
     private var userScrollProgress: IndexPath?
 
-    private var highlightedQuotes = [HighlightedQuote]()
-
     private lazy var collectionView: UICollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: layout
@@ -100,7 +98,6 @@ class ReadableViewController: UIViewController {
                     }
                     let controller =
                     HighlightsViewController(
-                        highlights: highlightedQuotes.sorted { $0.index < $1.index },
                         viewModel: viewModel
                     )
                     present(controller, animated: true)
@@ -481,7 +478,7 @@ extension ReadableViewController {
 extension ReadableViewController {
     /// Builds the highlighted quotes list from the presenters
     private func fetchQuotes() {
-        highlightedQuotes.removeAll()
+        var quotes = [HighlightedQuote]()
         guard let viewModel = readableViewModel as? SavedItemViewModel else {
             return
         }
@@ -490,7 +487,7 @@ extension ReadableViewController {
                let highlights = viewModel.highlights {
                 indexes.forEach {
                     if let highlight = highlights[safe: $0] {
-                        highlightedQuotes.append(
+                        quotes.append(
                             HighlightedQuote(
                                 remoteID: highlight.remoteID,
                                 index: $0,
@@ -502,5 +499,6 @@ extension ReadableViewController {
                 }
             }
         }
+        viewModel.highlightedQuotes = quotes
     }
 }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -71,6 +71,8 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
 
     @Published private(set) var isPresentingHooray = false
 
+    @Published var highlightedQuotes = [HighlightedQuote]()
+
     private var _dismissReason: DismissReason = .swipe {
         willSet {
             if newValue == .system {

--- a/Tests iOS/ReaderTests.swift
+++ b/Tests iOS/ReaderTests.swift
@@ -187,18 +187,21 @@ class ReaderTests: XCTestCase {
         // So we instead grab all text views within reader mode and expect them to decrease in height.
 
         let textViews = app.readerView.articleTextViews
-        let currentHeights: [Double] = textViews.map { textElement in
-            textElement.frame.height
-        }
+        let oldTextView = textViews.first!
+        let oldText = oldTextView.value as! String
+        let oldHeight = oldTextView.frame.height
+
         self.tapFontSizeDecreaseButton()
         self.tapFontSizeDecreaseButton()
         self.tapFontSizeDecreaseButton()
 
-        var i = 0
-        textViews.forEach({ text in
-            XCTAssertLessThan(text.frame.height, currentHeights[i], "Article text view did not shrink in height")
-            i+=1
-        })
+        let newTextView = textViews.first!
+        let newText = newTextView.value as! String
+        let newHeight = newTextView.frame.height
+        // ensure we are grabbing the same textview
+        XCTAssertEqual(oldText, newText)
+        // then ensure the textview has increased height
+        XCTAssertLessThan(newHeight, oldHeight)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
* Previously, when accessing the Highlights list from the overflow menu in the Reader, the list would dismiss itself after deleting one highlight, forcing the user to reload the list if they wanted to delete more than one.
    - This PR fixes this bug and only dismisses the list if there are no more highlights in it.
* This PR also adds support for highlight on swipe, though the feature is not available yet because it's work in progress.

## References 
* See issue code in branch name

## Implementation Details
* Update `HighlightRow`, remove dismiss action from delete
* Update `HighlightsView`
    - read the list from the viewModel so that it dynamically update the view
    - selectively dismiss depending on highlights count
* Update `ArticleComponentTextCell`, add support to highlight the entire component.

## Test Steps
* Build/run this branch
* Make sure you have highlights (or create some)
* Go to Saves and tap an article with one or more highlights
* Tap overflow -> Highlights
* Make sure the view can be dismissed at any time by tapping the "Close" (`X`) button
* Delete one or more highlights:
    - if there are highlights left after deleting, make sure the list is updated and the view do not dismiss
    - if there are no highlights left: make sure the view dismisses itself
* Tap on a collection and select some text in the description
* Make sure you don't see the "Highlight" menu item


## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
