### PR TITLE
Support triggering premium upsell screen from an external link

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/SignedOut.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/SignedOut.swift
@@ -18,6 +18,7 @@ public extension Events.SignedOut {
         case savesFilter
         case savesAddUrl
         case settingsSignin
+        case external
     }
 }
 

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -14,6 +14,8 @@ public struct MainView: View {
     @ObservedObject var model: MainViewModel
     @ObservedObject var bannerPresenter: BannerPresenter
 
+    @State private var dismissReason: DismissReason = .swipe
+
     @State var tabBarHeightOffset: CGFloat = 0
     // TODO: SWIFTUI - Remove the following two properties once we release SwiftUI Home
     @Query(filter: #Predicate<FeatureFlag> { $0.name == "temp.ios.swiftui.home" })
@@ -81,6 +83,23 @@ public struct MainView: View {
         }
         // TODO: SWIFTUI - This is used for tab navigation purposes only, will change as we re-architect the app.
         .environmentObject(model)
+        .sheet(
+            isPresented: $model.isPresentingPremiumUpgrade,
+            onDismiss: {
+                model.trackPremiumDismissed(dismissReason: dismissReason)
+                if dismissReason == .system {
+                    model.isPresentingHooray = true
+                }
+        }
+        ) {
+            PremiumUpgradeView(dismissReason: self.$dismissReason, viewModel: model.makeExternalPremiumUpgradeViewModel())
+        }
+        .sheet(isPresented: $model.isPresentingHooray) {
+            PremiumUpgradeSuccessView()
+        }
+        .task {
+            model.trackPremiumUpsellViewed()
+        }
     }
 
     func makeUIKitHome() -> some View {

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -462,9 +462,8 @@ extension MainViewModel {
         let settingsRoute = SettingsRoute(action: navigationAction)
         let managePremiumRoute = ManagePremiumRoute(action: navigationAction)
         let listenRoute = ListenRoute(action: listenAction)
-        // NOTE: order matters, because there might be overlapping patterns
-        // we can probably optimize by having exclusive-patterns only routes, and handle additional logic within
-        // the route itself
+        /// **NOTE: order matters here, because there might be overlapping patterns.**
+        /// For example, `/premium/manage` must precede `/premium/`.
         linkRouter.addRoutes(
             [
                 // specialized routes
@@ -479,11 +478,11 @@ extension MainViewModel {
                 savesRoute,
                 settingsRoute,
                 managePremiumRoute,
+                externalPremiumUpsellRoute,
                 genericItemRoute,
                 // pocket.co/[path] routes
                 pocketShareRoute,
                 brazeIconSwitcherRoute,
-                externalPremiumUpsellRoute,
                 shortUrlRoute
             ]
         )

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -13,6 +13,7 @@ import Localization
 import CoreSpotlight
 import SharedPocketKit
 import AppIntents
+import Analytics
 
 @MainActor
 public class MainViewModel: ObservableObject {
@@ -25,6 +26,10 @@ public class MainViewModel: ObservableObject {
     @Published var selectedSection: AppSection = .home
 
     @Published var showBanner: Bool = false
+
+    @Published var isPresentingPremiumUpgrade: Bool = false
+
+    @Published var isPresentingHooray = false
 
     private var subscriptions: Set<AnyCancellable> = []
     private let userDefaults: UserDefaults
@@ -384,6 +389,19 @@ extension MainViewModel {
             self?.account.isPresentingIconSwitcher = true
         }
 
+        let externalPremiumUpsellAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
+            self?.account.dismissAll()
+            switch Services.shared.user.status {
+            case .premium:
+                self?.selectedSection = .account
+                self?.account.isPresentingPremiumStatus = true
+            case .free:
+                self?.isPresentingPremiumUpgrade = true
+            case .unknown:
+                break
+            }
+        }
+
         let navigationAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
             self?.account.dismissAll()
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
@@ -434,6 +452,7 @@ extension MainViewModel {
         let pocketShareRoute = PocketShareRoute(action: pocketShareUrlRoutingAction)
         let pocketReadRoute = PocketReadRoute(action: pocketReadUrlRoutingAction)
         let brazeIconSwitcherRoute = BrazeIconSwitcherRoute(action: brazeShowIconSwitcherAction)
+        let externalPremiumUpsellRoute = ExternalPremiumUpsellRoute(action: externalPremiumUpsellAction)
         let homeRoute = HomeRoute(action: navigationAction)
         let savesRoute = SavesRoute(action: navigationAction)
         let settingsRoute = SettingsRoute(action: navigationAction)
@@ -460,8 +479,36 @@ extension MainViewModel {
                 // pocket.co/[path] routes
                 pocketShareRoute,
                 brazeIconSwitcherRoute,
+                externalPremiumUpsellRoute,
                 shortUrlRoute
             ]
         )
+    }
+}
+
+// MARK: premium upgrade
+extension MainViewModel {
+    /// track premium upgrade view dismissed
+    func trackPremiumDismissed(dismissReason: DismissReason) {
+        switch dismissReason {
+        case .swipe, .button, .closeButton:
+            Services.shared.tracker.track(event: Events.Premium.premiumUpgradeViewDismissed(reason: dismissReason))
+        case .system:
+            break
+        }
+    }
+
+    /// Premium upgrade view model constructor for external deeplink invocation
+    func makeExternalPremiumUpgradeViewModel() -> PremiumUpgradeViewModel {
+        PremiumUpgradeViewModel(
+            store: Services.shared.subscriptionStore,
+            tracker: Services.shared.tracker,
+            source: .external,
+            networkPathMonitor: NWPathMonitor()
+        )
+    }
+    /// track premium upsell viewed
+    func trackPremiumUpsellViewed() {
+        Services.shared.tracker.track(event: Events.Settings.premiumUpsellViewed())
     }
 }

--- a/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainViewModel.swift
@@ -391,6 +391,10 @@ extension MainViewModel {
 
         let externalPremiumUpsellAction: (URL, ReadableSource) -> Void = { [weak self] url, source in
             self?.account.dismissAll()
+            guard Services.shared.accessService.accessLevel.isAuthenticated else {
+                Services.shared.accessService.requestAuthentication(.external)
+                return
+            }
             switch Services.shared.user.status {
             case .premium:
                 self?.selectedSection = .account

--- a/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
+++ b/PocketKit/Sources/PocketKit/Settings/SettingsView.swift
@@ -25,7 +25,7 @@ struct SettingsView: View {
 }
 
 struct SettingsForm: View {
-    @State var dismissReason: DismissReason = .swipe
+    @State private var dismissReason: DismissReason = .swipe
     @ObservedObject var model: AccountViewModel
 
     var body: some View {

--- a/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
@@ -244,6 +244,23 @@ struct BrazeIconSwitcherRoute: Route {
 }
 
 @MainActor
+struct ExternalPremiumUpsellRoute: Route {
+    let host: String? = "pocket.co"
+    let scheme = "https"
+    let path = "/braze/premium"
+    let source: ReadableSource = .external
+    let action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
 struct ListenRoute: Route {
     let host: String? = "getpocket.com"
     let scheme: String = "https"

--- a/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
@@ -29,7 +29,7 @@ private extension URLComponents {
 
 private extension URL {
     /// Builds `URLComponents` matching the passed elements, if they exist
-    /// NOTE: the matching criteria for path is contains instead of equality, to account
+    /// NOTE: the matching criteria for path is `contains` instead of `==`, to account
     /// for localized paths.
     /// - Parameters:
     ///   - host: the host to match
@@ -245,9 +245,26 @@ struct BrazeIconSwitcherRoute: Route {
 
 @MainActor
 struct ExternalPremiumUpsellRoute: Route {
-    let host: String? = "pocket.co"
+    let host: String? = "getpocket.com"
     let scheme = "https"
-    let path = "/braze/premium"
+    let path = "/premium/"
+    let source: ReadableSource = .external
+    let action: (URL, ReadableSource) -> Void
+
+    init(action: @escaping (URL, ReadableSource) -> Void) {
+        self.action = action
+    }
+
+    nonisolated func matchedUrlString(from url: URL) -> String? {
+        url.matched(host: host, scheme: scheme, path: path)
+    }
+}
+
+@MainActor
+struct ExternalPremiumManageRoute: Route {
+    let host: String? = "getpocket.com"
+    let scheme = "https"
+    let path = "/premium/manage/"
     let source: ReadableSource = .external
     let action: (URL, ReadableSource) -> Void
 

--- a/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
+++ b/PocketKit/Sources/PocketKit/UniversalLinks/Route.swift
@@ -261,23 +261,6 @@ struct ExternalPremiumUpsellRoute: Route {
 }
 
 @MainActor
-struct ExternalPremiumManageRoute: Route {
-    let host: String? = "getpocket.com"
-    let scheme = "https"
-    let path = "/premium/manage/"
-    let source: ReadableSource = .external
-    let action: (URL, ReadableSource) -> Void
-
-    init(action: @escaping (URL, ReadableSource) -> Void) {
-        self.action = action
-    }
-
-    nonisolated func matchedUrlString(from url: URL) -> String? {
-        url.matched(host: host, scheme: scheme, path: path)
-    }
-}
-
-@MainActor
 struct ListenRoute: Route {
     let host: String? = "getpocket.com"
     let scheme: String = "https"

--- a/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
+++ b/PocketKit/Sources/SharedPocketKit/PremiumUpgradeSource.swift
@@ -9,4 +9,5 @@ public enum PremiumUpgradeSource: String {
     case tags
     case premiumFonts
     case highlights
+    case external
 }


### PR DESCRIPTION
## Goal
* This PR adds support to trigger a premium upgrade screen from an external link
* If the user has already a premium subscription, they will be redirected to the premium status page
* If the user is logged out, they will see the FxA prompt.

## Test Steps
* Build and run this branch
* Test the cases described above
