### PR TITLE
Highlights - fix crash when opening certain items

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
@@ -186,10 +186,12 @@ extension Array where Element == ArticleComponent {
 
         let scanner = Scanner(string: parseableText)
         var componentCursor = 0
+        // a stack (fifo) where the annotation start tags (aka where an highlight starts) get pushed
+        // every time an end tag is found, a tag gets popped
         var tagStack = [String]()
 
         while !scanner.isAtEnd {
-            guard scanner.scanUpToString(HighlightConstants.commonTag) != nil else {
+            guard scanner.scanUpToString(HighlightConstants.commonTag) != nil, !scanner.isAtEnd else {
                 return patchedComponents
             }
             let beforeIndex = Swift.max(parseableText.index(before: scanner.currentIndex), parseableText.startIndex)

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -148,7 +148,8 @@ class ReadableViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        guard let userProgress = readableViewModel.readingProgress() else {
+        guard let userProgress = readableViewModel.readingProgress(),
+        userProgress.item < collectionView.numberOfItems(inSection: userProgress.section) else {
             return
         }
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -7,6 +7,7 @@ import Sync
 import Textile
 import Combine
 import Analytics
+import Localization
 import Kingfisher
 import SafariServices
 
@@ -405,7 +406,7 @@ extension ReadableViewController {
                       let currentCell = self.collectionView.cellForItem(at: indexPath) as? ArticleComponentTextCell else {
                     return nil
                 }
-                let action = UIContextualAction(style: .normal, title: "Highlight") {_, _, completion in
+                let action = UIContextualAction(style: .normal, title: Localization.EditAction.highlight) {_, _, completion in
                     currentCell.highlightAll()
                     completion(true)
                 }


### PR DESCRIPTION
## Summary
* This PR adds another safeguard when parsing text for highlights, as the resulting scanned string could not be nil at the end

## References 
* branch name

## Implementation Details
* Update `ArticleComponentHighlights`, add an end-of-scanner check after scanning up to a tag
* Also update `ReadableViewController`, add safeguard when scrolling to an `IndexPath` that represents the user progress.

## Test Steps
* Open several already highlighted items and make sure the app does not crash

## PR Checklist:
- [ ] ~~Added Unit / UI tests~~ NA
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
