### PR TITLE
SwiftUI Home - Fix card impressions firing at the same time

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/CarouselView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/CarouselView.swift
@@ -23,7 +23,7 @@ struct CarouselView: View {
 private extension CarouselView {
     func makeCarousel() -> some View {
         ScrollView(.horizontal) {
-            HStack(spacing: Self.defaultSpacing) {
+            LazyHStack(spacing: Self.defaultSpacing) {
                 ForEach(cards) {
                     CardView(
                         card: $0,

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
@@ -18,7 +18,7 @@ struct SlateView: View {
     @EnvironmentObject var navigation: HomeNavigation
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
                 if let slateTitle {
                     makeHeader(slateTitle)

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
@@ -28,6 +28,7 @@ struct SlateView: View {
             .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
             CarouselView(cards: carouselCards, useGrid: layoutWidth.isRegular)
         }
+        .padding(.bottom, 32)
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/CardFooter.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/Card elements/CardFooter.swift
@@ -105,13 +105,11 @@ private extension CardFooter {
     /// Action button: save/saved and/or favorite
     @ViewBuilder
     func makeActionButton() -> some View {
-        HStack(alignment: .bottom) {
-            if card.enableFavoriteAction {
-                makeFavoriteButton()
-            }
-            if card.enableSaveAction {
-                makeSaveButton()
-            }
+        if card.enableFavoriteAction {
+            makeFavoriteButton()
+        }
+        if card.enableSaveAction {
+            makeSaveButton()
         }
     }
 

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
@@ -48,17 +48,6 @@ struct CardView: View {
 
     var body: some View {
         makeBody()
-            .onAppear {
-                homeActions
-                    .trackCardImpression(
-                        AnalyticsInfo(
-                            type: card.type,
-                            url: card.givenURL,
-                            index: card.index,
-                            recommendationID: card.recommendationID
-                        )
-                    )
-            }
     }
 }
 
@@ -158,10 +147,40 @@ private extension CardView {
             HStack(alignment: .top) {
                 makeTextStack()
                 Spacer()
+                LazyHStack {
+                    Spacer()
+                        .frame(width: 1)
+                        .onAppear {
+                            homeActions
+                                .trackCardImpression(
+                                    AnalyticsInfo(
+                                        type: card.type,
+                                        url: card.givenURL,
+                                        index: card.index,
+                                        recommendationID: card.recommendationID
+                                    )
+                                )
+                        }
+                }
                 makeImage()
             }
         case .large:
             makeImage()
+            LazyVStack {
+                Spacer()
+                    .frame(height: 1)
+                    .onAppear {
+                        homeActions
+                            .trackCardImpression(
+                                AnalyticsInfo(
+                                    type: card.type,
+                                    url: card.givenURL,
+                                    index: card.index,
+                                    recommendationID: card.recommendationID
+                                )
+                            )
+                    }
+            }
             makeTextStack()
         }
     }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
                         .frame(height: 16)
                     if accessService.accessLevel.isAuthenticated {
                         RecentSavesView()
-                        SharedWithYouView()
+                        // SharedWithYouView()
                     } else if accessService.accessLevel.isAnonymous {
                         SigninBannerView { accessService.requestAuthentication(.homeBanner) }
                             .padding()
@@ -35,6 +35,7 @@ struct HomeView: View {
             .refreshable {
                 await homeActions.refreshRecommendations(isForced: true)
             }
+            .scrollIndicators(.hidden)
             .background(Color(.ui.white1))
             .navigationTitle(Localization.home)
             .environment(\.carouselWidth, carouselWidth(proxy.size))

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
                         .frame(height: 16)
                     if accessService.accessLevel.isAuthenticated {
                         RecentSavesView()
-                        // SharedWithYouView()
+                        SharedWithYouView()
                     } else if accessService.accessLevel.isAnonymous {
                         SigninBannerView { accessService.requestAuthentication(.homeBanner) }
                             .padding()

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -19,7 +19,7 @@ struct HomeView: View {
     var body: some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack {
+                LazyVStack {
                     Spacer()
                         .frame(height: 16)
                     if accessService.accessLevel.isAuthenticated {

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Top level views/RecommendationsView.swift
@@ -30,54 +30,56 @@ struct RecommendationsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 32) {
-            switch viewState {
-            case .loading:
-                if slates.isEmpty {
-                    makeLoadingView()
-                } else {
-                    makeSlatesView()
-                }
-            case .ready:
-                if slates.isEmpty {
-                    makeOfflineView()
-                } else {
-                    makeSlatesView()
-                }
-            case .offline:
-                makeOfflineView()
-            }
-        }
-        .task {
-            networkMonitor.start()
-            guard viewState != .loading else { return }
-            viewState = .loading
-            await homeActions.refreshRecommendations()
-            viewState = .ready
-        }
-        .onChange(of: networkMonitor.status, initial: true) { oldStatus, newStatus in
-            guard oldStatus != newStatus else { return }
-            switch newStatus {
-            case .unsatisfied, .requiresConnection:
-                viewState = .offline
-            case .satisfied:
+        makeBody()
+            .task {
+                networkMonitor.start()
+                guard viewState != .loading else { return }
                 viewState = .loading
-                Task {
-                    await homeActions.refreshRecommendations()
-                    viewState = .ready
-                }
-            default:
-                break
+                await homeActions.refreshRecommendations()
+                viewState = .ready
             }
-        }
-        .onDisappear {
-            networkMonitor.cancel()
-        }
+            .onChange(of: networkMonitor.status, initial: true) { oldStatus, newStatus in
+                guard oldStatus != newStatus else { return }
+                switch newStatus {
+                case .unsatisfied, .requiresConnection:
+                    viewState = .offline
+                case .satisfied:
+                    viewState = .loading
+                    Task {
+                        await homeActions.refreshRecommendations()
+                        viewState = .ready
+                    }
+                default:
+                    break
+                }
+            }
+            .onDisappear {
+                networkMonitor.cancel()
+            }
     }
 }
 
 // MARK: view builders and helpers
 private extension RecommendationsView {
+    @ViewBuilder
+    private func makeBody() -> some View {
+        switch viewState {
+        case .loading:
+            if slates.isEmpty {
+                makeLoadingView()
+            } else {
+                makeSlatesView()
+            }
+        case .ready:
+            if slates.isEmpty {
+                makeOfflineView()
+            } else {
+                makeSlatesView()
+            }
+        case .offline:
+            makeOfflineView()
+        }
+    }
     @ViewBuilder
     func makeSlatesView() -> some View {
         ForEach(slates) {
@@ -104,27 +106,27 @@ private extension RecommendationsView {
             .sorted(by: { $0.sortIndex < $1.sortIndex })
             .prefix(6)
             .compactMap {
-            if let item = $0.item {
-                return HomeCardConfiguration(
-                    givenURL: item.givenURL,
-                    sharedWithYouUrlString: nil,
-                    type: .recommendation,
-                    index: Int(item.recommendation?.sortIndex ?? 0), // sortIndex should not be nil, but just in case, let's have a default
-                    shareURL: item.shareURL,
-                    domain: item.bestDomain,
-                    timeToRead: item.timeToRead,
-                    isSyndicated: item.isSyndicated,
-                    recommendationID: item.recommendation?.analyticsID,
-                    bestTitle: item.bestTitle,
-                    slug: item.collectionSlug,
-                    excerpt: item.excerpt,
-                    topImageURL: item.topImageURL,
-                    enableSaveAction: true,
-                    enableShareMenuAction: true,
-                    enableReportMenuAction: true
-                )
+                if let item = $0.item {
+                    return HomeCardConfiguration(
+                        givenURL: item.givenURL,
+                        sharedWithYouUrlString: nil,
+                        type: .recommendation,
+                        index: Int(item.recommendation?.sortIndex ?? 0), // sortIndex should not be nil, but just in case, let's have a default
+                        shareURL: item.shareURL,
+                        domain: item.bestDomain,
+                        timeToRead: item.timeToRead,
+                        isSyndicated: item.isSyndicated,
+                        recommendationID: item.recommendation?.analyticsID,
+                        bestTitle: item.bestTitle,
+                        slug: item.collectionSlug,
+                        excerpt: item.excerpt,
+                        topImageURL: item.topImageURL,
+                        enableSaveAction: true,
+                        enableShareMenuAction: true,
+                        enableReportMenuAction: true
+                    )
+                }
+                return nil
             }
-            return nil
-        }
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -18,11 +18,8 @@ public struct MainView: View {
     // TODO: SWIFTUI - Remove the following two properties once we release SwiftUI Home
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
-#if DEBUG
-    @State private var assigned: Bool = true
-#else
+
     @State private var assigned: Bool = false
-#endif
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {
@@ -67,11 +64,7 @@ public struct MainView: View {
             guard let swiftuiFeatureFlag = featureFlag.first else {
                 return
             }
-#if DEBUG
-            return
-#else
             assigned = swiftuiFeatureFlag.assigned
-#endif
         }
         .banner(data: bannerPresenter.bannerData, show: $bannerPresenter.shouldPresentBanner, bottomOffset: 49)
         .task {
@@ -80,7 +73,7 @@ public struct MainView: View {
                 Tips.hideAllTipsForTesting()
             }
             do {
-                try Tips.configure()
+try Tips.configure()
             } catch {
                 Log.capture(message: "Unable to initialize tips - \(error)")
             }

--- a/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
+++ b/PocketKit/Sources/PocketKit/SharedWithYou/SharedWithYouStore.swift
@@ -41,11 +41,6 @@ extension SharedWithYouStore: SWHighlightCenterDelegate {
 // MARK: private helpers
 private extension SharedWithYouStore {
     func start() {
-        do {
-            try source.deleteAllSharedWithYouItems()
-        } catch {
-            Log.capture(message: "SWH: starting store - error while attempting to delete existing highlights. Detail: \(error)")
-        }
         highlightCenter.delegate = self
     }
 


### PR DESCRIPTION
## Goal
* Avoid rendering all cards in Home at the same time, for better allocation and more accurate analytics.

> [!NOTE]
> the presence of a `LazyVStack` in both `HomeView` and `RecommendationsView` caused glitches when scrolling. Removing the one in `RecommendationsView` still works fine, since the views will still be embedded in the outer `LazyVStack` and `ScrollView`

## Test Steps
* Build/run attached to Xcode and make sure that, in the console, you see the appropriate number of tracking impression events.
