### PR TITLE
Fix syndicated articles not opening in Reader from collections

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionViewModel.swift
@@ -362,10 +362,10 @@ extension CollectionViewModel {
                 )
             )
         // Check if item has an associated recommendation
-        } else if let item = story.item, !item.shouldOpenInWebView(override: featureFlags.shouldDisableReader), let recommendation = item.recommendation {
+        } else if let item = story.item, !item.shouldOpenInWebView(override: featureFlags.shouldDisableReader) {
             selectedItem = .recommendable(
                 RecommendableItemViewModel(
-                    item: recommendation.item,
+                    item: item,
                     source: source,
                     accessService: accessService,
                     tracker: tracker,


### PR DESCRIPTION
## Goal
* The navigation logic from native collections (which will need refactoring pretty soon) was wrong in case of syndicated articles

## Test Steps
* Open a collection with syndicated articles and make sure they open in the Reader

