### PR TITLE
Tags: renaming improvements

### DIFF
--- a/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
+++ b/PocketKit/Sources/Localization/Resources/en.lproj/Localizable.strings
@@ -199,6 +199,8 @@
 "tags.renameTag" = "Rename tag";
 "tags.renameTag.message" = "Enter a new name for this tag";
 "tags.renameTag.prompt" = "Tag name";
+"tags.renameTag.tagAlreadyInUse.title" = "Tag already in use";
+"tags.renameTag.tagAlreadyInUse.message" = "This tag is already in use, please choose a different name.";
 
 //Reader 
 "reader.activity.save" = "Save";

--- a/PocketKit/Sources/Localization/Strings.swift
+++ b/PocketKit/Sources/Localization/Strings.swift
@@ -715,6 +715,12 @@ public enum Localization {
       public static let message = Localization.tr("Localizable", "tags.renameTag.message", fallback: "Enter a new name for this tag")
       /// Tag name
       public static let prompt = Localization.tr("Localizable", "tags.renameTag.prompt", fallback: "Tag name")
+      public enum TagAlreadyInUse {
+        /// This tag is already in use, please choose a different name.
+        public static let message = Localization.tr("Localizable", "tags.renameTag.tagAlreadyInUse.message", fallback: "This tag is already in use, please choose a different name.")
+        /// Tag already in use
+        public static let title = Localization.tr("Localizable", "tags.renameTag.tagAlreadyInUse.title", fallback: "Tag already in use")
+      }
     }
     public enum Section {
       /// Recent tags

--- a/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
@@ -8,10 +8,10 @@ import Textile
 
 struct EditTagsBottomBar: ViewModifier {
     @Binding var editMode: EditMode
+    @Binding var showRenameAlert: Bool
     let selectedItems: Set<TagType>
     let onDelete: () -> Void
     let onRename: (String) -> Void
-    @State private var showRenameAlert: Bool = false
     @State private var showDeleteAlert: Bool = false
     @State private var name = ""
 
@@ -33,6 +33,7 @@ struct EditTagsBottomBar: ViewModifier {
                             onRename(name)
                             name = ""
                         })
+                        .disabled(name.isEmpty)
                     } message: {
                         Text(Localization.Tags.RenameTag.message)
                     }
@@ -61,7 +62,7 @@ struct EditTagsBottomBar: ViewModifier {
 }
 
 extension View {
-    public func editBottomBar(editMode: Binding<EditMode>, selectedItems: Set<TagType>, onDelete: @escaping () -> Void, onRename: @escaping (String) -> Void) -> some View {
-        self.modifier(EditTagsBottomBar(editMode: editMode, selectedItems: selectedItems, onDelete: onDelete, onRename: onRename))
+    public func editBottomBar(editMode: Binding<EditMode>, showRenameAlert: Binding<Bool>, selectedItems: Set<TagType>, onDelete: @escaping () -> Void, onRename: @escaping (String) -> Void) -> some View {
+        self.modifier(EditTagsBottomBar(editMode: editMode, showRenameAlert: showRenameAlert, selectedItems: selectedItems, onDelete: onDelete, onRename: onRename))
     }
 }

--- a/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TaggedFilter/EditTagsBottomBar.swift
@@ -29,11 +29,20 @@ struct EditTagsBottomBar: ViewModifier {
                         TextField(Localization.Tags.RenameTag.prompt, text: $name)
                             .autocapitalization(.none)
                         Button(Localization.cancel, role: .cancel, action: {})
-                        Button(Localization.rename, role: .destructive, action: {
-                            onRename(name)
-                            name = ""
-                        })
-                        .disabled(name.isEmpty)
+                        // Apparently, iOS17+ does not play well with the .disabled() method
+                        // so we just keep the button as it is for now on it.
+                        if #available(iOS 18.0, *) {
+                            Button(Localization.rename, role: .destructive, action: {
+                                onRename(name)
+                                name = ""
+                            })
+                            .disabled(name.isEmpty)
+                        } else {
+                            Button(Localization.rename, role: .destructive, action: {
+                                onRename(name)
+                                name = ""
+                            })
+                        }
                     } message: {
                         Text(Localization.Tags.RenameTag.message)
                     }

--- a/PocketKit/Sources/PocketKit/Tags/TaggedFilter/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TaggedFilter/TagsFilterViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import Textile
 import SharedPocketKit
 
+@MainActor
 class TagsFilterViewModel: ObservableObject {
     /// Grab the latest tags from the database on each ask for them to ensure we are up to date
     private var fetchedTags: [Tag] {

--- a/PocketKit/Sources/PocketKit/Tags/TaggedFilter/TagsFilterViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/TaggedFilter/TagsFilterViewModel.swift
@@ -29,6 +29,7 @@ class TagsFilterViewModel: ObservableObject {
     }
 
     @Published var selectedTag: TagType?
+    @Published var presentExistingTagAlert: Bool = false
 
     init(source: Source, tracker: Tracker, userDefaults: UserDefaults, user: User, selectAllAction: @escaping () -> Void?) {
         self.source = source
@@ -59,21 +60,23 @@ class TagsFilterViewModel: ObservableObject {
         }
     }
 
-    func rename(from oldName: String?, to newName: String) {
+    func rename(from oldName: String?, to newName: String) -> Bool {
         guard let oldName else {
             Log.capture(message: "Unable to rename tag due to oldName being nil")
-            return
+            return false
         }
         let newName = newName.lowercased()
 
         // TODO: To be updated when working on https://getpocket.atlassian.net/browse/IN-1350
         guard let tag: Tag = fetchedTags.filter({ $0.name == oldName }).first,
               !fetchedTags.compactMap({ $0.name }).contains(newName) else {
+            presentExistingTagAlert = true
             Log.capture(message: "Unable to rename tag due to name already existing")
-            return
+            return false
         }
         source.renameTag(from: tag, to: newName)
         trackTagRename(from: oldName, to: newName)
+        return true
     }
 }
 


### PR DESCRIPTION
## Goal
This PR
* Provides feedback to the user when they attempt to rename a tag to an existing tag name, instead of just dismissing the tag remaining alert and scrolling to the new tag name (which was not assigned)
* Prevents renaming to an empty string

## Test Steps
* Do what the "After" video does and make sure it's consistent with what you see

## Video

Before | After
-- | --
<video src=https://github.com/user-attachments/assets/6f7d43f2-b106-4398-b0b6-94a40621e844> | <video src=https://github.com/user-attachments/assets/ca72fbaf-6140-40b4-8302-89c9ff2586f7>


