### PR TITLE
Fix broken view hierarchy in Xcode

### DIFF
--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -12,12 +12,7 @@ struct PocketApp: App {
     @Environment(\.scenePhase)
     var scenePhase
 
-    let rootViewModel: RootViewModel
-
-    init() {
-        self.rootViewModel = RootViewModel()
-        rootViewModel.start()
-    }
+    @StateObject private var rootViewModel = RootViewModel()
 
     var body: some Scene {
         WindowGroup {

--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 @main
 struct PocketApp: App {
-    @UIApplicationDelegateAdaptor var delegate: PocketAppDelegate
+    @UIApplicationDelegateAdaptor private var delegate: PocketAppDelegate
 
     @Environment(\.scenePhase)
     var scenePhase

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -48,7 +48,7 @@ public class RootViewModel: ObservableObject {
             guard let self else { return }
             self.persistentContainerDidReset()
         }
-        start()
+        startObservingLogin()
     }
 
     init(
@@ -69,7 +69,7 @@ public class RootViewModel: ObservableObject {
         self.refreshCoordinators = refreshCoordinators
     }
 
-    private func start() {
+    private func startObservingLogin() {
         // Register for login notifications
         NotificationCenter.default.publisher(
             for: .userLoggedIn

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -66,9 +66,10 @@ public class RootViewModel: ObservableObject {
         self.widgetsSessionService = widgetsSessionService
         self.notificationCenter = notificationCenter
         self.refreshCoordinators = refreshCoordinators
+        start()
     }
 
-    public func start() {
+    private func start() {
         // Register for login notifications
         NotificationCenter.default.publisher(
             for: .userLoggedIn

--- a/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootViewModel.swift
@@ -48,6 +48,7 @@ public class RootViewModel: ObservableObject {
             guard let self else { return }
             self.persistentContainerDidReset()
         }
+        start()
     }
 
     init(
@@ -66,7 +67,6 @@ public class RootViewModel: ObservableObject {
         self.widgetsSessionService = widgetsSessionService
         self.notificationCenter = notificationCenter
         self.refreshCoordinators = refreshCoordinators
-        start()
     }
 
     private func start() {

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -55,10 +55,37 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.notificationCenter = services.notificationCenter
 
         super.init()
-        Services.initTestUtilsIfPresent(appSession: appSession, userDefaults: userDefaults, source: source)
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        startLogging()
+        processCommandLineArguments()
+        setupSession()
+        setupAdjust()
+        setupTracker()
+        initializeCoordinators()
+        initializeTextile()
+        handleLegacyMigration()
+        startSubscriptionStore()
+        setupBadge(application: application)
+        return true
+    }
+
+    /// Sets orientations to use for the views
+    /// - Parameters:
+    ///   - application: singleton app object
+    ///   - window: window whose interface orientations you want to retrieve
+    /// - Returns: orientations to use for the view
+    public func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return .all }
+        return PocketAppDelegate.phoneOrientationLock
+    }
+}
+
+// MARK: didFinishLaunching steps
+extension PocketAppDelegate {
+    /// Starts the `Log` engine
+    private func startLogging() {
         Log.start(
             dsn: Keys.shared.sentryDSN,
             tracesSampler: { context in
@@ -82,14 +109,60 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
                 return sample
             }
         )
+    }
+
+    /// Process any command line arguments (e. g. to setup the testing environment)
+    private func processCommandLineArguments() {
+        if CommandLine.arguments.contains("clearKeychain") {
+            appSession.currentSession = nil
+        }
+
+        if CommandLine.arguments.contains("clearUserDefaults") {
+            userDefaults.resetKeys()
+        }
+
+        if CommandLine.arguments.contains("clearCoreData") {
+            source.clear()
+        }
 
         if CommandLine.arguments.contains("clearImageCache") {
             Textiles.clearImageCache()
         }
+    }
 
-        // Setup adjust early on because we attach the ad id to the UserEntity.
-        enableAdjust()
+    /// Clears the session if it's the first launch, otherwise sets it up with the available environment info.
+    private func setupSession() {
+        SignOutOnFirstLaunch(
+            appSession: appSession,
+            user: user,
+            userDefaults: userDefaults
+        ).execute()
 
+        if let guid = ProcessInfo.processInfo.environment["sessionGUID"],
+           let accessToken = ProcessInfo.processInfo.environment["accessToken"],
+           let userIdentifier = ProcessInfo.processInfo.environment["sessionUserID"] {
+            appSession.currentSession = Session(
+                guid: guid,
+                accessToken: accessToken,
+                userIdentifier: userIdentifier
+            )
+        }
+    }
+
+    /// Setup the adjust environment
+    /// Note: this needs to be called early on because we attach the ad id to the UserEntity.
+    private func setupAdjust() {
+        let adjustAppToken = Keys.shared.adjustAppToken
+        let environment = ADJEnvironmentProduction
+        let adjustConfig = ADJConfig(
+            appToken: adjustAppToken,
+            environment: environment
+        )
+        Adjust.appDidLaunch(adjustConfig)
+    }
+
+    /// Setup the tracker
+    private func setupTracker() {
         // Reset and attach at least an api user entity on app launch
         self.tracker.resetPersistentEntities([
             APIUserEntity(consumerKey: self.consumerKey)
@@ -99,49 +172,53 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             // Attach a user entity at launch if it exists
             tracker.addPersistentEntity(UserEntity(guid: currentSession.guid, userID: currentSession.userIdentifier, adjustAdId: Adjust.adid()))
         }
+    }
 
-        self.refreshCoordinators.forEach({ $0.initialize() })
+    /// Initialize `Textile`
+    private func initializeTextile() {
+        Textiles.initialize()
+    }
+
+    /// Initialize any `RefreshCoordinator`
+    private func initializeCoordinators() {
+        refreshCoordinators.forEach({ $0.initialize() })
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.source.restore()
         }
-        Textiles.initialize()
+    }
 
+    /// Legacy migration helper
+    private func handleLegacyMigration() {
         if CommandLine.arguments.contains("skipLegacyAccountMigration") == false {
             migrateLegacyAccount()
         }
-
         // The session backup utility can be started after user migration since
         // the session can possibly already be backed up, i.e if used for user migration
         sessionBackupUtility.start()
+    }
 
+    /// Start pocket premium subscriptions store
+    private func startSubscriptionStore() {
         if appSession.currentSession != nil {
             // If the user is not logged in, we can start the subscription
             // in preparation for in-app purchases. Otherwise, the store
             // listens for log in / out events to appropriately start / stop.
             subscriptionStore.start()
         }
+    }
 
+    /// Setup the badge
+    /// - Parameter application: the current application
+    private func setupBadge(application: UIApplication) {
         appBadgeSetup = AppBadgeSetup(
             source: source,
             userDefaults: userDefaults,
             badgeProvider: application
         )
-
-        return true
-    }
-
-    /// Sets orientations to use for the views
-    /// - Parameters:
-    ///   - application: singleton app object
-    ///   - window: window whose interface orientations you want to retrieve
-    /// - Returns: orientations to use for the view
-    public func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return .all }
-        return PocketAppDelegate.phoneOrientationLock
     }
 
     /// Attempt to migrate a legacy (v7) account to v8
-    func migrateLegacyAccount() {
+    private func migrateLegacyAccount() {
         let legacyUserMigration = LegacyUserMigration(
             userDefaults: userDefaults,
             encryptedStore: PocketEncryptedStore(),
@@ -195,15 +272,5 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
             legacyUserMigration.forceSkip()
             Log.capture(error: error)
         }
-    }
-
-    func enableAdjust() {
-        let adjustAppToken = Keys.shared.adjustAppToken
-        let environment = ADJEnvironmentProduction
-        let adjustConfig = ADJConfig(
-            appToken: adjustAppToken,
-            environment: environment
-        )
-        Adjust.appDidLaunch(adjustConfig)
     }
 }

--- a/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
+++ b/PocketKit/Sources/PocketKit/PocketAppDelegate.swift
@@ -55,6 +55,7 @@ public class PocketAppDelegate: UIResponder, UIApplicationDelegate {
         self.notificationCenter = services.notificationCenter
 
         super.init()
+        Services.initTestUtilsIfPresent(appSession: appSession, userDefaults: userDefaults, source: source)
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -283,7 +283,7 @@ struct Services {
             user: user,
             userDefaults: userDefaults
         ).signOutOnFirstLaunch()
-        Self.initTestUtilsIfPresent(appSession: appSession, userDefaults: userDefaults, source: source)
+        // Self.initTestUtilsIfPresent(appSession: appSession, userDefaults: userDefaults, source: source)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -243,34 +243,6 @@ struct Services {
         lastLaunchedAppVersion.launched()
     }
 
-    /**
-     This used to live in AppDelegate but didFinishLaunching is not called
-     before the SwiftUI lifecycle in iOS 17 to setup everything.
-     */
-    static func initTestUtilsIfPresent(appSession: AppSession, userDefaults: UserDefaults, source: Sync.Source) {
-        if CommandLine.arguments.contains("clearKeychain") {
-            appSession.currentSession = nil
-        }
-
-        if CommandLine.arguments.contains("clearUserDefaults") {
-            userDefaults.resetKeys()
-        }
-
-        if CommandLine.arguments.contains("clearCoreData") {
-            source.clear()
-        }
-
-        if let guid = ProcessInfo.processInfo.environment["sessionGUID"],
-           let accessToken = ProcessInfo.processInfo.environment["accessToken"],
-           let userIdentifier = ProcessInfo.processInfo.environment["sessionUserID"] {
-            appSession.currentSession = Session(
-                guid: guid,
-                accessToken: accessToken,
-                userIdentifier: userIdentifier
-            )
-        }
-    }
-
     /// Starts up all services as required.
     /// - Parameter onReset: The function to call if a service has been reset.
     /// - Note: `onReset` can be called when a migration within the persistent container fails
@@ -278,12 +250,6 @@ struct Services {
         if persistentContainer.didReset {
             onReset()
         }
-        SignOutOnFirstLaunch(
-            appSession: appSession,
-            user: user,
-            userDefaults: userDefaults
-        ).signOutOnFirstLaunch()
-        // Self.initTestUtilsIfPresent(appSession: appSession, userDefaults: userDefaults, source: source)
     }
 }
 

--- a/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
+++ b/PocketKit/Sources/SaveToPocketKit/MainViewController.swift
@@ -53,7 +53,7 @@ class MainViewController: UIViewController {
             appSession: appSession,
             user: user,
             userDefaults: userDefaults
-        ).signOutOnFirstLaunch()
+        ).execute()
 
         let legacyUserMigration = LegacyUserMigration(
             userDefaults: userDefaults,

--- a/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
+++ b/PocketKit/Sources/SharedPocketKit/SignOutOnFirstLaunch.swift
@@ -30,7 +30,7 @@ public class SignOutOnFirstLaunch {
         }
     }
 
-    public func signOutOnFirstLaunch() {
+    public func execute() {
         guard !hasAppBeenLaunchedPreviously else {
             return
         }


### PR DESCRIPTION

## Summary
* Apparently, not declaring `RootViewModel` as a state object works but breaks the view hierarchy in Xcode..

## References 
* Links to docs, tickets, designs if available

## Implementation Details
* Declared `@StateObject private var rootViewModel = RootViewModel()` in `PocketApp`, removed the `init()` and added the `start()` method to the `init()` method in `RootViewModel`. This should not make a difference since the passed objects and the sequence of calls is unchanged. We need to do additional considerations when we enable multi windows, but the model likely can stay the same.

## Test Steps
* Build/run with Xcode, then make sure the view hierarchy appears
* Smoke test the app and make sure it works as expected

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

