### PR TITLE
Fixes: crash and localized collection

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -139,9 +139,9 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
     }
 
     lazy var dismissReason: Binding<DismissReason> = {
-        .init(get: {
+        .init(get: { @MainActor in
             self._dismissReason
-        }, set: { reason in
+        }, set: { @MainActor reason in
             self._dismissReason = reason
         })
     }()

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -197,12 +197,17 @@ class HomeViewModel: NSObject {
 
     /// Fetch the latest data from core data and get the NSFetechedResults Controllers subscribing to updates
     func fetch() {
-        do {
-            try recentSavesController.performFetch()
-            try recomendationsController.performFetch()
-            try sharedWithYouController.performFetch()
-        } catch {
-            Log.capture(error: error)
+        // NOTE: despite HomeViewModel runs on MainActor, this call ends up on a different thread
+        // when the app is backgrounded, thus we force it back to the main queue to avoid crashes
+        // since these fetched result controller are created on viewContext
+        DispatchQueue.main.async { [unowned self] in
+            do {
+                try recentSavesController.performFetch()
+                try recomendationsController.performFetch()
+                try sharedWithYouController.performFetch()
+            } catch {
+                Log.capture(error: error)
+            }
         }
     }
 

--- a/PocketKit/Sources/Sync/Collection/CollectionUrlFormatter.swift
+++ b/PocketKit/Sources/Sync/Collection/CollectionUrlFormatter.swift
@@ -5,23 +5,36 @@
 import Foundation
 
 /// A formatter for collection URLs
+/// valid formats are
+/// https://getpocket.com/collections/[slug] (unlocalized)
+/// https://getpocket.com/[locale]/collections/[slug] (localized)
 public struct CollectionUrlFormatter {
     static let scheme = "https"
     static let host = "getpocket.com"
     static let collectionComponent = "collections"
     static let collectionComponentIndex = 1
+    static let localizedCollectionComponentIndex = 2
     static let slugComponentIndex = 2
-    static let pathComponentsCount = 3
+    static let localizedSlugComponentIndex = 3
+    static let minPathComponentsCount = 3
 
     public init() {}
 
-    public static func collectionUrl(_ urlString: String) -> URL? {
+    private static func collectionUrl(_ urlString: String, collectionIndex: Int) -> URL? {
         guard let url = URL(string: urlString), url.host == Self.host,
-              url.pathComponents.count >= Self.pathComponentsCount,
-              url.pathComponents[safe: Self.collectionComponentIndex] == Self.collectionComponent else {
+              url.pathComponents.count >= Self.minPathComponentsCount,
+              url.pathComponents[safe: collectionIndex] == Self.collectionComponent else {
             return nil
         }
         return url
+    }
+
+    private static func unlocalizedCollectionUrl(_ urlString: String) -> URL? {
+        collectionUrl(urlString, collectionIndex: Self.collectionComponentIndex)
+    }
+
+    private static func localizedCollectionUrl(_ urlString: String) -> URL? {
+        collectionUrl(urlString, collectionIndex: Self.localizedCollectionComponentIndex)
     }
 
     public static func collectionUrlString(_ slug: String) -> String {
@@ -35,13 +48,19 @@ public struct CollectionUrlFormatter {
     }
 
     public static func isCollectionUrl(_ urlString: String) -> Bool {
-        collectionUrl(urlString) != nil
+        unlocalizedCollectionUrl(urlString) ?? localizedCollectionUrl(urlString) != nil
     }
 
+    /// Extracts the slug from a collection url, if the passed string maps to a valid collection url
+    /// - Parameter urlString: the url string
+    /// - Returns: the slug or nil
     public static func slug(from urlString: String) -> String? {
-        guard let url = collectionUrl(urlString) else {
-            return nil
+        if let url = unlocalizedCollectionUrl(urlString) {
+            return url.pathComponents[safe: Self.slugComponentIndex]
         }
-        return url.pathComponents[safe: Self.slugComponentIndex]
+        if let url = localizedCollectionUrl(urlString) {
+            return url.pathComponents[safe: Self.localizedSlugComponentIndex]
+        }
+        return nil
     }
 }

--- a/PocketKit/Tests/PocketKitTests/Collections/CollectionUrlFormatterTests.swift
+++ b/PocketKit/Tests/PocketKitTests/Collections/CollectionUrlFormatterTests.swift
@@ -23,12 +23,6 @@ class CollectionUrlFormatterTests: XCTestCase {
         return Self.wrongUrlStrings[index]
     }
 
-    func testCorrectUrlStringReturnsUrl() {
-        let url = CollectionUrlFormatter.collectionUrl(Self.correctUrlString)
-        XCTAssertNotNil(url)
-        XCTAssertEqual(Self.correctUrlString, url?.absoluteString)
-    }
-
     func testCorrectUrlStringIsRecognized() {
         XCTAssertTrue(CollectionUrlFormatter.isCollectionUrl(Self.correctUrlString))
     }
@@ -37,10 +31,6 @@ class CollectionUrlFormatterTests: XCTestCase {
         let slug = CollectionUrlFormatter.slug(from: Self.correctUrlString)
         XCTAssertNotNil(slug)
         XCTAssertEqual(slug, "slug-1")
-    }
-
-    func testWrongUrlStringReturnsNilUrl() {
-        XCTAssertNil(CollectionUrlFormatter.collectionUrl(Self.pickAWrongString()))
     }
 
     func testWrongUrlStringIsRecognized() {


### PR DESCRIPTION
## Goal
* This PR attempts to fix a background crash reported in Sentry, and adds support for localized collections

## Test Steps
* make sure localized collections open in the native view
* Background the app, enable/disable the internet connection and make sure there are no crashes

## Issues
POCKET-10334
POCKET-10335