### PR TITLE
Fix - `shareUrl` was not updated in a Recommendation after saving it

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -66,7 +66,7 @@ class RecommendableItemViewModel: ReadableViewModel {
             shareUrl = url
         } else {
             Task {
-                try? await source.requestShareUrl(item.givenURL)
+                shareUrl = try? await source.requestShareUrl(item.givenURL)
             }
         }
     }


### PR DESCRIPTION

## Summary
* This PR fixes a bug that caused `shareUrl` not being updated after being retrieved from the backend, in a recently saved recommendation

## References 
* Branch name

## Implementation Details
* See summary

## Test Steps
* Save a recommendation then navigate to it then share and make sure the link is correct.

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots
