### PR TITLE
Add Home, Saves, Settings, Listen and Premium Status deep links

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "5421f94cc859eb65f5ae3866165a053aa634431e",
-        "version" : "8.32.0"
+        "revision" : "f8d9bc344a052a26f51c8cecec93724b871ef36b",
+        "version" : "8.33.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SvenTiigi/YouTubePlayerKit.git",
       "state" : {
-        "revision" : "5ade0dfbabaf7456069b4e8f604de261bf6d7c67",
-        "version" : "1.8.0"
+        "revision" : "fe1c1ec340f6d79866131432ecaa190fd6bbc4cb",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -56,6 +56,7 @@ protocol ReadableViewModel: ReadableViewControllerDelegate {
     var itemSaveStatus: ItemSaveStatus { get }
     var premiumURL: String? { get }
     var shouldAllowHighlights: Bool { get }
+    var shouldOpenListenOnAppear: Bool { get }
 
     func delete()
     /// Opens an item presented in the reader in a web view instead

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -38,6 +38,7 @@ class RecommendableItemViewModel: ReadableViewModel {
     private let userDefaults: UserDefaults
     let tracker: Tracker
     let shouldAllowHighlights = false
+    let shouldOpenListenOnAppear: Bool = false
 
     private var savedItemCancellable: AnyCancellable?
     private var savedItemSubscriptions: Set<AnyCancellable> = []

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/SavedItemViewModel.swift
@@ -51,6 +51,8 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
 
     let shouldAllowHighlights = true
 
+    let shouldOpenListenOnAppear: Bool
+
     @Published private(set) var _actions: [ItemAction] = []
     var actions: Published<[ItemAction]>.Publisher { $_actions }
 
@@ -107,7 +109,8 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
         userDefaults: UserDefaults,
         notificationCenter: NotificationCenter,
         readableSource: ReadableSource = .app,
-        featureFlagService: FeatureFlagServiceProtocol
+        featureFlagService: FeatureFlagServiceProtocol,
+        shouldOpenListenOnAppear: Bool = false
     ) {
         self.item = item
         self.source = source
@@ -120,6 +123,7 @@ class SavedItemViewModel: ReadableViewModel, ObservableObject {
         self.notificationCenter = notificationCenter
         self.readableSource = readableSource
         self.featureFlagService = featureFlagService
+        self.shouldOpenListenOnAppear = shouldOpenListenOnAppear
 
         item.publisher(for: \.isFavorite).sink { [weak self] _ in
             self?.buildActions()

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -508,7 +508,7 @@ extension HomeViewModel {
         }
     }
 
-    func select(savedItem: SavedItem, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app) {
+    func select(savedItem: SavedItem, at indexPath: IndexPath? = nil, readableSource: ReadableSource = .app, shouldOpenListenOnAppear: Bool = false) {
         if let slug = savedItem.item?.collection?.slug ?? savedItem.item?.collectionSlug {
             selectedReadableType = .collection(CollectionViewModel(
                 slug: slug,
@@ -534,7 +534,8 @@ extension HomeViewModel {
                 userDefaults: userDefaults,
                 notificationCenter: notificationCenter,
                 readableSource: readableSource,
-                featureFlagService: featureFlags
+                featureFlagService: featureFlags,
+                shouldOpenListenOnAppear: shouldOpenListenOnAppear
             )
 
             if let item = savedItem.item, item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -100,6 +100,11 @@ class ReadableHostViewController: UIViewController {
         }.store(in: &subscriptions)
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        lockOrientation(.allButUpsideDown)
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // This view is hosted in SwitUI and it seems that hidesBottomBarWhenPushed is not resepected,
@@ -107,14 +112,16 @@ class ReadableHostViewController: UIViewController {
         self.tabBarController?.tabBar.isHidden = true
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if let viewModel = readableViewModel as? SavedItemViewModel, viewModel.isListenSupported, viewModel.shouldOpenListenOnAppear {
+            listen()
+        }
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        lockOrientation(.allButUpsideDown)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -363,20 +363,18 @@ extension MainViewModel {
 
         let navigationAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
             self?.account.dismissAll()
-            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
-                switch components.path {
-                case "/home":
-                    self?.selectedSection = .home
-                case "/saves":
-                    self?.selectedSection = .saves
-                case "/settings":
-                    self?.selectedSection = .account
-                case "/premium/manage":
-                    self?.selectedSection = .account
-                    self?.account.isPresentingPremiumStatus = true
-                default:
-                    break
-                }
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+                return
+            }
+            if components.path.contains("/home") {
+                self?.selectedSection = .home
+            } else if components.path.contains("/saves") {
+                self?.selectedSection = .saves
+            } else if components.path.contains("/settings") {
+                self?.selectedSection = .account
+            } else if components.path.contains("/premium/manage") {
+                self?.selectedSection = .account
+                self?.account.isPresentingPremiumStatus = true
             }
         }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -361,6 +361,49 @@ extension MainViewModel {
             self?.account.isPresentingIconSwitcher = true
         }
 
+        let navigationAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
+            self?.account.dismissAll()
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+                switch components.path {
+                case "/home":
+                    self?.selectedSection = .home
+                case "/saves":
+                    self?.selectedSection = .saves
+                case "/settings":
+                    self?.selectedSection = .account
+                case "/premium/manage":
+                    self?.selectedSection = .account
+                    self?.account.isPresentingPremiumStatus = true
+                default:
+                    break
+                }
+            }
+        }
+
+        let listenAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
+            self?.account.dismissAll()
+            self?.selectedSection = .home
+            Task {
+                do {
+                    if let item = try await self?.source.fetchViewItem(from: url.absoluteString) {
+                        if let savedItem = item.savedItem {
+                            // if the saved item is found, open it and attempt to start listening
+                            self?.home.select(savedItem: savedItem, readableSource: source, shouldOpenListenOnAppear: true)
+                            // otherwise, we can still fall back to the usual actions
+                        } else if let recommendation = item.recommendation {
+                            self?.home.select(recommendation: recommendation, readableSource: source)
+                        } else {
+                            self?.home.select(externalItem: item)
+                        }
+                    } else {
+                        fallbackAction(url)
+                    }
+                } catch {
+                    fallbackAction(url)
+                }
+            }
+        }
+
         let widgetRoute = WidgetRoute(action: routingAction)
         let collectionRoute = CollectionRoute(action: routingAction)
         let syndicatedRoute = SyndicationRoute(action: routingAction)
@@ -370,18 +413,31 @@ extension MainViewModel {
         let pocketShareRoute = PocketShareRoute(action: pocketShareUrlRoutingAction)
         let pocketReadRoute = PocketReadRoute(action: pocketReadUrlRoutingAction)
         let brazeIconSwitcherRoute = BrazeIconSwitcherRoute(action: brazeShowIconSwitcherAction)
+        let homeRoute = HomeRoute(action: navigationAction)
+        let savesRoute = SavesRoute(action: navigationAction)
+        let settingsRoute = SettingsRoute(action: navigationAction)
+        let managePremiumRoute = ManagePremiumRoute(action: navigationAction)
+        let listenRoute = ListenRoute(action: listenAction)
         // NOTE: order matters, because there might be overlapping patterns
         // we can probably optimize by having exclusive-patterns only routes, and handle additional logic within
         // the route itself
         linkRouter.addRoutes(
             [
+                // specialized routes
                 widgetRoute,
+                spotlightRoute,
+                // getpocket.com/[path] routes
                 collectionRoute,
                 syndicatedRoute,
-                genericItemRoute,
-                spotlightRoute,
-                pocketShareRoute,
                 pocketReadRoute,
+                listenRoute,
+                homeRoute,
+                savesRoute,
+                settingsRoute,
+                managePremiumRoute,
+                genericItemRoute,
+                // pocket.co/[path] routes
+                pocketShareRoute,
                 brazeIconSwitcherRoute,
                 shortUrlRoute
             ]

--- a/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
@@ -13,6 +13,72 @@ protocol Route {
     func matchedUrlString(from url: URL) -> String?
 }
 
+// MARK: Url utilities
+private extension URLComponents {
+    /// Remove the `utm_source` component from url components, if it exists
+    var removedUtmSource: URLComponents {
+        var normalizedComponents = self
+        // remove utm_source and other external query items to obtain the item url
+        let updatedQueryItems = normalizedComponents.queryItems?.filter {
+            $0.name != "utm_source"
+        }
+        normalizedComponents.queryItems = updatedQueryItems
+        return normalizedComponents
+    }
+}
+
+private extension URL {
+    /// Look for a match between the passed url with the passed host and scheme, and extract
+    /// the origin url from from the query item named `url`. This is commonly used for special
+    /// urls like widgets and Spotlight, but also some standard urls that contain a different origin.
+    /// - Parameters:
+    ///   - host: the host to match
+    ///   - scheme: the scheme to match
+    /// - Returns: the absolute string of the matched url found, or nil
+    func origin(host: String?, scheme: String?, path: String) -> String? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+              components.host == host,
+              components.scheme == scheme,
+              components.path == path else {
+            return nil
+        }
+        return components.queryItems?.first(where: { $0.name == "url" })?.value
+    }
+    /// Look for a match between the passed url with the passed host, scheme and path.
+    /// The returned value is the url absolute string minus the `utm_source` query item.
+    /// This is done to match the format of stored `Item` urls.
+    /// - Parameters:
+    ///   - host: the host to match
+    ///   - scheme: the scheme to match
+    ///   - path: the path to match
+    /// - Returns: the absolute string of the matched url, if it's found.
+    func matched(host: String?, scheme: String?, path: String) -> String? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+              components.host == host,
+              components.scheme == scheme,
+              components.path.contains(path) else {
+            return nil
+        }
+        return components.removedUtmSource.url?.absoluteString
+    }
+
+    /// Look for a match between the passed url with the passed host and scheme.
+    /// The returned value is the url absolute string minus the `utm_source` query item.
+    /// This is done to match the format of stored `Item` urls.
+    /// - Parameters:
+    ///   - host: the host to match
+    ///   - scheme: the scheme to match
+    /// - Returns: the absolute string of the matched url, if it's found.
+    func matched(host: String?, scheme: String?) -> String? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+              components.host == host,
+              components.scheme == scheme else {
+            return nil
+        }
+        return components.removedUtmSource.url?.absoluteString
+    }
+}
+
 @MainActor
 struct SpotlightRoute: Route {
     let host: String? = nil
@@ -26,12 +92,7 @@ struct SpotlightRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.scheme == scheme,
-              components.path == path else {
-            return nil
-        }
-        return components.queryItems?.first(where: { $0.name == "url" })?.value
+        url.origin(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -48,13 +109,7 @@ struct WidgetRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path == path else {
-            return nil
-        }
-        return components.queryItems?.first(where: { $0.name == "url" })?.value
+        url.origin(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -71,19 +126,7 @@ struct CollectionRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path.contains(path) else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -100,19 +143,7 @@ struct SyndicationRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path.contains(path) else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -129,18 +160,7 @@ struct GenericItemRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme)
     }
 }
 
@@ -157,18 +177,7 @@ struct ShortUrlRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme)
     }
 }
 
@@ -185,19 +194,7 @@ struct PocketShareRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path.contains(path) else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -214,19 +211,7 @@ struct PocketReadRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path.contains(path) else {
-            return nil
-        }
-        var normalizedComponents = components
-        // remove utm_source and other external query items to obtain the item url
-        let updatedQueryItems = normalizedComponents.queryItems?.filter {
-            $0.name != "utm_source"
-        }
-        normalizedComponents.queryItems = updatedQueryItems
-        return normalizedComponents.url?.absoluteString
+        url.matched(host: host, scheme: scheme, path: path)
     }
 }
 
@@ -243,12 +228,91 @@ struct BrazeIconSwitcherRoute: Route {
     }
 
     nonisolated func matchedUrlString(from url: URL) -> String? {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              components.host == host,
-              components.scheme == scheme,
-              components.path.contains(path) else {
-            return nil
-        }
-        return url.absoluteString
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct ListenRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme: String = "https"
+    let path: String = "/listen"
+    let source: ReadableSource = .external
+    var action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.origin(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct HomeRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme: String = "https"
+    let path: String = "/home"
+    let source: ReadableSource = .external
+    var action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct SavesRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme: String = "https"
+    let path: String = "/saves"
+    let source: ReadableSource = .external
+    var action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct SettingsRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme: String = "https"
+    let path: String = "/settings"
+    let source: ReadableSource = .external
+    var action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct ManagePremiumRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme: String = "https"
+    let path: String = "/premium/manage"
+    let source: ReadableSource = .external
+    var action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
     }
 }


### PR DESCRIPTION
## Goal
Expand deep link capabilities by adding the following links
* https://getpocket.com/home : takes to Home
* https://getpocket.com/saves: takes to Saves
* https://getpocket.com/settings: takes to Settings
* https://getpocket.com/premium/manage: opens the premium status modal.
* https://getpocket.com/listen?url=[article_url]: checks that the item is saved and supports listen, and open the listen modal, otherwise opens the item if it exists, or goes to Safari as fallback action
This PR also updates some dependencies.

> [!NOTE]
> this PR works in conjunction with the related PR on dotcom (look for the same issue in that repo)

## Test Steps
* build the above links, send them (e.g via iMessage) to an iPhone that has this branch installed and verify they work as described. 

