### PR TITLE
Search Saves via Siri or App Shortcuts

### DIFF
--- a/Pocket Intents/Localizable.xcstrings
+++ b/Pocket Intents/Localizable.xcstrings
@@ -1,15 +1,203 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Find saved articles related to ${criteria}" : {
-
-    },
-    "intents.searchSaves.criteria.title" : {
+    "intents.searchSaves.criteria.summary" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kriterien, die von der Pocket-Suchfunktion verwendet werden."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Search Criteria"
+            "value" : "Criteria used by Pocket's search functionality."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterios utilizados por la función de búsqueda de Pocket."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterios utilizados por la función de búsqueda de Pocket."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critères utilisés par la fonctionnalité de recherche de Pocket."
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critères utilisés par la fonctionnalité de recherche de Pocket."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criteri utilizzati dalla funzione di ricerca di Pocket."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket の検索機能で使用される条件。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket 검색 기능에서 사용되는 기준."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criteria gebruikt door de zoekfunctie van Pocket."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kryteria używane przez funkcję wyszukiwania w Pocket."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critérios usados pela funcionalidade de pesquisa do Pocket."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critérios usados pela funcionalidade de pesquisa do Pocket."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Критерии, используемые функцией поиска Pocket."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket 搜索功能使用的条件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket 搜尋功能使用的條件。"
+          }
+        }
+      }
+    },
+    "intents.searchSaves.criteria.title" : {
+      "comment" : "Title of the search criteria parameter",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suchkriterien"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search criteria"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterios de búsqueda"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterios de búsqueda"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critères de recherche"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critères de recherche"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criteri di ricerca"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索条件"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 기준"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoekcriteria"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kryteria wyszukiwania"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critérios de pesquisa"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Critérios de pesquisa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Критерии поиска"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索条件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索條件"
           }
         }
       }
@@ -18,10 +206,100 @@
       "comment" : "Description for the search saves intent",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche nach Inhalten in deinen Pocket-Speicherungen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Search something in your Pocket saves"
+            "value" : "Search for content within your Pocket saves."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar contenido en tus guardados de Pocket."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar contenido en tus guardados de Pocket."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher du contenu dans vos enregistrements Pocket."
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher du contenu dans vos sauvegardes Pocket."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca fra gli articoli salvati in Pocket"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket に保存したコンテンツを検索。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket에 저장된 콘텐츠 검색."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoek naar inhoud in je Pocket-opslag."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukaj treści w swoich zapisach w Pocket."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar conteúdo nas suas salvagens do Pocket."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar conteúdo nas suas gravações do Pocket."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск контента в ваших сохранениях Pocket."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Pocket 保存内容中搜索。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Pocket 保存的內容中搜尋。"
           }
         }
       }
@@ -29,10 +307,100 @@
     "intents.searchSaves.title" : {
       "comment" : "Title for the search saves intent",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche in Pocket"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Search Pocket"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en Pocket"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en Pocket"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans Pocket"
+          }
+        },
+        "fr-CA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans Pocket"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca in Pocket"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket を検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pocket 검색"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoek in Pocket"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukaj w Pocket"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar no Pocket"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar no Pocket"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск в Pocket"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索 Pocket"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋 Pocket"
           }
         }
       }

--- a/Pocket Intents/Localizable.xcstrings
+++ b/Pocket Intents/Localizable.xcstrings
@@ -1,0 +1,42 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Find saved articles related to ${criteria}" : {
+
+    },
+    "intents.searchSaves.criteria.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search Criteria"
+          }
+        }
+      }
+    },
+    "intents.searchSaves.description" : {
+      "comment" : "Description for the search saves intent",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search something in your Pocket saves"
+          }
+        }
+      }
+    },
+    "intents.searchSaves.title" : {
+      "comment" : "Title for the search saves intent",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search Pocket"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Pocket Intents/PocketShortcuts.swift
+++ b/Pocket Intents/PocketShortcuts.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import AppIntents
+
+class PocketShortcuts: AppShortcutsProvider {
+    static var shortcutTitleColor = ShortcutTileColor.orange
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SearchSavesIntent(),
+            phrases: [
+                "Find articles about \(\.$criteria) in \(.applicationName)",
+                "Search for \(\.$criteria) in \(.applicationName)"
+            ],
+            shortTitle: "Pocket Saves",
+            systemImageName: "bookmark.fill"
+        )
+    }
+}

--- a/Pocket Intents/PocketShortcuts.swift
+++ b/Pocket Intents/PocketShortcuts.swift
@@ -12,14 +12,10 @@ class PocketShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: SearchSavesIntent(),
             phrases: [
-                "Find articles about \(\.$criteria) in \(.applicationName)",
-                "Search for \(\.$criteria) in \(.applicationName)",
-                "Search \(.applicationName) for \(\.$criteria)",
-                "Go to \(.applicationName) and search Saves",
-                "Go to \(.applicationName) and search for \(\.$criteria)",
-                "Find me some cool stuff in \(.applicationName)"
+                "Find me some cool stuff in \(.applicationName)",
+                "Search \(.applicationName)"
             ],
-            shortTitle: "Pocket Saves",
+            shortTitle: "intents.searchSaves.title",
             systemImageName: "bookmark.fill"
         )
     }

--- a/Pocket Intents/PocketShortcuts.swift
+++ b/Pocket Intents/PocketShortcuts.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import AppIntents
+import Localization
 
 class PocketShortcuts: AppShortcutsProvider {
     static var shortcutTitleColor = ShortcutTileColor.orange
@@ -12,7 +13,7 @@ class PocketShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: SearchSavesIntent(),
             phrases: [
-                "Find me some cool stuff in \(.applicationName)",
+                "Show me some cool stuff in \(.applicationName)",
                 "Search \(.applicationName)"
             ],
             shortTitle: "intents.searchSaves.title",

--- a/Pocket Intents/PocketShortcuts.swift
+++ b/Pocket Intents/PocketShortcuts.swift
@@ -13,7 +13,11 @@ class PocketShortcuts: AppShortcutsProvider {
             intent: SearchSavesIntent(),
             phrases: [
                 "Find articles about \(\.$criteria) in \(.applicationName)",
-                "Search for \(\.$criteria) in \(.applicationName)"
+                "Search for \(\.$criteria) in \(.applicationName)",
+                "Search \(.applicationName) for \(\.$criteria)",
+                "Go to \(.applicationName) and search Saves",
+                "Go to \(.applicationName) and search for \(\.$criteria)",
+                "Find me some cool stuff in \(.applicationName)"
             ],
             shortTitle: "Pocket Saves",
             systemImageName: "bookmark.fill"

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -5,14 +5,16 @@
 import Foundation
 import AppIntents
 import Localization
-@preconcurrency import PocketKit
+import PocketKit
 
+/// Intent that enables search Pocket Saves via Siri or App Shortcuts
 struct SearchSavesIntent: AppIntent {
     static var title: LocalizedStringResource = "intents.searchSaves.title"
     static var description = IntentDescription("intents.searchSaves.description")
     static var openAppWhenRun: Bool = true
 
     @Dependency private var mainViewModel: MainViewModel?
+    @Dependency private var savesContainerViewModel: SavesContainerViewModel
     @Dependency private var defaultSeatch: DefaultSearchViewModel
 
     @Parameter(title: "intents.searchSaves.criteria.title")
@@ -26,6 +28,8 @@ struct SearchSavesIntent: AppIntent {
     func perform() async throws -> some IntentResult {
         guard let mainViewModel else { return .result() }
         mainViewModel.selectSavesTabForIntent()
+        // for now we only support saves.
+        savesContainerViewModel.selection = .saves
         defaultSeatch.searchIntentCriteria = criteria
         return .result()
     }

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import AppIntents
+@preconcurrency import PocketKit
+
+struct SearchSavesIntent: AppIntent {
+    static var title: LocalizedStringResource = "Search for Articles"
+    static var description = IntentDescription("Search for saved articles in Pocket.")
+    static var openAppWhenRun: Bool = true
+
+    @Dependency private var mainViewModel: MainViewModel?
+    @Dependency private var defaultSeatch: DefaultSearchViewModel
+
+    @Parameter var criteria: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Find articles related to \(\.$criteria)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        guard let mainViewModel else { return .result() }
+        mainViewModel.selectSavesTab()
+        defaultSeatch.searchText = criteria
+        defaultSeatch.updateSearchResults(with: criteria)
+        return .result()
+    }
+}

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -7,14 +7,15 @@ import AppIntents
 @preconcurrency import PocketKit
 
 struct SearchSavesIntent: AppIntent {
-    static var title: LocalizedStringResource = "Search for Articles"
+    static var title: LocalizedStringResource = "Search Pocket"
     static var description = IntentDescription("Search for saved articles in Pocket.")
     static var openAppWhenRun: Bool = true
 
     @Dependency private var mainViewModel: MainViewModel?
     @Dependency private var defaultSeatch: DefaultSearchViewModel
 
-    @Parameter var criteria: String
+    @Parameter(title: "Cool stuff about")
+    var criteria: String
 
     static var parameterSummary: some ParameterSummary {
         Summary("Find articles related to \(\.$criteria)")
@@ -25,7 +26,6 @@ struct SearchSavesIntent: AppIntent {
         guard let mainViewModel else { return .result() }
         mainViewModel.selectSavesTab()
         defaultSeatch.searchText = criteria
-        defaultSeatch.updateSearchResults(with: criteria)
         return .result()
     }
 }

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -7,18 +7,18 @@ import AppIntents
 @preconcurrency import PocketKit
 
 struct SearchSavesIntent: AppIntent {
-    static var title: LocalizedStringResource = "Search Pocket"
-    static var description = IntentDescription("Search for saved articles in Pocket.")
+    static var title: LocalizedStringResource = "intents.searchSaves.title"
+    static var description = IntentDescription("intents.searchSaves.description")
     static var openAppWhenRun: Bool = true
 
     @Dependency private var mainViewModel: MainViewModel?
     @Dependency private var defaultSeatch: DefaultSearchViewModel
 
-    @Parameter(title: "Cool stuff about")
+    @Parameter(title: "intents.searchSaves.criteria.title")
     var criteria: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Find articles related to \(\.$criteria)")
+        Summary("Find saved articles related to \(\.$criteria)")
     }
 
     @MainActor

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import AppIntents
+import Localization
 @preconcurrency import PocketKit
 
 struct SearchSavesIntent: AppIntent {
@@ -18,14 +19,14 @@ struct SearchSavesIntent: AppIntent {
     var criteria: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Find saved articles related to \(\.$criteria)")
+        Summary("intents.searchSaves.criteria.summary")
     }
 
     @MainActor
     func perform() async throws -> some IntentResult {
         guard let mainViewModel else { return .result() }
-        mainViewModel.selectSavesTab()
-        defaultSeatch.searchText = criteria
+        mainViewModel.selectSavesTabForIntent()
+        defaultSeatch.searchIntentCriteria = criteria
         return .result()
     }
 }

--- a/Pocket Intents/SearchSavesIntent.swift
+++ b/Pocket Intents/SearchSavesIntent.swift
@@ -16,7 +16,8 @@ struct SearchSavesIntent: AppIntent {
     @Dependency private var mainViewModel: MainViewModel?
     @Dependency private var savesContainerViewModel: SavesContainerViewModel
     @Dependency private var defaultSeatch: DefaultSearchViewModel
-
+    // this simple intent triggers the search in Pocket and uses
+    // just a String as a parameter, not an AppEntity
     @Parameter(title: "intents.searchSaves.criteria.title")
     var criteria: String
 

--- a/Pocket Intents/de.lproj/AppShortcuts.strings
+++ b/Pocket Intents/de.lproj/AppShortcuts.strings
@@ -1,0 +1,3 @@
+"Show me some cool stuff in ${applicationName}" = "Zeig mir coole Sachen in ${applicationName}";
+"Search ${applicationName}" = "Suche in ${applicationName}";
+

--- a/Pocket Intents/en.lproj/AppShortcuts.strings
+++ b/Pocket Intents/en.lproj/AppShortcuts.strings
@@ -1,7 +1,2 @@
-/* 
-  AppShortcuts.strings
-  Pocket
-
-  Created by Giorgio Ruscigno on 8/29/24.
-  
-*/
+"Show me some cool stuff in ${applicationName}" = "Show me some cool stuff in ${applicationName}";
+"Search ${applicationName}" = "Search ${applicationName}";

--- a/Pocket Intents/en.lproj/AppShortcuts.strings
+++ b/Pocket Intents/en.lproj/AppShortcuts.strings
@@ -1,0 +1,7 @@
+/* 
+  AppShortcuts.strings
+  Pocket
+
+  Created by Giorgio Ruscigno on 8/29/24.
+  
+*/

--- a/Pocket Intents/es-419.lproj/AppShortcuts.strings
+++ b/Pocket Intents/es-419.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Muéstrame cosas geniales en ${applicationName}";
+"Search ${applicationName}" = "Buscar en ${applicationName}";

--- a/Pocket Intents/es.lproj/AppShortcuts.strings
+++ b/Pocket Intents/es.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Muéstrame cosas interesantes en ${applicationName}";
+"Search ${applicationName}" = "Buscar en ${applicationName}";

--- a/Pocket Intents/fr-CA.lproj/AppShortcuts.strings
+++ b/Pocket Intents/fr-CA.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Montre-moi des affaires cool dans ${applicationName}";
+"Search ${applicationName}" = "Rechercher dans ${applicationName}";

--- a/Pocket Intents/fr.lproj/AppShortcuts.strings
+++ b/Pocket Intents/fr.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Montre-moi des trucs sympas dans ${applicationName}";
+"Search ${applicationName}" = "Rechercher dans ${applicationName}";

--- a/Pocket Intents/it.lproj/AppShortcuts.strings
+++ b/Pocket Intents/it.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Mostrami articoli interessanti in ${applicationName}";
+"Search ${applicationName}" = "Cerca in ${applicationName}";

--- a/Pocket Intents/ja.lproj/AppShortcuts.strings
+++ b/Pocket Intents/ja.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "${applicationName} の中で面白いものを見せて。";
+"Search ${applicationName}" = "${applicationName} を検索";

--- a/Pocket Intents/ko.lproj/AppShortcuts.strings
+++ b/Pocket Intents/ko.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "${applicationName}에서 멋진 것들을 보여줘.";
+"Search ${applicationName}" = "${applicationName} 검색";

--- a/Pocket Intents/nl.lproj/AppShortcuts.strings
+++ b/Pocket Intents/nl.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Laat me wat coole dingen zien in ${applicationName}";
+"Search ${applicationName}" = "Zoek in ${applicationName}";

--- a/Pocket Intents/pl.lproj/AppShortcuts.strings
+++ b/Pocket Intents/pl.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Pokaż mi coś fajnego w ${applicationName}";
+"Search ${applicationName}" = "Wyszukaj w ${applicationName}";

--- a/Pocket Intents/pt-BR.lproj/AppShortcuts.strings
+++ b/Pocket Intents/pt-BR.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Mostre-me coisas legais no ${applicationName}";
+"Search ${applicationName}" = "Pesquisar no ${applicationName}";

--- a/Pocket Intents/pt-PT.lproj/AppShortcuts.strings
+++ b/Pocket Intents/pt-PT.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Mostre-me coisas fixes no ${applicationName}";
+"Search ${applicationName}" = "Pesquisar no ${applicationName}";

--- a/Pocket Intents/ru.lproj/AppShortcuts.strings
+++ b/Pocket Intents/ru.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "Покажи мне что-нибудь интересное в ${applicationName}";
+"Search ${applicationName}" = "Поиск в ${applicationName}";

--- a/Pocket Intents/zh-Hans.lproj/AppShortcuts.strings
+++ b/Pocket Intents/zh-Hans.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "给我看看 ${applicationName} 里的一些很酷的东西。";
+"Search ${applicationName}" = "搜索 ${applicationName}";

--- a/Pocket Intents/zh-Hant.lproj/AppShortcuts.strings
+++ b/Pocket Intents/zh-Hant.lproj/AppShortcuts.strings
@@ -1,0 +1,2 @@
+"Show me some cool stuff in ${applicationName}" = "給我看看 ${applicationName} 裡一些很酷的東西。";
+"Search ${applicationName}" = "搜尋 ${applicationName}";

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
 		AAB4F3A62BBCA6140047A003 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A52BBCA6140047A003 /* BrazeNotificationService */; };
 		AAB4F3A82BBCA6140047A003 /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A72BBCA6140047A003 /* BrazePushStory */; };
+		AABD1F812C73073500797EAB /* PocketShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD1F802C73073500797EAB /* PocketShortcuts.swift */; };
+		AABD1F852C7309AD00797EAB /* SearchSavesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD1F842C7309AD00797EAB /* SearchSavesIntent.swift */; };
 		AADE043C2C64380300F9BD9F /* AnonymousModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */; };
 		AAEE908229B69BA70028587D /* PremiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908129B69BA70028587D /* PremiumTests.swift */; };
 		AAEE908429B69E9F0028587D /* PremiumUpgradeViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */; };
@@ -347,6 +349,8 @@
 		AA8BADEB2BC88C64004F1959 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
+		AABD1F802C73073500797EAB /* PocketShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketShortcuts.swift; sourceTree = "<group>"; };
+		AABD1F842C7309AD00797EAB /* SearchSavesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSavesIntent.swift; sourceTree = "<group>"; };
 		AAC9F5AA2B0BDBF800FD614A /* UITests-4.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-4.xctestplan"; sourceTree = "<group>"; };
 		AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousModeTests.swift; sourceTree = "<group>"; };
 		AAE33A7F2A0ED5A600214652 /* ItemWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItemWidgets.entitlements; sourceTree = "<group>"; };
@@ -945,7 +949,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1500;
+				LastSwiftUpdateCheck = 1610;
 				LastUpgradeCheck = 1530;
 				TargetAttributes = {
 					166A81AF2637406C0015AA1D = {
@@ -1133,6 +1137,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				16BA7D6326851513009A17C1 /* PocketApp.swift in Sources */,
+				AABD1F852C7309AD00797EAB /* SearchSavesIntent.swift in Sources */,
+				AABD1F812C73073500797EAB /* PocketShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1368,6 +1374,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -1428,6 +1435,7 @@
 				MTL_FAST_MATH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
@@ -1447,7 +1455,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1479,7 +1487,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1866,6 +1874,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				POCKET_API_BASE_URL = "https://api.getpocket.com/graphql";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug_Tests;
@@ -1885,7 +1894,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		AA41DD8D2BD04DD6003CEDBF /* TopicRecommendationsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA41DD792BD04D09003CEDBF /* TopicRecommendationsWidget.swift */; };
 		AA41DD8F2BD04EC9003CEDBF /* Textile in Frameworks */ = {isa = PBXBuildFile; productRef = AA41DD8E2BD04EC9003CEDBF /* Textile */; };
 		AA41DD912BD04EF0003CEDBF /* Sync in Frameworks */ = {isa = PBXBuildFile; productRef = AA41DD902BD04EF0003CEDBF /* Sync */; };
+		AA561B912C740F10006DF948 /* PocketShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA561B8E2C740F10006DF948 /* PocketShortcuts.swift */; };
+		AA561B922C740F10006DF948 /* SearchSavesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA561B8F2C740F10006DF948 /* SearchSavesIntent.swift */; };
 		AA69A28429B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69A28329B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift */; };
 		AA7D6A2B2995F0A20094FD18 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */; };
 		AA8BADE42BC88A5D004F1959 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA8BADE32BC88A5D004F1959 /* PrivacyInfo.xcprivacy */; };
@@ -125,8 +127,6 @@
 		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
 		AAB4F3A62BBCA6140047A003 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A52BBCA6140047A003 /* BrazeNotificationService */; };
 		AAB4F3A82BBCA6140047A003 /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A72BBCA6140047A003 /* BrazePushStory */; };
-		AABD1F812C73073500797EAB /* PocketShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD1F802C73073500797EAB /* PocketShortcuts.swift */; };
-		AABD1F852C7309AD00797EAB /* SearchSavesIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD1F842C7309AD00797EAB /* SearchSavesIntent.swift */; };
 		AADE043C2C64380300F9BD9F /* AnonymousModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */; };
 		AAEE908229B69BA70028587D /* PremiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908129B69BA70028587D /* PremiumTests.swift */; };
 		AAEE908429B69E9F0028587D /* PremiumUpgradeViewElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEE908329B69E9F0028587D /* PremiumUpgradeViewElement.swift */; };
@@ -340,6 +340,8 @@
 		AA41DD772BD04D09003CEDBF /* RecentSavesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSavesWidget.swift; sourceTree = "<group>"; };
 		AA41DD782BD04D09003CEDBF /* RecommendationsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationsWidget.swift; sourceTree = "<group>"; };
 		AA41DD792BD04D09003CEDBF /* TopicRecommendationsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicRecommendationsWidget.swift; sourceTree = "<group>"; };
+		AA561B8E2C740F10006DF948 /* PocketShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketShortcuts.swift; sourceTree = "<group>"; };
+		AA561B8F2C740F10006DF948 /* SearchSavesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSavesIntent.swift; sourceTree = "<group>"; };
 		AA69A28329B7FC6E00BBA644 /* SearchGetPremiumEmptyViewElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchGetPremiumEmptyViewElement.swift; sourceTree = "<group>"; };
 		AA7D6A2A2995F0A20094FD18 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		AA8BADE32BC88A5D004F1959 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -349,8 +351,6 @@
 		AA8BADEB2BC88C64004F1959 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
-		AABD1F802C73073500797EAB /* PocketShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketShortcuts.swift; sourceTree = "<group>"; };
-		AABD1F842C7309AD00797EAB /* SearchSavesIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSavesIntent.swift; sourceTree = "<group>"; };
 		AAC9F5AA2B0BDBF800FD614A /* UITests-4.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-4.xctestplan"; sourceTree = "<group>"; };
 		AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousModeTests.swift; sourceTree = "<group>"; };
 		AAE33A7F2A0ED5A600214652 /* ItemWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItemWidgets.entitlements; sourceTree = "<group>"; };
@@ -485,6 +485,7 @@
 				650D169B28FFA54B00EE9339 /* Dangerfile.swift */,
 				650D169A28FFA42800EE9339 /* Package.swift */,
 				650D169728FFA40B00EE9339 /* Sources */,
+				AA561B902C740F10006DF948 /* Pocket Intents */,
 				9367E9D62A05AF070052DF47 /* Launch Screen */,
 				16973354263CBB290003DE2A /* Config */,
 				166A81C32637406C0015AA1D /* Tests iOS */,
@@ -752,6 +753,15 @@
 				AA41DD7A2BD04D09003CEDBF /* Widgets */,
 			);
 			path = ItemWidgetsKit;
+			sourceTree = "<group>";
+		};
+		AA561B902C740F10006DF948 /* Pocket Intents */ = {
+			isa = PBXGroup;
+			children = (
+				AA561B8E2C740F10006DF948 /* PocketShortcuts.swift */,
+				AA561B8F2C740F10006DF948 /* SearchSavesIntent.swift */,
+			);
+			path = "Pocket Intents";
 			sourceTree = "<group>";
 		};
 		F204A76127E22EC50010E155 /* SaveToPocket */ = {
@@ -1137,8 +1147,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				16BA7D6326851513009A17C1 /* PocketApp.swift in Sources */,
-				AABD1F852C7309AD00797EAB /* SearchSavesIntent.swift in Sources */,
-				AABD1F812C73073500797EAB /* PocketShortcuts.swift in Sources */,
+				AA561B912C740F10006DF948 /* PocketShortcuts.swift in Sources */,
+				AA561B922C740F10006DF948 /* SearchSavesIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1455,7 +1465,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1487,7 +1497,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1894,7 +1904,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		AA8BADEC2BC88C64004F1959 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA8BADEB2BC88C64004F1959 /* PrivacyInfo.xcprivacy */; };
 		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
 		AA9FE0802C7FB3590081B7A3 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */; };
+		AAA2C2E32C80D62200F044F8 /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = AAA2C2E12C80D62200F044F8 /* AppShortcuts.strings */; };
 		AAB4F3A62BBCA6140047A003 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A52BBCA6140047A003 /* BrazeNotificationService */; };
 		AAB4F3A82BBCA6140047A003 /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A72BBCA6140047A003 /* BrazePushStory */; };
 		AADE043C2C64380300F9BD9F /* AnonymousModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */; };
@@ -353,6 +354,22 @@
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
 		AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		AAA2C2E22C80D62200F044F8 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2F32C80D98900F044F8 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
+		AAA2C2F42C80D98E00F044F8 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
+		AAA2C2F52C80D99100F044F8 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2F62C80D99300F044F8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2F72C80D99600F044F8 /* fr-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-CA"; path = "fr-CA.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
+		AAA2C2F82C80D99900F044F8 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2F92C80D99C00F044F8 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2FA2C80D99F00F044F8 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2FB2C80D9A200F044F8 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2FC2C80D9A500F044F8 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C2FD2C80D9A900F044F8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
+		AAA2C2FE2C80D9AC00F044F8 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
+		AAA2C2FF2C80D9B000F044F8 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C3002C80D9B400F044F8 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
+		AAA2C3012C80D9B700F044F8 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
 		AAC9F5AA2B0BDBF800FD614A /* UITests-4.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-4.xctestplan"; sourceTree = "<group>"; };
 		AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousModeTests.swift; sourceTree = "<group>"; };
 		AAE33A7F2A0ED5A600214652 /* ItemWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItemWidgets.entitlements; sourceTree = "<group>"; };
@@ -763,6 +780,7 @@
 				AA561B8E2C740F10006DF948 /* PocketShortcuts.swift */,
 				AA561B8F2C740F10006DF948 /* SearchSavesIntent.swift */,
 				AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */,
+				AAA2C2E12C80D62200F044F8 /* AppShortcuts.strings */,
 			);
 			path = "Pocket Intents";
 			sourceTree = "<group>";
@@ -1043,6 +1061,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				65D3105229CEACF100952D64 /* PKTListenResources.bundle in Resources */,
+				AAA2C2E32C80D62200F044F8 /* AppShortcuts.strings in Resources */,
 				16E32B0226851AEB000CC36D /* Assets.xcassets in Resources */,
 				AA9FE0802C7FB3590081B7A3 /* Localizable.xcstrings in Resources */,
 				938D45322A05B87D00E68B0B /* Launch Screen.storyboard in Resources */,
@@ -1323,6 +1342,32 @@
 			targetProxy = AA2E890E2A0D8849004A27BD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		AAA2C2E12C80D62200F044F8 /* AppShortcuts.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AAA2C2E22C80D62200F044F8 /* en */,
+				AAA2C2F32C80D98900F044F8 /* zh-Hans */,
+				AAA2C2F42C80D98E00F044F8 /* zh-Hant */,
+				AAA2C2F52C80D99100F044F8 /* nl */,
+				AAA2C2F62C80D99300F044F8 /* fr */,
+				AAA2C2F72C80D99600F044F8 /* fr-CA */,
+				AAA2C2F82C80D99900F044F8 /* de */,
+				AAA2C2F92C80D99C00F044F8 /* it */,
+				AAA2C2FA2C80D99F00F044F8 /* ja */,
+				AAA2C2FB2C80D9A200F044F8 /* ko */,
+				AAA2C2FC2C80D9A500F044F8 /* pl */,
+				AAA2C2FD2C80D9A900F044F8 /* pt-BR */,
+				AAA2C2FE2C80D9AC00F044F8 /* pt-PT */,
+				AAA2C2FF2C80D9B000F044F8 /* ru */,
+				AAA2C3002C80D9B400F044F8 /* es */,
+				AAA2C3012C80D9B700F044F8 /* es-419 */,
+			);
+			name = AppShortcuts.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		166A81D82637406C0015AA1D /* Debug */ = {

--- a/Pocket.xcodeproj/project.pbxproj
+++ b/Pocket.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		AA8BADEA2BC88C4B004F1959 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA8BADE92BC88C4B004F1959 /* PrivacyInfo.xcprivacy */; };
 		AA8BADEC2BC88C64004F1959 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA8BADEB2BC88C64004F1959 /* PrivacyInfo.xcprivacy */; };
 		AA9DB97429B6E6480046AEF6 /* Test_Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */; };
+		AA9FE0802C7FB3590081B7A3 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */; };
 		AAB4F3A62BBCA6140047A003 /* BrazeNotificationService in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A52BBCA6140047A003 /* BrazeNotificationService */; };
 		AAB4F3A82BBCA6140047A003 /* BrazePushStory in Frameworks */ = {isa = PBXBuildFile; productRef = AAB4F3A72BBCA6140047A003 /* BrazePushStory */; };
 		AADE043C2C64380300F9BD9F /* AnonymousModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */; };
@@ -351,6 +352,7 @@
 		AA8BADEB2BC88C64004F1959 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA909AC8299EFD3A00F90FA7 /* secrets_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets_test.xcconfig; sourceTree = "<group>"; };
 		AA909ACC299F4D5400F90FA7 /* Test_Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Test_Subscriptions.storekit; sourceTree = "<group>"; };
+		AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		AAC9F5AA2B0BDBF800FD614A /* UITests-4.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "UITests-4.xctestplan"; sourceTree = "<group>"; };
 		AADE043B2C64380300F9BD9F /* AnonymousModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousModeTests.swift; sourceTree = "<group>"; };
 		AAE33A7F2A0ED5A600214652 /* ItemWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ItemWidgets.entitlements; sourceTree = "<group>"; };
@@ -760,6 +762,7 @@
 			children = (
 				AA561B8E2C740F10006DF948 /* PocketShortcuts.swift */,
 				AA561B8F2C740F10006DF948 /* SearchSavesIntent.swift */,
+				AA9FE07F2C7FB3590081B7A3 /* Localizable.xcstrings */,
 			);
 			path = "Pocket Intents";
 			sourceTree = "<group>";
@@ -1041,6 +1044,7 @@
 			files = (
 				65D3105229CEACF100952D64 /* PKTListenResources.bundle in Resources */,
 				16E32B0226851AEB000CC36D /* Assets.xcassets in Resources */,
+				AA9FE0802C7FB3590081B7A3 /* Localizable.xcstrings in Resources */,
 				938D45322A05B87D00E68B0B /* Launch Screen.storyboard in Resources */,
 				AA8BADE42BC88A5D004F1959 /* PrivacyInfo.xcprivacy in Resources */,
 				9367E9E82A05B6A10052DF47 /* Launch Screen.xcassets in Resources */,

--- a/PocketApp.swift
+++ b/PocketApp.swift
@@ -17,6 +17,9 @@ struct PocketApp: App {
     var body: some Scene {
         WindowGroup {
             RootView(model: rootViewModel)
+                .onAppear {
+                    PocketShortcuts.updateAppShortcutParameters()
+                }
         }.onChange(of: scenePhase) { newValue in
             rootViewModel.scenePhaseDidChange(newValue)
         }

--- a/PocketKit/Sources/Analytics/AppEvents/PocketIntents.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/PocketIntents.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Events triggered by Pocket Intents used for app shortcuts, Siri and Apple Intelligence
+public extension Events {
+    struct PocketIntents {}
+}
+
+public extension Events.PocketIntents {
+    /// The search saves intent was triggered
+    static func searchSavesIntentCalled(_ criteria: String) -> Engagement {
+        Engagement(uiEntity: UiEntity(.screen, identifier: "intents.searchSaves", value: criteria))
+    }
+}

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -212,7 +212,7 @@ public class MainViewModel: ObservableObject {
         saves.clearPresentedWebReaderURL()
     }
 
-    public func selectSavesTab() {
+    public func selectSavesTabForIntent() {
         self.selectedSection = .saves
     }
 

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -50,46 +50,48 @@ public class MainViewModel: ObservableObject {
                 networkPathMonitor: NWPathMonitor()
             )
         }
+        let savesContainerViewModel = SavesContainerViewModel(
+            tracker: Services.shared.tracker,
+            searchList: defaultSearch,
+            savedItemsList: SavedItemsListViewModel(
+                source: Services.shared.source,
+                tracker: Services.shared.tracker.childTracker(hosting: .saves.saves),
+                viewType: .saves,
+                listOptions: .saved(userDefaults: Services.shared.userDefaults),
+                notificationCenter: .default,
+                user: Services.shared.user,
+                store: Services.shared.subscriptionStore,
+                refreshCoordinator: Services.shared.savesRefreshCoordinator,
+                networkPathMonitor: NWPathMonitor(),
+                userDefaults: Services.shared.userDefaults,
+                featureFlags: Services.shared.featureFlagService,
+                accessService: Services.shared.accessService
+            ),
+            archivedItemsList: SavedItemsListViewModel(
+                source: Services.shared.source,
+                tracker: Services.shared.tracker.childTracker(hosting: .saves.archive),
+                viewType: .archive,
+                listOptions: .archived(userDefaults: Services.shared.userDefaults),
+                notificationCenter: .default,
+                user: Services.shared.user,
+                store: Services.shared.subscriptionStore,
+                refreshCoordinator: Services.shared.archiveRefreshCoordinator,
+                networkPathMonitor: NWPathMonitor(),
+                userDefaults: Services.shared.userDefaults,
+                featureFlags: Services.shared.featureFlagService,
+                accessService: Services.shared.accessService
+            ),
+            addSavedItemModel: AddSavedItemViewModel(
+                source: Services.shared.source,
+                tracker: Services.shared.tracker.childTracker(hosting: .saves.saves)
+            ),
+            accessService: Services.shared.accessService
+        )
+        AppDependencyManager.shared.add(dependency: savesContainerViewModel)
         AppDependencyManager.shared.add(dependency: defaultSearch)
         self.init(
             defaultSearch: defaultSearch,
-            saves: SavesContainerViewModel(
-                tracker: Services.shared.tracker,
-                searchList: defaultSearch,
-                savedItemsList: SavedItemsListViewModel(
-                    source: Services.shared.source,
-                    tracker: Services.shared.tracker.childTracker(hosting: .saves.saves),
-                    viewType: .saves,
-                    listOptions: .saved(userDefaults: Services.shared.userDefaults),
-                    notificationCenter: .default,
-                    user: Services.shared.user,
-                    store: Services.shared.subscriptionStore,
-                    refreshCoordinator: Services.shared.savesRefreshCoordinator,
-                    networkPathMonitor: NWPathMonitor(),
-                    userDefaults: Services.shared.userDefaults,
-                    featureFlags: Services.shared.featureFlagService,
-                    accessService: Services.shared.accessService
-                ),
-                archivedItemsList: SavedItemsListViewModel(
-                    source: Services.shared.source,
-                    tracker: Services.shared.tracker.childTracker(hosting: .saves.archive),
-                    viewType: .archive,
-                    listOptions: .archived(userDefaults: Services.shared.userDefaults),
-                    notificationCenter: .default,
-                    user: Services.shared.user,
-                    store: Services.shared.subscriptionStore,
-                    refreshCoordinator: Services.shared.archiveRefreshCoordinator,
-                    networkPathMonitor: NWPathMonitor(),
-                    userDefaults: Services.shared.userDefaults,
-                    featureFlags: Services.shared.featureFlagService,
-                    accessService: Services.shared.accessService
-                ),
-                addSavedItemModel: AddSavedItemViewModel(
-                    source: Services.shared.source,
-                    tracker: Services.shared.tracker.childTracker(hosting: .saves.saves)
-                ),
-                accessService: Services.shared.accessService
-            ),
+            saves: savesContainerViewModel,
             home: HomeViewModel(
                 source: Services.shared.source,
                 tracker: Services.shared.tracker.childTracker(hosting: .home.screen),

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -181,16 +181,23 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate, UISea
         navigationItem.preferredSearchBarPlacement = .stacked
         navigationItem.searchController?.showsSearchResultsController = true
 
-        searchViewModel.$searchText.dropFirst().sink { searchText in
-            self.updateSearchBar(searchText: searchText)
-        }.store(in: &subscriptions)
+        searchViewModel
+            .$searchText
+            .receive(on: DispatchQueue.main)
+            .sink { searchText in
+                self.updateSearchBar(searchText: searchText)
+            }
+            .store(in: &subscriptions)
     }
 
     func updateSearchBar(searchText: String) {
-        let searchBar = navigationItem.searchController?.searchBar
-        searchBar?.becomeFirstResponder()
-        searchBar?.text = searchText
-        searchBar?.resignFirstResponder()
+        guard let searchBar = navigationItem.searchController?.searchBar,
+              !searchText.isEmpty else {
+            return
+        }
+        searchBar.becomeFirstResponder()
+        searchBar.text = searchText
+        searchBar.resignFirstResponder()
     }
 
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -59,7 +59,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate, UISea
         }
     }
 
-    var isFromSaves: Bool
+    private var isFromSaves: Bool
 
     private let viewControllers: [SelectableViewController]
     private var searchViewModel: DefaultSearchViewModel

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -188,6 +188,7 @@ class SavesContainerViewController: UIViewController, UISearchBarDelegate, UISea
 
     func updateSearchBar(searchText: String) {
         let searchBar = navigationItem.searchController?.searchBar
+        searchBar?.becomeFirstResponder()
         searchBar?.text = searchText
         searchBar?.resignFirstResponder()
     }

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewModel.swift
@@ -9,13 +9,13 @@ import SharedPocketKit
 import Analytics
 
 @MainActor
-class SavesContainerViewModel {
-    enum Selection {
+public class SavesContainerViewModel {
+    public enum Selection {
         case saves
         case archive
     }
 
-    @Published var selection: Selection = .saves
+    @Published public var selection: Selection = .saves
 
     let tracker: Tracker
     let searchList: DefaultSearchViewModel

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -191,6 +191,7 @@ public class DefaultSearchViewModel: ObservableObject {
                 guard let self else { return }
                 if let criteria, !criteria.isEmpty {
                     searchText = criteria
+                    tracker.track(event: Events.PocketIntents.searchSavesIntentCalled(criteria))
                 }
             }
             .store(in: &subscriptions)

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -35,6 +35,7 @@ protocol SearchResultActionDelegate: AnyObject {
 }
 
 /// View model that holds business logic for the SearchView
+@MainActor
 public class DefaultSearchViewModel: ObservableObject {
     static let recentSearchesKey = UserDefaults.Key.recentSearches
     // search-specific subscriptions, get cleared at each search
@@ -71,7 +72,7 @@ public class DefaultSearchViewModel: ObservableObject {
     }
 
     private(set) var scopeTitles: [String] = SearchScope.defaultScopes.map { $0.rawValue }
-    var selectedScope: SearchScope = .saves
+    private var selectedScope: SearchScope = .saves
 
     @Published var showBanner: Bool = false
     @Published var isPresentingPremiumUpgrade = false

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -35,7 +35,7 @@ protocol SearchResultActionDelegate: AnyObject {
 }
 
 /// View model that holds business logic for the SearchView
-class DefaultSearchViewModel: ObservableObject {
+public class DefaultSearchViewModel: ObservableObject {
     static let recentSearchesKey = UserDefaults.Key.recentSearches
 
     private var subscriptions: [AnyCancellable] = []
@@ -79,7 +79,7 @@ class DefaultSearchViewModel: ObservableObject {
     @Published var isPresentingReportIssue = false
     @Published var searchState: SearchViewState?
     @Published var selectedItem: SelectedItem?
-    @Published var searchText = "" {
+    @Published public var searchText = "" {
         didSet {
             updateSearchResults(with: searchText)
         }
@@ -202,7 +202,7 @@ class DefaultSearchViewModel: ObservableObject {
 
     /// Handles logic for when a user enters a search, such as showing Get Premium for user in All Items, checking if user is Offline or submitting a search
     /// - Parameter searchTerm: the term the user enters in search bar
-    func updateSearchResults(with searchTerm: String) {
+    public func updateSearchResults(with searchTerm: String) {
         let shouldShowUpsell = !isPremium && selectedScope == .all
 
         guard !shouldShowUpsell else {
@@ -680,7 +680,7 @@ extension DefaultSearchViewModel {
 }
 
 extension DefaultSearchViewModel: SavedItemsControllerDelegate {
-    func controller(
+    public func controller(
         _ controller: SavedItemsController,
         didChange savedItem: SavedItem,
         at indexPath: IndexPath?,
@@ -690,7 +690,7 @@ extension DefaultSearchViewModel: SavedItemsControllerDelegate {
         // no-op
     }
 
-    func controller(_ controller: SavedItemsController, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+    public func controller(_ controller: SavedItemsController, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
         guard case .searchResults(let items) = searchState, let savedItems = items.map({ $0.item }) as? [SavedItem] else {
             return
         }

--- a/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SearchItemsList/SearchViewModel.swift
@@ -37,8 +37,10 @@ protocol SearchResultActionDelegate: AnyObject {
 /// View model that holds business logic for the SearchView
 public class DefaultSearchViewModel: ObservableObject {
     static let recentSearchesKey = UserDefaults.Key.recentSearches
-
-    private var subscriptions: [AnyCancellable] = []
+    // search-specific subscriptions, get cleared at each search
+    private var searchSubscriptions = Set<AnyCancellable>()
+    // all other subscriptions
+    private var subscriptions = Set<AnyCancellable>()
     private let networkPathMonitor: NetworkPathMonitor
     private var lastPathStatus: NWPath.Status?
     private let user: User
@@ -55,8 +57,6 @@ public class DefaultSearchViewModel: ObservableObject {
     private var archiveOnlineSearch: OnlineSearch
     private var allOnlineSearch: OnlineSearch
     private var premiumOnlineSearch: PremiumOnlineSearch
-    // separated from the subscriptions array as that one gets cleared between searches
-    private var userStatusListener: AnyCancellable?
 
     private let tracker: Tracker
     private let itemsController: SavedItemsController
@@ -79,11 +79,8 @@ public class DefaultSearchViewModel: ObservableObject {
     @Published var isPresentingReportIssue = false
     @Published var searchState: SearchViewState?
     @Published var selectedItem: SelectedItem?
-    @Published public var searchText = "" {
-        didSet {
-            updateSearchResults(with: searchText)
-        }
-    }
+    @Published var searchText = ""
+    @Published public var searchIntentCriteria: String?
 
     /// Create the banner details to populate the view
     var bannerData: BannerModifier.BannerData {
@@ -163,9 +160,13 @@ public class DefaultSearchViewModel: ObservableObject {
 
         networkPathMonitor.start(queue: .global())
         observeNetworkChanges()
+        setupPublishersSubscriptions()
+    }
+
+    private func setupPublishersSubscriptions() {
         // Listen for user status changes and update the UI accordingly.
         // Drop the first occurrence that happens when user is initialized.
-        userStatusListener = user
+        user
             .statusPublisher
             .dropFirst()
             .receive(on: DispatchQueue.main)
@@ -175,6 +176,24 @@ public class DefaultSearchViewModel: ObservableObject {
                 }
                 self?.searchState = self?.defaultState
             }
+            .store(in: &subscriptions)
+        // listen for search intent criteria, and trigger the action
+        // only when the app becomes active. This ensures the search
+        // controller can become active and show the search results.
+        Publishers
+            .Zip(
+                $searchIntentCriteria,
+                NotificationCenter.default.publisher(
+                    for: UIApplication.didBecomeActiveNotification
+                )
+            )
+            .sink { [weak self] criteria, _ in
+                guard let self else { return }
+                if let criteria, !criteria.isEmpty {
+                    searchText = criteria
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     /// Updates the scope titles based on whether the user is enrolled in the premium search scopes experiment.
@@ -234,7 +253,7 @@ public class DefaultSearchViewModel: ObservableObject {
         currentSearchTerm = nil
 
         showBanner = false
-        subscriptions = []
+        searchSubscriptions.removeAll()
 
         savesLocalSearch = LocalSavesSearch(source: source)
         savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
@@ -246,7 +265,7 @@ public class DefaultSearchViewModel: ObservableObject {
     /// Resets the search objects if it does not have a cache before each search
     private func resetSearch(with term: String) {
         showBanner = false
-        subscriptions = []
+        searchSubscriptions.removeAll()
 
         if !savesOnlineSearch.hasCache(with: term) {
             savesOnlineSearch = OnlineSearch(source: source, scope: .saves)
@@ -350,7 +369,7 @@ public class DefaultSearchViewModel: ObservableObject {
                     self.showBanner = self.isPremium
                 }
             }
-            .store(in: &subscriptions)
+            .store(in: &searchSubscriptions)
     }
 
     /// Submit online search and update `searchState` with proper view
@@ -377,7 +396,7 @@ public class DefaultSearchViewModel: ObservableObject {
                     self.searchState = .emptyState(OfflineEmptyState(type: scope))
                 }
             }
-            .store(in: &subscriptions)
+            .store(in: &searchSubscriptions)
     }
 
     /// Submit premium experiment search and update `searchState` with proper view
@@ -401,7 +420,7 @@ public class DefaultSearchViewModel: ObservableObject {
                     self.searchState = .emptyState(OfflineEmptyState(type: scope))
                 }
             }
-            .store(in: &subscriptions)
+            .store(in: &searchSubscriptions)
     }
 
     /// Updates recent searches after user submits a search up to 5 terms


### PR DESCRIPTION
## Goal
* This PR adds an app Intent for Searching articles in your Saves list

> [!NOTE]
> As of now, the search is intentionally limited to `Saves` (not `Archive` nor `All`)

## Test Steps
* Build/run this branch
* Add the "Search Pocket" app shortcut to your shortcut, then run it or
* Tell Siri "Search Pocket" or "Show me some cool stuff in Pocket"
* Input the search criteria (via text or voice) and make sure the search triggers in Pocket and displays results accordingly

## Issue(s)
POCKET-10508

## Video
<div align="center">
  <video src="https://github.com/user-attachments/assets/8c6d0ea0-984f-4d61-b12d-03c408f63863"/>
</div>


