### PR TITLE
Make Reader navigation self-contained

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -224,9 +224,7 @@ class ReadableViewController: UIViewController {
             return
         }
 
-        let readerSettingsVC = ReaderSettingsViewController(settings: readable.readerSettings) { [weak self] in
-            // self?.model.clearIsPresentingReaderSettings()
-        }
+        let readerSettingsVC = ReaderSettingsViewController(settings: readable.readerSettings) {}
         readerSettingsVC.configurePocketDefaultDetents()
         self.present(readerSettingsVC, animated: true)
     }

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -94,8 +94,8 @@ class ReadableViewController: UIViewController {
             self?.updateContent()
         }.store(in: &subscriptions)
 
-        // we only want highlights for saved items
         if let viewModel = readableViewModel as? SavedItemViewModel {
+            // we only want highlights for saved items
             viewModel
                 .$isPresentingHighlights
                 .receive(on: DispatchQueue.main)
@@ -121,7 +121,8 @@ class ReadableViewController: UIViewController {
                 }
                 .store(in: &subscriptions)
 
-            viewModel.$isPresentingPremiumUpsell
+            viewModel
+                .$isPresentingPremiumUpsell
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] isPresenting in
                     guard let self, isPresenting else {
@@ -131,7 +132,8 @@ class ReadableViewController: UIViewController {
                 }
                 .store(in: &subscriptions)
 
-            viewModel.$isPresentingHooray
+            viewModel
+                .$isPresentingHooray
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] isPresenting in
                     guard let self, isPresenting else {
@@ -141,21 +143,37 @@ class ReadableViewController: UIViewController {
                 }
                 .store(in: &subscriptions)
 
-            viewModel.$presentedAlert.sink { [weak self] alert in
-                self?.present(alert: alert)
-            }.store(in: &subscriptions)
+            viewModel
+                .$presentedAlert
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] alert in
+                    self?.present(alert: alert)
+                }
+                .store(in: &subscriptions)
 
-            viewModel.$presentedWebReaderURL.sink { [weak self] url in
-                self?.present(url: url)
-            }.store(in: &subscriptions)
+            viewModel
+                .$presentedWebReaderURL
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] url in
+                    self?.present(url: url)
+                }
+                .store(in: &subscriptions)
 
-            viewModel.$sharedActivity.sink { [weak self] activity in
-                self?.present(activity: activity)
-            }.store(in: &subscriptions)
+            viewModel
+                .$sharedActivity
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] activity in
+                    self?.present(activity: activity)
+                }
+                .store(in: &subscriptions)
 
-            viewModel.$isPresentingReaderSettings.sink { [weak self] isPresenting in
-                self?.presentReaderSettings(isPresenting, on: readable)
-            }.store(in: &subscriptions)
+            viewModel
+                .$isPresentingReaderSettings
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isPresenting in
+                    self?.presentReaderSettings(isPresenting, on: readable)
+                }
+                .store(in: &subscriptions)
 
             viewModel.$presentedAddTags.sink { [weak self] addTagsViewModel in
                 self?.present(viewModel: addTagsViewModel)
@@ -163,13 +181,81 @@ class ReadableViewController: UIViewController {
 
             viewModel.events.sink { [weak self] event in
                 switch event {
-                case .contentUpdated:
+                case .contentUpdated, .save:
                     break
                 case .archive, .delete:
                     self?.popToPreviousScreen(navigationController: self?.navigationController)
                 }
             }.store(in: &subscriptions)
+        } else if let viewModel = readableViewModel as? RecommendableItemViewModel {
+            viewModel
+                .$presentedAlert
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] alert in
+                    self?.present(alert: alert)
+                }
+                .store(in: &subscriptions)
+
+            viewModel
+                .$presentedWebReaderURL
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] url in
+                    self?.present(url: url)
+                }
+                .store(in: &subscriptions)
+
+            viewModel
+                .$presentedWebReaderURL
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] url in
+                    self?.present(url: url)
+                }
+                .store(in: &subscriptions)
+
+            viewModel
+                .$sharedActivity
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] activity in
+                    self?.present(activity: activity)
+                }
+                .store(in: &subscriptions)
+
+            viewModel
+                .$isPresentingReaderSettings
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isPresenting in
+                    self?.presentReaderSettings(isPresenting, on: readable)
+                }
+                .store(in: &subscriptions)
+
+            viewModel
+                .$selectedItemToReport
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] selected in
+                self?.report(selected?.givenURL, recommendationId: selected?.recommendation?.analyticsID)
+            }
+            .store(in: &subscriptions)
         }
+    }
+
+    private func report(_ givenURL: String?, recommendationId: String?) {
+        guard let givenURL, let recommendationId else {
+            return
+        }
+
+        let host = ReportRecommendationHostingController(
+            givenURL: givenURL,
+            recommendationId: recommendationId,
+            tracker: readableViewModel.tracker,
+            onDismiss: {}
+        )
+
+        host.modalPresentationStyle = .formSheet
+        guard let presentedVC = self.presentedViewController else {
+            self.present(host, animated: true)
+            return
+        }
+        presentedVC.present(host, animated: true)
     }
 
     private func present(alert: PocketAlert?) {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableEvent.swift
@@ -5,6 +5,7 @@
 import Sync
 
 enum ReadableEvent {
+    case save
     case archive
     case delete
     case contentUpdated

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/RecommendableItemViewModel.swift
@@ -368,6 +368,7 @@ extension RecommendableItemViewModel {
         }
         source.save(item: item)
         trackSave()
+        _events.send(.save)
         completion(true)
     }
 

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -515,7 +515,7 @@ extension HomeViewController {
 
         viewModel.$events.receive(on: DispatchQueue.main).sink { [weak self] event in
             switch event {
-            case .contentUpdated, .none:
+            case .contentUpdated, .save, .none:
                 break
             case .archive, .delete:
                 self?.popToPreviousScreen()

--- a/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
+++ b/PocketKit/Sources/PocketKit/Item/ReadableHostViewController.swift
@@ -98,6 +98,20 @@ class ReadableHostViewController: UIViewController {
         readableViewModel.actions.receive(on: DispatchQueue.main).sink { [weak self] actions in
             self?.buildOverflowMenu(from: actions)
         }.store(in: &subscriptions)
+
+        readableViewModel
+            .events
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                if case .save = event,
+                   let items = self?.navigationItem.rightBarButtonItems,
+                   let saveButton = self?.saveButton,
+                   let index = items.firstIndex(of: saveButton),
+                   let archiveButton = self?.archiveButton {
+                    self?.navigationItem.rightBarButtonItems?[index] = archiveButton
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     override func viewDidLoad() {
@@ -195,15 +209,7 @@ class ReadableHostViewController: UIViewController {
 
     @objc
     private func save() {
-        readableViewModel.save { [weak self] success in
-            if success,
-               let items = self?.navigationItem.rightBarButtonItems,
-               let saveButton = self?.saveButton,
-               let index = items.firstIndex(of: saveButton),
-               let archiveButton = self?.archiveButton {
-                self?.navigationItem.rightBarButtonItems?[index] = archiveButton
-            }
-        }
+        readableViewModel.save { _ in }
     }
 
     @objc

--- a/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/SavesContainerViewController.swift
@@ -398,7 +398,7 @@ extension SavesContainerViewController {
 
         collection.$events.receive(on: DispatchQueue.main).sink { [weak self] event in
             switch event {
-            case .contentUpdated, .none:
+            case .contentUpdated, .save, .none:
                 break
             case .archive, .delete:
                 self?.popToPreviousScreen(navigationController: self?.navigationController)


### PR DESCRIPTION
## Goal
* Remove Reader navigation logic from both `HomeViewController` and `SavesContainerViewController` and move it into `ReadableViewController` itself, so it's self-contained and can be called from anywhere, including the new SwiftUI Home.

## Test Steps
* Build/run this branch
* make sure saved items, syndicated articles, web articles, slate details. and collections behave as expected, both when opening them from Home and from Saves

> [!NOTE]
> This PR should be reviewed in conjunction with the changes in the following commits

https://github.com/Pocket/pocket-ios/pull/1077/commits/bbed474c383fe55a04637a8d56df9eb5c0748b82
https://github.com/Pocket/pocket-ios/pull/1077/commits/b774767631122f68b770f500ca748e092165132f