### PR TITLE
Fix new Recommendations widget tip displaying at every launch

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -154,6 +154,7 @@ class ReadableViewController: UIViewController {
         super.viewDidAppear(animated)
         scrollToLastKnownPosition()
         if #available(iOS 17.0, *) {
+            PocketTipEvents.showSwipeHighlightsTip.sendDonation()
             displayTip(SwipeHighlightsTip(), configuration: nil, sourceView: nil)
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -172,6 +172,7 @@ class HomeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if #available(iOS 17.0, *), let sourceView = navigationController?.view ?? view {
+            PocketTipEvents.showNewRecommendationsWidgetTip.sendDonation()
             let x = view.bounds.width / 2
             let y: CGFloat = 0
             let sourceRect = CGRect(x: x, y: y, width: 0, height: 0)

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -74,6 +74,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if #available(iOS 17.0, *) {
+            PocketTipEvents.showSwipeArchiveTip.sendDonation()
             displayTip(SwipeArchiveTip(), configuration: nil, sourceView: nil)
         }
     }

--- a/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
+++ b/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
@@ -12,29 +12,51 @@ import TipKit
 /// Swipe highlights, Reader
 @available(iOS 17.0, *)
 struct SwipeHighlightsTip: Tip {
-    var id = "pocketTips.reader.swipeHighlights"
+    let id = "pocketTips.reader.swipeHighlights"
     let title: Text = Text(Localization.Tips.SwipeHighlights.title)
     let message: Text? = Text(Localization.Tips.SwipeHighlights.message)
     let image: Image? =  Image(uiImage: UIImage(asset: .highlights))
-    let options = [Tips.MaxDisplayCount(3)]
+    let options = [Tips.MaxDisplayCount(1)]
+    var rules: [Rule] {
+        #Rule(PocketTipEvents.showSwipeHighlightsTip) {
+            $0.donations.count == 1
+        }
+    }
 }
 
 /// Swipe to archive, Saves
 @available(iOS 17.0, *)
 struct SwipeArchiveTip: Tip {
-    var id = "pocketTips.saves.swipeArchive"
+    let id = "pocketTips.saves.swipeArchive"
     let title = Text(Localization.Tips.SwipeToArchive.title)
     let message: Text? = Text(Localization.Tips.SwipeToArchive.message)
     let image: Image? = Image(uiImage: UIImage(asset: .archive))
-    let options = [Tips.MaxDisplayCount(3)]
+    let options = [Tips.MaxDisplayCount(1)]
+    var rules: [Rule] {
+        #Rule(PocketTipEvents.showSwipeArchiveTip) {
+            $0.donations.count == 1
+        }
+    }
 }
 
 /// New Recommendation Widget, Home
 @available(iOS 17.0, *)
 struct NewRecommendationsWidgetTip: Tip {
-    var id = "pocketTips.home.newRecommendationsWidget"
+    let id = "pocketTips.home.newRecommendationsWidget"
     let title = Text(Localization.Tips.RecommendationsWidget.SelectTopic.title)
     let message: Text? = Text(Localization.Tips.RecommendationsWidget.SelectTopic.message)
     let image: Image? = nil
     let options = [Tips.MaxDisplayCount(1)]
+    var rules: [Rule] {
+        #Rule(PocketTipEvents.showNewRecommendationsWidgetTip) {
+            $0.donations.count == 1
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+enum PocketTipEvents {
+    static let showNewRecommendationsWidgetTip = Tips.Event(id: "pocketTips.events.showNewRecommendationsWidgetTip")
+    static let showSwipeHighlightsTip = Tips.Event(id: "pocketTips.events.showSwipeHighlightsTip")
+    static let showSwipeArchiveTip = Tips.Event(id: "pocketTips.events.showSwipeArchiveTip")
 }

--- a/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
+++ b/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
@@ -12,7 +12,7 @@ import TipKit
 /// Swipe highlights, Reader
 @available(iOS 17.0, *)
 struct SwipeHighlightsTip: Tip {
-    var id = UUID()
+    var id = "pocketTips.reader.swipeHighlights"
     let title: Text = Text(Localization.Tips.SwipeHighlights.title)
     let message: Text? = Text(Localization.Tips.SwipeHighlights.message)
     let image: Image? =  Image(uiImage: UIImage(asset: .highlights))
@@ -22,7 +22,7 @@ struct SwipeHighlightsTip: Tip {
 /// Swipe to archive, Saves
 @available(iOS 17.0, *)
 struct SwipeArchiveTip: Tip {
-    var id = UUID()
+    var id = "pocketTips.saves.swipeArchive"
     let title = Text(Localization.Tips.SwipeToArchive.title)
     let message: Text? = Text(Localization.Tips.SwipeToArchive.message)
     let image: Image? = Image(uiImage: UIImage(asset: .archive))
@@ -32,7 +32,7 @@ struct SwipeArchiveTip: Tip {
 /// New Recommendation Widget, Home
 @available(iOS 17.0, *)
 struct NewRecommendationsWidgetTip: Tip {
-    var id = UUID()
+    var id = "pocketTips.home.newRecommendationsWidget"
     let title = Text(Localization.Tips.RecommendationsWidget.SelectTopic.title)
     let message: Text? = Text(Localization.Tips.RecommendationsWidget.SelectTopic.message)
     let image: Image? = nil

--- a/PocketKit/Sources/PocketKit/Tips/TippableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Tips/TippableViewController.swift
@@ -31,7 +31,7 @@ struct TipUIConfiguration {
 extension TippableViewController {
     @available(iOS 17.0, *)
     func displayTip<T: Tip>(_ tip: T, configuration: TipUIConfiguration?, sourceView: UIView?) {
-        tipObservationTask = tipObservationTask ?? Task.delayed(byTimeInterval: 0.3) { @MainActor [weak self] in
+        tipObservationTask = tipObservationTask ?? Task.delayed(byTimeInterval: 0.5) { @MainActor [weak self] in
             guard let self else {
                 return
             }


### PR DESCRIPTION
## Summary
* This PR fixes a beta issue where the new Recommendations widget tip would show at every launch

## References 
* Branch name

## Implementation Details
* Add `Tips.Events` to vend the tips, to have better control on when to display them

## Test Steps
* build/run, make sure the new recommendations tip only shows once, regardless how you dismiss it

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
