### PR TITLE
Sync logic for Notes

### DIFF
--- a/PocketKit/Sources/PocketGraph/Fragments/NotesPart.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Fragments/NotesPart.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct NotesPart: PocketGraph.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment NotesPart on Note { __typename contentPreview createdAt id savedItem { __typename id } source title updatedAt }"#
+    #"fragment NotesPart on Note { __typename contentPreview docMarkdown createdAt id savedItem { __typename id } source title updatedAt archived deleted }"#
   }
 
   public let __data: DataDict
@@ -15,16 +15,21 @@ public struct NotesPart: PocketGraph.SelectionSet, Fragment {
   public static var __selections: [ApolloAPI.Selection] { [
     .field("__typename", String.self),
     .field("contentPreview", PocketGraph.Markdown?.self),
+    .field("docMarkdown", PocketGraph.Markdown?.self),
     .field("createdAt", PocketGraph.ISOString.self),
     .field("id", PocketGraph.ID.self),
     .field("savedItem", SavedItem?.self),
     .field("source", PocketGraph.ValidUrl?.self),
     .field("title", String?.self),
     .field("updatedAt", PocketGraph.ISOString.self),
+    .field("archived", Bool.self),
+    .field("deleted", Bool.self),
   ] }
 
   /// Markdown preview of the note content for summary view.
   public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+  /// Markdown representation of the note content
+  public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
   /// When this note was created
   public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
   /// This Note's identifier
@@ -39,26 +44,38 @@ public struct NotesPart: PocketGraph.SelectionSet, Fragment {
   public var title: String? { __data["title"] }
   /// When this note was last updated
   public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+  /// Whether this Note has been marked as archived (hide from default view).
+  public var archived: Bool { __data["archived"] }
+  /// Whether this Note has been marked for deletion (will be eventually
+  /// removed from the server). Clients should delete Notes from their local
+  /// storage if this value is true.
+  public var deleted: Bool { __data["deleted"] }
 
   public init(
     contentPreview: PocketGraph.Markdown? = nil,
+    docMarkdown: PocketGraph.Markdown? = nil,
     createdAt: PocketGraph.ISOString,
     id: PocketGraph.ID,
     savedItem: SavedItem? = nil,
     source: PocketGraph.ValidUrl? = nil,
     title: String? = nil,
-    updatedAt: PocketGraph.ISOString
+    updatedAt: PocketGraph.ISOString,
+    archived: Bool,
+    deleted: Bool
   ) {
     self.init(_dataDict: DataDict(
       data: [
         "__typename": PocketGraph.Objects.Note.typename,
         "contentPreview": contentPreview,
+        "docMarkdown": docMarkdown,
         "createdAt": createdAt,
         "id": id,
         "savedItem": savedItem._fieldData,
         "source": source,
         "title": title,
         "updatedAt": updatedAt,
+        "archived": archived,
+        "deleted": deleted,
       ],
       fulfilledFragments: [
         ObjectIdentifier(NotesPart.self)

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/CreateNoteMarkdownMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/CreateNoteMarkdownMutation.graphql.swift
@@ -46,6 +46,8 @@ public class CreateNoteMarkdownMutation: GraphQLMutation {
 
       /// Markdown preview of the note content for summary view.
       public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+      /// Markdown representation of the note content
+      public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
       /// When this note was created
       public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
       /// This Note's identifier
@@ -60,6 +62,12 @@ public class CreateNoteMarkdownMutation: GraphQLMutation {
       public var title: String? { __data["title"] }
       /// When this note was last updated
       public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+      /// Whether this Note has been marked as archived (hide from default view).
+      public var archived: Bool { __data["archived"] }
+      /// Whether this Note has been marked for deletion (will be eventually
+      /// removed from the server). Clients should delete Notes from their local
+      /// storage if this value is true.
+      public var deleted: Bool { __data["deleted"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/EditNoteContentMarkdownMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/EditNoteContentMarkdownMutation.graphql.swift
@@ -50,6 +50,8 @@ public class EditNoteContentMarkdownMutation: GraphQLMutation {
 
       /// Markdown preview of the note content for summary view.
       public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+      /// Markdown representation of the note content
+      public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
       /// When this note was created
       public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
       /// This Note's identifier
@@ -64,6 +66,12 @@ public class EditNoteContentMarkdownMutation: GraphQLMutation {
       public var title: String? { __data["title"] }
       /// When this note was last updated
       public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+      /// Whether this Note has been marked as archived (hide from default view).
+      public var archived: Bool { __data["archived"] }
+      /// Whether this Note has been marked for deletion (will be eventually
+      /// removed from the server). Clients should delete Notes from their local
+      /// storage if this value is true.
+      public var deleted: Bool { __data["deleted"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict

--- a/PocketKit/Sources/PocketGraph/Operations/Mutations/EditNoteTitleMutation.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Mutations/EditNoteTitleMutation.graphql.swift
@@ -49,6 +49,8 @@ public class EditNoteTitleMutation: GraphQLMutation {
 
       /// Markdown preview of the note content for summary view.
       public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+      /// Markdown representation of the note content
+      public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
       /// When this note was created
       public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
       /// This Note's identifier
@@ -63,6 +65,12 @@ public class EditNoteTitleMutation: GraphQLMutation {
       public var title: String? { __data["title"] }
       /// When this note was last updated
       public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+      /// Whether this Note has been marked as archived (hide from default view).
+      public var archived: Bool { __data["archived"] }
+      /// Whether this Note has been marked for deletion (will be eventually
+      /// removed from the server). Clients should delete Notes from their local
+      /// storage if this value is true.
+      public var deleted: Bool { __data["deleted"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/NoteQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/NoteQuery.graphql.swift
@@ -46,6 +46,8 @@ public class NoteQuery: GraphQLQuery {
 
       /// Markdown preview of the note content for summary view.
       public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+      /// Markdown representation of the note content
+      public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
       /// When this note was created
       public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
       /// This Note's identifier
@@ -60,6 +62,12 @@ public class NoteQuery: GraphQLQuery {
       public var title: String? { __data["title"] }
       /// When this note was last updated
       public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+      /// Whether this Note has been marked as archived (hide from default view).
+      public var archived: Bool { __data["archived"] }
+      /// Whether this Note has been marked for deletion (will be eventually
+      /// removed from the server). Clients should delete Notes from their local
+      /// storage if this value is true.
+      public var deleted: Bool { __data["deleted"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict

--- a/PocketKit/Sources/PocketGraph/Operations/Queries/NotesQuery.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Operations/Queries/NotesQuery.graphql.swift
@@ -7,11 +7,25 @@ public class NotesQuery: GraphQLQuery {
   public static let operationName: String = "Notes"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query Notes { notes { __typename edges { __typename cursor node { __typename ...NotesPart } } pageInfo { __typename endCursor hasNextPage hasPreviousPage startCursor } totalCount } }"#,
+      #"query Notes($pagination: PaginationInput, $filter: NoteFilterInput) { notes(pagination: $pagination, filter: $filter) { __typename edges { __typename cursor node { __typename ...NotesPart } } pageInfo { __typename endCursor hasNextPage hasPreviousPage startCursor } totalCount } }"#,
       fragments: [NotesPart.self]
     ))
 
-  public init() {}
+  public var pagination: GraphQLNullable<PaginationInput>
+  public var filter: GraphQLNullable<NoteFilterInput>
+
+  public init(
+    pagination: GraphQLNullable<PaginationInput>,
+    filter: GraphQLNullable<NoteFilterInput>
+  ) {
+    self.pagination = pagination
+    self.filter = filter
+  }
+
+  public var __variables: Variables? { [
+    "pagination": pagination,
+    "filter": filter
+  ] }
 
   public struct Data: PocketGraph.SelectionSet {
     public let __data: DataDict
@@ -19,7 +33,10 @@ public class NotesQuery: GraphQLQuery {
 
     public static var __parentType: ApolloAPI.ParentType { PocketGraph.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
-      .field("notes", Notes?.self),
+      .field("notes", Notes?.self, arguments: [
+        "pagination": .variable("pagination"),
+        "filter": .variable("filter")
+      ]),
     ] }
 
     /// Retrieve a user's Notes
@@ -81,6 +98,8 @@ public class NotesQuery: GraphQLQuery {
 
           /// Markdown preview of the note content for summary view.
           public var contentPreview: PocketGraph.Markdown? { __data["contentPreview"] }
+          /// Markdown representation of the note content
+          public var docMarkdown: PocketGraph.Markdown? { __data["docMarkdown"] }
           /// When this note was created
           public var createdAt: PocketGraph.ISOString { __data["createdAt"] }
           /// This Note's identifier
@@ -95,6 +114,12 @@ public class NotesQuery: GraphQLQuery {
           public var title: String? { __data["title"] }
           /// When this note was last updated
           public var updatedAt: PocketGraph.ISOString { __data["updatedAt"] }
+          /// Whether this Note has been marked as archived (hide from default view).
+          public var archived: Bool { __data["archived"] }
+          /// Whether this Note has been marked for deletion (will be eventually
+          /// removed from the server). Clients should delete Notes from their local
+          /// storage if this value is true.
+          public var deleted: Bool { __data["deleted"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict

--- a/PocketKit/Sources/PocketGraph/Schema/InputObjects/NoteFilterInput.graphql.swift
+++ b/PocketKit/Sources/PocketGraph/Schema/InputObjects/NoteFilterInput.graphql.swift
@@ -1,0 +1,55 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+/// Filter for retrieving Notes
+public struct NoteFilterInput: InputObject {
+  public private(set) var __data: InputDict
+
+  public init(_ data: InputDict) {
+    __data = data
+  }
+
+  public init(
+    isAttachedToSave: GraphQLNullable<Bool> = nil,
+    archived: GraphQLNullable<Bool> = nil,
+    since: GraphQLNullable<ISOString> = nil,
+    excludeDeleted: GraphQLNullable<Bool> = nil
+  ) {
+    __data = InputDict([
+      "isAttachedToSave": isAttachedToSave,
+      "archived": archived,
+      "since": since,
+      "excludeDeleted": excludeDeleted
+    ])
+  }
+
+  /// Filter to show notes which are attached to a source URL
+  /// directly or via clipping, or are standalone
+  /// notes. If not provided, notes will not be filtered by source url.
+  public var isAttachedToSave: GraphQLNullable<Bool> {
+    get { __data["isAttachedToSave"] }
+    set { __data["isAttachedToSave"] = newValue }
+  }
+
+  /// Filter to retrieve Notes by archived status (true/false).
+  /// If not provided, notes will not be filtered by archived status.
+  public var archived: GraphQLNullable<Bool> {
+    get { __data["archived"] }
+    set { __data["archived"] = newValue }
+  }
+
+  /// Filter to retrieve notes after a timestamp, e.g. for syncing.
+  public var since: GraphQLNullable<ISOString> {
+    get { __data["since"] }
+    set { __data["since"] = newValue }
+  }
+
+  /// Filter to choose whether to include notes marked for server-side
+  /// deletion in the response (defaults to false).
+  public var excludeDeleted: GraphQLNullable<Bool> {
+    get { __data["excludeDeleted"] }
+    set { __data["excludeDeleted"] = newValue }
+  }
+}

--- a/PocketKit/Sources/PocketGraph/user-defined-operations/notes.graphql
+++ b/PocketKit/Sources/PocketGraph/user-defined-operations/notes.graphql
@@ -1,5 +1,6 @@
 fragment NotesPart on Note {
     contentPreview
+    docMarkdown
     createdAt
     id
     savedItem {
@@ -8,6 +9,8 @@ fragment NotesPart on Note {
     source
     title
     updatedAt
+    archived
+    deleted
 }
 
 query Note($noteId: ID!) {
@@ -17,8 +20,8 @@ query Note($noteId: ID!) {
   }
 }
 
-query Notes {
-  notes {
+query Notes($pagination: PaginationInput, $filter: NoteFilterInput) {
+  notes(pagination: $pagination, filter: $filter) {
     edges {
       cursor
       node {

--- a/PocketKit/Sources/PocketGraphTestMocks/Note+Mock.graphql.swift
+++ b/PocketKit/Sources/PocketGraphTestMocks/Note+Mock.graphql.swift
@@ -10,8 +10,11 @@ public class Note: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Note>>
 
   public struct MockFields {
+    @Field<Bool>("archived") public var archived
     @Field<PocketGraph.Markdown>("contentPreview") public var contentPreview
     @Field<PocketGraph.ISOString>("createdAt") public var createdAt
+    @Field<Bool>("deleted") public var deleted
+    @Field<PocketGraph.Markdown>("docMarkdown") public var docMarkdown
     @Field<PocketGraph.ID>("id") public var id
     @Field<SavedItem>("savedItem") public var savedItem
     @Field<PocketGraph.ValidUrl>("source") public var source
@@ -22,8 +25,11 @@ public class Note: MockObject {
 
 public extension Mock where O == Note {
   convenience init(
+    archived: Bool? = nil,
     contentPreview: PocketGraph.Markdown? = nil,
     createdAt: PocketGraph.ISOString? = nil,
+    deleted: Bool? = nil,
+    docMarkdown: PocketGraph.Markdown? = nil,
     id: PocketGraph.ID? = nil,
     savedItem: Mock<SavedItem>? = nil,
     source: PocketGraph.ValidUrl? = nil,
@@ -31,8 +37,11 @@ public extension Mock where O == Note {
     updatedAt: PocketGraph.ISOString? = nil
   ) {
     self.init()
+    _setScalar(archived, for: \.archived)
     _setScalar(contentPreview, for: \.contentPreview)
     _setScalar(createdAt, for: \.createdAt)
+    _setScalar(deleted, for: \.deleted)
+    _setScalar(docMarkdown, for: \.docMarkdown)
     _setScalar(id, for: \.id)
     _setEntity(savedItem, for: \.savedItem)
     _setScalar(source, for: \.source)

--- a/PocketKit/Sources/PocketKit/Refresh/NotesRefreshCoordinator.swift
+++ b/PocketKit/Sources/PocketKit/Refresh/NotesRefreshCoordinator.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Sync
+import SharedPocketKit
+import Combine
+
+/// Handle refresh of user notes
+class NotesRefreshCoordinator: RefreshCoordinator {
+    let taskID: String = "com.mozilla.pocket.refresh.notes"
+
+    let refreshInterval: TimeInterval? = 60 * 60
+
+    let backgroundRequestType: BackgroundRequestType = .processing
+
+    let notificationCenter: NotificationCenter
+    let taskScheduler: BGTaskSchedulerProtocol
+    let appSession: SharedPocketKit.AppSession
+    var subscriptions: [AnyCancellable] = []
+    var sessionSubscriptions: [AnyCancellable] = []
+
+    private let source: Source
+
+    init(notificationCenter: NotificationCenter, taskScheduler: BGTaskSchedulerProtocol, appSession: AppSession, source: Source) {
+        self.notificationCenter = notificationCenter
+        self.taskScheduler = taskScheduler
+        self.appSession = appSession
+        self.source = source
+    }
+
+    func refresh(isForced: Bool) async {
+        // no op
+    }
+
+    func refresh(isForced: Bool = false, _ completion: @escaping () -> Void) {
+        self.source.refreshNotes {
+            completion()
+        }
+    }
+}

--- a/PocketKit/Sources/PocketKit/Services.swift
+++ b/PocketKit/Sources/PocketKit/Services.swift
@@ -29,6 +29,7 @@ struct Services {
     let homeRefreshCoordinator: HomeRefreshCoordinator
     let userRefreshCoordinator: UserRefreshCoordinator
     let featureFlagsRefreshCoordinator: FeatureFlagsRefreshCoordinator
+    let notesRefreshCoordinator: NotesRefreshCoordinator
     let refreshCoordinators: [RefreshCoordinator]
     let authClient: AuthorizationClient
     let accessService: PocketAccessService
@@ -155,6 +156,13 @@ struct Services {
             lastRefresh: lastRefresh
         )
 
+        notesRefreshCoordinator = NotesRefreshCoordinator(
+            notificationCenter: notificationCenter,
+            taskScheduler: BGTaskScheduler.shared,
+            appSession: appSession,
+            source: source
+        )
+
         refreshCoordinators = [
             savesRefreshCoordinator,
             archiveRefreshCoordinator,
@@ -162,7 +170,8 @@ struct Services {
             unresolvedSavesRefreshCoordinator,
             homeRefreshCoordinator,
             userRefreshCoordinator,
-            featureFlagsRefreshCoordinator
+            featureFlagsRefreshCoordinator,
+            notesRefreshCoordinator
         ]
 
         imageManager = ImageManager(

--- a/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
+++ b/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
@@ -10,11 +10,13 @@ public protocol LastRefresh {
     var lastRefreshTags: TimeInterval? { get }
     var lastRefreshHome: TimeInterval? { get }
     var lastRefreshFeatureFlags: TimeInterval? { get }
+    var lastRefreshNotes: TimeInterval? { get }
     func refreshedSaves()
     func refreshedArchive()
     func refreshedTags()
     func refreshedHome()
     func refreshedFeatureFlags()
+    func refreshedNotes()
     func reset()
 }
 
@@ -31,6 +33,7 @@ public struct UserDefaultsLastRefresh: LastRefresh {
         defaults.removeObject(forKey: Self.lastRefreshedTagsAtKey)
         defaults.removeObject(forKey: Self.lastRefreshedHomeAtKey)
         defaults.removeObject(forKey: Self.lastRefreshedFeatureFlagsAtKey)
+        defaults.removeObject(forKey: Self.lastRefreshedNotesAtKey)
     }
 }
 
@@ -119,7 +122,7 @@ extension UserDefaultsLastRefresh {
     }
 }
 
-// MARK: Home
+// MARK: Feature flags
 extension UserDefaultsLastRefresh {
     public static let lastRefreshedFeatureFlagsAtKey = UserDefaults.Key.lastRefreshedFeatureFlagsAt
 
@@ -137,5 +140,26 @@ extension UserDefaultsLastRefresh {
 
     public func refreshedFeatureFlags() {
         defaults.set(Date().timeIntervalSince1970, forKey: Self.lastRefreshedFeatureFlagsAtKey)
+    }
+}
+
+// MARK: Notes
+extension UserDefaultsLastRefresh {
+    public static let lastRefreshedNotesAtKey = UserDefaults.Key.lastRefreshNotesAt
+
+    public var lastRefreshNotes: TimeInterval? {
+        if hasRefreshedNotes {
+            return defaults.double(forKey: Self.lastRefreshedNotesAtKey)
+        } else {
+            return nil
+        }
+    }
+
+    public var hasRefreshedNotes: Bool {
+        defaults.value(forKey: Self.lastRefreshedNotesAtKey) != nil
+    }
+
+    public func refreshedNotes() {
+        defaults.set(Date().timeIntervalSince1970, forKey: Self.lastRefreshedNotesAtKey)
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
+++ b/PocketKit/Sources/SharedPocketKit/LastRefresh.swift
@@ -10,7 +10,8 @@ public protocol LastRefresh {
     var lastRefreshTags: TimeInterval? { get }
     var lastRefreshHome: TimeInterval? { get }
     var lastRefreshFeatureFlags: TimeInterval? { get }
-    var lastRefreshNotes: TimeInterval? { get }
+    // we use the ISO8601 String representation in this case
+    var lastRefreshNotes: String? { get }
     func refreshedSaves()
     func refreshedArchive()
     func refreshedTags()
@@ -38,7 +39,6 @@ public struct UserDefaultsLastRefresh: LastRefresh {
 }
 
 // MARK: Saves
-
 extension UserDefaultsLastRefresh {
     public static let lastRefreshedSavesAtKey = UserDefaults.Key.lastRefreshedSavesAt
 
@@ -147,9 +147,9 @@ extension UserDefaultsLastRefresh {
 extension UserDefaultsLastRefresh {
     public static let lastRefreshedNotesAtKey = UserDefaults.Key.lastRefreshNotesAt
 
-    public var lastRefreshNotes: TimeInterval? {
+    public var lastRefreshNotes: String? {
         if hasRefreshedNotes {
-            return defaults.double(forKey: Self.lastRefreshedNotesAtKey)
+            return defaults.string(forKey: Self.lastRefreshedNotesAtKey)
         } else {
             return nil
         }
@@ -160,6 +160,14 @@ extension UserDefaultsLastRefresh {
     }
 
     public func refreshedNotes() {
-        defaults.set(Date().timeIntervalSince1970, forKey: Self.lastRefreshedNotesAtKey)
+        defaults.set(ISO8601DateFormatter.rfc3339WithFractionalSeconds.string(from: Date()), forKey: Self.lastRefreshedNotesAtKey)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static var rfc3339WithFractionalSeconds: Self {
+        let formatter = Self()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
     }
 }

--- a/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
+++ b/PocketKit/Sources/SharedPocketKit/UserDefaultsKey.swift
@@ -20,6 +20,7 @@ public extension UserDefaults {
         case lastRefreshedSavesAt = "lastRefreshedSavesAt"
         case lastRefreshedHomeAt = "lastRefreshedHomeAt"
         case lastRefreshedFeatureFlagsAt = "lastRefreshedFeatureFlagsAt"
+        case lastRefreshNotesAt = "lastRefreshNotes"
         case listSelectedSortForSaved = "listSelectedSortForSaved"
         case listSelectedSortForArchive = "listSelectedSortForArchive"
         case readerFontSizeAdjustment = "readerFontSizeAdjustment"

--- a/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
+++ b/PocketKit/Sources/Sync/Operations/AsyncOperation.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-open class AsyncOperation: Operation {
+open class AsyncOperation: Operation, @unchecked Sendable {
     override public var isAsynchronous: Bool {
         true
     }

--- a/PocketKit/Sources/Sync/Operations/FetchNotes.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchNotes.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation

--- a/PocketKit/Sources/Sync/Operations/FetchNotes.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchNotes.swift
@@ -3,3 +3,176 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import Apollo
+import Combine
+import PocketGraph
+import SharedPocketKit
+import CoreData
+
+class FetchNotes: SyncOperation {
+    private let apollo: ApolloClientProtocol
+    private let space: Space
+    private let events: SyncEvents
+    private let initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>
+    private let lastRefresh: LastRefresh
+    // Force unwrapping, because the entry point, execute, will ensure that this exists with a guard
+    private var safeSpace: NotesSpace!
+
+    init(
+        apollo: ApolloClientProtocol,
+        space: Space,
+        events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
+        lastRefresh: LastRefresh
+    ) {
+        self.apollo = apollo
+        self.space = space
+        self.events = events
+        self.lastRefresh = lastRefresh
+        self.initialDownloadState = initialDownloadState
+    }
+
+    func execute(syncTaskId: NSManagedObjectID) async -> SyncOperationResult {
+        guard let safeSpace = DerivedSpace(space: space, taskID: syncTaskId) else {
+            return .retry(NoPersistentTaskOperationError())
+        }
+        self.safeSpace = safeSpace
+
+        do {
+            if lastRefresh.lastRefreshNotes != nil {
+                guard let lastRefreshTime = lastRefresh.lastRefreshNotes, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Notes.timeMustPass else {
+                    Log.info("Not refreshing notes from server, last refresh is not above tolerance of \(SyncConstants.Notes.timeMustPass) seconds")
+                    return .success
+                }
+            }
+
+            var firstSync = false
+            if lastRefresh.lastRefreshNotes == nil {
+                initialDownloadState.send(.started)
+                firstSync = true
+            }
+
+            try await fetchNotes(firstSync: firstSync)
+            lastRefresh.refreshedNotes()
+            return .success
+        } catch {
+            switch error {
+            case is URLSessionClient.URLSessionClientError:
+                Log.breadcrumb(
+                    category: "sync",
+                    level: .error,
+                    message: "URLSessionClient.URLSessionClientError with Error: \(error.localizedDescription)"
+                )
+                return .retry(error)
+            case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
+                switch response?.statusCode {
+                case .some((500...)):
+                    Log.breadcrumb(
+                        category: "sync",
+                        level: .error,
+                        message: "ResponseCodeInterceptor.ResponseCodeError with Error: \(error.localizedDescription) and status code \(String(describing: response?.statusCode))"
+                    )
+                    return .failure(error)
+                default:
+                    return .failure(error)
+                }
+            default:
+                Log.capture(error: error)
+                events.send(.error(error))
+                return .failure(error)
+            }
+        }
+    }
+
+    private func fetchNotes(firstSync: Bool) async throws {
+        var pagination = PaginationSpec(
+            maxItems: SyncConstants.Notes.firstLoadMaxCount,
+            pageSize: SyncConstants.Notes.initalPageSize,
+            cursor: safeSpace.currentCursor
+        )
+
+        var pageNumber = 1
+        var totalToDownload = SyncConstants.Notes.firstLoadMaxCount
+        repeat {
+            let result = try await fetchPage(pagination)
+
+            if let totalCount = result.data?.notes?.totalCount,
+               firstSync {
+                if pageNumber == 1 {
+                    totalToDownload = min(totalCount, totalToDownload)
+                }
+                let totalReaminingToDownload = min(totalToDownload, pagination.maxRemainingItemsAllowedToDownload)
+                let progress = Float(totalToDownload - totalReaminingToDownload) / Float(totalToDownload)
+                Log.breadcrumb(category: "sync.notes", level: .debug, message: "Download Progress: \(progress) - Remaining Downloading: \(totalReaminingToDownload)")
+                initialDownloadState.send(.paginating(totalCount: totalReaminingToDownload, currentPercentProgress: progress))
+            }
+
+            try updateLocalStorage(result: result)
+            pagination = pagination.nextPage(result: result, pageSize: SyncConstants.Notes.pageSize)
+            Log.breadcrumb(category: "sync.notes", level: .debug, message: "Finsihed loading page \(pageNumber)")
+            pageNumber += 1
+        } while pagination.shouldFetchNextPage
+
+        initialDownloadState.send(.completed)
+    }
+
+    private func fetchPage(_ pagination: PaginationSpec) async throws -> GraphQLResult<NotesQuery.Data> {
+        let query = NotesQuery(
+            pagination: .some(
+                PaginationInput(
+                    after: pagination.cursor ?? .none,
+                    first: .some(pagination.pageSize)
+                )
+            ), filter: .none
+        )
+
+        if let updatedSince = lastRefresh.lastRefreshNotes {
+            query.filter = .some(NoteFilterInput(since: .some("\(Int(updatedSince))")))
+        } else {
+            query.filter = .none
+        }
+
+        return try await apollo.fetch(query: query)
+    }
+
+    private func updateLocalStorage(result: GraphQLResult<NotesQuery.Data>) throws {
+        guard let edges = result.data?.notes?.edges,
+              let cursor = result.data?.notes?.pageInfo.endCursor else {
+            return
+        }
+        try safeSpace.updateNotes(edges: edges, cursor: cursor)
+    }
+
+    struct PaginationSpec {
+        let cursor: String?
+        let shouldFetchNextPage: Bool
+        let maxRemainingItemsAllowedToDownload: Int
+        let pageSize: Int
+
+        init(maxItems: Int, pageSize: Int, cursor: String? = nil) {
+            self.init(cursor: cursor, shouldFetchNextPage: false, maxRemainingItemsAllowedToDownload: maxItems, pageSize: pageSize)
+        }
+
+        private init(cursor: String?, shouldFetchNextPage: Bool, maxRemainingItemsAllowedToDownload: Int, pageSize: Int) {
+            self.cursor = cursor
+            self.shouldFetchNextPage = shouldFetchNextPage
+            self.maxRemainingItemsAllowedToDownload = maxRemainingItemsAllowedToDownload
+            self.pageSize = pageSize
+        }
+
+        func nextPage(result: GraphQLResult<NotesQuery.Data>, pageSize: Int) -> PaginationSpec {
+            guard let notes = result.data?.notes,
+                  let itemCount = notes.edges?.count,
+                  let endCursor = notes.pageInfo.endCursor else {
+                return PaginationSpec(cursor: nil, shouldFetchNextPage: false, maxRemainingItemsAllowedToDownload: maxRemainingItemsAllowedToDownload, pageSize: pageSize)
+            }
+
+            return PaginationSpec(
+                cursor: endCursor,
+                shouldFetchNextPage: notes.pageInfo.hasNextPage && itemCount < maxRemainingItemsAllowedToDownload,
+                maxRemainingItemsAllowedToDownload: min((maxRemainingItemsAllowedToDownload - itemCount), notes.totalCount),
+                pageSize: pageSize
+            )
+        }
+    }
+}

--- a/PocketKit/Sources/Sync/Operations/FetchNotes.swift
+++ b/PocketKit/Sources/Sync/Operations/FetchNotes.swift
@@ -40,7 +40,9 @@ class FetchNotes: SyncOperation {
 
         do {
             if lastRefresh.lastRefreshNotes != nil {
-                guard let lastRefreshTime = lastRefresh.lastRefreshNotes, Date().timeIntervalSince1970 - Double(lastRefreshTime) > SyncConstants.Notes.timeMustPass else {
+                guard let lastRefreshTime = lastRefresh.lastRefreshNotes,
+                      let lastRefreshDate = ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: lastRefreshTime),
+                      Date().timeIntervalSince(lastRefreshDate) > SyncConstants.Notes.timeMustPass else {
                     Log.info("Not refreshing notes from server, last refresh is not above tolerance of \(SyncConstants.Notes.timeMustPass) seconds")
                     return .success
                 }
@@ -127,7 +129,7 @@ class FetchNotes: SyncOperation {
         )
 
         if let updatedSince = lastRefresh.lastRefreshNotes {
-            query.filter = .some(NoteFilterInput(since: .some("\(Int(updatedSince))")))
+            query.filter = .some(NoteFilterInput(since: .some(updatedSince)))
         } else {
             query.filter = .none
         }

--- a/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncOperationFactory.swift
@@ -39,6 +39,14 @@ protocol SyncOperationFactory {
             urls: [String]
         ) -> SyncOperation
 
+    func fetchNotes(
+        apollo: ApolloClientProtocol,
+        space: Space,
+        events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
+        lastRefresh: LastRefresh
+    ) -> SyncOperation
+
     func savedItemMutationOperation<Mutation: GraphQLMutation>(
         apollo: ApolloClientProtocol,
         events: SyncEvents,
@@ -116,6 +124,22 @@ class OperationFactory: SyncOperationFactory {
             apollo: apollo,
             space: space,
             urls: urls
+        )
+    }
+
+    func fetchNotes(
+        apollo: ApolloClientProtocol,
+        space: Space,
+        events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
+        lastRefresh: LastRefresh
+    ) -> SyncOperation {
+        return FetchNotes(
+            apollo: apollo,
+            space: space,
+            events: events,
+            initialDownloadState: initialDownloadState,
+            lastRefresh: lastRefresh
         )
     }
 

--- a/PocketKit/Sources/Sync/Operations/SyncTask.swift
+++ b/PocketKit/Sources/Sync/Operations/SyncTask.swift
@@ -8,6 +8,7 @@ enum SyncTask: Codable {
     case fetchSaves
     case fetchArchive
     case fetchTags
+    case fetchNotes
     case favorite(givenURL: String)
     case unfavorite(givenURL: String)
     case delete(givenURL: String)

--- a/PocketKit/Sources/Sync/PocketSaveService.swift
+++ b/PocketKit/Sources/Sync/PocketSaveService.swift
@@ -203,7 +203,7 @@ public class PocketSaveService: SaveService {
     }
 }
 
-class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation {
+class SaveOperation<Mutation: GraphQLMutation>: AsyncOperation, @unchecked Sendable {
     private let apollo: ApolloClientProtocol
     private let osNotifications: OSNotificationCenter
     private let space: Space

--- a/PocketKit/Sources/Sync/PocketSource.swift
+++ b/PocketKit/Sources/Sync/PocketSource.swift
@@ -22,6 +22,7 @@ public class PocketSource: Source {
 
     public var initialSavesDownloadState: CurrentValueSubject<InitialDownloadState, Never>
     public var initialArchiveDownloadState: CurrentValueSubject<InitialDownloadState, Never>
+    public var initialNotesDownloadState: CurrentValueSubject<InitialDownloadState, Never>
 
     private let space: Space
     private let user: User
@@ -71,13 +72,18 @@ public class PocketSource: Source {
         makeBackgroundQueue("com.mozilla.pocket.fetch.sharedWithYou")
     }()
 
+    private let fetchNotesQueue: OperationQueue = {
+        makeBackgroundQueue("com.mozilla.pocket.fetch.notes")
+    }()
+
     private var allQueues: [OperationQueue] {
         [
             saveQueue,
             fetchSavesQueue,
             fetchArchiveQueue,
             fetchTagsQueue,
-            fetchSharedWithYouQueue
+            fetchSharedWithYouQueue,
+            fetchNotesQueue
         ]
     }
 
@@ -143,6 +149,7 @@ public class PocketSource: Source {
         self.osNotificationCenter = osNotificationCenter
         self.initialSavesDownloadState = .init(.unknown)
         self.initialArchiveDownloadState = .init(.unknown)
+        self.initialNotesDownloadState = .init(.unknown)
         self.userService = userService
 
         if lastRefresh.lastRefreshSaves != nil {
@@ -153,6 +160,11 @@ public class PocketSource: Source {
             initialArchiveDownloadState.send(.completed)
         }
 
+        if lastRefresh.lastRefreshNotes != nil {
+            initialNotesDownloadState.send(.completed)
+        }
+        // These notifications are used to notify the app when a SavedItem gets created/updated from the extension
+        // TODO: NOTES - We should be doing this for notes once we support notes creation from a browser extension
         osNotificationCenter.add(observer: notificationObserver, name: .savedItemCreated) { [weak self] in
             self?.handleSavedItemCreatedNotification()
         }
@@ -1241,6 +1253,15 @@ extension PocketSource {
             case .fetchSharedWithYouItems(let urls):
                 let operation = operations.fetchSharedWithYouItems(apollo: apollo, space: space, urls: urls)
                 enqueue(operation: operation, persistentTask: persistentTask, queue: fetchSharedWithYouQueue)
+            case .fetchNotes:
+                let operation = operations.fetchNotes(
+                    apollo: apollo,
+                    space: space,
+                    events: _events,
+                    initialDownloadState: initialNotesDownloadState,
+                    lastRefresh: lastRefresh
+                )
+                enqueue(operation: operation, persistentTask: persistentTask, queue: self.fetchNotesQueue)
             }
         }
     }
@@ -1538,6 +1559,18 @@ extension PocketSource {
 
 // MARK: Notes
 extension PocketSource {
+    public func refreshNotes(completion: (() -> Void)? = nil) {
+        let operation = operations.fetchNotes(
+            apollo: apollo,
+            space: space,
+            events: _events,
+            initialDownloadState: initialNotesDownloadState,
+            lastRefresh: lastRefresh
+        )
+
+        enqueue(operation: operation, task: .fetchNotes, queue: fetchSavesQueue, completion: completion)
+    }
+
     public func fetchNote(noteID: String) -> CDNote? {
         do {
             return try space.fetchNote(byRemoteID: noteID)

--- a/PocketKit/Sources/Sync/RemoteMapping/Note+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Note+RemoteMapping.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation

--- a/PocketKit/Sources/Sync/RemoteMapping/Note+RemoteMapping.swift
+++ b/PocketKit/Sources/Sync/RemoteMapping/Note+RemoteMapping.swift
@@ -3,3 +3,25 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import CoreData
+import PocketGraph
+import SharedPocketKit
+
+extension CDNote {
+    public typealias NoteEdge = NotesQuery.Data.Notes.Edge
+
+    // TODO: NOTES - The space argument will be used when we fetch relationships
+    public func update(from noteEdge: NoteEdge, with space: Space) {
+        self.title = noteEdge.node?.title
+        self.contentPreview = noteEdge.node?.contentPreview
+        self.body = noteEdge.node?.docMarkdown
+        if let createdAt = noteEdge.node?.createdAt {
+            self.createdAt = ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: createdAt)
+        }
+        if let updatedAt = noteEdge.node?.updatedAt {
+            self.updatedAt = ISO8601DateFormatter.rfc3339WithFractionalSeconds.date(from: updatedAt)
+        }
+        self.sourceUrl = noteEdge.node?.source
+        // TODO: NOTES - Add logic to update related Saved Item when we roll it out (or earlier)
+    }
+}

--- a/PocketKit/Sources/Sync/Source.swift
+++ b/PocketKit/Sources/Sync/Source.swift
@@ -167,6 +167,7 @@ public protocol Source {
     func objectID(from uri: URL) -> NSManagedObjectID?
 
     // MARK: Notes
+    func refreshNotes(completion: (() -> Void)?)
     func fetchNote(noteID: String) -> CDNote?
     func fetchNotes(for savedItem: CDSavedItem) -> [CDNote]?
     func fetchAllNotes() -> [CDNote]?

--- a/PocketKit/Sources/Sync/Space/DerivedSpace.swift
+++ b/PocketKit/Sources/Sync/Space/DerivedSpace.swift
@@ -24,6 +24,10 @@ protocol TagSpace: Paginated {
     func updateTags(edges: [CDTag.TagEdge?], cursor: String?) throws
 }
 
+protocol NotesSpace: Paginated {
+    func updateNotes(edges: [CDNote.NoteEdge?], cursor: String) throws
+}
+
 protocol SharedWithYouSpace {
     func cleanupSharedWithYouItems(validUrls: [String]) throws
     func updateSharedWithYouItem(url: String, sortOrder: Int, remote: CompactItem) throws
@@ -60,6 +64,14 @@ struct DerivedSpace {
             category: "sync",
             level: .info,
             message: "Updating/Inserting SavedItem with ID: \(itemID)"
+        )
+    }
+
+    private func logNoteUpdated(noteID: String) {
+        Log.breadcrumb(
+            category: "sync",
+            level: .info,
+            message: "Updating/Inserting Note with ID: \(noteID)"
         )
     }
 
@@ -173,6 +185,30 @@ extension DerivedSpace: SharedWithYouSpace {
             let sharedWithYouItem = try space.fetchSharedWithYouItem(with: url, in: context) ??
             CDSharedWithYouItem(context: context, url: url, sortOrder: Int32(sortOrder), item: item)
             sharedWithYouItem.sortOrder = Int32(sortOrder)
+        }
+        try saveContexts()
+    }
+}
+
+extension DerivedSpace: NotesSpace {
+    func updateNotes(edges: [CDNote.NoteEdge?], cursor: String) throws {
+        updateCursor(cursor)
+        edges.forEach {
+            guard let edge = $0, let node = edge.node else {
+                return
+            }
+
+            logNoteUpdated(noteID: node.id)
+
+            context.performAndWait {
+                let ID = node.id
+                let note = (try? space.fetchNote(byRemoteID: ID, context: context)) ?? CDNote(context: context, noteID: ID)
+                note.update(from: edge, with: space)
+
+                if node.deleted {
+                    space.delete(note, in: context)
+                }
+            }
         }
         try saveContexts()
     }

--- a/PocketKit/Sources/Sync/Space/Space.swift
+++ b/PocketKit/Sources/Sync/Space/Space.swift
@@ -268,7 +268,7 @@ extension Space {
 extension Space {
     func fetchNote(byRemoteID id: String, context: NSManagedObjectContext? = nil) throws -> CDNote? {
         let request = Requests.fetchNote(noteID: id)
-        request.predicate = NSPredicate(format: "remoteID = %@", id)
+        request.predicate = NSPredicate(format: "noteID = %@", id)
         request.fetchLimit = 1
         return try fetch(request, context: context).first
     }

--- a/PocketKit/Sources/Sync/SwiftData/Models/Note.swift
+++ b/PocketKit/Sources/Sync/SwiftData/Models/Note.swift
@@ -8,15 +8,15 @@ import SwiftData
 
 @Model
 public class Note {
-    var noteID: String
-    var createdAt: Date
-    var updatedAt: Date?
-    var sourceUrl: String?
-    var title: String?
-    var contentPreview: String?
-    var body: String?
-    var savedItem: SavedItem?
-    var image: Image?
+    public var noteID: String
+    public var createdAt: Date
+    public var updatedAt: Date?
+    public var sourceUrl: String?
+    public var title: String?
+    public var contentPreview: String?
+    public var body: String?
+    public var savedItem: SavedItem?
+    public var image: Image?
     public init(createdAt: Date, noteID: String) {
         self.createdAt = createdAt
         self.noteID = noteID

--- a/PocketKit/Sources/Sync/SyncConstants.swift
+++ b/PocketKit/Sources/Sync/SyncConstants.swift
@@ -58,4 +58,18 @@ public struct SyncConstants {
 
         public static let slateLineupIdentifier = "e39bc22a-6b70-4ed2-8247-4b3f1a516bd1"
     }
+
+    public struct Notes {
+        /// How many saves we load when a user logs in. As they save and use pocket they may accumilate more, but we only download the amount of latest saves here to start.
+        public static let firstLoadMaxCount = 10000
+
+        /// How many saves we should load on the first login request for saves, we use a small value here so the user immediately sees content.
+        public  static let initalPageSize = 15
+
+        /// How many saves to load per subsequent page until we hit our load count.
+        public  static let pageSize = 30
+
+        /// How many seconds must pass from the last load of saves data before we allow hitting the server again.
+        public static let timeMustPass = 5.0
+    }
 }

--- a/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
+++ b/PocketKit/Tests/PocketKitTests/Support/MockSource.swift
@@ -8,6 +8,9 @@ import CoreData
 import Combine
 
 class MockSource: Source {
+    func refreshNotes(completion: (() -> Void)?) {
+    }
+
     func fetchNote(noteID: String) -> Sync.CDNote? {
         nil
     }

--- a/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockLastRefresh.swift
@@ -5,6 +5,9 @@
 @testable import SharedPocketKit
 
 class MockLastRefresh: LastRefresh {
+    var lastRefreshNotes: String?
+    func refreshedNotes() {}
+
     // MARK: - lastRefresh saves
     typealias GetLastRefreshSavesImpl = () -> Double?
     private var getLastRefreshSavesImpl: GetLastRefreshSavesImpl?

--- a/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
+++ b/PocketKit/Tests/SyncTests/Support/MockOperationFactory.swift
@@ -17,7 +17,61 @@ class MockOperationFactory: SyncOperationFactory {
     private var lock: DispatchQueue = DispatchQueue(label: "")
 }
 
-// MARK: - fetchSaves
+// MARK: Notes
+extension MockOperationFactory {
+    typealias FetchNotesImpl = (
+        ApolloClientProtocol,
+        Space,
+        SyncEvents,
+        CurrentValueSubject<InitialDownloadState, Never>
+    ) -> SyncOperation
+
+    struct FetchNotesCall {
+        let apollo: ApolloClientProtocol
+        let space: Space
+        let events: SyncEvents
+        let initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>
+        let lastRefresh: LastRefresh
+    }
+
+    func stubFetchNotes(impl: @escaping FetchNotesImpl) {
+        implementations["fetchNotes"] = impl
+    }
+
+    func fetchNotes(
+        apollo: ApolloClientProtocol,
+        space: Space,
+        events: SyncEvents,
+        initialDownloadState: CurrentValueSubject<InitialDownloadState, Never>,
+        lastRefresh: LastRefresh
+    ) -> SyncOperation {
+        guard let impl = implementations["fetchNotes"] as? FetchNotesImpl else {
+            fatalError("\(Self.self).\(#function) has not been stubbed")
+        }
+
+        lock.sync {
+            calls["fetchNotes"] = (calls["fetchNotes"] ?? []) + [
+                FetchNotesCall(
+                    apollo: apollo,
+                    space: space,
+                    events: events,
+                    initialDownloadState: initialDownloadState,
+                    lastRefresh: lastRefresh
+                )
+            ]
+        }
+
+        return impl(apollo, space, events, initialDownloadState)
+    }
+
+    func fetchNotesCall(at index: Int) -> FetchNotesCall? {
+        guard let fetchNotesCalls = calls["fetchNotes"], index < fetchNotesCalls.count else {
+            return nil
+        }
+        return fetchNotesCalls[index] as? FetchNotesCall
+    }
+}
+
 extension MockOperationFactory {
     typealias FetchSavesImpl = (
         ApolloClientProtocol,

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -46,7 +46,7 @@ struct ClientAPIRequest {
     }
 
     var isForNotes: Bool {
-        self.operationName == "FetchNotes"
+        self.operationName == "Notes"
     }
 
     var isForArchivedContent: Bool {

--- a/Tests iOS/Support/RequestMatchers.swift
+++ b/Tests iOS/Support/RequestMatchers.swift
@@ -45,6 +45,10 @@ struct ClientAPIRequest {
         self.operationName == "FetchSaves" && !contains(#"ARCHIVED"#)
     }
 
+    var isForNotes: Bool {
+        self.operationName == "FetchNotes"
+    }
+
     var isForArchivedContent: Bool {
         self.operationName == "FetchArchive" && contains(#"ARCHIVED"#)
     }

--- a/Tests iOS/Support/Response+factories.swift
+++ b/Tests iOS/Support/Response+factories.swift
@@ -21,6 +21,11 @@ extension Response {
         }
     }
 
+    static func notes() -> Response {
+        // TODO: NOTES - Once the UI is ready we can edit this response to ui test Notes
+        Response(status: .ok)
+    }
+
     static func throttle() -> Response {
         Response {
             Status.tooManyRequests
@@ -390,6 +395,8 @@ extension Response {
             return .shortUrl()
         } else if apiRequest.isForCreateShareLink {
             return .createShareLink()
+        } else if apiRequest.isForNotes {
+            return .notes()
         } else {
             fatalError("Unexpected request")
         }


### PR DESCRIPTION
## Goal
* Add sync logic for notes
> [!NOTE]
> the sync logic will be updated when we add notes to SavedItems etc

## Test Steps
* Nothing testable with the UI yet, but if you have tools like Core Data Lab and access to Apollo studio, you can:
    - create notes from Apollo studio to your account (ideally more than 30 so you have more than one page, notes can also have the same title and content)
    - Launch the app, login with that same account, and observe the notes being populated in Core Data Lab (or any other SQLIte viewer of choice)
    - Make sure the fields you receive are consistent with what you see in Apollo studio

