### PR TITLE
Collection - fix crash when tapping on a collection story with syndicated article

### DIFF
--- a/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Collections/CollectionStoryViewModel.swift
@@ -89,7 +89,10 @@ extension CollectionStoryViewModel: ItemCellViewModel {
     }
 
     var domain: String? {
-        collectionStory.publisher
+        if let publisher = collectionStory.publisher, !publisher.isEmpty {
+            return publisher
+        }
+        return collectionStory.item?.bestDomain
     }
 
     var timeToRead: String? {

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -75,7 +75,9 @@ public extension NSMutableAttributedString {
 
     private func calculateLineHeight(for image: UIImage) -> CGFloat {
         var imageLineHeight: CGFloat = 0
-        if let font = self.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+        // we need to check if the string is empty, otherwise the attirbute(_:, _:, _:) method will
+        // throw an exception whatever is the index, causing the app to crash
+        if !self.string.isEmpty, let font = self.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
             /// See image to explain calculation here https://stackoverflow.com/questions/26105803/center-nstextattachment-image-next-to-single-line-uilabel
             imageLineHeight = (font.capHeight - image.size.height) / 2
         }

--- a/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
+++ b/PocketKit/Sources/Textile/NSAttributedString+Extensions.swift
@@ -76,7 +76,7 @@ public extension NSMutableAttributedString {
     private func calculateLineHeight(for image: UIImage) -> CGFloat {
         var imageLineHeight: CGFloat = 0
         // we need to check if the string is empty, otherwise the attirbute(_:, _:, _:) method will
-        // throw an exception whatever is the index, causing the app to crash
+        // raise an exception whatever is the index, causing the app to crash
         if !self.string.isEmpty, let font = self.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
             /// See image to explain calculation here https://stackoverflow.com/questions/26105803/center-nstextattachment-image-next-to-single-line-uilabel
             imageLineHeight = (font.capHeight - image.size.height) / 2


### PR DESCRIPTION
## Goal
* This PR fixes a crash occurring when tapping on a collection story with a syndicated article and an empty non-nil publisher.
* This was due to a missing check of boundaries in the method `calculateLineHeight(_:)` in `NSAttributedString+Extensions`. This method uses `attribute(_:at:effectiveRange:)` which will raise an exception if the string is empty since in that case there is no valid index to look at (more info [here](https://developer.apple.com/documentation/foundation/nsattributedstring/1408174-attribute))
* The PR also looks for a valid publisher in the related item if it cannot be found in the collection story.

> [!NOTE]
> This will be further refined when we switch to `Preview` for the display info, but we still want this fix to prevent the crash.
