### PR TITLE
fix(analytics): ensure we use the same analytics name for app icon switching

### DIFF
--- a/PocketKit/Sources/PocketKit/Settings/AppIcon/PocketAppIcon.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AppIcon/PocketAppIcon.swift
@@ -37,6 +37,19 @@ enum PocketAppIcon: String, CaseIterable, Identifiable {
         }
     }
 
+    var analyticsName: String {
+        switch self {
+        case .primary:
+            return "Default"
+        case .monochrome:
+            return "Monochrome"
+        case .classic:
+            return "Classic"
+        case .pride:
+            return "Pride"
+        }
+    }
+
     var previewName: String {
         rawValue + "-Preview"
     }

--- a/PocketKit/Sources/PocketKit/Settings/AppIcon/SelectIconView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/AppIcon/SelectIconView.swift
@@ -31,7 +31,7 @@ struct SelectIconView: View {
                     .onTapGesture {
                         Task {
                             await viewModel.updateAppIcon(to: PocketAppIcon.primary)
-                            viewModel.trackIconSelected(PocketAppIcon.primary.description)
+                            viewModel.trackIconSelected(PocketAppIcon.primary.analyticsName)
                         }
                     }
                 }
@@ -52,7 +52,7 @@ struct SelectIconView: View {
                         .onTapGesture {
                             Task {
                                 await viewModel.updateAppIcon(to: appIcon)
-                                viewModel.trackIconSelected(appIcon.description)
+                                viewModel.trackIconSelected(appIcon.analyticsName)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Use an analytics specific name for when someone selects an app icon