### PR TITLE
Listen: extend default language list to all supported languages

### DIFF
--- a/PocketKit/Sources/PocketKit/Listen/Listen.swift
+++ b/PocketKit/Sources/PocketKit/Listen/Listen.swift
@@ -26,7 +26,27 @@ class Listen: NSObject {
         self.source = source
         super.init()
         // Set a default set of languages that the server will overwrite when it loads
-        PKTListen.supportedLanguages = ["en"]
+        PKTListen.supportedLanguages = [
+            "da",
+            "nl",
+            "ko",
+            "ja",
+            "is",
+            "ro",
+            "cy",
+            "fr",
+            "it",
+            "ru",
+            "pt",
+            "sv",
+            "tr",
+            "en",
+            "es",
+            "pl",
+            "de",
+            "no"
+        ]
+
         PKTSetConsumerKey(consumerKey)
         PKTLocalRuntime.shared().start()
         PKTListen.sharedInstance().sessionDelegate = self


### PR DESCRIPTION
## Goal
* Extend the default languages list in listen, since there are cases where it might not be fetched from the server

## Test Steps
* Listen to something that you couldn't before
