### PR TITLE
Fix listen not working from home

### DIFF
--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -7,11 +7,12 @@ import Combine
 import Analytics
 import Sync
 import Textile
+import PKTListen
 
 class ReadableHostViewController: UIViewController {
     private let moreButtonItem: UIBarButtonItem
     private var subscriptions: [AnyCancellable] = []
-    private var readableViewModel: ReadableViewModel
+    private let readableViewModel: ReadableViewModel
 
     private lazy var archiveButton: UIBarButtonItem = {
         let archiveNavButton = UIBarButtonItem(
@@ -57,6 +58,10 @@ class ReadableHostViewController: UIViewController {
         )
 
         super.init(nibName: nil, bundle: nil)
+
+        if let savedItemViewModel = readableViewModel as? SavedItemViewModel {
+            savedItemViewModel.delegate = self
+        }
 
         title = nil
         navigationItem.largeTitleDisplayMode = .never
@@ -201,5 +206,18 @@ class ReadableHostViewController: UIViewController {
 
     var popoverAnchor: UIBarButtonItem? {
         navigationItem.rightBarButtonItems?[0]
+    }
+}
+
+// MARK: Listen article
+extension ReadableHostViewController: ReadableViewModelDelegate {
+    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen configuration: ListenConfiguration) {
+        showListen(configuration)
+    }
+
+    private func showListen(_ configuration: ListenConfiguration) {
+        let listen =  PKTListenContainerViewController(configuration: configuration.toAppConfiguration())
+        listen.title = configuration.title
+        self.present(listen, animated: true)
     }
 }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -353,8 +353,6 @@ extension SavesContainerViewController {
             return
         }
 
-        readable.delegate = self
-
         readable.$presentedAlert.sink { [weak self] alert in
             self?.present(alert: alert)
         }.store(in: &readableSubscriptions)
@@ -634,22 +632,15 @@ extension SavesContainerViewController: SFSafariViewControllerDelegate {
     }
 }
 
-extension SavesContainerViewController {
+// MARK: Listen filter list
+extension SavesContainerViewController: ItemsListViewModelDelegate {
+    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen configuration: ListenConfiguration) {
+        showListen(configuration)
+    }
+
     private func showListen(_ configuration: ListenConfiguration) {
         let listen =  PKTListenContainerViewController(configuration: configuration.toAppConfiguration())
         listen.title = configuration.title
         self.present(listen, animated: true)
-    }
-}
-
-extension SavesContainerViewController: ReadableViewModelDelegate {
-    func viewModel(_ readableViewModel: ReadableViewModel, didRequestListen configuration: ListenConfiguration) {
-        showListen(configuration)
-    }
-}
-
-extension SavesContainerViewController: ItemsListViewModelDelegate {
-    func viewModel(_ itemsListViewModel: any ItemsListViewModel, didRequestListen configuration: ListenConfiguration) {
-        showListen(configuration)
     }
 }


### PR DESCRIPTION
## Goal
* Fix a bug where listen was not working when opening a recent saves item from home. This was because the listen presenting logic was baked into `SavesContainerViewController`. We could have added the same logic to `HomeViewController`, but a better solution was to move it to `ReadableHostViewController`, so that Listen would work regardless where we decide to present the saved article from.

## Test Steps
* Build/run
* Open an article from Home/Recent Saves
* Make sure listen works
* Also test listen from Saves and from Saves list, and make sure it still works as expected.
