### PR TITLE
Fix Collections have missing items in certain conditions

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionStory+Extensions.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStory+Extensions.swift
@@ -8,4 +8,8 @@ extension CollectionStory {
     var isSaved: Bool {
         item?.savedItem != nil && item?.savedItem?.isArchived == false
     }
+
+    var isCollection: Bool {
+        item?.isCollection ?? CollectionUrlFormatter.isCollectionUrl(url)
+    }
 }

--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -34,7 +34,7 @@ struct CollectionStoryViewModel: Hashable {
 
 extension CollectionStoryViewModel: ItemCellViewModel {
     var attributedCollection: NSAttributedString? {
-        guard collectionStory.item?.isCollection == true else { return nil }
+        guard collectionStory.isCollection else { return nil }
         return NSAttributedString(string: Localization.Constants.collection, style: .recommendation.collection)
     }
 

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -581,7 +581,10 @@ private extension Space {
 
     func deleteOrphanedItems(context: NSManagedObjectContext) throws {
         let fetchRequest: NSFetchRequest<Item> = Item.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "recommendation = NULL && savedItem = NULL && sharedWithYouItem = NULL")
+        fetchRequest.predicate =
+        NSPredicate(
+            format: "recommendation = NULL && savedItem = NULL && sharedWithYouItem = NULL && collection == NULL && syndicatedArticle == NULL"
+        )
         try deleteEntities(request: fetchRequest, context: context)
     }
 


### PR DESCRIPTION
## Goal
* Fix an issue where some collections inside collections did not show as such, and were opened in a web view. That was caused by associated `Item`s to be purged unintentionally

## Test Steps
* Pick a collection (e.g. https://getpocket.com/collections/making-the-most-of-mental-health-awareness-month)
* Make sure the collections inside the collection show the "Collection" label and open in the native collections view
* Wait several minutes, refresh and make sure the above steps still succeed.
