### PR TITLE
Fix dates not showing up in the Reader

### DIFF
--- a/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
+++ b/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
@@ -8,7 +8,7 @@ extension DateFormatter {
     static let clientAPI: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeZone = .init(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
 
         return formatter
     }()

--- a/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
+++ b/PocketKit/Sources/Sync/DateFormatter+Extensions.swift
@@ -8,8 +8,16 @@ extension DateFormatter {
     static let clientAPI: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeZone = .init(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
 
         return formatter
     }()
+}
+
+extension ISO8601DateFormatter {
+    static var rfc3339WithFractionalSeconds: Self {
+        let formatter = Self()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
 }

--- a/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Item+remoteMapping.swift
@@ -48,7 +48,7 @@ extension CDItem {
         }
 
         updateIfNotEqual(\.excerpt, remote.preview?.excerpt)
-        updateIfNotEqual(\.datePublished, remote.preview?.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) })
+        updateIfNotEqual(\.datePublished, remote.preview?.datePublished.flatMap { ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: $0) })
         updateIfNotEqual(\.isArticle, remote.isArticle ?? false)
         updateIfNotEqual(\.imageness, remote.hasImage?.rawValue)
         updateIfNotEqual(\.videoness, remote.hasVideo?.rawValue)
@@ -119,6 +119,9 @@ extension CDItem {
         topImageURL = URL(string: corpusItem.preview.image?.url ?? corpusItem.imageUrl)
         domain = corpusItem.preview.domain?.name
         excerpt = corpusItem.preview.excerpt
+        if let date = corpusItem.preview.datePublished {
+            datePublished = ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: date)
+        }
 
         guard let context = managedObjectContext else {
             return
@@ -182,7 +185,7 @@ extension CDItem {
             wordCount = 0
         }
 
-        datePublished = storyItem.preview?.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) }
+        datePublished = storyItem.preview?.datePublished.flatMap { ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: $0) }
         isArticle = storyItem.isArticle ?? false
         imageness = storyItem.hasImage?.rawValue
         videoness = storyItem.hasVideo?.rawValue
@@ -256,7 +259,7 @@ extension CDItem {
             wordCount = 0
         }
         excerpt = summary.preview?.excerpt
-        datePublished = summary.preview?.datePublished.flatMap { DateFormatter.clientAPI.date(from: $0) }
+        datePublished = summary.preview?.datePublished.flatMap { ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: $0) }
         isArticle = summary.isArticle ?? false
         imageness = summary.hasImage?.rawValue
         videoness = summary.hasVideo?.rawValue


### PR DESCRIPTION

## Goal
* Fix a bug where dates were not shown anymore in the reader
    - Seems that the date formatter we were using had different format options than the dates we are now receiving (which are consistent with RFC 3339 with fractional seconds

## Test Steps
* Build/run this branch
* Open an article in the reader and make sure the date shows up in the metadata at the top of the page.
