### PR TITLE
Do not show highlights menu item in syndicated articles

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/BlockquoteComponentCell.swift
@@ -7,7 +7,18 @@ import UIKit
 class BlockquoteComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {
     var componentIndex: Int = 0
 
-    var onHighlight: ((Int, NSRange, String, String) -> Void)?
+    var onHighlight: ((Int, NSRange, String, String) -> Void)? {
+        didSet {
+            if let onHighlight {
+                textView.onHighlight = { [weak self] range, quote, text in
+                    guard let self else {
+                        return
+                    }
+                    onHighlight(componentIndex, range, quote, text)
+                }
+            }
+        }
+    }
 
     var isFullyHighlighted: Bool {
         textView.isFullyHighlighted
@@ -62,12 +73,6 @@ class BlockquoteComponentCell: UICollectionViewCell, ArticleComponentTextCell, A
             textView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             textView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
         ])
-        textView.onHighlight = { [weak self] range, quote, text in
-            guard let self else {
-                return
-            }
-            onHighlight?(componentIndex, range, quote, text)
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/CodeBlockComponentCell.swift
@@ -7,7 +7,18 @@ import UIKit
 class CodeBlockComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {
     var componentIndex: Int = 0
 
-    var onHighlight: ((Int, NSRange, String, String) -> Void)?
+    var onHighlight: ((Int, NSRange, String, String) -> Void)? {
+        didSet {
+            if let onHighlight {
+                textView.onHighlight = { [weak self] range, quote, text in
+                    guard let self else {
+                        return
+                    }
+                    onHighlight(componentIndex, range, quote, text)
+                }
+            }
+        }
+    }
 
     var isFullyHighlighted: Bool {
         textView.isFullyHighlighted
@@ -54,13 +65,6 @@ class CodeBlockComponentCell: UICollectionViewCell, ArticleComponentTextCell, Ar
             textView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             textView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor)
         ])
-
-        textView.onHighlight = { [weak self] range, quote, text in
-            guard let self else {
-                return
-            }
-            onHighlight?(componentIndex, range, quote, text)
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ImageComponentCell.swift
@@ -15,7 +15,18 @@ protocol ImageComponentCellModel {
 class ImageComponentCell: UICollectionViewCell {
     var componentIndex: Int = 0
 
-    var onHighlight: ((Int, NSRange, String, String) -> Void)?
+    var onHighlight: ((Int, NSRange, String, String) -> Void)? {
+        didSet {
+            if let onHighlight {
+                captionTextView.onHighlight = { [weak self] range, quote, text in
+                    guard let self else {
+                        return
+                    }
+                    onHighlight(componentIndex, range, quote, text)
+                }
+            }
+        }
+    }
 
     enum Constants {
         static let captionSpacing: CGFloat = 4
@@ -58,13 +69,6 @@ class ImageComponentCell: UICollectionViewCell {
             stack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             stack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
         ])
-
-        captionTextView.onHighlight = { [weak self] range, quote, text in
-            guard let self else {
-                return
-            }
-            onHighlight?(componentIndex, range, quote, text)
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/MarkdownComponentCell.swift
@@ -7,7 +7,18 @@ import UIKit
 class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, ArticleComponentTextViewDelegate {
     var componentIndex: Int = 0
 
-    var onHighlight: ((Int, NSRange, String, String) -> Void)?
+    var onHighlight: ((Int, NSRange, String, String) -> Void)? {
+        didSet {
+            if let onHighlight {
+                textView.onHighlight = { [weak self] range, quote, text in
+                    guard let self else {
+                        return
+                    }
+                    onHighlight(componentIndex, range, quote, text)
+                }
+            }
+        }
+    }
 
     var isFullyHighlighted: Bool {
         textView.isFullyHighlighted
@@ -53,13 +64,6 @@ class MarkdownComponentCell: UICollectionViewCell, ArticleComponentTextCell, Art
             // set lower priority to avoid conflict if content turns out to be blank
                 .with(priority: .defaultLow)
         ])
-
-        textView.onHighlight = { [weak self] range, quote, text in
-            guard let self else {
-                return
-            }
-            onHighlight?(componentIndex, range, quote, text)
-        }
     }
 
     var attributedContent: NSAttributedString? {

--- a/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
+++ b/PocketKit/Sources/PocketKit/Article/Highlights/ArticleComponentHighlights.swift
@@ -63,7 +63,6 @@ extension Array where Element == ArticleComponent {
 
     /// Extract highlightable components from the current array (excluding images, videos, etc)
     private var highlightableComponents: [Highlightable] {
-        // TODO: add support for image caption highlights?
         return self.compactMap { component in
             if case let .text(textComponent) = component {
                 return textComponent

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -283,12 +283,14 @@ extension ReadableViewController: UICollectionViewDataSource {
 
             return metaCell
         default:
-            let cell = presenters[indexPath.item].cell(for: indexPath, in: collectionView) { [weak self] index, range, quote, text in
+            let onHighlight = readableViewModel.shouldAllowHighlights ? { [weak self] index, range, quote, text in
                 guard let self, let viewModel = readableViewModel as? SavedItemViewModel else {
                     return
                 }
                 viewModel.saveHighlight(componentIndex: index, range: range, quote: quote, text: text)
-            }
+            } : nil
+            let cell = presenters[indexPath.item].cell(for: indexPath, in: collectionView, onHighlight: onHighlight)
+
             if let cell = cell as? ArticleComponentTextCell {
                 cell.delegate = self
             }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -414,11 +414,13 @@ extension ReadableViewController {
             var config = UICollectionLayoutListConfiguration(appearance: .plain)
             config.backgroundColor = UIColor(.ui.white1)
             config.showsSeparators = false
-            config.trailingSwipeActionsConfigurationProvider = { [unowned self] indexPath in
-                guard let actions = buildSwipeActions(at: indexPath) else {
-                    return nil
+            if readableViewModel.shouldAllowHighlights {
+                config.trailingSwipeActionsConfigurationProvider = { [unowned self] indexPath in
+                    guard let actions = buildSwipeActions(at: indexPath) else {
+                        return nil
+                    }
+                    return UISwipeActionsConfiguration(actions: actions)
                 }
-                return UISwipeActionsConfiguration(actions: actions)
             }
             let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -55,6 +55,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var shareUrl: String? { get }
     var itemSaveStatus: ItemSaveStatus { get }
     var premiumURL: String? { get }
+    var shouldAllowHighlights: Bool { get }
 
     func delete()
     /// Opens an item presented in the reader in a web view instead

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -37,6 +37,7 @@ class RecommendableItemViewModel: ReadableViewModel {
     private let user: User
     private let userDefaults: UserDefaults
     let tracker: Tracker
+    let shouldAllowHighlights = false
 
     private var savedItemCancellable: AnyCancellable?
     private var savedItemSubscriptions: Set<AnyCancellable> = []

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -49,6 +49,8 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
 
     let tracker: Tracker
 
+    let shouldAllowHighlights = true
+
     @Published private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -303,14 +303,16 @@ extension HomeViewModel {
             guard let savedItem = source.viewObject(id: objectID) as? SavedItem else {
                 return
             }
-
             select(savedItem: savedItem, at: indexPath)
         case .recommendationHero(let objectID), .recommendationCarousel(let objectID):
             guard let recommendation = source.viewObject(id: objectID) as? Recommendation else {
                 return
             }
-
-            select(recommendation: recommendation, at: indexPath)
+            if let savedItem = recommendation.item.savedItem {
+                select(savedItem: savedItem, at: indexPath)
+            } else {
+                select(recommendation: recommendation, at: indexPath)
+            }
         case .sharedWithYou(let objectID):
             guard let sharedWithYouItem = source.viewObject(id: objectID) as? SharedWithYouItem else {
                 return


### PR DESCRIPTION
## Goal
* This PR
* Removes the highlight menu item on unsaved syndicated articles
* Removes the swipe to highlight feature on unsaved syndicated articles
* Also fixes a bug where, if a syndicated article was saved, it did not allow highlights

## Test Steps
* Test highlights on saves and syndicated from home and make sure they work as expected

