### PR TITLE
Tags: do not present edit tag screen when tapping an existing tag in Saves

### DIFF
--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -334,7 +334,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
             guard let name = button?.titleLabel?.text else { return }
             let predicate = NSPredicate(format: "%@ IN tags.name", name)
             self?.fetchItems(with: [predicate])
-            self?.handleFilterSelection(with: .tagged)
+            self?.filterByTag()
             self?.updateSnapshotForTagFilter(with: name)
         })
     }
@@ -728,9 +728,7 @@ extension SavedItemsListViewModel {
                     self?.selectCell(with: .filterButton(.all))
                 }
             )
-            filterTagAnalytics()
-            selectedFilters.removeAll()
-            selectedFilters.insert(filter)
+            filterByTag()
         default:
             if selectedFilters.contains(filter) {
                 selectedFilters.remove(filter)
@@ -742,7 +740,9 @@ extension SavedItemsListViewModel {
         }
     }
 
-    private func filterTagAnalytics() {
+    private func filterByTag() {
+        selectedFilters.removeAll()
+        selectedFilters.insert(.tagged)
         let event = SnowplowEngagement(type: .general, value: nil)
         let contexts: Context = UIContext.button(identifier: .taggedChip)
         tracker.track(event: event, [contexts])


### PR DESCRIPTION
## Summary
* This PR fixes an issue that caused the edit tags sheet to be presented when tapping an existing tag from a cell.

## References 
* (if not otherwise specified, the issue reference is contained in the branch name)

## Implementation Details
* Update `SavedItemViewModel`, remove tag sheet presentation code when tapping an existing tag.

## Test Steps
* Tap a tag, verify that the filter works and the edit tag sheet does not appear.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA
