### PR TITLE
Analytics: add Home, Saves, Archives and Reader impressions

### DIFF
--- a/PocketKit/Sources/Analytics/AppEvents/Home.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Home.swift
@@ -8,6 +8,18 @@ public extension Events {
 }
 
 public extension Events.Home {
+    /// User views the `Home` screen
+    static func homeScreenImpression() -> Impression {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "global-nav.home"
+            )
+        )
+    }
+
     /**
      Fired when a card in the `Recent Saves` section scrolls into view
      */

--- a/PocketKit/Sources/Analytics/AppEvents/Reader.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Reader.swift
@@ -8,6 +8,18 @@ public extension Events {
 }
 
 public extension Events.Reader {
+    /// User views the `Reader` screen
+    static func readerScreenImpression() -> Impression {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "article.screen"
+            )
+        )
+    }
+
     /**
      Fired when the user views an unsupported content cell in the `Reader`
      */

--- a/PocketKit/Sources/Analytics/AppEvents/Saves.swift
+++ b/PocketKit/Sources/Analytics/AppEvents/Saves.swift
@@ -9,6 +9,30 @@ public extension Events {
 }
 
 public extension Events.Saves {
+    /// User views the `Saves` screen
+    static func savesScreenImpression() -> Impression {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "global-nav.saves"
+            )
+        )
+    }
+
+    /// User views the `Archived Items` screen
+    static func archivesScreenImpression() -> Impression {
+        return Impression(
+            component: .screen,
+            requirement: .viewable,
+            uiEntity: UiEntity(
+                .screen,
+                identifier: "global-nav.archives"
+            )
+        )
+    }
+
     /// Returns a ContentOpen event for a url that was opened within Saves
     /// - Parameters:
     ///     - destination: Internal, or external, based on whether the content was opened in the reader or web view, respectively

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -364,6 +364,7 @@ class ReadableViewController: UIViewController {
             PocketTipEvents.showSwipeHighlightsTip.sendDonation()
             displayTip(SwipeHighlightsTip(), configuration: nil, sourceView: nil)
         }
+        readableViewModel.trackReaderScreenImpression()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewModel/ReadableViewModel.swift
@@ -171,6 +171,10 @@ extension ReadableViewModel {
 
 // MARK: - Analytics
 extension ReadableViewModel {
+    /// Reader screen viewed
+    func trackReaderScreenImpression() {
+        tracker.track(event: Events.Reader.readerScreenImpression())
+    }
     /// track when user views unsupported content cell
     func trackUnsupportedContentViewed() {
         tracker.track(event: Events.Reader.unsupportedContentViewed(url: url))

--- a/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewController.swift
@@ -212,6 +212,11 @@ class HomeViewController: UIViewController {
         handleRefresh {}
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        model.trackHomeScreenImpression()
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
+++ b/PocketKit/Sources/PocketKit/Home/HomeViewModel.swift
@@ -1119,7 +1119,7 @@ private extension HomeViewModel {
     }
 }
 
-// MARK: Recommendations - Editor's Picks widget
+// MARK: Recommendations - Recommendations widget
 private extension HomeViewModel {
     func updateRecommendationsWidget() {
         guard let sections = recomendationsController.sections, !sections.isEmpty else {
@@ -1137,5 +1137,12 @@ private extension HomeViewModel {
 
     func setRecommendationsWidgetOffline() {
         recommendationsWidgetUpdateService.update([:])
+    }
+}
+
+// MARK: Screen impression
+extension HomeViewModel {
+    func trackHomeScreenImpression() {
+        tracker.track(event: Events.Home.homeScreenImpression())
     }
 }

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Models/HomeActions.swift
@@ -94,6 +94,12 @@ struct HomeActions {
 
 // MARK: Analytics
 extension HomeActions {
+    func trackHomeScreenImpression() {
+        Task(priority: .background) {
+            let tracker = await Services.shared.tracker
+            tracker.track(event: Events.Home.homeScreenImpression())
+        }
+    }
     func trackCardImpression(_ info: AnalyticsInfo) {
         Task(priority: .background) {
             let tracker = await Services.shared.tracker

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeView.swift
@@ -35,6 +35,9 @@ struct HomeView: View {
             .refreshable {
                 await homeActions.refreshRecommendations(isForced: true)
             }
+            .onAppear {
+                homeActions.trackHomeScreenImpression()
+            }
             .contentMargins(.bottom, -32)
             .scrollIndicators(.hidden)
             .background(Color(.ui.white1))

--- a/PocketKit/Sources/PocketKit/Main/MainView.swift
+++ b/PocketKit/Sources/PocketKit/Main/MainView.swift
@@ -92,9 +92,6 @@ public struct MainView: View {
         .sheet(isPresented: $model.isPresentingHooray) {
             PremiumUpgradeSuccessView()
         }
-        .task {
-            model.trackPremiumUpsellViewed()
-        }
     }
 
     func makeUIKitHome() -> some View {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewController.swift
@@ -78,6 +78,7 @@ class ItemsListViewController<ViewModel: ItemsListViewModel>: UIViewController, 
             PocketTipEvents.showSwipeArchiveTip.sendDonation()
             displayTip(SwipeArchiveTip(), configuration: nil, sourceView: nil)
         }
+        model.trackScreenImpression()
     }
 
     override func loadView() {

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/ItemsListViewModel.swift
@@ -150,4 +150,6 @@ protocol ItemsListViewModel: AnyObject {
     func prefetch(itemsAt: [IndexPath])
 
     func reloadSnapshot(for identifiers: [ItemsListCell<ItemIdentifier>])
+
+    func trackScreenImpression()
 }

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/SavedItemsList/SavedItemsListViewModel.swift
@@ -554,6 +554,15 @@ class SavedItemsListViewModel: NSObject, ItemsListViewModel {
         return snapshot
     }
 
+    func trackScreenImpression() {
+        switch viewType {
+        case .saves:
+            tracker.track(event: Events.Saves.savesScreenImpression())
+        case .archive:
+            tracker.track(event: Events.Saves.archivesScreenImpression())
+        }
+    }
+
     func willDisplay(_ cell: ItemsListCell<NSManagedObjectID>) {
         if case .item = cell {
             withSavedItem(from: cell) { [weak self] item in


### PR DESCRIPTION
## Goal
* Add screen impression events for Home, Saves/Archive and Reader(article) screens

## Test Steps
* run and check for the events in the console
* test both UIKit and SwiftUI Home(s)
