### PR TITLE
SwiftUI Home - Add pull-to-refresh and empty states

### DIFF
--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90821204f99e29d2b76666bac683f71db3e70906a21155af9ceb556825a0a7ee",
+  "originHash" : "31d54fac20a7507cb77720eefee422603ebada3dd561b77ca688a68c6d9bfebb",
   "pins" : [
     {
       "identity" : "apollo-ios",
@@ -71,6 +71,15 @@
       "state" : {
         "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
         "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
       }
     },
     {

--- a/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pocket.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "31d54fac20a7507cb77720eefee422603ebada3dd561b77ca688a68c6d9bfebb",
+  "originHash" : "d0602067664e1d6e82f7f55103a061c00815f8df13e387f87685f50f6aab5fed",
   "pins" : [
     {
       "identity" : "apollo-ios",
@@ -71,15 +71,6 @@
       "state" : {
         "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
         "version" : "4.5.0"
-      }
-    },
-    {
-      "identity" : "nuke",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke.git",
-      "state" : {
-        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
-        "version" : "12.8.0"
       }
     },
     {

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", from: "9.3.0"),
         .package(url: "https://github.com/adjust/ios_sdk", from: "4.38.3"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", from: "5.1.0"),
-        .package(url: "https://github.com/vadymmarkov/Fakery", from: "5.1.0")
+        .package(url: "https://github.com/vadymmarkov/Fakery", from: "5.1.0"),
+        .package(url: "https://github.com/kean/Nuke.git", from: "12.8.0")
     ],
     targets: [
         .binaryTarget(
@@ -77,7 +78,11 @@ let package = Package(
                 .product(name: "BrazeUI", package: "braze-swift-sdk"),
                 .product(name: "Adjust", package: "ios_sdk"),
                 // Used by listen, ideally we put this there, but there were some c99 compilker issues, this used to be included by snowplow but is not anymore
-                .product(name: "FMDB", package: "fmdb")
+                .product(name: "FMDB", package: "fmdb"),
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "NukeUI", package: "Nuke"),
+                .product(name: "NukeVideo", package: "Nuke"),
+                .product(name: "NukeExtensions", package: "Nuke")
             ],
             swiftSettings: [
                     .enableExperimentalFeature("StrictConcurrency=complete")

--- a/PocketKit/Package.swift
+++ b/PocketKit/Package.swift
@@ -36,8 +36,7 @@ let package = Package(
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", from: "9.3.0"),
         .package(url: "https://github.com/adjust/ios_sdk", from: "4.38.3"),
         .package(url: "https://github.com/RNCryptor/RNCryptor.git", from: "5.1.0"),
-        .package(url: "https://github.com/vadymmarkov/Fakery", from: "5.1.0"),
-        .package(url: "https://github.com/kean/Nuke.git", from: "12.8.0")
+        .package(url: "https://github.com/vadymmarkov/Fakery", from: "5.1.0")
     ],
     targets: [
         .binaryTarget(
@@ -78,11 +77,7 @@ let package = Package(
                 .product(name: "BrazeUI", package: "braze-swift-sdk"),
                 .product(name: "Adjust", package: "ios_sdk"),
                 // Used by listen, ideally we put this there, but there were some c99 compilker issues, this used to be included by snowplow but is not anymore
-                .product(name: "FMDB", package: "fmdb"),
-                .product(name: "Nuke", package: "Nuke"),
-                .product(name: "NukeUI", package: "Nuke"),
-                .product(name: "NukeVideo", package: "Nuke"),
-                .product(name: "NukeExtensions", package: "Nuke")
+                .product(name: "FMDB", package: "fmdb")
             ],
             swiftSettings: [
                     .enableExperimentalFeature("StrictConcurrency=complete")

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
@@ -86,14 +86,6 @@ struct HomeActions {
     /// Refresh recommendations
     /// - Parameters:
     ///   - isForced: Whether or not the user forced the refresh
-    ///   - completion: Completion block to call
-    @MainActor
-    func refreshRecommendations(isForced: Bool = false, completion: @escaping () -> Void) {
-        Services.shared.homeRefreshCoordinator.refresh(isForced: isForced) {
-            completion()
-        }
-    }
-    /// Async version of the recommendation refresh method, with no completion handler.
     @MainActor
     func refreshRecommendations(isForced: Bool = false) async {
         await Services.shared.homeRefreshCoordinator.refresh(isForced: isForced)

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
@@ -4,6 +4,7 @@
 
 import Analytics
 @preconcurrency import Sync
+import SwiftUI
 
 // TODO: SWIFTUI - Add analytics
 /// Type that contains all the actions that can be performed from Home and its detail views
@@ -80,6 +81,22 @@ struct HomeActions {
     func fetchCollection(slug: String) async {
         let source = await Services.shared.source
         try? await source.fetchCollection(by: slug)
+    }
+
+    /// Refresh recommendations
+    /// - Parameters:
+    ///   - isForced: Whether or not the user forced the refresh
+    ///   - completion: Completion block to call
+    @MainActor
+    func refreshRecommendations(isForced: Bool = false, completion: @escaping () -> Void) {
+        Services.shared.homeRefreshCoordinator.refresh(isForced: isForced) {
+            completion()
+        }
+    }
+    /// Async version of the recommendation refresh method, with no completion handler.
+    @MainActor
+    func refreshRecommendations(isForced: Bool = false) async {
+        await Services.shared.homeRefreshCoordinator.refresh(isForced: isForced)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
@@ -3,3 +3,27 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import Sync
+import Network
+
+final class NetworkMonitor: ObservableObject {
+    private let monitor: NetworkPathMonitor
+
+    @Published private(set) var status: NWPath.Status = .satisfied
+
+    init() {
+        self.monitor = NWPathMonitor()
+        monitor.updateHandler = { [weak self] path in
+            self?.status = path.status
+        }
+
+        func start(queue: DispatchQueue? = nil) {
+            let queue = queue ?? DispatchQueue.global(qos: .utility)
+            monitor.start(queue: queue)
+        }
+
+        func cancel() {
+            monitor.cancel()
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Utilities/NetworkMonitor.swift
@@ -16,14 +16,14 @@ final class NetworkMonitor: ObservableObject {
         monitor.updateHandler = { [weak self] path in
             self?.status = path.status
         }
+    }
 
-        func start(queue: DispatchQueue? = nil) {
-            let queue = queue ?? DispatchQueue.global(qos: .utility)
-            monitor.start(queue: queue)
-        }
+    func start(queue: DispatchQueue? = nil) {
+        let queue = queue ?? DispatchQueue.global(qos: .utility)
+        monitor.start(queue: queue)
+    }
 
-        func cancel() {
-            monitor.cancel()
-        }
+    func cancel() {
+        monitor.cancel()
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/RemoteImage.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/RemoteImage.swift
@@ -5,8 +5,6 @@
 import Kingfisher
 import SwiftUI
 import Textile
-import NukeUI
-import Nuke
 
 /// A resizable remote image backed by `KingFisher`
 /// if `url` is nil and  `usePlaceholder` is true it will return a placeholder view
@@ -17,13 +15,13 @@ struct RemoteImage: View {
     let usePlaceholder: Bool
 
     var body: some View {
-        // makeNukeImage()
         makeKFImage()
-        // makeAsyncImage()
     }
 }
 
+// MARK: view builders
 private extension RemoteImage {
+    // TODO: SWIFTUI - we keep these for comparison for now, when finished, we should remove the dependency and the methods that we won't use.
     @ViewBuilder
     func makeKFImage() -> some View {
         if let url {
@@ -48,36 +46,6 @@ private extension RemoteImage {
                 .backgroundDecode()
                 .scaleFactor(UIScreen.main.scale)
                 .resizable()
-        } else if usePlaceholder {
-            Color(.ui.grey6)
-        }
-    }
-
-    @ViewBuilder
-    func makeNukeImage() -> some View {
-        if let url {
-            LazyImage(url: url) { state in
-                if let image = state.image {
-                    image
-                        .resizable()
-                }
-            }
-                .processors([ImageProcessors.Resize(size: imageSize, crop: true)])
-        } else if usePlaceholder {
-            Color(.ui.grey6)
-        }
-    }
-
-    @ViewBuilder
-    func makeAsyncImage() -> some View {
-        if let url {
-            AsyncImage(url: url) { phase in
-                if let image = phase.image {
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                }
-            }
         } else if usePlaceholder {
             Color(.ui.grey6)
         }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/RemoteImage.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/RemoteImage.swift
@@ -5,6 +5,8 @@
 import Kingfisher
 import SwiftUI
 import Textile
+import NukeUI
+import Nuke
 
 /// A resizable remote image backed by `KingFisher`
 /// if `url` is nil and  `usePlaceholder` is true it will return a placeholder view
@@ -15,6 +17,15 @@ struct RemoteImage: View {
     let usePlaceholder: Bool
 
     var body: some View {
+        // makeNukeImage()
+        makeKFImage()
+        // makeAsyncImage()
+    }
+}
+
+private extension RemoteImage {
+    @ViewBuilder
+    func makeKFImage() -> some View {
         if let url {
             KFImage(url)
                 .placeholder { progress in
@@ -37,6 +48,36 @@ struct RemoteImage: View {
                 .backgroundDecode()
                 .scaleFactor(UIScreen.main.scale)
                 .resizable()
+        } else if usePlaceholder {
+            Color(.ui.grey6)
+        }
+    }
+
+    @ViewBuilder
+    func makeNukeImage() -> some View {
+        if let url {
+            LazyImage(url: url) { state in
+                if let image = state.image {
+                    image
+                        .resizable()
+                }
+            }
+                .processors([ImageProcessors.Resize(size: imageSize, crop: true)])
+        } else if usePlaceholder {
+            Color(.ui.grey6)
+        }
+    }
+
+    @ViewBuilder
+    func makeAsyncImage() -> some View {
+        if let url {
+            AsyncImage(url: url) { phase in
+                if let image = phase.image {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                }
+            }
         } else if usePlaceholder {
             Color(.ui.grey6)
         }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/Native Collections/NativeCollectionView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/Native Collections/NativeCollectionView.swift
@@ -106,8 +106,7 @@ struct NativeCollectionView: View {
                 makeOverflowMenu()
             }
         } else {
-            // TODO: SWIFTUI - Replace this with the loading animation
-            Text("Loading Collection")
+            LoadingView.loadingIndicator(Localization.LoadingView.message)
                 .onAppear {
                     Task {
                         await homeActions.fetchCollection(slug: destination.slug)

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Empty state views/OfflineView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Empty state views/OfflineView.swift
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Localization
+import SwiftUI
+import Textile
+
+struct OfflineView: View {
+    var body: some View {
+        VStack(spacing: Constants.stackSpacing) {
+            Constants.image
+                .aspectRatio(contentMode: .fit)
+            Spacer()
+            Text(Constants.offlineTitle)
+                .style(Constants.offlineTitleStyle)
+            Text(Constants.offlineSubTitle)
+                .style(Constants.offlineSubTitleStyle)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+// MARK: Constants
+private extension OfflineView {
+    enum Constants {
+        static let image = Image(asset: .looking)
+        static let offlineTitle = Localization.noInternetConnection
+        static let offlineTitleStyle: Style = .header.sansSerif.h2.with(weight: .semibold)
+        static let offlineSubTitle = Localization.LooksLikeYouReOffline.tryCheckingYourMobileDataOrWifi
+        static let offlineSubTitleStyle: Style = .header.sansSerif.p2.with {
+            $0
+                .with(alignment: .center)
+                .with(lineHeight: .explicit(28))
+                .with(lineSpacing: 12)
+        }
+        static let stackSpacing: CGFloat = 20
+    }
+}

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -29,6 +29,10 @@ struct HomeView: View {
                     RecommendationsView()
                 }
             }
+            .refreshable {
+                // TODO: SWIFTUI - add actual refresh code
+                print("Please code an actual refresh!")
+            }
             .background(Color(.ui.white1))
             .navigationTitle(Localization.home)
             .environment(\.carouselWidth, carouselWidth(proxy.size))

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -9,7 +9,10 @@ import Sync
 
 struct HomeView: View {
     @Environment(\.horizontalSizeClass)
-    var horizontalSizeClass
+    private var horizontalSizeClass
+
+    @Environment(\.homeActions)
+    private var homeActions
 
     @EnvironmentObject private var accessService: PocketAccessService
 
@@ -30,8 +33,7 @@ struct HomeView: View {
                 }
             }
             .refreshable {
-                // TODO: SWIFTUI - add actual refresh code
-                print("Please code an actual refresh!")
+                await homeActions.refreshRecommendations(isForced: true)
             }
             .background(Color(.ui.white1))
             .navigationTitle(Localization.home)

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
@@ -11,7 +11,7 @@ struct RecommendationsView: View {
     private var slates: [Slate]
 
     var body: some View {
-        LazyVStack(spacing: 32) {
+        VStack(spacing: 32) {
             if !slates.isEmpty {
                 ForEach(slates) {
                     if let recommendations = $0.recommendations, !recommendations.isEmpty {
@@ -23,7 +23,7 @@ struct RecommendationsView: View {
                     }
                 }
             } else {
-                // TODO: SWIFTUI - Replace with the lottie animation
+                // TODO: SWIFTUI - Replace with the lottie animation or offline view, depending on state
                 Text("Pocket")
             }
         }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import Localization
+import Textile
 import SwiftData
 import SwiftUI
 import Sync
@@ -38,7 +40,7 @@ struct RecommendationsView: View {
                 }
             case .ready:
                 if slates.isEmpty {
-                    makeErrorView()
+                    makeOfflineView()
                 } else {
                     makeSlatesView()
                 }
@@ -46,25 +48,32 @@ struct RecommendationsView: View {
                 makeOfflineView()
             }
         }
-        .onAppear {
+        .task {
+            networkMonitor.start()
             // TODO: SWIFTUI - remove this flag once we replace existing home with SwiftUI Home
             let enabled = false
             guard viewState != .loading, enabled else { return }
-            homeActions.refreshRecommendations {
-                viewState = .ready
-            }
+            viewState = .loading
+            await homeActions.refreshRecommendations()
+            viewState = .ready
         }
-        .onChange(of: networkMonitor.status, initial: false) { oldStatus, newStatus in
+        .onChange(of: networkMonitor.status, initial: true) { oldStatus, newStatus in
             guard oldStatus != newStatus else { return }
             switch newStatus {
             case .unsatisfied, .requiresConnection:
                 viewState = .offline
             case .satisfied:
-                viewState = .ready
-                // TODO: SWIFTUI - handle reloading when transitioning from offline to online
+                viewState = .loading
+                Task {
+                    await homeActions.refreshRecommendations()
+                    viewState = .ready
+                }
             default:
                 break
             }
+        }
+        .onDisappear {
+            networkMonitor.cancel()
         }
     }
 }
@@ -85,18 +94,11 @@ private extension RecommendationsView {
     }
 
     func makeLoadingView() -> some View {
-        // TODO: SWIFTUI - Replace this text with the appropriate view
-        Text("Loading view goes here")
+        LoadingView.loadingIndicator(Localization.LoadingView.message)
     }
 
     func makeOfflineView() -> some View {
-        // TODO: SWIFTUI - Replace this text with the appropriate view
-        Text("Offilne view goes here")
-    }
-
-    func makeErrorView() -> some View {
-        // TODO: SWIFTUI - Replace this text with the appropriate view
-        Text("Error view goes here")
+        OfflineView()
     }
 
     func cards( for recommendations: [Recommendation]) -> [HomeCardConfiguration] {

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
@@ -7,30 +7,98 @@ import SwiftUI
 import Sync
 
 struct RecommendationsView: View {
+    private enum ViewState {
+        case loading
+        case ready
+        case offline
+    }
+
+    @State private var viewState: ViewState = .ready
+
     @Query(sort: \Slate.sortIndex, order: .forward)
     private var slates: [Slate]
 
+    @StateObject private var networkMonitor: NetworkMonitor
+
+    @Environment(\.homeActions)
+    private var homeActions
+
+    init() {
+        _networkMonitor = StateObject(wrappedValue: NetworkMonitor())
+    }
+
     var body: some View {
         VStack(spacing: 32) {
-            if !slates.isEmpty {
-                ForEach(slates) {
-                    if let recommendations = $0.recommendations, !recommendations.isEmpty {
-                        SlateView(
-                            remoteID: $0.remoteID,
-                            slateTitle: $0.name,
-                            cards: cards(for: recommendations)
-                        )
-                    }
+            switch viewState {
+            case .loading:
+                if slates.isEmpty {
+                    makeLoadingView()
+                } else {
+                    makeSlatesView()
                 }
-            } else {
-                // TODO: SWIFTUI - Replace with the lottie animation or offline view, depending on state
-                Text("Pocket")
+            case .ready:
+                if slates.isEmpty {
+                    makeErrorView()
+                } else {
+                    makeSlatesView()
+                }
+            case .offline:
+                makeOfflineView()
+            }
+        }
+        .onAppear {
+            // TODO: SWIFTUI - remove this flag once we replace existing home with SwiftUI Home
+            let enabled = false
+            guard viewState != .loading, enabled else { return }
+            homeActions.refreshRecommendations {
+                viewState = .ready
+            }
+        }
+        .onChange(of: networkMonitor.status, initial: false) { oldStatus, newStatus in
+            guard oldStatus != newStatus else { return }
+            switch newStatus {
+            case .unsatisfied, .requiresConnection:
+                viewState = .offline
+            case .satisfied:
+                viewState = .ready
+                // TODO: SWIFTUI - handle reloading when transitioning from offline to online
+            default:
+                break
             }
         }
     }
 }
 
+// MARK: view builders and helpers
 private extension RecommendationsView {
+    @ViewBuilder
+    func makeSlatesView() -> some View {
+        ForEach(slates) {
+            if let recommendations = $0.recommendations, !recommendations.isEmpty {
+                SlateView(
+                    remoteID: $0.remoteID,
+                    slateTitle: $0.name,
+                    cards: cards(for: recommendations)
+                )
+            }
+        }
+    }
+
+    func makeLoadingView() -> some View {
+        // TODO: SWIFTUI - Replace this text with the appropriate view
+        Text("Loading view goes here")
+    }
+
+    func makeOfflineView() -> some View {
+        // TODO: SWIFTUI - Replace this text with the appropriate view
+        Text("Offilne view goes here")
+    }
+
+    func makeErrorView() -> some View {
+        // TODO: SWIFTUI - Replace this text with the appropriate view
+        Text("Error view goes here")
+    }
+
     func cards( for recommendations: [Recommendation]) -> [HomeCardConfiguration] {
         recommendations
             .sorted(by: { $0.sortIndex < $1.sortIndex })

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -18,8 +18,11 @@ public struct MainView: View {
     // TODO: SWIFTUI - Remove the following two properties once we release SwiftUI Home
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
-
+#if DEBUG
+    @State private var assigned: Bool = true
+#else
     @State private var assigned: Bool = false
+#endif
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {
@@ -88,7 +91,7 @@ public struct MainView: View {
                 return
             }
 #if DEBUG
-            assigned = true
+            return
 #else
             assigned = swiftuiFeatureFlag.assigned
 #endif

--- a/PocketKit/Sources/PocketKit/Refresh/ArchiveRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/ArchiveRefreshCoordinator.swift
@@ -30,6 +30,10 @@ class ArchiveRefreshCoordinator: RefreshCoordinator {
         self.source = source
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         self.source.refreshArchive {
             completion()

--- a/PocketKit/Sources/PocketKit/Refresh/FeatureFlagsRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/FeatureFlagsRefreshCoordinator.swift
@@ -33,6 +33,10 @@ class FeatureFlagsRefreshCoordinator: RefreshCoordinator {
         self.lastRefresh = lastRefresh
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         Log.debug("Refresh feature flags called, isForced: \(String(describing: isForced))")
 

--- a/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/HomeRefreshCoordinator.swift
@@ -37,6 +37,27 @@ class HomeRefreshCoordinator: RefreshCoordinator {
         self.lastRefresh = lastRefresh
     }
 
+    func refresh(isForced: Bool = false) async {
+        if shouldRefresh(isForced: isForced), !isRefreshing {
+            do {
+                if isForced {
+                    forceRefreshedAt = Date()
+                }
+                self.isRefreshing = true
+                try await self.source.fetchUnifiedHomeLineup()
+                self.lastRefresh.refreshedHome()
+                Log.breadcrumb(category: "refresh", level: .info, message: "Home Refresh Occur")
+            } catch {
+                Log.capture(error: error)
+            }
+            isRefreshing = false
+        } else if isRefreshing {
+            Log.debug("Already refreshing Home, not going to add to the queue")
+        } else {
+            Log.debug("Not refreshing Home, too early to ask for new data")
+        }
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         Log.debug("Refresh home called, isForced: \(String(describing: isForced))")
 

--- a/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/RefreshCoordinator.swift
@@ -36,6 +36,8 @@ protocol RefreshCoordinator: AnyObject {
     /// - Parameter completion: The callback to execute upon finishing data loading
     /// - Parameter isForced: Whether or not a user manaully triggered the refreshing
     func refresh(isForced: Bool, _ completion: @escaping () -> Void)
+    /// Async version of the refresh method, with no completion handler.
+    func refresh(isForced: Bool) async
 }
 
 /// An Abstract extension  that can be used to implement background refreshing and implement some default logic like observing to login/logout and foregorund notifications.

--- a/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/SavesRefreshCoordinator.swift
@@ -30,6 +30,10 @@ class SavesRefreshCoordinator: RefreshCoordinator {
         self.source = source
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         self.source.refreshSaves {
             completion()

--- a/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/TagsRefreshCoordinator.swift
@@ -38,6 +38,10 @@ class TagsRefreshCoordinator: RefreshCoordinator {
         self.lastRefresh = lastRefresh
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         Log.debug("Refresh tags called, isForced: \(String(describing: isForced))")
 

--- a/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UnresolvedSavesRefreshCoordinator.swift
@@ -30,6 +30,10 @@ class UnresolvedSavesRefreshCoordinator: RefreshCoordinator {
         self.source = source
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         self.source.resolveUnresolvedSavedItems {
             completion()

--- a/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/UserRefreshCoordinator.swift
@@ -30,6 +30,10 @@ class UserRefreshCoordinator: RefreshCoordinator {
         self.source = source
     }
 
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
     func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
         Task { [weak self] in
             guard let self else {

--- a/PocketKit/Sources/Textile/Animations/LoadingView.swift
+++ b/PocketKit/Sources/Textile/Animations/LoadingView.swift
@@ -25,6 +25,7 @@ public struct LoadingView: View {
             Text(message).style(.pocketLoadingView.loadingViewText(textColor))
             Spacer()
         }
+        .frame(minWidth: 0, maxWidth: .infinity)
         .background(Color(backgroundColor))
         .foregroundColor(Color(foregroundColor))
         .opacity(0.9)

--- a/PocketKit/Sources/Textile/Animations/LoadingView.swift
+++ b/PocketKit/Sources/Textile/Animations/LoadingView.swift
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import Lottie
 import SwiftUI
-import Textile
 
-public struct PocketLoadingView: View {
+public struct LoadingView: View {
     let message: String
     let textColor: ColorAsset
     let backgroundColor: ColorAsset
@@ -19,7 +19,8 @@ public struct PocketLoadingView: View {
     public var body: some View {
         VStack {
             Spacer()
-            LottieView(.loading)
+            Lottie.LottieView(animation: .named("loading.json", bundle: .module, subdirectory: "Assets"))
+                .playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: .loop)))
                 .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 100)
             Text(message).style(.pocketLoadingView.loadingViewText(textColor))
             Spacer()
@@ -32,12 +33,12 @@ public struct PocketLoadingView: View {
 }
 
 // MARK: predefined styles
-public extension PocketLoadingView {
-    static func overlay(_ message: String) -> PocketLoadingView {
-        PocketLoadingView(message, textColor: .ui.white, backgroundColor: .ui.grey3, foregroundColor: .ui.white1)
+public extension LoadingView {
+    static func overlay(_ message: String) -> LoadingView {
+        LoadingView(message, textColor: .ui.white, backgroundColor: .ui.grey3, foregroundColor: .ui.white1)
     }
 
-    static func loadingIndicator(_ message: String) -> PocketLoadingView {
-        PocketLoadingView(message, textColor: .ui.black1, backgroundColor: .ui.white1, foregroundColor: .ui.white1)
+    static func loadingIndicator(_ message: String) -> LoadingView {
+        LoadingView(message, textColor: .ui.black1, backgroundColor: .ui.white1, foregroundColor: .ui.white1)
     }
 }


### PR DESCRIPTION
## Goal
This PR
* Adds pull-to-refresh to SwiftUI home
* Handles loading and offline states on both home and native collections
* Optimizes the home `VStack` and remote image loading

## Test Steps
* make sure pull to refresh happens
* Make sure you see the loading screen when the view is loading and there are no recommendations to display
* verify that the ui runs smoother
