### PR TITLE
remove native collections feature flag

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -310,7 +310,7 @@ extension CollectionViewModel {
 
     private func selectItem(with story: CollectionStory) {
         // Check if item is a collection
-        if let slug = story.item?.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = story.item?.collectionSlug {
             selectedItem = .collection(
                 CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
             )

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -387,7 +387,7 @@ extension HomeViewModel {
         var destination: ContentOpen.Destination = .internal
         let item = recommendation.item
 
-        if let slug = recommendation.collection?.slug ?? recommendation.item.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = recommendation.collection?.slug ?? recommendation.item.collectionSlug {
             selectedReadableType = .collection(CollectionViewModel(
                 slug: slug,
                 source: source,
@@ -467,7 +467,7 @@ extension HomeViewModel {
     }
 
     func select(savedItem: SavedItem, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app) {
-        if let slug = savedItem.item?.collection?.slug ?? savedItem.item?.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = savedItem.item?.collection?.slug ?? savedItem.item?.collectionSlug {
             selectedReadableType = .collection(CollectionViewModel(
                 slug: slug,
                 source: source,
@@ -506,7 +506,7 @@ extension HomeViewModel {
 
     func select(sharedWithYouItem: SharedWithYouItem, at indexPath: IndexPath, readableSource: ReadableSource = .app) {
         var destination: ContentOpen.Destination = .internal
-        if let slug = sharedWithYouItem.item.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = sharedWithYouItem.item.collectionSlug {
             selectedReadableType = .collection(CollectionViewModel(
                 slug: slug,
                 source: source,

--- a/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/ShareWithYouListViewModel.swift
@@ -100,7 +100,7 @@ extension SharedWithYouListViewModel {
         let item = sharedWithYouItem.item
         var destination: ContentOpen.Destination = .internal
 
-        if let slug = item.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = item.collectionSlug {
             selectedCollectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
         } else if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             guard let bestURL = URL(percentEncoding: item.bestURL) else { return }

--- a/PocketKit/Sources/PocketKit/Home/Lists/SlateDetailViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/Lists/SlateDetailViewModel.swift
@@ -127,7 +127,7 @@ extension SlateDetailViewModel {
         let item = recommendation.item
         var destination: ContentOpen.Destination = .internal
 
-        if let slug = recommendation.collection?.slug ?? recommendation.item.collectionSlug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = recommendation.collection?.slug ?? recommendation.item.collectionSlug {
             selectedCollectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
         } else if item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             guard let bestURL = URL(percentEncoding: item.bestURL) else { return }
@@ -146,10 +146,7 @@ extension SlateDetailViewModel {
             destination = .internal
         }
 
-        guard
-            let slate = recommendation.slate,
-            let slateLineup = slate.slateLineup
-        else {
+        guard let slate = recommendation.slate else {
             Log.capture(message: "Selected recommendation without an associated slate and slatelineup, not logging analytics")
             return
         }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -636,7 +636,7 @@ extension SavedItemsListViewModel {
             featureFlagService: featureFlags
         )
 
-        if let slug = readable.collection?.slug ?? readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = readable.collection?.slug ?? readable.slug {
             let collectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
             selectedItem = .collection(collectionViewModel)
         } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -525,7 +525,7 @@ extension DefaultSearchViewModel: SearchResultActionDelegate {
             featureFlagService: featureFlags
         )
 
-        if let slug = readable.slug, featureFlags.isAssigned(flag: .nativeCollections) {
+        if let slug = readable.slug {
             let collectionViewModel = CollectionViewModel(slug: slug, source: source, tracker: tracker, user: user, store: store, networkPathMonitor: networkPathMonitor, userDefaults: userDefaults, featureFlags: featureFlags, notificationCenter: notificationCenter)
             selectedItem = .collection(collectionViewModel)
         } else if savedItem.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {

--- a/PocketKit/Sources/SharedPocketKit/CurrentFeatureFlags.swift
+++ b/PocketKit/Sources/SharedPocketKit/CurrentFeatureFlags.swift
@@ -10,7 +10,6 @@ public enum CurrentFeatureFlags: String, CaseIterable {
     case profileSampling = "perm.ios.sentry.profile"
     case reportIssue = "perm.ios.report_issue"
     case disableReader = "perm.ios.disable_reader"
-    case nativeCollections = "perm.ios.native_collections"
     case disableOnlineListen = "perm.ios.listen.disableOnline"
     case premiumSearchScopesExperiment = "EXPERIMENT_POCKET_PREMIUM_SEARCH_SCOPES"
     case bestOf20231PercentSticker = "BEST_OF_2023_1_PERCENT_STICKER"
@@ -30,8 +29,6 @@ public enum CurrentFeatureFlags: String, CaseIterable {
             return "Enable the Report an Issue feature when users encounter an error"
         case .disableReader:
             return "Disable the Reader to force use of a Web view for viewing content"
-        case .nativeCollections:
-            return "Enable native collections instead of opening collections in web view"
         case .disableOnlineListen:
             return "Disable online listen support, and fall back to offline TTS"
         case .premiumSearchScopesExperiment:

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionViewModelTests.swift
@@ -37,13 +37,6 @@ class CollectionViewModelTests: XCTestCase {
         notificationCenter = .default
 
         userDefaults = UserDefaults(suiteName: "CollectionViewModelTests")
-        featureFlags.stubIsAssigned { flag, variant in
-            if flag == .nativeCollections {
-                return true
-            }
-            XCTFail("Unknown feature flag")
-            return false
-        }
         self.collectionController = space.makeCollectionStoriesController(slug: "slug-1")
     }
 


### PR DESCRIPTION
## Goal
* This PR removes the native collections feature flag.
> [!NOTE] 
> the feature flag itself will be deleted in the future, down the road once we know that most users have migrated to the version that does not contain the check.

## Test Steps
* Make sure a collection opens in the native view
