### PR TITLE
Fix NSInternalInconsistency Exception errors

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -185,7 +185,8 @@ class ReadableViewController: UIViewController {
 
     private func scrollToLastKnownPosition() {
         guard let userProgress = readableViewModel.readingProgress(),
-        userProgress.item < collectionView.numberOfItems(inSection: userProgress.section) else {
+              userProgress.section < collectionView.numberOfSections,
+              userProgress.item < collectionView.numberOfItems(inSection: userProgress.section) else {
             return
         }
 

--- a/PocketKit/Sources/PocketKit/Home/GridSectionProvider.swift
+++ b/PocketKit/Sources/PocketKit/Home/GridSectionProvider.swift
@@ -145,6 +145,9 @@ final class GridSectionLayoutProvider {
     ///   - margin: margin for the section layout
     /// - Returns: section layout
     private func createSectionFromGroup(with components: (CGFloat, [NSCollectionLayoutItem]), and margin: CGFloat) -> NSCollectionLayoutSection {
+        guard !components.1.isEmpty else {
+            return .empty()
+        }
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: .init(
                 widthDimension: .fractionalWidth(1),

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -48,15 +48,15 @@ class HomeViewController: UIViewController {
     private lazy var layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
         guard let self else {
             Log.breadcrumb(category: "home", level: .debug, message: "Returning a nil section. Reason: HomeViewController is nil.")
-            return nil
+            return .empty()
         }
         guard let dataSource = self.dataSource else {
             Log.breadcrumb(category: "home", level: .debug, message: "Returning a nil section. Reason: datasource is nil.")
-            return nil
+            return .empty()
         }
         guard let section = dataSource.sectionIdentifier(for: sectionIndex) else {
             Log.breadcrumb(category: "home", level: .debug, message: "Returning a nil section. Reason: sectionIdentifier for \(sectionIndex) is nil.")
-            return nil
+            return .empty()
         }
 
         switch section {

--- a/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
+++ b/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
@@ -5,6 +5,8 @@
 import UIKit
 
 extension NSCollectionLayoutSection {
+    /// Provides an empty section fof collection view compositional layout
+    /// - Returns: the empty section
     static func empty() -> NSCollectionLayoutSection {
         return NSCollectionLayoutSection(
             group: NSCollectionLayoutGroup.vertical(

--- a/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
+++ b/PocketKit/Sources/PocketKit/NSCollectionLayoutSection+empty.swift
@@ -9,14 +9,14 @@ extension NSCollectionLayoutSection {
         return NSCollectionLayoutSection(
             group: NSCollectionLayoutGroup.vertical(
                 layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .fractionalHeight(1)
+                    widthDimension: .fractionalWidth(0),
+                    heightDimension: .fractionalHeight(0)
                 ),
                 subitems: [
                     NSCollectionLayoutItem(
                         layoutSize: NSCollectionLayoutSize(
-                            widthDimension: .fractionalWidth(1),
-                            heightDimension: .fractionalHeight(1)
+                            widthDimension: .fractionalWidth(0),
+                            heightDimension: .fractionalHeight(0)
                         )
                     )
                 ]


### PR DESCRIPTION
## Goal
* This PR attempts to tackle a few `NSInternalInconsistencyException` errors seen in the app: these are all related to invalid section creation or indexing in a `UICollectionView` that uses compositional layout.

## Test Steps
* Build/run
* Smoke test the app
* Install it on a real device and make sure no background crashes occur

