### PR TITLE
Add Tip to explain Shared With You Actions

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -374,3 +374,6 @@
 "tips.swipeHighlights.message" = "Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.";
 "tips.recommendationsWidget.selectTopic.title" = "New Recommendations Widget!";
 "tips.recommendationsWidget.selectTopic.message" = "Long-press on the Recommendations Widget to choose a topic of interest.\nInstall multiple widgets to keep track of all your favorite topics.";
+"tips.sharedWithYouActions.title" = "Shared With You actions";
+"tips.sharedWithYouActions.message" = "Tap the attribution view to reply, long press it to remove an item or reply.";
+

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -374,6 +374,6 @@
 "tips.swipeHighlights.message" = "Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.";
 "tips.recommendationsWidget.selectTopic.title" = "New Recommendations Widget!";
 "tips.recommendationsWidget.selectTopic.message" = "Long-press on the Recommendations Widget to choose a topic of interest.\nInstall multiple widgets to keep track of all your favorite topics.";
-"tips.sharedWithYouActions.title" = "Tap here to reply to this message or long press to remove this item.";
-"tips.sharedWithYouActions.message" = "Tap the attribution view to reply, long press it to remove an item or reply.";
+"tips.sharedWithYouActions.title" = "Shared With You actions";
+"tips.sharedWithYouActions.message" = "Tap here to reply to this message or long press to remove this item.";
 

--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -374,6 +374,6 @@
 "tips.swipeHighlights.message" = "Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.";
 "tips.recommendationsWidget.selectTopic.title" = "New Recommendations Widget!";
 "tips.recommendationsWidget.selectTopic.message" = "Long-press on the Recommendations Widget to choose a topic of interest.\nInstall multiple widgets to keep track of all your favorite topics.";
-"tips.sharedWithYouActions.title" = "Shared With You actions";
+"tips.sharedWithYouActions.title" = "Tap here to reply to this message or long press to remove this item.";
 "tips.sharedWithYouActions.message" = "Tap the attribution view to reply, long press it to remove an item or reply.";
 

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -728,8 +728,8 @@ public enum Localization {
     public enum SharedWithYouActions {
       /// Tap the attribution view to reply, long press it to remove an item or reply.
       public static let message = Localization.tr("Localizable", "tips.sharedWithYouActions.message", fallback: "Tap the attribution view to reply, long press it to remove an item or reply.")
-      /// Shared With You actions
-      public static let title = Localization.tr("Localizable", "tips.sharedWithYouActions.title", fallback: "Shared With You actions")
+      /// Tap here to reply to this message or long press to remove this item.
+      public static let title = Localization.tr("Localizable", "tips.sharedWithYouActions.title", fallback: "Tap here to reply to this message or long press to remove this item.")
     }
     public enum SwipeHighlights {
       /// Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -725,6 +725,12 @@ public enum Localization {
         public static let title = Localization.tr("Localizable", "tips.recommendationsWidget.selectTopic.title", fallback: "New Recommendations Widget!")
       }
     }
+    public enum SharedWithYouActions {
+      /// Tap the attribution view to reply, long press it to remove an item or reply.
+      public static let message = Localization.tr("Localizable", "tips.sharedWithYouActions.message", fallback: "Tap the attribution view to reply, long press it to remove an item or reply.")
+      /// Shared With You actions
+      public static let title = Localization.tr("Localizable", "tips.sharedWithYouActions.title", fallback: "Shared With You actions")
+    }
     public enum SwipeHighlights {
       /// Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.
       public static let message = Localization.tr("Localizable", "tips.swipeHighlights.message", fallback: "Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.")

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -726,10 +726,10 @@ public enum Localization {
       }
     }
     public enum SharedWithYouActions {
-      /// Tap the attribution view to reply, long press it to remove an item or reply.
-      public static let message = Localization.tr("Localizable", "tips.sharedWithYouActions.message", fallback: "Tap the attribution view to reply, long press it to remove an item or reply.")
       /// Tap here to reply to this message or long press to remove this item.
-      public static let title = Localization.tr("Localizable", "tips.sharedWithYouActions.title", fallback: "Tap here to reply to this message or long press to remove this item.")
+      public static let message = Localization.tr("Localizable", "tips.sharedWithYouActions.message", fallback: "Tap here to reply to this message or long press to remove this item.")
+      /// Shared With You actions
+      public static let title = Localization.tr("Localizable", "tips.sharedWithYouActions.title", fallback: "Shared With You actions")
     }
     public enum SwipeHighlights {
       /// Swipe left on a paragraph to highlight it. Alternatively, swipe and select 'Delete Highlights' to remove any existing highlighting.

--- a/PocketKit/Sources/PocketKit/Home/Cells/Carousel/SharedWithYouCarouselCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/Cells/Carousel/SharedWithYouCarouselCell.swift
@@ -21,7 +21,7 @@ class SharedWithYouCarouselCell: UICollectionViewCell {
         return stackView
     }()
 
-    private lazy var attributionView: SWAttributionView = {
+    private(set) lazy var attributionView: SWAttributionView = {
         let attributionView = SWAttributionView()
         attributionView.translatesAutoresizingMaskIntoConstraints = false
         attributionView.displayContext = .summary

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -169,18 +169,6 @@ class HomeViewController: UIViewController {
         handleRefresh()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        if #available(iOS 17.0, *), let sourceView = navigationController?.view ?? view {
-            PocketTipEvents.showNewRecommendationsWidgetTip.sendDonation()
-            let x = view.bounds.width / 2
-            let y: CGFloat = 0
-            let sourceRect = CGRect(x: x, y: y, width: 0, height: 0)
-            let configuration = TipUIConfiguration(sourceRect: sourceRect, permittedArrowDirections: .init(rawValue: 0), backgroundColor: nil, tintColor: nil)
-            displayTip(NewRecommendationsWidgetTip(), configuration: configuration, sourceView: sourceView)
-        }
-    }
-
     private func handleRefresh(isForced: Bool = false) {
         model.refresh(isForced: isForced) { [weak self] in
             DispatchQueue.main.async {
@@ -264,6 +252,16 @@ extension HomeViewController {
             }
 
             cell.configure(with: configuration)
+            // Show Shared With You Tip on the first attribution view
+            if indexPath.item == 0, #available(iOS 17.0, *) {
+                let sourceView = cell.attributionView
+                PocketTipEvents.showSharedWithYouTip.sendDonation()
+                let x: CGFloat = 80
+                let y: CGFloat = 20
+                let sourceRect = CGRect(x: x, y: y, width: 0, height: 0)
+                let configuration = TipUIConfiguration(sourceRect: sourceRect, permittedArrowDirections: .up, backgroundColor: nil, tintColor: nil)
+                displayTip(SharedWithYouTip(), configuration: configuration, sourceView: sourceView)
+            }
             return cell
         }
     }

--- a/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
+++ b/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
@@ -59,7 +59,7 @@ struct NewRecommendationsWidgetTip: Tip {
 struct SharedWithYouTip: Tip {
     let id = "pocketTips.home.sharedWithYouActions"
     let title = Text(Localization.Tips.SharedWithYouActions.title)
-    let message: Text? = Text(Localization.Tips.SharedWithYouActions.message)
+    let message: Text? = nil
     let image: Image? = nil
     let options = [Tips.MaxDisplayCount(1)]
     var rules: [Rule] {

--- a/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
+++ b/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
@@ -54,9 +54,25 @@ struct NewRecommendationsWidgetTip: Tip {
     }
 }
 
+/// Shared With You, Home
+@available(iOS 17.0, *)
+struct SharedWithYouTip: Tip {
+    let id = "pocketTips.home.sharedWithYouActions"
+    let title = Text(Localization.Tips.SharedWithYouActions.title)
+    let message: Text? = Text(Localization.Tips.SharedWithYouActions.message)
+    let image: Image? = nil
+    let options = [Tips.MaxDisplayCount(1)]
+    var rules: [Rule] {
+        #Rule(PocketTipEvents.showSharedWithYouTip) {
+            $0.donations.count == 1
+        }
+    }
+}
+
 @available(iOS 17.0, *)
 enum PocketTipEvents {
     static let showNewRecommendationsWidgetTip = Tips.Event(id: "pocketTips.events.showNewRecommendationsWidgetTip")
     static let showSwipeHighlightsTip = Tips.Event(id: "pocketTips.events.showSwipeHighlightsTip")
     static let showSwipeArchiveTip = Tips.Event(id: "pocketTips.events.showSwipeArchiveTip")
+    static let showSharedWithYouTip = Tips.Event(id: "pocketTips.events.showSharedWithYouTip")
 }

--- a/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
+++ b/PocketKit/Sources/PocketKit/Tips/PocketTips.swift
@@ -59,7 +59,7 @@ struct NewRecommendationsWidgetTip: Tip {
 struct SharedWithYouTip: Tip {
     let id = "pocketTips.home.sharedWithYouActions"
     let title = Text(Localization.Tips.SharedWithYouActions.title)
-    let message: Text? = nil
+    let message: Text? = Text(Localization.Tips.SharedWithYouActions.message)
     let image: Image? = nil
     let options = [Tips.MaxDisplayCount(1)]
     var rules: [Rule] {


### PR DESCRIPTION
## Goal
* This PR adds an explanatory tip for the Shared With You Actions:
    - Tap to reply
    - Long press to delete an item or reply

## Test Steps
* Build run on an actual device where you have shared Pocket content from another user on iMessage
* Verify that the tip shows (see screenshot)

## Screenshots
<p align=center>
<img width = 320 src=https://github.com/Pocket/pocket-ios/assets/34376330/3abb37e2-3528-41c4-bfee-fdebff3d7ea8>
</p>
