### PR TITLE
Reader - scroll to the last known position only when the view first appears

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -43,6 +43,8 @@ class ReadableViewController: UIViewController {
 
     private var isReloading = false
 
+    var hasAppearedAfterLoading = false
+
     private var userScrollProgress: IndexPath?
     // Tippable view controller properties
     var tipObservationTask: Task<Void, Error>?
@@ -353,7 +355,10 @@ class ReadableViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        scrollToLastKnownPosition()
+        if !hasAppearedAfterLoading {
+            scrollToLastKnownPosition()
+            hasAppearedAfterLoading = true
+        }
         // do not vend the tip on syndicated articles
         if readableViewModel is SavedItemViewModel {
             PocketTipEvents.showSwipeHighlightsTip.sendDonation()


### PR DESCRIPTION
## Goal
* The last known position is intended to take the reader to the approximate point where the user left off last time they opened the article. As of today it's triggered even when a view is pushed/popped (or presented/dismissed) on top of the reader, which is unnecessary since the system will retain the accurate position. This PR changes this behavior and uses the last known position only when the article is first opened.

fixes: #1089

## Test Steps
* Build/run
* Open an article in the reader
* Scroll down until you like
* Tap on a link, if there is one available, or tap on the safari icon to reveal the original view
* Tap "Done" to dismiss the view and make sure the previous scrolling position is maintained.
* Go back to home or Saves
* Reopen the article
* Make sure the reader scrolls to a position close to the one you left off.
