### PR TITLE
Fix wrong format for heading after highlighting

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -667,9 +667,9 @@ private extension SavedItemViewModel {
         }
     }
 
-    /// Some heading components could be patched in a way that the annotation tags contain the heading markdown
-    /// If this happens, `Down` would not interpret the markdown correctly, resulting in wrong headings in the article.
-    /// To fix this, we move the start annotation tag right after the markdown indicator
+    /// Some heading components could be patched in a way that the start annotation tag is positioned right before the heading markdown tag.
+    /// If this happens, `Down` would not interpret the markdown correctly, resulting in wrong format displayed.
+    /// To fix this, we move the start annotation tag right after the markdown indicator.
     func normalizeHeadingIfNeeded(_ content: String, level: Int) -> String {
         let tag = "<pkt_tag_annotation>"
         guard content.contains(tag + "#") else {


### PR DESCRIPTION

## Summary
* This PR fixes an issue where highlighting an entire heading paragraph causes the wrong format to be displayed in the Reader

## References 
* NA
## Implementation Details
* Update `SavedItemViewModel`, parse heading content and move highlight start tag if it happens to be right before the heading markdown tag, as this would cause Down not to interpret it correctly

## Test Steps
* Highlight an entire heading and make sure it displays correctly

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
