### PR TITLE
SwiftUI Home - Signed out banner and actions

### DIFF
--- a/PocketKit/Sources/PocketKit/Authorization/PocketAccessService.swift
+++ b/PocketKit/Sources/PocketKit/Authorization/PocketAccessService.swift
@@ -17,6 +17,20 @@ final class PocketAccessService: NSObject, ObservableObject {
         case onboarding // onboarding screen only
         case anonymous // limited access
         case authenticated // full access
+
+        var isAnonymous: Bool {
+            switch self {
+            case .onboarding, .authenticated: return false
+            case .anonymous: return true
+            }
+        }
+
+        var isAuthenticated: Bool {
+            switch self {
+            case .onboarding, .anonymous: return false
+            case .authenticated: return true
+            }
+        }
     }
 
     private let authorizationClient: AuthorizationClient

--- a/PocketKit/Sources/PocketKit/Home/Cells/SigninBannerCell.swift
+++ b/PocketKit/Sources/PocketKit/Home/Cells/SigninBannerCell.swift
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import Localization
-import SharedPocketKit
-import SwiftUI
-import Textile
+import UIKit
 
 /// Cell that displays the Sign in or sign up banner at the top of the Home screen in anonymous mode.
 /// This cell embeds a SwiftUI view.
@@ -16,62 +13,4 @@ class SigninBannerCell: UICollectionViewCell {
         contentView.pinSubviewToAllEdges(view)
         accessibilityIdentifier = "home-signinBanner"
     }
-}
-
-/// The SwiftUI view associated with `SigninBannerCell`
-struct SigninBannerView: View {
-    private let title = Localization.LoggedOut.Banner.title
-    private let buttonTitle = Localization.LoggedOut.continue
-
-    @Environment(\.horizontalSizeClass)
-    private var horizontalSize
-
-    let action: () -> Void
-
-    var body: some View {
-        if horizontalSize == .regular {
-            makeRegularWidthView()
-        } else {
-            makeCompactWidthView()
-        }
-    }
-
-    func makeCompactWidthView() -> some View {
-        VStack(spacing: 8) {
-            Text(title)
-                .style(.title)
-            Button {
-                action()
-            }
-        label: {
-            Text(buttonTitle).style(.buttonLabel)
-                .frame(maxWidth: .infinity)
-                .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
-        }
-        .buttonStyle(ActionsPrimaryButtonStyle())
-        }
-        .homeCellStyle()
-    }
-
-    func makeRegularWidthView() -> some View {
-        HStack {
-            Text(title)
-                .style(.title)
-            Spacer()
-            Button {
-                action()
-            }
-        label: {
-            Text(buttonTitle).style(.buttonLabel)
-                .padding(EdgeInsets(top: 12, leading: 48, bottom: 12, trailing: 48))
-        }
-        .buttonStyle(ActionsPrimaryButtonStyle())
-        }
-        .homeCellStyle()
-    }
-}
-
-private extension Style {
-    static let title: Self = .header.sansSerif.h6.with { $0.with(alignment: .center).with(lineSpacing: 6) }.with(color: .ui.black1)
-    static let buttonLabel: Self = .header.sansSerif.h7.with(color: .ui.white)
 }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
@@ -12,15 +12,33 @@ struct HomeActions {
     // This is on purpose since we do not want to keep a reference here, and once we are fully
     // migrated to SwiftUI we will likely leverage the environment or something like swift-dependencies
     // https://github.com/pointfreeco/swift-dependencies for dependency injection.
+
+    /// Prompts the FxA login
+    @MainActor
+    func requestAuthentication(_ type: CardType) {
+        /// **NOTE: recommendation, collection and collectionStory are the only three types of source handled from SwiftUI Home
+        var loginSource: Events.SignedOut.LoginSource = .recommendationCard
+        if type == .collection {
+            loginSource = .collection
+        } else if type == .collectionStory {
+            loginSource = .collectionStory
+        }
+        Services.shared.accessService.requestAuthentication(loginSource)
+    }
+
     @MainActor
     func saveAction(isSaved: Bool, givenURL: String, info: AnalyticsInfo) {
-        let source = Services.shared.source
-        if isSaved {
-            source.archive(from: givenURL)
-        } else {
-            source.save(from: givenURL)
+        if Services.shared.accessService.accessLevel.isAnonymous {
+            requestAuthentication(info.type)
+        } else if Services.shared.accessService.accessLevel.isAuthenticated {
+            let source = Services.shared.source
+            if isSaved {
+                source.archive(from: givenURL)
+            } else {
+                source.save(from: givenURL)
+            }
+            trackSave(info)
         }
-        trackSave(info)
     }
 
     @MainActor

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
@@ -43,7 +43,7 @@ struct CardView: View {
         let givenUrl = card.givenURL
         var savedItemDescriptor = FetchDescriptor<SavedItem>(predicate: #Predicate<SavedItem> { $0.item?.givenURL == givenUrl })
         savedItemDescriptor.fetchLimit = 1
-        _fetchedSavedItem = Query(savedItemDescriptor) // , animation: .easeIn)
+        _fetchedSavedItem = Query(savedItemDescriptor, animation: .easeInOut)
     }
 
     var body: some View {
@@ -55,7 +55,7 @@ struct CardView: View {
                             type: card.type,
                             url: card.givenURL,
                             index: card.index,
-                            recommendationID: card.recommendationID // item?.recommendation?.analyticsID
+                            recommendationID: card.recommendationID
                         )
                     )
             }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/Native Collections/NativeCollectionView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/Native Collections/NativeCollectionView.swift
@@ -163,6 +163,23 @@ struct NativeCollectionView: View {
                 }
             }
 
+            if savedItem == nil {
+                Button(action: {
+                    Haptics.defaultTap()
+                    if recommendationID != nil {
+                        showReportArticle = true
+                    } else {
+                        showReportError = true
+                    }
+                }) {
+                    Label {
+                        Text(Localization.ItemAction.report)
+                    } icon: {
+                        Image(asset: .alert)
+                    }
+                }
+            }
+
             ShareableURLView(givenURL: destination.givenURL, shareURL: item?.shareURL)
                 .simultaneousGesture(TapGesture().onEnded {
                     homeActions.trackShare(

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -11,14 +11,21 @@ struct HomeView: View {
     @Environment(\.horizontalSizeClass)
     var horizontalSizeClass
 
+    @EnvironmentObject private var accessService: PocketAccessService
+
     var body: some View {
         GeometryReader { proxy in
             ScrollView {
                 VStack {
                     Spacer()
                         .frame(height: 16)
-                    RecentSavesView()
-                    SharedWithYouView()
+                    if accessService.accessLevel.isAuthenticated {
+                        RecentSavesView()
+                        SharedWithYouView()
+                    } else if accessService.accessLevel.isAnonymous {
+                        SigninBannerView { accessService.requestAuthentication(.homeBanner) }
+                            .padding()
+                    }
                     RecommendationsView()
                 }
             }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/SigninBannerView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/SigninBannerView.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Localization
+import SwiftUI
+import Textile
+
+/// The SwiftUI view containing the Sign in or sign up banner.
+struct SigninBannerView: View {
+    private let title = Localization.LoggedOut.Banner.title
+    private let buttonTitle = Localization.LoggedOut.continue
+
+    @Environment(\.horizontalSizeClass)
+    private var horizontalSize
+
+    let action: () -> Void
+
+    var body: some View {
+        if horizontalSize == .regular {
+            makeRegularWidthView()
+        } else {
+            makeCompactWidthView()
+        }
+    }
+
+    func makeCompactWidthView() -> some View {
+        VStack(spacing: 8) {
+            Text(title)
+                .style(.title)
+            Button {
+                action()
+            }
+        label: {
+            Text(buttonTitle).style(.buttonLabel)
+                .frame(maxWidth: .infinity)
+                .padding(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
+        }
+        .buttonStyle(ActionsPrimaryButtonStyle())
+        }
+        .homeCellStyle()
+    }
+
+    func makeRegularWidthView() -> some View {
+        HStack {
+            Text(title)
+                .style(.title)
+            Spacer()
+            Button {
+                action()
+            }
+        label: {
+            Text(buttonTitle).style(.buttonLabel)
+                .padding(EdgeInsets(top: 12, leading: 48, bottom: 12, trailing: 48))
+        }
+        .buttonStyle(ActionsPrimaryButtonStyle())
+        }
+        .homeCellStyle()
+    }
+}
+
+private extension Style {
+    static let title: Self = .header.sansSerif.h6.with { $0.with(alignment: .center).with(lineSpacing: 6) }.with(color: .ui.black1)
+    static let buttonLabel: Self = .header.sansSerif.h7.with(color: .ui.white)
+}

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -19,7 +19,7 @@ public struct MainView: View {
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
 
-    @State private var assigned: Bool = true
+    @State private var assigned: Bool = false
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {
@@ -83,12 +83,12 @@ public struct MainView: View {
             }
         }
         .zIndex(-1)
-//        .onChange(of: featureFlag, initial: false) {
-//            guard let swiftuiFeatureFlag = featureFlag.first else {
-//                return
-//            }
-//            assigned = swiftuiFeatureFlag.assigned
-//        }
+        .onChange(of: featureFlag, initial: false) {
+            guard let swiftuiFeatureFlag = featureFlag.first else {
+                return
+            }
+            assigned = swiftuiFeatureFlag.assigned
+        }
         .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
         .task {
             // Initialize tips at app start/user login

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -19,7 +19,7 @@ public struct MainView: View {
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
 
-    @State private var assigned: Bool = false
+    @State private var assigned: Bool = true
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {
@@ -83,12 +83,12 @@ public struct MainView: View {
             }
         }
         .zIndex(-1)
-        .onChange(of: featureFlag, initial: false) {
-            guard let swiftuiFeatureFlag = featureFlag.first else {
-                return
-            }
-            assigned = swiftuiFeatureFlag.assigned
-        }
+//        .onChange(of: featureFlag, initial: false) {
+//            guard let swiftuiFeatureFlag = featureFlag.first else {
+//                return
+//            }
+//            assigned = swiftuiFeatureFlag.assigned
+//        }
         .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
         .task {
             // Initialize tips at app start/user login

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -87,7 +87,11 @@ public struct MainView: View {
             guard let swiftuiFeatureFlag = featureFlag.first else {
                 return
             }
+#if DEBUG
+            assigned = true
+#else
             assigned = swiftuiFeatureFlag.assigned
+#endif
         }
         .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
         .task {

--- a/PocketKit/Sources/PocketKit/Main/RootView.swift
+++ b/PocketKit/Sources/PocketKit/Main/RootView.swift
@@ -48,11 +48,15 @@ private extension RootView {
             .onContinueUserActivity(CSSearchableItemActionType, perform: { userActivity in
                 model.handleSpotlight(userActivity)
             })
+            // TODO: SWIFTUI - Once we move away from Services, these need to be handled with DI
             .modelContainer(Services.shared.dataController)
+            .environmentObject(Services.shared.accessService)
     }
 
-    func loggedOutView(model: LoggedOutViewModel) -> LoggedOutViewControllerSwiftUI {
+    func loggedOutView(model: LoggedOutViewModel) -> some View {
         LoggedOutViewControllerSwiftUI(model: model)
+            // TODO: SWIFTUI - Once we move away from Services, this needs to be handled with DI
+            .environmentObject(Services.shared.accessService)
     }
 }
 


### PR DESCRIPTION
## Goal
* Add the signed out banner and actions to SwiftUI Home

## Test Steps
* Build/run
* Logout or, if it's a fresh install, tap "skip sing-in"
* Go to SwiftUI Home and make sure the signed out banner appears and allows you to sign in. Make sure all the other signed out actions are still in place (e.g. sign in dialog when attempting to save, no recent saves and shared with you, etc)

