### PR TITLE
Fix Spotlight search items not opening in the app

### DIFF
--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -11,6 +11,7 @@ import UIKit
 import Textile
 import Localization
 import CoreSpotlight
+import CoreData
 
 @MainActor
 class MainViewModel: ObservableObject {
@@ -226,8 +227,10 @@ extension MainViewModel {
 
     @MainActor
     func handleSpotlight(_ userActivity: NSUserActivity) {
-        guard let urlString = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String,
-              let savedItem = source.fetchViewContextSavedItem(urlString) else {
+        guard let uriRepresentation = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String,
+              let uri = URL(string: uriRepresentation),
+              let objectID = source.objectID(from: uri),
+              let savedItem = source.viewObject(id: objectID) as? SavedItem else {
             return
         }
         var components = URLComponents()

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -11,7 +11,6 @@ import UIKit
 import Textile
 import Localization
 import CoreSpotlight
-import CoreData
 
 @MainActor
 class MainViewModel: ObservableObject {

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -1309,3 +1309,9 @@ extension PocketSource {
         return try space.fetch(Requests.fetchSavedItems()).count
     }
 }
+// MARK: ObjectID from URI Representation
+extension PocketSource {
+    public func objectID(from uri: URL) -> NSManagedObjectID? {
+        viewContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: uri)
+    }
+}

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -146,4 +146,7 @@ public protocol Source {
     func makeSharedWithYouController() -> RichFetchedResultsController<SharedWithYouItem>
     func getItemShortUrl(_ itemUrl: String) async throws -> String?
     func deleteAllSharedWithYouItems() throws
+
+    // MARK: ObjectID from URI Representation
+    func objectID(from uri: URL) -> NSManagedObjectID?
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,6 +8,10 @@ import CoreData
 import Combine
 
 class MockSource: Source {
+    func objectID(from uri: URL) -> NSManagedObjectID? {
+        return nil
+    }
+
     func deleteAllSharedWithYouItems() throws {
     }
 


### PR DESCRIPTION
## Summary
* Fixed an issue where tapping on a saved item found with Spotlight would only open the app, not the item itself.

## References 
* Branch name

## Implementation Details
* Update `MainViewModel.handleSpotlight(_:)`, use the `URI` representation of the `NSManagedObjectID` from `userActivity` to retrieve the saved item to display

## Test Steps
* Search a saved item in Spotlight, tap it and make sure the item opens in the app.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
