### PR TITLE
Add new onboarding screen

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -362,6 +362,9 @@
 
 // Logged out
 "loggedOut.continue" = "Continue";
+"loggedOut.continue.authenticate" = "Sign up or sign in";
+"loggedOut.continue.signedOut" = "Continue signed out";
+"loggedOut.footer" = "By proceeding, you agree to the Pocket [Terms of Service](https://getpocket.com/tos) and [Privacy Notice](https://getpocket.com/privacy)";
 
 // Errors
 "error.problemOccurred" = "A problem occurred";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -321,6 +321,14 @@ public enum Localization {
   public enum LoggedOut {
     /// Continue
     public static let `continue` = Localization.tr("Localizable", "loggedOut.continue", fallback: "Continue")
+    /// By proceeding, you agree to the Pocket [Terms of Service](https://getpocket.com/tos) and [Privacy Notice](https://getpocket.com/privacy)
+    public static let footer = Localization.tr("Localizable", "loggedOut.footer", fallback: "By proceeding, you agree to the Pocket [Terms of Service](https://getpocket.com/tos) and [Privacy Notice](https://getpocket.com/privacy)")
+    public enum Continue {
+      /// Sign up or sign in
+      public static let authenticate = Localization.tr("Localizable", "loggedOut.continue.authenticate", fallback: "Sign up or sign in")
+      /// Continue signed out
+      public static let signedOut = Localization.tr("Localizable", "loggedOut.continue.signedOut", fallback: "Continue signed out")
+    }
     public enum Offline {
       /// Looks like you're offline. Try checking your mobile data or wifi.
       public static let detail = Localization.tr("Localizable", "loggedOut.offline.detail", fallback: "Looks like you're offline. Try checking your mobile data or wifi.")

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 import Textile
 import SwiftUI
 import Localization
-import SharedPocketKit
 
 struct LoggedOutViewControllerSwiftUI: UIViewControllerRepresentable {
     var model: LoggedOutViewModel

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import Textile
 import SwiftUI
 import Localization
+import SharedPocketKit
 
 struct LoggedOutViewControllerSwiftUI: UIViewControllerRepresentable {
     var model: LoggedOutViewModel
@@ -138,22 +139,44 @@ private struct LoggedOutCarouselPageView: View {
 }
 
 private struct LoggedOutActionsView: View {
-    private let viewModel: LoggedOutViewModel
+    @ObservedObject private var viewModel: LoggedOutViewModel
 
     init(viewModel: LoggedOutViewModel) {
         self.viewModel = viewModel
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Button {
                 viewModel.authenticate()
             } label: {
-                Text(Localization.LoggedOut.continue).style(.header.sansSerif.h8.with(color: .ui.white))
+                Text(signInText).style(.header.sansSerif.h8.with(color: .ui.white))
                     .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
                     .frame(maxWidth: 320)
             }
             .buttonStyle(ActionsPrimaryButtonStyle())
+            if viewModel.showNewOnboarding {
+                Button {
+                    // TODO: Add signed out home navigation
+                } label: {
+                    Text(Localization.LoggedOut.Continue.signedOut).style(.header.sansSerif.h8.with(underlineStyle: .single).with(color: .ui.black1))
+                        .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
+                        .frame(maxWidth: 320)
+                }
+                if let footerMarkdown {
+                    Text(footerMarkdown)
+                        .tint(Color(ColorAsset.ui.grey5))
+                }
+            }
         }
+    }
+}
+
+private extension LoggedOutActionsView {
+    @MainActor var signInText: String {
+        viewModel.showNewOnboarding ? Localization.LoggedOut.Continue.authenticate : Localization.LoggedOut.continue
+    }
+    var footerMarkdown: AttributedString? {
+        try? AttributedString(markdown: Localization.LoggedOut.footer, options: .init(allowsExtendedAttributes: true))
     }
 }

--- a/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
+++ b/PocketKit/Sources/PocketKit/LoggedOut/LoggedOutViewController.swift
@@ -164,7 +164,9 @@ private struct LoggedOutActionsView: View {
                 }
                 if let footerMarkdown {
                     Text(footerMarkdown)
-                        .tint(Color(ColorAsset.ui.grey5))
+                        .style(.header.sansSerif.p3.with(color: .ui.grey5).with(alignment: .center))
+                        .tint(Color(ColorAsset.ui.black1))
+                        .padding([.leading, .trailing], 32)
                 }
             }
         }

--- a/PocketKit/Sources/SharedPocketKit/CurrentFeatureFlags.swift
+++ b/PocketKit/Sources/SharedPocketKit/CurrentFeatureFlags.swift
@@ -15,6 +15,7 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case premiumSearchScopesExperiment = "EXPERIMENT_POCKET_PREMIUM_SEARCH_SCOPES"
     case bestOf20231PercentSticker = "BEST_OF_2023_1_PERCENT_STICKER"
     case bestOf20235PercentSticker = "BEST_OF_2023_5_PERCENT_STICKER"
+    case newOnboarding = "temp.ios.newOnboarding"
 
     /// Description to use in a debug menu
     public var description: String {
@@ -39,6 +40,8 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "User is part of the top 1 percent of Pocket readers"
         case .bestOf20235PercentSticker:
             return "User is part of the top 5 percent of Pocket readers"
+        case .newOnboarding:
+            return "New Onboarding Experience"
         }
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -12,5 +12,4 @@ public extension Notification.Name {
     static let serverError = Notification.Name("com.mozilla.pocket.serverError")
     static let unauthorizedResponse = Notification.Name("com.mozilla.pocket.unauthorizedResponse")
     static let migrationError = Notification.Name("com.mozilla.pocket.migrationError")
-    static let featureFlagsUpdated = Notification.Name("com.mozilla.pocket.featureFlagsUpdated")
 }

--- a/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
+++ b/PocketKit/Sources/SharedPocketKit/NotificationCenter+EventNames.swift
@@ -12,4 +12,5 @@ public extension Notification.Name {
     static let serverError = Notification.Name("com.mozilla.pocket.serverError")
     static let unauthorizedResponse = Notification.Name("com.mozilla.pocket.unauthorizedResponse")
     static let migrationError = Notification.Name("com.mozilla.pocket.migrationError")
+    static let featureFlagsUpdated = Notification.Name("com.mozilla.pocket.featureFlagsUpdated")
 }

--- a/PocketKit/Sources/Textile/Style/Style+SwiftUI.swift
+++ b/PocketKit/Sources/Textile/Style/Style+SwiftUI.swift
@@ -66,6 +66,7 @@ public extension Text {
             .multilineTextAlignment(SwiftUI.TextAlignment(style.paragraph.alignment))
             .lineSpacing(style.paragraph.lineSpacing ?? 0)
             .italic(style.fontDescriptor.slant == .italic)
+            .underline(style.underlineStyle == .single)
     }
 }
 

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -33,6 +33,7 @@ class LoggedOutViewModelTests: XCTestCase {
         tracker = MockTracker()
         mockAuthenticationSession = MockAuthenticationSession()
         userManagementService = MockUserManagementService()
+        featureFlags = MockFeatureFlagService()
 
         subscriptions = []
 

--- a/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/LoggedOutViewModelTests.swift
@@ -17,6 +17,7 @@ class LoggedOutViewModelTests: XCTestCase {
     private var tracker: MockTracker!
     private var mockAuthenticationSession: MockAuthenticationSession!
     private var userManagementService: MockUserManagementService!
+    private var featureFlags: MockFeatureFlagService!
 
     private var subscriptions: Set<AnyCancellable>!
 
@@ -54,14 +55,16 @@ class LoggedOutViewModelTests: XCTestCase {
         authorizationClient: AuthorizationClient? = nil,
         appSession: AppSession? = nil,
         networkPathMonitor: NetworkPathMonitor? = nil,
-        tracker: Tracker? = nil
+        tracker: Tracker? = nil,
+        featureFlags: FeatureFlagServiceProtocol? = nil
     ) -> LoggedOutViewModel {
         let viewModel = LoggedOutViewModel(
             authorizationClient: authorizationClient ?? self.authorizationClient,
             appSession: appSession ?? self.appSession,
             networkPathMonitor: networkPathMonitor ?? self.networkPathMonitor,
             tracker: tracker ?? self.tracker,
-            userManagementService: userManagementService ?? self.userManagementService
+            userManagementService: userManagementService ?? self.userManagementService,
+            featureFlags: featureFlags ?? self.featureFlags
         )
         viewModel.contextProvider = self
         return viewModel


### PR DESCRIPTION
## Goal
* Add the new onboarding screen that includes the "Continue signed out" button as well as privacy and TOS links

## Test Steps
* enable the `temp.ios.newOnboarding` feature flag, or just set the `showNewOnboarding = true` in `LoggedOutViewModel`, line 97
* Verify that the new onboarding screen appears (see screenshot)
* Verify that the "Sign up or sign in" behaves as the existing "Continue" button
* Verify that privacy and tos links work
> [!IMPORTANT]
> if you enable the feature flag, remember to disable it!

> [!NOTE]
> the "Continue signed out" button, currently does nothing and that's expected.

## Screenshots
<p align=center>
<img width=320 src=https://github.com/Pocket/pocket-ios/assets/34376330/cf6f0f28-94ea-4634-a319-1d7cf2932beb>
</p>
