### PR TITLE
Improve tip presentation on saves

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -154,7 +154,8 @@ class ReadableViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         scrollToLastKnownPosition()
-        if #available(iOS 17.0, *) {
+        // do not vend the tip on syndicated articles
+        if #available(iOS 17.0, *), readableViewModel is SavedItemViewModel {
             PocketTipEvents.showSwipeHighlightsTip.sendDonation()
             displayTip(SwipeHighlightsTip(), configuration: nil, sourceView: nil)
         }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -73,7 +73,8 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if #available(iOS 17.0, *) {
+        // do not vend the tip if there are no items to swipe
+        if #available(iOS 17.0, *), model.emptyState == nil {
             PocketTipEvents.showSwipeArchiveTip.sendDonation()
             displayTip(SwipeArchiveTip(), configuration: nil, sourceView: nil)
         }


### PR DESCRIPTION
## Goal
* On saves list, do not show the tip if the list is empty
* In the reader, only show the tip when reading a saved item

## Issues
POCKET-10399
POCKET-10400