### PR TITLE
Fix articles not opening when offline, and non parseable items sometimes being presented as articles

### DIFF
--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Cards/CardView.swift
@@ -126,8 +126,11 @@ private extension CardView {
             var externalDestination = false
             if let slug = card.slug {
                 navigation.navigateTo(NativeCollectionDestination(slug: slug, givenURL: card.givenURL))
-            } else if savedItem != nil {
-                navigation.navigateTo(ReadableDestination(.saved(card.givenURL)))
+            } else if let savedItem,                                                // We are legally allowed to open the item in reader view
+                        savedItem.item?.isArticle == true,                          // except one of the following conditions is met:
+                        savedItem.item?.isVideo == false,                           // a) the item is not an article (i.e. it was not parseable)
+                        savedItem.item?.isImage == false {                          // b) the item is an image
+                navigation.navigateTo(ReadableDestination(.saved(card.givenURL)))   // c) the item is a video
             } else if card.isSyndicated {
                 navigation.navigateTo(ReadableDestination(.syndicated(card.givenURL)))
             } else if URL(string: card.givenURL) != nil {

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/ReaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/Detail views/ReaderView.swift
@@ -7,7 +7,7 @@ import Network
 
 /// SwiftUI version of the `Reader`
 struct ReaderView: UIViewControllerRepresentable {
-    let route: ReadableDestination
+    let destination: ReadableDestination
 
     class Coordinator {
         var parentObserver: NSKeyValueObservation?
@@ -40,10 +40,10 @@ struct ReaderView: UIViewControllerRepresentable {
 
 private extension ReaderView {
     func makeReadableViewModel() -> ReadableViewModel? {
-        if let savedItemUrlString = route.savedItemUrlString {
+        if let savedItemUrlString = destination.savedItemUrlString {
             return SavedItemViewModel.fromURL(savedItemUrlString)
         }
-        if let syndictedUrlString = route.itemUrlString {
+        if let syndictedUrlString = destination.itemUrlString {
             return RecommendableItemViewModel.fromURL(syndictedUrlString)
         }
         return nil

--- a/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeRootView.swift
+++ b/PocketKit/Sources/PocketKit/Home/SwiftUI/Views/HomeRootView.swift
@@ -20,7 +20,7 @@ struct HomeRootView: View {
             HomeView()
                 .navigationDestination(for: NativeCollectionDestination.self) { NativeCollectionView(destination: $0) }
                 .navigationDestination(for: ReadableDestination.self) {
-                    ReaderView(route: $0)
+                    ReaderView(destination: $0)
                         .ignoresSafeArea(.all)
                 }
                 .navigationDestination(for: SlateDestination.self) { SlateDetailView(destination: $0) }

--- a/PocketKit/Sources/Sync/Article/Article.swift
+++ b/PocketKit/Sources/Sync/Article/Article.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@objc(Article)
 public class Article: NSObject, Codable {
     public static var supportsSecureCoding: Bool = true
 
@@ -11,10 +12,12 @@ public class Article: NSObject, Codable {
 
     public init(components: [ArticleComponent]) {
         self.components = components
+        super.init()
     }
 }
+
 @objc(ArticleTransformer)
-class ArticleTransformer: ValueTransformer {
+class ArticleTransformer: NSSecureUnarchiveFromDataTransformer {
     static let name = NSValueTransformerName(rawValue: String(describing: ArticleTransformer.self))
 
     override func transformedValue(_ value: Any?) -> Any? {
@@ -30,7 +33,7 @@ class ArticleTransformer: ValueTransformer {
             return nil
         }
 
-        return try? JSONEncoder().encode(article) as NSData
+        return try? JSONEncoder().encode(article)
     }
 
     override class func transformedValueClass() -> AnyClass {

--- a/PocketKit/Sources/Sync/Operations/SyncTask.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncTask.swift
@@ -52,7 +52,7 @@ class SyncTaskTransformer: NSSecureUnarchiveFromDataTransformer {
             return nil
         }
 
-        return try? JSONEncoder().encode(syncTaskContainer) as NSData
+        return try? JSONEncoder().encode(syncTaskContainer)
     }
 
     override class func transformedValueClass() -> AnyClass {


### PR DESCRIPTION
## Goal
Fix the following issues on article:
- articles not opening when offline
- sometimes, in SwiftUI Home, the app attempted to display urls as articles when they were not parseable

## Test Steps
* Go off-line and make sure you can view articles
* Save a non-parseable item then access it from recent saves on SwftUI home and make sure it goes to a web view

