### PR TITLE
Highlights - Swipe from the trailing edge to highlight an entire paragraph

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -73,7 +73,7 @@ class ImageComponentCell: UICollectionViewCell {
 
     var imageHeight: CGFloat?
 
-    func size() -> CGSize {
+    private var preferredSize: CGSize {
         let availableWidth = readableContentGuide.layoutFrame.width
 
         var height = imageHeight ?? availableWidth * 9 / 16
@@ -91,7 +91,7 @@ class ImageComponentCell: UICollectionViewCell {
 
     override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
         let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
-        attributes.size.height = size().height
+        attributes.size.height = preferredSize.height
         return attributes
     }
 }
@@ -126,7 +126,7 @@ extension ImageComponentCell {
                 self?.imageView.backgroundColor = model.imageViewBackgroundColor(imageSize: result.image.size)
                 self?.imageHeight = result.image.size.height
                 imageLoaded?(result.image)
-//                self?.layoutIfNeeded()
+                self?.layoutIfNeeded()
             case .failure:
                 break
             }

--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -70,6 +70,30 @@ class ImageComponentCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
     }
+
+    var imageHeight: CGFloat?
+
+    func size() -> CGSize {
+        let availableWidth = readableContentGuide.layoutFrame.width
+
+        var height = imageHeight ?? availableWidth * 9 / 16
+
+        if let caption = captionTextView.attributedText, !caption.string.isEmpty {
+            height += ImageComponentCell.Constants.captionSpacing
+            height += caption.sizeFitting(availableWidth: availableWidth).height
+        }
+
+        height += ImageComponentCell.Constants.layoutMargins.top
+        height += ImageComponentCell.Constants.layoutMargins.bottom
+
+        return CGSize(width: availableWidth, height: height)
+    }
+
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+        attributes.size.height = size().height
+        return attributes
+    }
 }
 
 extension ImageComponentCell {
@@ -100,7 +124,9 @@ extension ImageComponentCell {
             switch result {
             case .success(let result):
                 self?.imageView.backgroundColor = model.imageViewBackgroundColor(imageSize: result.image.size)
+                self?.imageHeight = result.image.size.height
                 imageLoaded?(result.image)
+//                self?.layoutIfNeeded()
             case .failure:
                 break
             }

--- a/PocketKit/Sources/PocketKit/Article/Cells/VimeoComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/VimeoComponentCell.swift
@@ -25,6 +25,8 @@ class VimeoComponentCell: UICollectionViewCell {
         }
     }
 
+    var oembedSize: CGSize?
+
     weak var delegate: VimeoComponentCellDelegate?
 
     private let webView: WKWebView = {
@@ -47,6 +49,13 @@ class VimeoComponentCell: UICollectionViewCell {
         view.text = Localization.thisVideoCouldNotBeLoaded
         return view
     }()
+
+    private var preferredSize: CGSize {
+        CGSize(
+            width: oembedSize?.width ?? readableContentGuide.layoutFrame.width,
+            height: oembedSize?.height ?? readableContentGuide.layoutFrame.width * 9 / 16
+        )
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -83,6 +92,12 @@ class VimeoComponentCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+        attributes.size.height = preferredSize.height
+        return attributes
+    }
+
     private func updateContent() {
         switch mode {
         case .loading(let content):
@@ -105,6 +120,7 @@ class VimeoComponentCell: UICollectionViewCell {
             loadingView.isHidden = true
             loadingView.stopAnimating()
         }
+        layoutIfNeeded()
     }
 
     private func invokeErrorViewAction() {

--- a/PocketKit/Sources/PocketKit/Article/Cells/YouTubeVideoComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/YouTubeVideoComponentCell.swift
@@ -31,6 +31,10 @@ class YouTubeVideoComponentCell: UICollectionViewCell {
         return webView
     }()
 
+    private var preferredSize: CGSize {
+        CGSize(width: readableContentGuide.layoutFrame.width, height: readableContentGuide.layoutFrame.width * 9 / 16)
+    }
+
     var player: YouTubePlayer {
         hostingView.player
     }
@@ -80,6 +84,12 @@ class YouTubeVideoComponentCell: UICollectionViewCell {
         fatalError("Unable to instantiate \(Self.self) from xib/storyboard")
     }
 
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+        attributes.size.height = preferredSize.height
+        return attributes
+    }
+
     func cue(vid: String) {
         player.cue(source: .video(id: vid))
     }
@@ -103,6 +113,7 @@ private extension YouTubeVideoComponentCell {
         case .error:
             setError()
         }
+        layoutIfNeeded()
     }
 
     func setLoading() {

--- a/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
@@ -46,6 +46,9 @@ class VimeoComponentPresenter: ArticleComponentPresenter {
 
             do {
                 oEmbed = try await oEmbedService.fetch(request: request)
+                if let width = oEmbed?.width, let height = oEmbed?.height {
+                    vimeoCell.oembedSize = CGSize(width: width, height: height)
+                }
             } catch {
                 vimeoCell.mode = .error
                 return

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -152,7 +152,8 @@ class ReadableViewController: UIViewController {
             return
         }
 
-        collectionView.selectItem(at: userProgress, animated: true, scrollPosition: .top)
+        collectionView.selectItem(at: userProgress, animated: true, scrollPosition: .centeredVertically)
+        collectionView.setNeedsLayout()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -407,7 +408,7 @@ extension ReadableViewController {
                     currentCell.highlightAll()
                     completion(true)
                 }
-                action.backgroundColor = UIColor(.ui.highlight)
+                action.backgroundColor = UIColor(.ui.highlightAction)
                 return UISwipeActionsConfiguration(actions: [action])
             }
             let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
@@ -464,7 +465,7 @@ extension ReadableViewController {
                     component: component,
                     componentIndex: index
                 ) { [weak self] in
-                    self?.layout.invalidateLayout()
+                    self?.collectionView.layoutIfNeeded()
                 }
             default:
                 return UnsupportedComponentPresenter(readableViewModel: readableViewModel, componentIndex: index)

--- a/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/HighlightAction.colorset/Contents.json
+++ b/PocketKit/Sources/Textile/Style/Colors/Colors.xcassets/UI/HighlightAction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x53",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x05",
+          "green" : "0x46",
+          "red" : "0x98"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
+++ b/PocketKit/Sources/Textile/Style/Colors/Palettes.swift
@@ -43,6 +43,7 @@ public struct UIPalette {
     public let skeletonCellImageBackground = ColorAsset.ui("skeletonCellImageBackground")
 
     public let highlight = ColorAsset.ui("Highlight")
+    public let highlightAction = ColorAsset.ui("HighlightAction")
 }
 
 public struct BrandingPalette {


### PR DESCRIPTION
## Summary
* This PR enables highlight on swipe, which allows yo highlight an entire paragraph in the reader by swiping from the trailing edge.

## References 
* Branch name
## Implementation Details
* Transform the reader section into a list
* Add a trailing swipe action that will trigger highlight on the entire text of the paragraph
* Set preferred content sizes explicitly for any component that downloads content asynchronously 

## Test Steps
* Open a saved item, swipe from the trailing edge and make sure the text of the corresponding paragraph is highlighted

> [!NOTE]
> as of now, we only support highlighting of paragraphs that do not contain highlights
> also, removing highlights by swipe is not yet supported.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA