### PR TITLE
Fix a bug with Recent Saves See All

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -585,7 +585,7 @@ extension HomeViewController {
     func show(_ seeAll: SeeAll?) {
         switch seeAll {
         case .saves:
-            self.tabBarController?.selectedIndex = 1
+            break // this case consists of changing the selected index in MainViewModel, thus is handled in MainViewModel
         case .slate(let slateViewModel):
             show(slateViewModel)
         case .sharedWithYou(let sharedWithYouViewModel):

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -52,6 +52,16 @@ enum SeeAll {
     case saves
     case slate(SlateDetailViewModel)
     case sharedWithYou(SharedWithYouListViewModel)
+
+    var isSaves: Bool {
+        switch self {
+        case .saves:
+            return true
+        default:
+            return false
+        }
+    }
+
     @MainActor
     func clearRecommendationToReport() {
         switch self {

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -136,6 +136,14 @@ public class MainViewModel: ObservableObject {
             linkRouter: LinkRouter()
         )
         setupLinkRouter()
+        home
+            .$tappedSeeAll
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] seeAll in
+                guard let self, let seeAll, seeAll.isSaves else { return }
+                selectedSection = .saves
+            }
+            .store(in: &subscriptions)
     }
 
     init(

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -136,6 +136,7 @@ public class MainViewModel: ObservableObject {
             linkRouter: LinkRouter()
         )
         setupLinkRouter()
+        // TODO: SWIFTUI - This subscription (as well as the entire HomeViewModel) should be removed when we switch to SwiftUI Home.
         home
             .$tappedSeeAll
             .receive(on: DispatchQueue.main)


### PR DESCRIPTION
## Goal
* This PR fixes a bug that caused the view to pop back to **Home** after briefly displaying the **Saves** tab, when tapping on **See All** from **Recent Saves**.
* This also fixes a long standing bug where tapping on **Recent Saves' See All** button from **Home**, did not change the tab bar selected icon.

> [!NOTE]
> The reason for this bug seems to be caused by unpredictable behavior when changing the wrapping `TabBarController`'s `selectedIndex` of `HomeViewController`. While I did not investigate the depth of this behavior, is totally reasonable to change `MainViewModel`'s `selectedSection` instead, since that is the property observed by `MainView` to select any tab.

## Test Steps
* Go to Home Depot(the old one, not SwiftUI)
* Tap See All on Recent saves
* Make sure the saves tab is shown, it stays there and the tab bar icon updates accordingly.

