### PR TITLE
fix(search): ensure no empty object is passed via search filters

### DIFF
--- a/PocketKit/Sources/Sync/Operations/SearchService.swift
+++ b/PocketKit/Sources/Sync/Operations/SearchService.swift
@@ -91,9 +91,9 @@ public class PocketSearchService: SearchService {
         var items: [SearchSavedItem] = []
         let pagination = PaginationInput(after: GraphQLNullable<String>(stringLiteral: lastEndCursor), first: GraphQLNullable<Int>(integerLiteral: Constants.pageSize))
 
-        let filter = getSearchFilter(with: scope)
+        let filter = getSearchFilter(with: scope) ?? .null
         let sortOrder = getSortOrder()
-        let query = SearchSavedItemsQuery(term: getTerm(term, for: scope), pagination: .init(pagination), filter: .some(filter), sort: .some(sortOrder))
+        let query = SearchSavedItemsQuery(term: getTerm(term, for: scope), pagination: .init(pagination), filter: filter, sort: .some(sortOrder))
         let result = try await apollo.fetch(query: query)
         result.data?.user?.searchSavedItems?.edges.forEach { edge in
             var searchSavedItem = SearchSavedItem(remoteItem: edge.node.savedItem.fragments.savedItemParts)
@@ -109,20 +109,20 @@ public class PocketSearchService: SearchService {
         _results = items
     }
 
-    private func getSearchFilter(with scope: SearchScope) -> SearchFilterInput {
+    private func getSearchFilter(with scope: SearchScope) -> SearchFilterInput? {
         switch scope {
         case .saves:
             return SearchFilterInput(status: .init(.unread))
         case .archive:
             return SearchFilterInput(status: .init(.archived))
         case .all:
-            return SearchFilterInput()
+            return nil
         case .premiumSearchByTitle:
             return SearchFilterInput(onlyTitleAndURL: true)
         case .premiumSearchByTag:
-            return SearchFilterInput()
+            return nil
         case .premiumSearchByContent:
-            return SearchFilterInput()
+            return nil
         }
     }
 

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -82,8 +82,8 @@ class PocketSearchServiceTests: XCTestCase {
         await fulfillment(of: [searchExpectation], timeout: 2)
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
-        XCTAssertEqual(call?.query.term, "search-term")
-        XCTAssertNil(call?.query.filter)
+        XCTAssertEqual(call!.query.term, "search-term")
+        XCTAssertNil(call?.query.filter.status)
     }
 
     // MARK: Pagination
@@ -173,7 +173,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "tag:\"search term\"")
-        XCTAssertNil(call?.query.filter)
+        XCTAssertNil(call?.query.filter.status)
     }
 
     func test_search_forTag_withPrefix_fetchesSearchSavedItemsQueryWithCorrectTerm() async throws {
@@ -191,7 +191,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "#search")
-        XCTAssertNil(call?.query.filter)
+        XCTAssertNil(call?.query.filter.status)
     }
 
     func test_search_forContent_fetchesSearchSavedItemsQueryWithTerm() async throws {
@@ -209,7 +209,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
-        XCTAssertNil(call?.query.filter)
+        XCTAssertNil(call?.query.filter.status)
     }
 }
 

--- a/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
+++ b/PocketKit/Tests/SyncTests/Support/PocketSearchServiceTests.swift
@@ -83,7 +83,7 @@ class PocketSearchServiceTests: XCTestCase {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
-        XCTAssertEqual(call?.query.filter.status, .init(.none))
+        XCTAssertNil(call?.query.filter)
     }
 
     // MARK: Pagination
@@ -173,7 +173,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "tag:\"search term\"")
-        XCTAssertEqual(call?.query.filter.status, .init(.none))
+        XCTAssertNil(call?.query.filter)
     }
 
     func test_search_forTag_withPrefix_fetchesSearchSavedItemsQueryWithCorrectTerm() async throws {
@@ -191,7 +191,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "#search")
-        XCTAssertEqual(call?.query.filter.status, .init(.none))
+        XCTAssertNil(call?.query.filter)
     }
 
     func test_search_forContent_fetchesSearchSavedItemsQueryWithTerm() async throws {
@@ -209,7 +209,7 @@ extension PocketSearchServiceTests {
 
         let call: MockApolloClient.FetchCall<SearchSavedItemsQuery>? = self.apollo.fetchCall(at: 0)
         XCTAssertEqual(call?.query.term, "search-term")
-        XCTAssertEqual(call?.query.filter.status, .init(.none))
+        XCTAssertNil(call?.query.filter)
     }
 }
 

--- a/Tests iOS/HomeTests.swift
+++ b/Tests iOS/HomeTests.swift
@@ -229,7 +229,7 @@ class HomeTests: PocketXCTestCase {
 
         app.navigationBar.buttons["Home"].tap()
 
-        XCTAssertTrue(app.homeView.carouselCardLabel("Mozilla ").exists)
+        XCTAssertTrue(app.homeView.carouselCardLabel("slate-1-rec-2.example.com ").exists)
     }
 
     func test_tappingSaveButtonInRecommendationCell_savesItemToList() {


### PR DESCRIPTION
## Goal

Ensure no empty object is passed to the search query which does not work atm.