### PR TITLE
Fix copy in rename tag alert

### DIFF
--- a/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
@@ -25,7 +25,7 @@ struct EditTagsBottomBar: ViewModifier {
                     }
                     .accessibilityIdentifier("rename-button")
                     .disabled(selectedItems.count != 1)
-                    .alert(Localization.Tags.deleteTag, isPresented: $showRenameAlert) {
+                    .alert(Localization.Tags.renameTag, isPresented: $showRenameAlert) {
                         TextField(Localization.Tags.RenameTag.prompt, text: $name)
                             .autocapitalization(.none)
                         Button(Localization.cancel, role: .cancel, action: {})
@@ -34,7 +34,7 @@ struct EditTagsBottomBar: ViewModifier {
                             name = ""
                         })
                     } message: {
-                        Text(Localization.Tags.DeleteTag.message)
+                        Text(Localization.Tags.RenameTag.message)
                     }
 
                     Spacer()


### PR DESCRIPTION
## Summary
* Fixes the copy in the rename tag alert, that was wrongly displaying delete tag copy

## References 
* Branch name

## Implementation Details
* See summary

## Test Steps
* Go to saves, tap "Tagged" then edit and attempt to rename a tag
* make sure the copy refers to renaming a tag

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

## Screenshots

before | after
-- | --
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-05-09 at 15 15 02](https://github.com/Pocket/pocket-ios/assets/34376330/ea6ea330-00ab-47cd-872a-7b9a8f69aa81) | ![Simulator Screenshot - iPhone 15 - 2024-05-09 at 15 14 30](https://github.com/Pocket/pocket-ios/assets/34376330/640ce8a2-55d3-4006-851a-65d232fa0541)

