### PR TITLE
Enable Strict Concurrency on PocketKit

### DIFF
--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // This Source Code Form is subject to the terms of the Mozilla Public
@@ -78,6 +78,10 @@ let package = Package(
                 // Used by listen, ideally we put this there, but there were some c99 compilker issues, this used to be included by snowplow but is not anymore
                 .product(name: "FMDB", package: "fmdb")
             ],
+            swiftSettings: [
+                    // TODO: Remove `=targeted` to use the default `complete`.
+                    .enableExperimentalFeature("StrictConcurrency=targeted")
+                ],
             linkerSettings: [.unsafeFlags(["-ObjC"])] // Needed to load categories in PKTListen
         ),
         .testTarget(

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -79,7 +79,7 @@ let package = Package(
                 .product(name: "FMDB", package: "fmdb")
             ],
             swiftSettings: [
-                    // TODO: Remove `=targeted` to use the default `complete`.
+                    // TODO: remove targeted to enable complete (default)
                     .enableExperimentalFeature("StrictConcurrency=targeted")
                 ],
             linkerSettings: [.unsafeFlags(["-ObjC"])] // Needed to load categories in PKTListen

--- a/PocketKit/Sources/Analytics/Context/ContentContext.swift
+++ b/PocketKit/Sources/Analytics/Context/ContentContext.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public struct ContentContext: Context {
     public static let schema = "iglu:com.pocket/content/jsonschema/1-0-0"
 

--- a/PocketKit/Sources/Analytics/Context/Context.swift
+++ b/PocketKit/Sources/Analytics/Context/Context.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public protocol Context: Encodable {
     static var schema: String { get }
 }

--- a/PocketKit/Sources/Analytics/Context/RecommendationContext.swift
+++ b/PocketKit/Sources/Analytics/Context/RecommendationContext.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public struct RecommendationContext: Context {
     public static let schema = "iglu:com.pocket/recommendation/jsonschema/1-0-0"
 

--- a/PocketKit/Sources/Analytics/Context/SlateContext.swift
+++ b/PocketKit/Sources/Analytics/Context/SlateContext.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public struct SlateContext: Context {
     public static let schema = "iglu:com.pocket/slate/jsonschema/1-0-0"
 

--- a/PocketKit/Sources/Analytics/Context/SlateLineupContext.swift
+++ b/PocketKit/Sources/Analytics/Context/SlateLineupContext.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public struct SlateLineupContext: Context {
     public static let schema = "iglu:com.pocket/slate_lineup/jsonschema/1-0-0"
 

--- a/PocketKit/Sources/Analytics/Context/UIContext.swift
+++ b/PocketKit/Sources/Analytics/Context/UIContext.swift
@@ -5,7 +5,6 @@
 public typealias UIHierarchy = UInt
 public typealias UIIndex = UInt
 
-@available(*, deprecated, message: "Use Entities moving forward")
 public struct UIContext: Context {
     public static let schema = "iglu:com.pocket/ui/jsonschema/1-0-3"
 

--- a/PocketKit/Sources/Analytics/Tracker/Tracker.swift
+++ b/PocketKit/Sources/Analytics/Tracker/Tracker.swift
@@ -6,10 +6,8 @@ import SnowplowTracker
 
 public protocol Tracker {
     func addPersistentEntity(_ entity: Entity)
-    @available(*, deprecated, message: "Use track with an explict Event defintion")
     func track<T: OldEvent>(event: T, _ contexts: [Context]?)
     func track(event: Event, filename: String, line: Int, column: Int, funcName: String)
-    @available(*, deprecated, message: "No need to longer use a child tracker")
     func childTracker(with contexts: [Context]) -> Tracker
     func resetPersistentEntities(_ entities: [Entity])
 }

--- a/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/ArticleMetadataPresenter.swift
@@ -44,6 +44,7 @@ private extension Style {
     }
 }
 
+@MainActor
 struct ArticleMetadataPresenter {
     private let readableViewModel: ReadableViewModel
     private let readerSettings: ReaderSettings

--- a/PocketKit/Sources/PocketKit/Article/Presenters/ArticleComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/ArticleComponentPresenter.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+@MainActor
 protocol ArticleComponentPresenter {
     @MainActor
     func cell(for indexPath: IndexPath, in collectionView: UICollectionView, onHighlight: ((Int, NSRange, String, String) -> Void)?) -> UICollectionViewCell

--- a/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/UnsupportedComponentPresenter.swift
@@ -38,6 +38,7 @@ class UnsupportedComponentPresenter: ArticleComponentPresenter {
         // no op
     }
 
+    @MainActor
     private func handleShowInWebReaderButtonTap() {
         readableViewModel?.showWebReader()
         readableViewModel?.trackUnsupportedContentButtonTapped()

--- a/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/VimeoComponentPresenter.swift
@@ -5,6 +5,7 @@
 import Sync
 import UIKit
 
+@MainActor
 class VimeoComponentPresenter: ArticleComponentPresenter {
     var componentIndex: Int
 

--- a/PocketKit/Sources/PocketKit/Article/Presenters/YouTubeVideoComponentPresenter.swift
+++ b/PocketKit/Sources/PocketKit/Article/Presenters/YouTubeVideoComponentPresenter.swift
@@ -8,6 +8,7 @@ import Combine
 import CoreGraphics
 import UIKit
 
+@MainActor
 class YouTubeVideoComponentPresenter: ArticleComponentPresenter {
     var componentIndex: Int
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -25,6 +25,7 @@ protocol ReadableViewModelDelegate: AnyObject {
     func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen configuration: ListenConfiguration)
 }
 
+@MainActor
 protocol ReadableViewModel: ReadableViewControllerDelegate {
     typealias EventPublisher = AnyPublisher<ReadableEvent, Never>
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Combine
-import Sync
+@preconcurrency import Sync
 import Foundation
 import Textile
 import UIKit

--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -12,6 +12,7 @@ import Analytics
 import Network
 
 /// View model that holds logic for the native collection view
+@MainActor
 class CollectionViewModel: NSObject {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -18,6 +18,7 @@ enum ReadableType {
     case webViewSavedItem(SavedItemViewModel)
     case collection(CollectionViewModel)
 
+    @MainActor
     func clearIsPresentingReaderSettings() {
         switch self {
         case .recommendable(let recommendationViewModel):
@@ -46,7 +47,7 @@ enum SeeAll {
     case saves
     case slate(SlateDetailViewModel)
     case sharedWithYou(SharedWithYouListViewModel)
-
+    @MainActor
     func clearRecommendationToReport() {
         switch self {
         case .saves, .sharedWithYou:
@@ -55,7 +56,7 @@ enum SeeAll {
             viewModel.clearRecommendationToReport()
         }
     }
-
+    @MainActor
     func clearPresentedWebReaderURL() {
         switch self {
         case .saves:
@@ -66,7 +67,7 @@ enum SeeAll {
             viewModel.clearPresentedWebReaderURL()
         }
     }
-
+    @MainActor
     func clearSharedActivity() {
         switch self {
         case .saves:
@@ -77,7 +78,7 @@ enum SeeAll {
             viewModel.clearSharedActivity()
         }
     }
-
+    @MainActor
     func clearIsPresentingReaderSettings() {
         switch self {
         case .saves:
@@ -88,7 +89,7 @@ enum SeeAll {
             viewModel.clearIsPresentingReaderSettings()
         }
     }
-
+    @MainActor
     func clearSelectedItem() {
         switch self {
         case .saves:

--- a/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Analytics
 import SharedPocketKit
 
+@MainActor
 class SharedWithYouListViewModel {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
 

--- a/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
@@ -75,7 +75,6 @@ class SharedWithYouListViewModel {
                 return
             }
 
-            let item = sharedWithYouItem.item
             tracker.track(event: Events.SharedWithYou.cardImpression(url: sharedWithYouItem.url, index: indexPath.item))
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/Lists/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/SlateDetailViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Analytics
 import SharedPocketKit
 
+@MainActor
 class SlateDetailViewModel {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Cell>
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -4,7 +4,7 @@
 
 import Combine
 import Network
-import Sync
+@preconcurrency import Sync
 import Foundation
 import BackgroundTasks
 import UIKit

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/PocketItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/SwiftUI/PocketItemViewModel.swift
@@ -8,6 +8,7 @@ import Sync
 import SharedPocketKit
 
 /// View model used for List Item to handle actions for a specific item
+@MainActor
 class PocketItemViewModel: ObservableObject {
     private let tracker: Tracker
     private let source: Source

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -13,6 +13,7 @@ enum SelectedItem {
     case webView(SavedItemViewModel?)
     case collection(CollectionViewModel?)
 
+    @MainActor
     func clearPresentedWebReaderURL() {
         switch self {
         case .readable(let viewModel):
@@ -21,7 +22,7 @@ enum SelectedItem {
             break
         }
     }
-
+    @MainActor
     func clearSharedActivity() {
         switch self {
         case .readable(let viewModel):
@@ -30,7 +31,7 @@ enum SelectedItem {
             break
         }
     }
-
+    @MainActor
     func clearIsPresentingReaderSettings() {
         switch self {
         case .readable(let readable):
@@ -106,10 +107,12 @@ enum ItemsListEvent<ItemIdentifier: Hashable> {
     case networkStatusUpdated
 }
 
+@MainActor
 protocol ItemsListViewModelDelegate: AnyObject {
     func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen: ListenConfiguration)
 }
 
+@MainActor
 protocol ItemsListViewModel: AnyObject {
     associatedtype ItemIdentifier: Hashable
     typealias Snapshot = NSDiffableDataSourceSnapshot<ItemsListSection, ItemsListCell<ItemIdentifier>>

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import CoreData
-import Sync
+@preconcurrency import Sync
 import Analytics
 import Combine
 import UIKit
@@ -235,6 +235,7 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         source.retryImmediately()
     }
 
+    @MainActor
     func preview(for cell: ItemsListCell<NSManagedObjectID>) -> (ReadableViewModel, Bool)? {
         guard case .item(let itemID) = cell else {
             return nil

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -484,6 +484,7 @@ class DefaultSearchViewModel: ObservableObject {
 }
 
 extension DefaultSearchViewModel: SearchResultActionDelegate {
+    @MainActor
     func itemViewModel(_ searchItem: PocketItem, index: Int) -> PocketItemViewModel {
         return PocketItemViewModel(
             item: searchItem,
@@ -499,6 +500,7 @@ extension DefaultSearchViewModel: SearchResultActionDelegate {
         )
     }
 
+    @MainActor
     func select(_ searchItem: PocketItem, index: Int) {
         guard
             let savedItem = source.fetchOrCreateSavedItem(

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PocketSubscriptionStore.swift
@@ -8,6 +8,7 @@ import StoreKit
 import Sync
 
 /// A concrete implementation of SubscriptionStore that handles premium subscriptions purchases from the App Store
+@MainActor
 final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     // Available subscriptions on the App Store
     @Published private(set) var subscriptions: [PremiumSubscription] = []
@@ -33,7 +34,9 @@ final class PocketSubscriptionStore: SubscriptionStore, ObservableObject {
     }
 
     deinit {
-        stop()
+        Task {
+            await stop()
+        }
     }
 
     /// Fetch available subscriptions from the App Store

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PremiumSubscription.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/PremiumSubscription.swift
@@ -6,7 +6,7 @@ import StoreKit
 import Localization
 
 /// A type that maps to a subscription product on the App Store
-public struct PremiumSubscription {
+public struct PremiumSubscription: Sendable {
     let product: Product
 
     var name: String {

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/SubscriptionStore.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/Model/SubscriptionStore.swift
@@ -29,6 +29,7 @@ public enum PurchaseState {
 }
 
 /// Generic type representing a subscription store
+@MainActor
 public protocol SubscriptionStore {
     var subscriptions: [PremiumSubscription] { get }
     var subscriptionsPublisher: Published<[PremiumSubscription]>.Publisher { get }

--- a/PocketKit/Sources/PocketKit/PremiumUpgrade/ViewModel/PremiumUpgradeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/PremiumUpgrade/ViewModel/PremiumUpgradeViewModel.swift
@@ -13,6 +13,7 @@ import Localization
 /// Factory to construct and inject `PremiumUpgradeViewModel` where needed
 typealias PremiumUpgradeViewModelFactory = (PremiumUpgradeSource) -> PremiumUpgradeViewModel
 
+@MainActor
 class PremiumUpgradeViewModel: ObservableObject {
     private let store: SubscriptionStore
     private let tracker: Tracker

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -11,6 +11,7 @@ import SharedPocketKit
 import Kingfisher
 import Network
 
+@MainActor
 struct Services {
     static let shared: Services = Services()
 

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -10,6 +10,7 @@ import Textile
 import Foundation
 import Analytics
 
+@MainActor
 class PocketAddTagsViewModel: AddTagsViewModel {
     private let item: SavedItem
     private let source: Source

--- a/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SavedItem/SavedItemViewModel.swift
@@ -131,6 +131,7 @@ class SavedItemViewModel {
         }
     }
 
+    @MainActor
     func showAddTagsView(from context: ExtensionContext?) {
         if let url = savedItem?.url {
             tracker.track(event: Events.SaveTo.addTagsEngagement(url: url))

--- a/PocketKit/Sources/SharedPocketKit/PremiumSubscriptionType.swift
+++ b/PocketKit/Sources/SharedPocketKit/PremiumSubscriptionType.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 /// An enum that maps all available subscription IDs on the App Store
-public enum PremiumSubscriptionType: String {
+public enum PremiumSubscriptionType: String, Sendable {
     case monthly
     case annual
     case unknown

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
@@ -6,6 +6,7 @@ import Combine
 import SwiftUI
 import Textile
 
+@MainActor
 public protocol AddTagsViewModel: ObservableObject {
     var placeholderText: String { get }
     var emptyStateText: String { get }

--- a/PocketKit/Sources/Sync/Collection/Collection+Extension.swift
+++ b/PocketKit/Sources/Sync/Collection/Collection+Extension.swift
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Sync
-
 public extension Collection {
     var collectionItemUrl: String {
         CollectionUrlFormatter.collectionUrlString(slug)

--- a/PocketKit/Sources/Sync/OEmbedService.swift
+++ b/PocketKit/Sources/Sync/OEmbedService.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@MainActor
 public class OEmbedService {
     public enum Error: Swift.Error {
         case anError
@@ -51,12 +52,14 @@ public class OEmbedService {
     }
 }
 
+@MainActor
 public struct OEmbed: Decodable {
     public let html: String?
     public let width: Int?
     public let height: Int?
 }
 
+@MainActor
 public struct OEmbedRequest {
     public let id: String?
     public let width: Int?

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -208,7 +208,7 @@ class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation {
     private let osNotifications: OSNotificationCenter
     private let space: Space
     private let savedItem: SavedItem
-    private let mutation: any GraphQLMutation
+    private let mutation: Mutation
     private let savedItemParts: (any RootSelectionSet) -> SavedItemParts?
 
     private var task: Cancellable?
@@ -242,7 +242,7 @@ class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation {
         super.cancel()
     }
 
-    private func performMutation<Mutation: GraphQLMutation>(mutation: Mutation) {
+    private func performMutation(mutation: Mutation) {
         task = apollo.perform(mutation: mutation, publishResultToStore: false, context: nil, queue: .global(qos: .userInitiated)) { [weak self] result in
             guard case .success(let graphQLResult) = result,
                     let data = graphQLResult.data,

--- a/PocketKit/Sources/Sync/SyncEvent.swift
+++ b/PocketKit/Sources/Sync/SyncEvent.swift
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import ObjectiveC
+
 public enum SyncEvent {
     case error(Error)
     case loadedArchivePage

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -24,6 +24,7 @@ class CollectionViewModelTests: XCTestCase {
 
     private var subscriptions: Set<AnyCancellable> = []
 
+    @MainActor
     override func setUp() {
         super.setUp()
         source = MockSource()
@@ -53,6 +54,7 @@ class CollectionViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         slug: String,
         source: Source? = nil,
@@ -78,6 +80,7 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     // MARK: - Collection Actions
+    @MainActor
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() throws {
         let item = space.buildSavedItem().item
         let story = space.buildCollectionStory()
@@ -117,6 +120,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectArchive, expectArchiveEvent], timeout: 1)
     }
 
+    @MainActor
     func test_moveToSaves_withSavedItem_sendsRequestToSource_AndRefreshes() throws {
         let item = space.buildSavedItem().item
         let story = space.buildCollectionStory()
@@ -150,6 +154,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectMoveToSaves], timeout: 1)
     }
 
+    @MainActor
     func test_moveToSaves_withoutSavedItem_sendsRequestToSource_AndRefreshes() {
         let collection = setupCollection(with: nil)
 
@@ -170,6 +175,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectMoveToSaves], timeout: 1)
     }
 
+    @MainActor
     func test_savedCollection_buildsCorrectActions() throws {
         // not-favorited, not-archived
         let savedItem = space.buildSavedItem(isFavorite: false, isArchived: false)
@@ -214,6 +220,7 @@ class CollectionViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_favorite_delegatesToSource() throws {
         let item = space.buildSavedItem(isFavorite: false).item
         let story = space.buildCollectionStory()
@@ -250,6 +257,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectFavorite], timeout: 1)
     }
 
+    @MainActor
     func test_unfavorite_delegatesToSource() throws {
         let item = space.buildSavedItem(isFavorite: true).item
         let story = space.buildCollectionStory()
@@ -286,6 +294,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectUnfavorite], timeout: 1)
     }
 
+    @MainActor
     func test_tagsAction_withNoTags_isAddTags() throws {
         let item = space.buildSavedItem(tags: []).item
         let story = space.buildCollectionStory()
@@ -308,6 +317,7 @@ class CollectionViewModelTests: XCTestCase {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_tagsAction_withTags_isEditTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"]).item
         let story = space.buildCollectionStory()
@@ -330,6 +340,7 @@ class CollectionViewModelTests: XCTestCase {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_addTagsAction_sendsAddTagsViewModel() throws {
         let item = space.buildSavedItem(tags: ["tag 1"]).item
         let story = space.buildCollectionStory()
@@ -362,6 +373,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectAddTags], timeout: 2)
     }
 
+    @MainActor
     func test_delete_delegatesToSource_andSendsDeleteEvent() throws {
         let item = space.buildSavedItem(isFavorite: true).item
         let story = space.buildCollectionStory()
@@ -403,6 +415,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [expectDelete, expectDeleteEvent], timeout: 1)
     }
 
+    @MainActor
     func test_report_updatesSelectedRecommendationToReport() throws {
         let item = space.buildItem()
         let story = space.buildCollectionStory()
@@ -432,6 +445,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_share_updatesSharedActivity() throws {
         let item = space.buildItem()
         let story = space.buildCollectionStory()
@@ -463,6 +477,7 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     // MARK: - Cell Selection
+    @MainActor
     func test_select_withSavedItem_andIsArticle_setsReadableViewModel() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem().item
@@ -491,6 +506,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [readableExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_select_withSavedItem_andIsNotArticle_setsWebView() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem().item
@@ -517,6 +533,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [webExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_select_withRecommendation_andIsSyndicated_setsReadableViewModel() {
         let collectionItem = space.buildItem()
         let storyItem = space.buildItem(syndicatedArticle: space.buildSyndicatedArticle())
@@ -545,6 +562,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [readableExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_select_withRecommendation_andIsNotSyndicated_setsWebView() {
         let collectionItem = space.buildItem()
         let storyItem = space.buildItem()
@@ -571,6 +589,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [webExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_select_withNotSyndicated_andIsNotSaved_setsWebView() {
         let collectionItem = space.buildItem()
         let storyItem = space.buildItem()
@@ -595,6 +614,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [webExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_select_withCollection_showsNativeCollectionView() throws {
         let item = space.buildItem(givenURL: "https://getpocket.com/collections/slug-1")
         let story = space.buildCollectionStory(item: item)
@@ -629,6 +649,7 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     // MARK: - Story Actions
+    @MainActor
     func test_reportAction_forStories_updatesSelectedStoryToReport() throws {
         let item = space.buildItem()
         let story = space.buildCollectionStory(item: item)
@@ -660,6 +681,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_shareAction_forStories_updatesSelectedStoryToShare() throws {
         let item = space.buildItem()
         let story = space.buildCollectionStory(item: item)
@@ -699,6 +721,7 @@ class CollectionViewModelTests: XCTestCase {
         return collection
     }
 
+    @MainActor
     func test_snapshot_whenNetworkIsInitiallyAvailable_hasCorrectSnapshot() {
         let item = space.buildItem()
         let collection = setupCollection(with: item)
@@ -711,6 +734,7 @@ class CollectionViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.snapshot.indexOfSection(.error))
     }
 
+    @MainActor
     func test_snapshot_whenNetworkIsUnavailable_andNoLocalData_hasCorrectSnapshot() throws {
         networkPathMonitor.update(status: .unsatisfied)
 
@@ -736,6 +760,7 @@ class CollectionViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 1)
     }
 
+    @MainActor
     func test_snapshot_whenOffline_thenReconnects_hasCorrectSnapshot() async {
         networkPathMonitor.update(status: .unsatisfied)
 
@@ -772,6 +797,7 @@ class CollectionViewModelTests: XCTestCase {
     }
 
     // MARK: - Error Handling
+    @MainActor
     func test_snapshot_withFetchingCollectionError_hasCorrectSnapshot() async throws {
         let item = space.buildItem()
         let collection = setupCollection(with: item)

--- a/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/ImageComponentPresenterTests.swift
@@ -11,6 +11,7 @@ class ImageComponentPresenterTests: XCTestCase { }
 
 // MARK: - ImageComponentCell Model
 extension ImageComponentPresenterTests {
+    @MainActor
     func test_model_withCaption_shouldShow() {
         let component = ImageComponent(
             caption: "a caption",
@@ -25,6 +26,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.shouldHideCaption, false)
     }
 
+    @MainActor
     func test_model_withNoCaption_shouldHide() {
         let component = ImageComponent(
             caption: " ",
@@ -39,6 +41,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.shouldHideCaption, true)
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withImageSizeAndCaption_returnsClearBackground() {
         let component = ImageComponent(
             caption: "a caption",
@@ -54,6 +57,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withImageSizeAndNoCaption_returnsClearBackground() {
         let component = ImageComponent(
             caption: " ",
@@ -69,6 +73,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withSmallImageSizeAndCaption_returnsGreyBackground() {
         let component = ImageComponent(
             caption: "a caption",
@@ -84,6 +89,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.ui.grey7))
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withSmallImageSizeAndNoCaption_returnsClearBackground() {
         let component = ImageComponent(
             caption: " ",
@@ -99,6 +105,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withNoImageAndCaption_returnsClearBackground() {
         let component = ImageComponent(
             caption: "a caption",
@@ -114,6 +121,7 @@ extension ImageComponentPresenterTests {
         XCTAssertEqual(presenter.imageViewBackgroundColor(imageSize: imageSize), UIColor(.clear))
     }
 
+    @MainActor
     func test_model_imageViewBackgroundColor_withNoImageAndNoCaption_returnsClearBackground() {
         let component = ImageComponent(
             caption: nil,

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -21,7 +21,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
 
-    @MainActor 
+    @MainActor
     override func setUp() {
         super.setUp()
         source = MockSource()

--- a/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/PocketAddTagsViewModelTests.swift
@@ -21,6 +21,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
 
+    @MainActor 
     override func setUp() {
         super.setUp()
         source = MockSource()
@@ -42,6 +43,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         try await super.tearDown()
     }
 
+    @MainActor
     private func subject(
         item: SavedItem,
         source: Source? = nil,
@@ -63,6 +65,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_addTag_withValidName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in
@@ -76,6 +79,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2"])
     }
 
+    @MainActor
     func test_addTag_withAlreadyExistingName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in
@@ -89,6 +93,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
+    @MainActor
     func test_addTag_withWhitespaceName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in
@@ -102,6 +107,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
+    @MainActor
     func test_addTags_delegatesToSourceAndCallsSaveAction() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in
@@ -126,6 +132,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertNotNil(source.addTagsToSavedItemCall(at: 0))
     }
 
+    @MainActor
     func test_recentTags_withThreeTags_andPremiumUser_returnsNoRecentTags() {
         let item = space.buildSavedItem(tags: [])
         let expectFetchAllTagsCall = expectation(description: "expect source.fetchAllTags()")
@@ -154,6 +161,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
+    @MainActor
     func test_recentTags_withMoreThanThreeTags_andPremiumUser_returnsRecentTags() {
         let item = space.buildSavedItem(tags: [])
         let expectRetrieveTagsCall = expectation(description: "expect source.retrieveTags(excluding:)")
@@ -185,6 +193,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
+    @MainActor
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() {
         let item = space.buildSavedItem(tags: [])
         let expectRetrieveTagsCall = expectation(description: "expect source.retrieveTags(excluding:)")
@@ -216,6 +225,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
+    @MainActor
     func test_allOtherTags_retrievesValidTagNames_inSortedOrder() {
         let item = space.buildSavedItem(tags: ["a"])
         let expectRetrieveTagsCall = expectation(description: "expect source.retrieveTags(excluding:)")
@@ -239,6 +249,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertNotNil(source.retrieveTagsCall(at: 0))
     }
 
+    @MainActor
     func test_removeTag_withValidName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1", "tag 2", "tag 3"])
         source.stubRetrieveTags { _ in
@@ -252,6 +263,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 3"])
     }
 
+    @MainActor
     func test_removeTag_withNotExistingName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1", "tag 2", "tag 3"])
         source.stubRetrieveTags { _ in
@@ -265,6 +277,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2", "tag 3"])
     }
 
+    @MainActor
     func test_newTagInput_withTags_showFiltersTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in
@@ -297,6 +310,7 @@ class PocketAddTagsViewModelTests: XCTestCase {
         wait(for: [expectFilterTagsCall], timeout: 2)
     }
 
+    @MainActor
     func test_newTagInput_withNoTags_showAllTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         source.stubRetrieveTags { _ in

--- a/PocketKit/Tests/PocketKitTests/RecommendableItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/RecommendableItemViewModelTests.swift
@@ -38,6 +38,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         recommendation: Recommendation,
         source: Source? = nil,
@@ -56,6 +57,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_init_buildsCorrectActions() throws {
         // not saved
         do {
@@ -96,6 +98,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_whenItemChanges_rebuildsActions() throws {
         let item = space.buildItem()
         let recommendation = try space.createRecommendation(item: item)
@@ -133,6 +136,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_displaySettings_updatesIsPresentingReaderSettings() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -145,6 +149,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isPresentingReaderSettings, true)
     }
 
+    @MainActor
     func test_favorite_delegatesToSource() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(isFavorite: false, item: item)
@@ -163,6 +168,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectFavorite], timeout: 2)
     }
 
+    @MainActor
     func test_unfavorite_delegatesToSource() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(isFavorite: true, item: item)
@@ -181,6 +187,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectUnfavorite], timeout: 2)
     }
 
+    @MainActor
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -209,6 +216,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectDelete, expectDeleteEvent], timeout: 2)
     }
 
+    @MainActor
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -235,6 +243,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectArchive, expectArchiveEvent], timeout: 2)
     }
 
+    @MainActor
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(isArchived: true, item: item)
@@ -252,6 +261,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectMoveFromArchiveToSaves], timeout: 2)
     }
 
+    @MainActor
     func test_share_updatesSharedActivity() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -264,6 +274,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.sharedActivity)
     }
 
+    @MainActor
     func test_showWebReader_updatesPresentedWebReaderURL() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -276,6 +287,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.presentedWebReaderURL, URL(string: item.bestURL)!)
     }
 
+    @MainActor
     func test_save_delegatesToSource() {
         let recommendation = space.buildRecommendation(item: space.buildItem())
 
@@ -292,6 +304,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [expectSave], timeout: 2)
     }
 
+    @MainActor
     func test_report_updatesSelectedRecommendationToReport() {
         let recommendation = space.buildRecommendation(item: space.buildItem())
 
@@ -307,6 +320,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_externalSave_forwardsToSource() throws {
         source.stubSaveURL { _ in }
 
@@ -317,6 +331,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(source.saveURLCall(at: 0)?.url, url)
     }
 
+    @MainActor
     func test_externalCopy_copiesToClipboard() throws {
         let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
@@ -327,6 +342,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(pasteboard.url, url)
     }
 
+    @MainActor
     func test_externalShare_updatesSharedActivity() throws {
         let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://getpocket.com")!
@@ -335,6 +351,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.sharedActivity)
     }
 
+    @MainActor
     func test_externalOpen_updatesPresentedWebReaderURL() throws {
         let viewModel = try subject(recommendation: space.createRecommendation(item: space.buildItem()))
         let url = URL(string: "https://example.com")!
@@ -343,6 +360,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.presentedWebReaderURL, url)
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenMarticleIsNil_fetchesDetailsForRecommendation() {
         let recommendation = space.buildRecommendation(
             item: space.buildItem()
@@ -367,6 +385,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertNotNil(recommendation.item.article)
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenMarticleIsNilAfterFetching_returnsWebView() {
         let recommendation = space.buildRecommendation(
             item: space.buildItem()
@@ -390,6 +409,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         XCTAssertNil(recommendation.item.article)
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenMarticleIsPresent_immediatelySendsContentUpdatedEvent() {
         let recommendation = space.buildRecommendation(
             item: space.buildItem(article: .init(components: []))
@@ -410,6 +430,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [receivedEvent], timeout: 2)
     }
 
+    @MainActor
     func test_webActivitiesActions_whenRecommendation_notSaved() {
         let recommendation = space.buildRecommendation(
             item: space.buildItem()
@@ -430,6 +451,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_webActivitiesActions_whenRecommendation_isSaved() throws {
         let item = space.buildItem()
         let recommendation = space.buildRecommendation(
@@ -453,6 +475,7 @@ class RecommendableItemViewModelTests: XCTestCase {
         wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_readerProgress() throws {
         let item = space.buildItem()
         let recommendation = space.buildRecommendation(

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
@@ -23,7 +23,8 @@ class SavedItemViewModelTests: XCTestCase {
     private var featureFlagService: MockFeatureFlagService!
 
     private var subscriptions: Set<AnyCancellable> = []
-
+    
+    @MainActor
     override func setUp() {
         super.setUp()
         source = MockSource()
@@ -46,6 +47,7 @@ class SavedItemViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         item: SavedItem,
         source: Source? = nil,
@@ -70,6 +72,7 @@ class SavedItemViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_init_buildsCorrectActions() {
         // not-favorited, not-archived
         do {
@@ -90,6 +93,7 @@ class SavedItemViewModelTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_whenItemChanges_rebuildsActions() {
         let item = space.buildSavedItem(isFavorite: false, isArchived: true)
         let viewModel = subject(item: item)
@@ -107,6 +111,7 @@ class SavedItemViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenItemDetailsAreNotAvailable_fetchesItemDetails_andSendsEvent() throws {
         let savedItem = space.buildSavedItem()
         savedItem.item?.article = nil
@@ -137,6 +142,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(call?.savedItem, savedItem)
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenItemDetailsAreNotAvailable_afterFetching_doesNotSendEvent() throws {
         let savedItem = space.buildSavedItem()
         savedItem.item?.article = nil
@@ -165,6 +171,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(savedItem.item?.article, nil)
     }
 
+    @MainActor
     func test_fetchDetailsIfNeeded_whenItemDetailsAreAlreadyAvailable_immediatelySendsContentUpdatedEvent() {
         source.stubFetchDetails { _ in
             XCTFail("Expected no calls to fetch details, but lo, it has been called.")
@@ -191,6 +198,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertNil(source.fetchDetailsCall(at: 0))
     }
 
+    @MainActor
     func test_displaySettings_updatesIsPresentingReaderSettings() {
         let viewModel = subject(item: space.buildSavedItem())
         viewModel.invokeAction(title: "Display settings")
@@ -198,6 +206,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.isPresentingReaderSettings, true)
     }
 
+    @MainActor
     func test_favorite_delegatesToSource() {
         let item = space.buildSavedItem(isFavorite: false)
         let expectFavorite = expectation(description: "expect source.favorite(_:)")
@@ -213,6 +222,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectFavorite], timeout: 2)
     }
 
+    @MainActor
     func test_unfavorite_delegatesToSource() {
         let item = space.buildSavedItem(isFavorite: true)
         let expectUnfavorite = expectation(description: "expect source.unfavorite(_:)")
@@ -228,6 +238,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectUnfavorite], timeout: 2)
     }
 
+    @MainActor
     func test_tagsAction_withNoTags_isAddTags() throws {
         let savedItem = space.buildSavedItem(tags: [])
         try space.save()
@@ -237,6 +248,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_tagsAction_withTags_isEditTags() throws {
         let savedItem = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -246,6 +258,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_addTagsAction_sendsAddTagsViewModel() {
         let viewModel = subject(item: space.buildSavedItem(tags: ["tag 1"]))
         source.stubRetrieveTags { _ in return nil }
@@ -261,6 +274,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectAddTags], timeout: 2)
     }
 
+    @MainActor
     func test_delete_delegatesToSource_andSendsDeleteEvent() {
         let item = space.buildSavedItem(isFavorite: true)
         let viewModel = subject(item: item)
@@ -287,6 +301,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectDelete, expectDeleteEvent], timeout: 2)
     }
 
+    @MainActor
     func test_archive_sendsRequestToSource_andSendsArchiveEvent() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -312,6 +327,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectArchive, expectArchiveEvent], timeout: 2)
     }
 
+    @MainActor
     func test_moveFromArchiveToSaves_sendsRequestToSource_AndRefreshes() {
         let item = space.buildItem()
         let savedItem = space.buildSavedItem(item: item)
@@ -328,12 +344,14 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [expectMoveFromArchiveToSaves], timeout: 2)
     }
 
+    @MainActor
     func test_share_updatesSharedActivity() {
         let viewModel = subject(item: space.buildSavedItem())
         viewModel.invokeAction(title: "Share")
         XCTAssertNotNil(viewModel.sharedActivity)
     }
 
+    @MainActor
     func test_showWebReader_updatesPresentedWebReaderURL() {
         let item = space.buildSavedItem()
         let viewModel = subject(item: item)
@@ -342,6 +360,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.presentedWebReaderURL?.absoluteString, item.bestURL)
     }
 
+    @MainActor
     func test_externalSave_forwardsToSource() {
         source.stubSaveURL { _ in }
 
@@ -352,6 +371,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(source.saveURLCall(at: 0)?.url, url)
     }
 
+    @MainActor
     func test_externalCopy_copiesToClipboard() {
         let viewModel = subject(item: space.buildSavedItem())
         let url = URL(string: "https://getpocket.com")!
@@ -360,6 +380,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(pasteboard.url, url)
     }
 
+    @MainActor
     func test_externalShare_updatesSharedActivity() {
         let viewModel = subject(item: space.buildSavedItem())
         let url = URL(string: "https://getpocket.com")!
@@ -368,6 +389,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.sharedActivity)
     }
 
+    @MainActor
     func test_externalOpen_updatesPresentedWebReaderURL() {
         let viewModel = subject(item: space.buildSavedItem())
         let url = URL(string: "https://getpocket.com")!
@@ -376,6 +398,7 @@ class SavedItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.presentedWebReaderURL, url)
     }
 
+    @MainActor
     func test_webActivitiesActions_whenItemIsSaved_canArchive() throws {
         let savedItem = space.buildSavedItem()
 
@@ -395,6 +418,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_webActivitiesActions_whenItemIsArchive_canMoveToSaves() throws {
         let savedItem = space.buildSavedItem()
         savedItem.isArchived = true
@@ -415,6 +439,7 @@ class SavedItemViewModelTests: XCTestCase {
         wait(for: [webActivitiesExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_readerProgress() throws {
         let savedItem = space.buildSavedItem()
         try space.save()

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemViewModelTests.swift
@@ -23,7 +23,7 @@ class SavedItemViewModelTests: XCTestCase {
     private var featureFlagService: MockFeatureFlagService!
 
     private var subscriptions: Set<AnyCancellable> = []
-    
+
     @MainActor
     override func setUp() {
         super.setUp()

--- a/PocketKit/Tests/PocketKitTests/Saves/SavedItemsListViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Saves/SavedItemsListViewModelTests.swift
@@ -28,8 +28,9 @@ class SavedItemsListViewModelTests: XCTestCase {
     var userDefaults: UserDefaults!
     var featureFlags: MockFeatureFlagService!
 
+    @MainActor
     override func setUp() {
-        try super.setUp()
+        super.setUp()
         source = MockSource()
         tracker = MockTracker()
         featureFlags = MockFeatureFlagService()
@@ -85,6 +86,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         source: Source? = nil,
         tracker: Tracker? = nil,
@@ -110,6 +112,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_applySortingOnSavesSavedItems() throws {
         _ = (1...2).map {
             space.buildSavedItem(
@@ -136,6 +139,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotSent], timeout: 2)
     }
 
+    @MainActor
     func test_shouldSelectCell_whenItemIsPending_returnsFalse() throws {
         let viewModel = subject()
         let item = space.buildPendingSavedItem()
@@ -144,6 +148,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldSelectCell(with: .item(item.objectID)))
     }
 
+    @MainActor
     func test_shouldSelectCell_whenItemIsNotPending_returnsFalse() throws {
         let viewModel = subject()
 
@@ -153,6 +158,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldSelectCell(with: .item(item.objectID)))
     }
 
+    @MainActor
     func test_selectCell_whenItemIsArticle_setsSelectedItemToReaderView() throws {
         let viewModel = subject()
         let savedItem = space.buildPendingSavedItem()
@@ -173,6 +179,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertNotNil(item)
     }
 
+    @MainActor
     func test_selectCell_whenItemIsNotAnArticle_setsSelectedItemToWebView() throws {
         let viewModel = subject()
         let item = space.buildItem(isArticle: false)
@@ -194,6 +201,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertNotNil(url)
     }
 
+    @MainActor
     func test_selectCell_whenItemIsArticle_withSettingsOriginalViewEnabled_setsSelectedItemToWebView() throws {
         let viewModel = subject()
         let savedItem = space.buildPendingSavedItem()
@@ -216,6 +224,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertNotNil(url)
     }
 
+    @MainActor
     func test_selectedItem_whenNil_sendsSelectionCleared() {
         let viewModel = subject()
 
@@ -232,6 +241,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [eventSent], timeout: 2)
     }
 
+    @MainActor
     func test_selectedItem_whenReaderView_doesNotSendSelectionCleared() {
         let viewModel = subject()
 
@@ -246,6 +256,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [eventSent], timeout: 2)
     }
 
+    @MainActor
     func test_selectedItem_whenWebView_doesNotSendSelectionCleared() {
         let viewModel = subject()
 
@@ -260,6 +271,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [eventSent], timeout: 2)
     }
 
+    @MainActor
     func test_sourceEvents_whenEventIsSavedItemCreated_sendsSnapshotWithNewItem() {
         let savedItem = space.buildSavedItem()
 
@@ -278,6 +290,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotSent], timeout: 2)
     }
 
+    @MainActor
     func test_sourceEvents_whenEventIsSavedItemUpdated_sendsSnapshotWithUpdatedItem() {
         let savedItem = space.buildSavedItem()
         try? space.save()
@@ -295,6 +308,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotSent], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_withNoItems_includesSavesEmptyState() {
         let viewModel = subject()
 
@@ -313,6 +327,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_withNoItems_includesFavoritesEmptyState() {
         let viewModel = subject()
         viewModel.selectCell(with: .filterButton(.favorites), sender: UIView())
@@ -332,6 +347,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_withNoItems_includesTagsEmptyState() {
         source.stubFetchAllTags {
             []
@@ -354,6 +370,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_withItems_doesNotIncludeSavesEmptyState() {
         _ = space.buildSavedItem()
         try? space.save()
@@ -373,6 +390,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_withItems_doesNotIncludeFavoritesEmptyState() {
         _ = space.buildSavedItem(isFavorite: true)
         try? space.save()
@@ -394,6 +412,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_refreshSaves_callsRetryImmediatelyOnSource() {
         source.stubRefreshSaves { _ in }
         source.stubRetryImmediately { }
@@ -404,6 +423,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         XCTAssertNotNil(source.retryImmediatelyCall(at: 0))
     }
 
+    @MainActor
     func test_receivedSnapshots_whenInitialDownloadIsInProgress_insertsPlaceholderCells() throws {
         let savedItem = space.buildSavedItem()
         try? space.save()
@@ -426,6 +446,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [receivedSnapshot], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_whenSavesInitialDownloadIsStarted_insertsPlaceholderCells() throws {
         source.initialSavesDownloadState.send(.started)
 
@@ -445,6 +466,7 @@ class SavedItemsListViewModelTests: XCTestCase {
         wait(for: [receivedSnapshot], timeout: 2)
     }
 
+    @MainActor
     func test_receivedSnapshots_whenArchiveInitialDownloadIsStarted_insertsPlaceholderCells() throws {
         source.initialArchiveDownloadState.send(.started)
 
@@ -467,6 +489,7 @@ class SavedItemsListViewModelTests: XCTestCase {
 
 // MARK: - Tags
 extension SavedItemsListViewModelTests {
+    @MainActor
     func test_tagsAction_whenUnarchived_withNoTags_isAddTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -477,6 +500,7 @@ extension SavedItemsListViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_tagsAction_whenArchived_withNoTags_isAddTags() throws {
         let item = space.buildSavedItem(isArchived: true, tags: [])
         try space.save()
@@ -487,6 +511,7 @@ extension SavedItemsListViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_tagsAction_whenUnarchived_withTags_isEditTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -497,6 +522,7 @@ extension SavedItemsListViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_tagsAction_whenArchived_withTags_isEditTags() throws {
         let item = space.buildSavedItem(isArchived: true, tags: ["tag 1"])
         try space.save()
@@ -507,6 +533,7 @@ extension SavedItemsListViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor
     func test_addTagsAction_sendsAddTagsViewModel() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -528,6 +555,7 @@ extension SavedItemsListViewModelTests {
         wait(for: [expectAddTags], timeout: 2)
     }
 
+    @MainActor
     func test_fetch_whenTaggedSelected_sendsTagsFilterViewModel() throws {
         source.stubFetchAllTags {
             []
@@ -545,6 +573,7 @@ extension SavedItemsListViewModelTests {
         wait(for: [expectTagFiltersCall], timeout: 2)
     }
 
+    @MainActor
     func test_tagModel_calculatesTagHeightAndWidth() {
         let viewModel = subject()
         let model = viewModel.tagModel(with: "tag 0")

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -25,6 +25,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     private var notificationCenter: NotificationCenter!
     private var featureFlags: MockFeatureFlagService!
 
+    @MainActor 
     override func setUpWithError() throws {
         try super.setUpWithError()
         networkPathMonitor = MockNetworkPathMonitor()
@@ -59,6 +60,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         networkPathMonitor: NetworkPathMonitor? = nil,
         user: User,
@@ -90,6 +92,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Update Scope
+    @MainActor
     func test_updateScope_forFreeUser_withOnlineSaves_showsSearchEmptyState() async {
         source.stubSearchItems { _ in return [] }
         let user = MockUser()
@@ -102,6 +105,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is SearchEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forFreeUser_withOnlineArchive_showsSearchEmptyState() async {
         source.stubSearchItems { _ in return [] }
 
@@ -115,6 +119,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is SearchEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forFreeUser_withAll_showsGetPremiumEmptyState() async {
         source.stubSearchItems { _ in return [] }
 
@@ -128,6 +133,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is GetPremiumEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withSaves_showsRecentSearchEmptyState() async {
         source.stubSearchItems { _ in return [] }
 
@@ -140,6 +146,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is RecentSearchEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withArchive_showsRecentSearchEmptyState() async {
         source.stubSearchItems { _ in return [] }
 
@@ -152,6 +159,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is RecentSearchEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withAll_showsRecentSearchEmptyState() async {
         source.stubSearchItems { _ in return [] }
 
@@ -165,6 +173,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: Select Search Scope
+    @MainActor
     func test_updateScope_forFreeUser_withSavesAndTerm_showsResults() async throws {
         try setupLocalSavesSearch()
         let user = MockUser()
@@ -179,6 +188,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertEqual(results.compactMap { $0.title.string }, ["saved-item-1", "saved-item-2"])
     }
 
+    @MainActor
     func test_updateScope_forFreeUser_withArchiveAndTerm_showsResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -203,6 +213,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateScope_forFreeUser_withAllAndTerm_showsGetPremiumEmptyState() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -218,6 +229,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is GetPremiumEmptyState)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withSavesAndTerm_showsResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -243,6 +255,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withArchiveAndTerm_showsResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -267,6 +280,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateScope_forPremiumUser_withAllAndTerm_showsResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -292,6 +306,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Update Search Results
+    @MainActor
     func test_updateSearchResults_forFreeUser_withNoItems_showsNoResultsEmptyState() async {
         source.stubSearchItems { _ in return [] }
         let term = "search-term"
@@ -306,6 +321,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is NoResultsEmptyState)
     }
 
+    @MainActor
     func test_updateSearchResults_forFreeUser_withItems_showsResults() async throws {
         let term = "search-term"
         try setupLocalSavesSearch()
@@ -323,6 +339,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertEqual(results.compactMap { $0.title.string }, ["saved-item-1", "saved-item-2"])
     }
 
+    @MainActor
     func test_updateSearchResults_forFreeUser_withAll_showsGetPremiumForAllItems() async {
         let user = MockUser()
         let viewModel = await subject(user: user)
@@ -336,6 +353,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is GetPremiumEmptyState)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_withNoItems_showsNoResultsEmptyState() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -361,6 +379,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [searchExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_withItems_showsResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -387,6 +406,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Offline States
+    @MainActor
     func test_updateSearchResults_forFreeUser_withOfflineArchive_showsOfflineEmptyState() async {
         networkPathMonitor.update(status: .unsatisfied)
         let user = MockUser()
@@ -400,6 +420,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_withOfflineArchive_showsOfflineEmptyState() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -425,6 +446,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_withOfflineAll_showsOfflineEmptyState() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -440,6 +462,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is OfflineEmptyState)
     }
 
+    @MainActor
     func test_selectingScope_whenOffline_showsOfflineEmptyState() async {
         await setupOnlineSearch(with: "search-term")
 
@@ -462,6 +485,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Recent Searches
+    @MainActor
     func test_recentSearches_withFreeUser_hasNoRecentSearches() async {
         source.stubSearchItems { _ in [] }
 
@@ -478,6 +502,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTFail("Should have failed")
     }
 
+    @MainActor
     func test_recentSearches_withNewTerm_showsRecentSearches() async {
         searchService.stubSearch { _, _ in }
 
@@ -493,6 +518,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertEqual(searches, ["search-term"])
     }
 
+    @MainActor
     func test_recentSearches_withDuplicateTerm_showsRecentSearches() async {
         searchService.stubSearch { _, _ in }
 
@@ -509,6 +535,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertEqual(searches, ["search-term"])
     }
 
+    @MainActor
     func test_recentSearches_withEmptyTerm_showsRecentSearchEmptyState() async {
         searchService.stubSearch { _, _ in }
 
@@ -524,6 +551,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertTrue(emptyStateViewModel is RecentSearchEmptyState)
     }
 
+    @MainActor
     func test_recentSearches_withNewTerms_showsMaxSearches() async {
         searchService.stubSearch { _, _ in }
 
@@ -544,6 +572,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         XCTAssertEqual(searches, ["search-term-2", "search-term-3", "search-term-4", "search-term-5", "search-term-6"])
     }
 
+    @MainActor
     func test_recentSearches_withPreviousSearch_updatesSearches() async {
         searchService.stubSearch { _, _ in }
 
@@ -565,6 +594,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Clear
+    @MainActor
     func test_clear_resetsSearchResults() async {
         let term = "search-term"
         await setupOnlineSearch(with: term)
@@ -607,6 +637,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [recentSearchesExpectation], timeout: 2.0, enforceOrder: false)
     }
 
+    @MainActor
     func test_search_whenDeviceRegainsInternetConnection_submitsSearch() async {
         await setupOnlineSearch(with: "search-term")
 
@@ -648,6 +679,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: - Error Handling
+    @MainActor
     func test_updateSearchResults_forPremiumUser_withOnlineSavesError_showsLocalSaves() async throws {
         let errorExpectation = expectation(description: "should throw an error")
         searchService.stubSearch { _, _ in
@@ -676,6 +708,7 @@ class DefaultSearchViewModelTests: XCTestCase {
         await fulfillment(of: [errorExpectation, localSavesExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateSearchResults_withInternetConnectionError_showsOfflineView() async throws {
         let searchErrorExpectation = expectation(description: "should throw an error")
         searchService.stubSearch { _, _ in
@@ -701,6 +734,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     }
 
     // MARK: Load More Search Results (Pagination)
+    @MainActor
     func test_loadMoreSearchResults_forItem_showsNextPaginationResults() async {
         searchService.stubSearch { _, _ in }
 
@@ -763,6 +797,7 @@ class DefaultSearchViewModelTests: XCTestCase {
 
 // MARK: - Premium search experiment
 extension DefaultSearchViewModelTests {
+    @MainActor
     func test_updateSearchResults_forPremiumUser_inExperiment_searchingByTitle_withOnlineSavesError_showsOfflineView() async throws {
         featureFlags.stubIsAssigned { _, _ in
             return true
@@ -793,6 +828,7 @@ extension DefaultSearchViewModelTests {
         await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_inExperiment_searchingByTag_withOnlineSavesError_showsOfflineView() async throws {
         featureFlags.stubIsAssigned { _, _ in
             return true
@@ -823,6 +859,7 @@ extension DefaultSearchViewModelTests {
         await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_updateSearchResults_forPremiumUser_inExperiment_searchingByContent_withOnlineSavesError_showsOfflineView() async throws {
         let errorExpectation = expectation(description: "should throw an error")
         searchService.stubSearch { _, _ in
@@ -849,6 +886,7 @@ extension DefaultSearchViewModelTests {
         await fulfillment(of: [errorExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_search_inExperiment_whenDeviceRegainsInternetConnection_submitsSearch() async {
         featureFlags.stubIsAssigned { _, _ in
             return true
@@ -895,6 +933,7 @@ extension DefaultSearchViewModelTests {
         await fulfillment(of: [offlineExpectation, onlineExpectation], timeout: 30, enforceOrder: true)
     }
 
+    @MainActor
     func test_selectingScope_inExperiment_whenOffline_showsOfflineEmptyState() async {
         featureFlags.stubIsAssigned { _, _ in
             return true
@@ -922,6 +961,7 @@ extension DefaultSearchViewModelTests {
 
     // Since the logic is the same for title, tag, and content (aside from which query filter is used),
     // we will assume that this single scope test will act the same for the others.
+    @MainActor
     func test_updateScope_forPremiumUser_inExperiment_withTitleAndTerm_showsResults() async {
         featureFlags.stubIsAssigned { _, _ in
             return true

--- a/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/DefaultSearchViewModelTests.swift
@@ -25,7 +25,7 @@ class DefaultSearchViewModelTests: XCTestCase {
     private var notificationCenter: NotificationCenter!
     private var featureFlags: MockFeatureFlagService!
 
-    @MainActor 
+    @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
         networkPathMonitor = MockNetworkPathMonitor()

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
@@ -19,6 +19,7 @@ class PocketItemViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
 
+    @MainActor 
     override func setUp() {
         super.setUp()
         source = MockSource()
@@ -40,6 +41,7 @@ class PocketItemViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         item: PocketItem,
         index: Int = 0,
@@ -62,6 +64,7 @@ class PocketItemViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_favoriteAction_delegatesToSource_updatesPublishedProperty() {
         let item = space.buildSavedItem()
 
@@ -86,6 +89,7 @@ class PocketItemViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isFavorite)
     }
 
+    @MainActor
     func test_unfavoriteAction_delegatesToSource_updatesPublishedProperty() {
         let item = space.buildSavedItem(isFavorite: true)
 
@@ -110,6 +114,7 @@ class PocketItemViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isFavorite)
     }
 
+    @MainActor
     func test_shareAction_presentsShareSheet() {
         let item = space.buildSavedItem()
 
@@ -120,6 +125,7 @@ class PocketItemViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.presentShareSheet)
     }
 
+    @MainActor
     func test_addTagsAction_sendsAddTagsViewModel() {
         let item = space.buildSavedItem(tags: ["tag-0"])
         source.stubRetrieveTags { _ in return nil }
@@ -139,6 +145,7 @@ class PocketItemViewModelTests: XCTestCase {
         XCTAssertEqual(tagsViewModel.tags, ["tag-0"])
     }
 
+    @MainActor
     func test_archiveAction_delegatesToSource() {
         let item = space.buildSavedItem()
         let expectArchive = expectation(description: "expect source.archive(_:)")
@@ -159,6 +166,7 @@ class PocketItemViewModelTests: XCTestCase {
         wait(for: [expectArchive, expectFetchSavedItemCall], timeout: 2)
     }
 
+    @MainActor
     func test_unarchiveAction_delegatesToSource() {
         let item = space.buildSavedItem()
         let expectUnarchive = expectation(description: "expect source.unarchive(_:)")
@@ -179,6 +187,7 @@ class PocketItemViewModelTests: XCTestCase {
         wait(for: [expectUnarchive, expectFetchSavedItemCall], timeout: 2)
     }
 
+    @MainActor
     func test_deleteAction_delegatesToSource() {
         let item = space.buildSavedItem()
         let expectDelete = expectation(description: "expect source.delete(_:)")
@@ -200,6 +209,7 @@ class PocketItemViewModelTests: XCTestCase {
         wait(for: [expectDelete, expectFetchSavedItemCall], timeout: 2)
     }
 
+    @MainActor
     func test_fetchSavedItem_withURLandRemoteParts_shouldMatch() {
         let item = space.buildSavedItem()
         let searchItem = setupSearchItem()

--- a/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Search/PocketItemViewModelTests.swift
@@ -19,7 +19,7 @@ class PocketItemViewModelTests: XCTestCase {
     private var subscriptionStore: SubscriptionStore!
     private var networkPathMonitor: MockNetworkPathMonitor!
 
-    @MainActor 
+    @MainActor
     override func setUp() {
         super.setUp()
         source = MockSource()

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -24,6 +24,7 @@ class SlateDetailViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var notificationCenter: NotificationCenter!
 
+    @MainActor 
     override func setUp() {
         super.setUp()
         source = MockSource()
@@ -52,6 +53,7 @@ class SlateDetailViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor
     func subject(
         slate: Slate,
         source: Source? = nil,
@@ -73,6 +75,7 @@ class SlateDetailViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     func test_fetch_whenRecentSavesIsEmpty_andSlateLineupIsUnavailable_sendsLoadingSnapshot() throws {
         let slate: Slate = try space.createSlate(
             remoteID: "slate-1",
@@ -91,6 +94,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [receivedLoadingSnapshot], timeout: 2)
     }
 
+    @MainActor
     func test_fetch_sendsSnapshotWithItemForEachRecommendation() throws {
         let recommendations: [Recommendation] = [
             space.buildRecommendation(remoteID: "slate-1-recommendation-1", item: space.buildItem()),
@@ -122,6 +126,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_snapshot_whenRecommendationIsSaved_updatesSnapshot() throws {
         let item = space.buildItem()
         let recommendations = [
@@ -156,6 +161,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [snapshotExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_selectCell_whenSelectingRecommendation_recommendationIsReadable_updatesSelectedReadable() throws {
         let savedItem = try space.createSavedItem(item: space.buildItem())
         let recommendation = space.buildRecommendation(item: savedItem.item!)
@@ -184,6 +190,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [readableExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_selectCell_whenSelectingRecommendation_recommendationIsNotReadable_updatesPresentedWebReaderURL() throws {
         let item = space.buildItem()
         let recommendation = space.buildRecommendation(item: item)
@@ -232,6 +239,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [urlExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_selectCell_whenSelectingRecommendation_withSettingsOriginalViewEnabled_setsWebViewURL() throws {
         let savedItem = try space.createSavedItem(item: space.buildItem())
         let recommendation = space.buildRecommendation(item: savedItem.item!)
@@ -261,6 +269,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [webViewExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_reportAction_forRecommendation_updatesSelectedRecommendationToReport() throws {
         let item = space.buildItem()
         let recommendation = space.buildRecommendation(item: item)
@@ -284,6 +293,7 @@ class SlateDetailViewModelTests: XCTestCase {
         wait(for: [reportExpectation], timeout: 2)
     }
 
+    @MainActor
     func test_primaryAction_whenRecommendationIsNotSaved_savesWithSource() throws {
         source.stubSaveRecommendation { _ in }
 
@@ -303,6 +313,7 @@ class SlateDetailViewModelTests: XCTestCase {
         XCTAssertEqual(source.saveRecommendationCall(at: 0)?.recommendation.objectID, recommendation.objectID)
     }
 
+    @MainActor
     func test_primaryAction_whenRecommendationIsSaved_archivesWithSource() throws {
         source.stubArchiveRecommendation { _ in }
 

--- a/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/SlateDetailViewModelTests.swift
@@ -24,7 +24,7 @@ class SlateDetailViewModelTests: XCTestCase {
     private var networkPathMonitor: MockNetworkPathMonitor!
     private var notificationCenter: NotificationCenter!
 
-    @MainActor 
+    @MainActor
     override func setUp() {
         super.setUp()
         source = MockSource()

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -38,6 +38,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    @MainActor 
     private func subject(
         item: SavedItem,
         tracker: Tracker? = nil,
@@ -58,6 +59,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         )
     }
 
+    @MainActor 
     func test_addTag_withValidName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -68,6 +70,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2"])
     }
 
+    @MainActor 
     func test_addTag_withAlreadyExistingName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -78,6 +81,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
+    @MainActor 
     func test_addTag_withWhitespaceName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -88,6 +92,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
+    @MainActor 
     func test_addTags_delegatesToSaveServiceAndCallsSaveAction() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -107,6 +112,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(item.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"])
     }
 
+    @MainActor 
     func test_recentTags_withThreeTags_andPremiumUser_returnsNoRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -128,6 +134,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
+    @MainActor 
     func test_recentTags_withMoreThanThreeTags_andPremiumUser_returnsRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -149,6 +156,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
+    @MainActor 
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -170,6 +178,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
+    @MainActor
     func test_recentTags_withTags_returnsRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -190,6 +199,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
+    @MainActor
     func test_allOtherTags_retrievesValidTagNames_inSortedOrder() throws {
         let item = space.buildSavedItem(tags: ["a"])
         try space.save()
@@ -211,6 +221,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
     }
 
+    @MainActor
     func test_recentTags_inMostRecentOrder() throws {
         let item = space.buildSavedItem(tags: ["a"])
         try space.save()
@@ -232,6 +243,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.otherTags, [TagType.tag("b"), TagType.tag("c")])
     }
 
+    @MainActor
     func test_removeTag_withValidName_updatesTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -242,6 +254,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 3"])
     }
 
+    @MainActor
     func test_removeTag_withNotExistingName_updatesTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -252,6 +265,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2", "tag 3"])
     }
 
+    @MainActor
     func test_newTagInput_withTags_showFiltersTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -283,6 +297,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         wait(for: [expectFilterTagsCall], timeout: 2)
     }
 
+    @MainActor
     func test_newTagInput_withNoTags_showAllTags() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()

--- a/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SaveToAddTagsViewModelTests.swift
@@ -38,7 +38,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    @MainActor 
+    @MainActor
     private func subject(
         item: SavedItem,
         tracker: Tracker? = nil,
@@ -59,7 +59,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         )
     }
 
-    @MainActor 
+    @MainActor
     func test_addTag_withValidName_updatesTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -70,7 +70,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1", "tag 2"])
     }
 
-    @MainActor 
+    @MainActor
     func test_addTag_withAlreadyExistingName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -81,7 +81,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
-    @MainActor 
+    @MainActor
     func test_addTag_withWhitespaceName_doesNotUpdateTags() {
         let item = space.buildSavedItem(tags: ["tag 1"])
         let viewModel = subject(item: item) { _ in }
@@ -92,7 +92,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tags, ["tag 1"])
     }
 
-    @MainActor 
+    @MainActor
     func test_addTags_delegatesToSaveServiceAndCallsSaveAction() throws {
         let item = space.buildSavedItem(tags: ["tag 1"])
         try space.save()
@@ -112,7 +112,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(item.tags?.compactMap { ($0 as? Tag)?.name }, ["tag 1", "tag 2"])
     }
 
-    @MainActor 
+    @MainActor
     func test_recentTags_withThreeTags_andPremiumUser_returnsNoRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -134,7 +134,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [])
     }
 
-    @MainActor 
+    @MainActor
     func test_recentTags_withMoreThanThreeTags_andPremiumUser_returnsRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()
@@ -156,7 +156,7 @@ class SaveToAddTagsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recentTags, [TagType.recent("tag 3"), TagType.recent("tag 2"), TagType.recent("tag 1")])
     }
 
-    @MainActor 
+    @MainActor
     func test_recentTags_withMoreThanThreeTags_andFreeUser_returnsNoRecentTags() throws {
         let item = space.buildSavedItem(tags: [])
         try space.save()

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -360,6 +360,7 @@ extension SavedItemViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
+    @MainActor 
     func test_addTagsAction_sendsAddTagsViewModel() {
         let viewModel = subject()
         saveService.stubRetrieveTags { _ in return nil }

--- a/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
+++ b/PocketKit/Tests/SaveToPocketKitTests/SavedItemViewModelTests.swift
@@ -360,7 +360,7 @@ extension SavedItemViewModelTests {
         XCTAssertTrue(hasCorrectTitle)
     }
 
-    @MainActor 
+    @MainActor
     func test_addTagsAction_sendsAddTagsViewModel() {
         let viewModel = subject()
         saveService.stubRetrieveTags { _ in return nil }

--- a/PocketKit/Tests/SyncTests/OEmbedServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/OEmbedServiceTests.swift
@@ -19,17 +19,19 @@ class OEmbedServiceTests: XCTestCase {
             return (data, response)
         }
 
-        let service = OEmbedService(session: session)
-        let oEmbedRequest = OEmbedRequest(
+        let service = await OEmbedService(session: session)
+        let oEmbedRequest = await OEmbedRequest(
             id: "286898202",
             width: 335
         )
 
         let oEmbed = try await service.fetch(request: oEmbedRequest)
-
-        XCTAssertEqual(oEmbed.html, #"<iframe src="https://player.vimeo.com/video/286898202"></iframe>"#)
-        XCTAssertEqual(oEmbed.width, 480)
-        XCTAssertEqual(oEmbed.height, 360)
+        let html = await oEmbed.html
+        let width = await oEmbed.width
+        let height = await oEmbed.height
+        XCTAssertEqual(html, #"<iframe src="https://player.vimeo.com/video/286898202"></iframe>"#)
+        XCTAssertEqual(width, 480)
+        XCTAssertEqual(height, 360)
 
         XCTAssertEqual(
             session.dataTaskCalls[0].request.url!.absoluteString,


### PR DESCRIPTION
## Summary
* This PR is one of the many to prepare Pocket iOS for Swift 6.
* Specifically, this one enables strict concurrency on the `PocketKit` target

## References 
* Branch name

## Implementation Details
* Add `Sendable` conformance where applicable
* Add view models and other view-related types to `MainActor`

## Test Steps
* Smoke test the app and ensure it behaves properly

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Basic Self QA

