### PR TITLE
Prevent saving a search term as a new tag

### DIFF
--- a/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Tags/PocketAddTagsViewModel.swift
@@ -95,7 +95,10 @@ class PocketAddTagsViewModel: AddTagsViewModel {
 
     /// Saves tags to an item
     func saveTags() {
-        addNewTag(with: newTagInput)
+        // if the user has not added any tag from this input, we allow to save it as a new tag
+        if tags.isEmpty {
+            addNewTag(with: newTagInput)
+        }
         trackSaveTagsToItem()
         source.replaceTags(item, tags: tags)
         saveAction()

--- a/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
+++ b/PocketKit/Sources/SaveToPocketKit/SaveToAddTagsViewModel.swift
@@ -68,7 +68,10 @@ class SaveToAddTagsViewModel: AddTagsViewModel {
 
     /// Saves tags to an item
     func saveTags() {
-        addNewTag(with: newTagInput)
+        // if the user has not added any tag from this input, we allow to save it as a new tag
+        if tags.isEmpty {
+            addNewTag(with: newTagInput)
+        }
         trackSaveTagsToItem()
         saveAction(tags)
         recentTagsFactory.updateRecentTags(with: originalTagNames, and: tags)


### PR DESCRIPTION
## Goal
* This PR fixes a bug where, upon searching for tags in the add tags view, selecting one or more tags from the search and hitting save, also saves the search term as a tag.
* The fix will solve this issue, while still allow a one tap tag creation if users have not selected any tag from the list.

## Test Steps
* Follow the steps described above and make sure it works as described.

## Screenshots
