### PR TITLE
Track cells from SwiftUI when they are 50% visible

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Card groups/SlateView.swift
@@ -18,7 +18,7 @@ struct SlateView: View {
     @EnvironmentObject var navigation: HomeNavigation
 
     var body: some View {
-        LazyVStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
                 if let slateTitle {
                     makeHeader(slateTitle)

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
@@ -47,7 +47,24 @@ struct CardView: View {
     }
 
     var body: some View {
-        makeBody()
+        if #available(iOS 18.0, *) {
+            makeBody()
+                .onScrollVisibilityChange(threshold: 0.5) { isVisible in
+                    if isVisible {
+                        homeActions
+                            .trackCardImpression(
+                                AnalyticsInfo(
+                                    type: card.type,
+                                    url: card.givenURL,
+                                    index: card.index,
+                                    recommendationID: card.recommendationID
+                                )
+                            )
+                    }
+                }
+        } else {
+            makeBody()
+        }
     }
 }
 
@@ -145,6 +162,23 @@ private extension CardView {
         switch size {
         case .medium:
             HStack(alignment: .top) {
+                makeMediumTopContnet()
+            }
+        case .large:
+            makeLargeTopContnet()
+        }
+    }
+
+    @ViewBuilder
+    func makeMediumTopContnet() -> some View {
+        if #available(iOS 18.0, *) {
+            HStack(alignment: .top) {
+                makeTextStack()
+                Spacer()
+                makeImage()
+            }
+        } else {
+            HStack(alignment: .top) {
                 makeTextStack()
                 Spacer()
                 LazyHStack {
@@ -164,7 +198,15 @@ private extension CardView {
                 }
                 makeImage()
             }
-        case .large:
+        }
+    }
+
+    @ViewBuilder
+    func makeLargeTopContnet() -> some View {
+        if #available(iOS 18.0, *) {
+            makeImage()
+            makeTextStack()
+        } else {
             makeImage()
             LazyVStack {
                 Spacer()

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
@@ -161,9 +161,7 @@ private extension CardView {
     func makeTopContent() -> some View {
         switch size {
         case .medium:
-            HStack(alignment: .top) {
-                makeMediumTopContnet()
-            }
+            makeMediumTopContnet()
         case .large:
             makeLargeTopContnet()
         }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -35,6 +35,7 @@ struct HomeView: View {
             .refreshable {
                 await homeActions.refreshRecommendations(isForced: true)
             }
+            .contentMargins(.bottom, -32)
             .scrollIndicators(.hidden)
             .background(Color(.ui.white1))
             .navigationTitle(Localization.home)

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -19,7 +19,7 @@ public struct MainView: View {
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
 
-    @State private var assigned: Bool = true
+    @State private var assigned: Bool = false
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -19,7 +19,7 @@ public struct MainView: View {
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
     private var featureFlag: [FeatureFlag]
 
-    @State private var assigned: Bool = false
+    @State private var assigned: Bool = true
 
     public var body: some View {
         TabView(selection: $model.selectedSection) {

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -74,7 +74,7 @@ public struct MainView: View {
                 Tips.hideAllTipsForTesting()
             }
             do {
-try Tips.configure()
+                try Tips.configure()
             } catch {
                 Log.capture(message: "Unable to initialize tips - \(error)")
             }


### PR DESCRIPTION
## Goal
* on iOS 18, use the new `onScrollVisibilityChange(threshold:_:)` to improve tracking reliability

## Test Steps
* Build this branch and check the tracks in the console

