### PR TITLE
Edit/Add tags improvements

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "d2ced2d961b34573ebd2ea0567a2f1408e90f0ae",
-        "version" : "8.34.0"
+        "revision" : "e2ac1723a4a9632e291c171b6e25a0c403b0fecb",
+        "version" : "8.35.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-objc-tracker",
       "state" : {
-        "revision" : "20b1fea9c58334e569cb63d71875d3c2d0243483",
-        "version" : "6.0.7"
+        "revision" : "bf1495987d63dc3595270df1a1bb516bfef8585f",
+        "version" : "6.0.8"
       }
     },
     {

--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -95,6 +95,7 @@ class PocketAddTagsViewModel: AddTagsViewModel {
 
     /// Saves tags to an item
     func saveTags() {
+        addNewTag(with: newTagInput)
         trackSaveTagsToItem()
         source.replaceTags(item, tags: tags)
         saveAction()

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -68,6 +68,7 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
 
     /// Saves tags to an item
     func saveTags() {
+        addNewTag(with: newTagInput)
         trackSaveTagsToItem()
         saveAction(tags)
         recentTagsFactory.updateRecentTags(with: originalTagNames, and: tags)

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsView.swift
@@ -2,9 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import Localization
 import SwiftUI
-import UIKit
-import Combine
 import Textile
 
 public struct AddTagsView<ViewModel>: View where ViewModel: AddTagsViewModel {
@@ -48,17 +47,17 @@ public struct AddTagsView<ViewModel>: View where ViewModel: AddTagsViewModel {
                         .focused($isTextFieldFocused)
                         .accessibilityIdentifier("enter-tag-name")
                 }
-                .navigationTitle("Add Tags")
+                .navigationTitle(viewModel.tags.isEmpty ? Localization.addTags : Localization.ItemAction.editTags)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Save", action: {
+                        Button(Localization.ItemAction.save, action: {
                             viewModel.saveTags()
                             dismiss()
                         }).accessibilityIdentifier("save-button")
                     }
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel", action: {
+                        Button(Localization.cancel, action: {
                             dismiss()
                         })
                     }

--- a/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
+++ b/PocketKit/Sources/SharedPocketKit/Tags/AddTagsViewModel.swift
@@ -38,6 +38,7 @@ public extension AddTagsViewModel {
     /// Add tag after user enters tag name in the text field
     /// - Parameter tag: tag name user input in the text field
     /// - Returns: true if tag is a valid input
+    @discardableResult
     func addNewTag(with tag: String) -> Bool {
         let tagName = validateInput(tag)
         guard !tagName.isEmpty,


### PR DESCRIPTION
## Goal
* Improve the add/edit tags experience:
    - Allow to save a tag typed in the text field without the need of hitting return before tapping "Save"
        - Applies to both the app and the save extension
    - Localize the edit tags view
    - Update the view title depending on whether or not there are existing tags. If there aren't, it'll be "Add Tags", otherwise "Edit tags"
 * This PR also bumps dependencies to the latest available

## Test Steps
* Add/edit tags and make sure the behavior matched what's described in the above section

## Screenshots

<div align="center">
  <video src="https://github.com/user-attachments/assets/25ca739a-4bd1-4ab3-ab1d-4ae0ee763042"/>
</div>
