### PR TITLE
Fix high CPU usage in the Reader, when called from Home

### DIFF
--- a/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
+++ b/PocketKit/Sources/PocketKit/Article/Cells/ArticleComponentTextCell.swift
@@ -55,7 +55,7 @@ protocol ArticleComponentTextViewDelegate: AnyObject {
 // A subclass of UITextView that overrides certain actions (e.g Share),
 // and delegates the response to these actions to its delegate.
 class ArticleComponentTextView: UITextView {
-    var actionDelegate: ArticleComponentTextViewDelegate?
+    weak var actionDelegate: ArticleComponentTextViewDelegate?
 
     var onHighlight: ((NSRange, String, String) -> Void)?
 

--- a/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
+++ b/PocketKit/Sources/PocketKit/Article/ReadableViewController.swift
@@ -46,8 +46,7 @@ class ReadableViewController: UIViewController {
     var hasAppearedAfterLoading = false
 
     private var userScrollProgress: IndexPath?
-    // Tippable view controller properties
-    var tipObservationTask: Task<Void, Error>?
+
     weak var tipViewController: UIViewController?
 
     private lazy var collectionView: UICollectionView = UICollectionView(
@@ -207,14 +206,6 @@ class ReadableViewController: UIViewController {
                 .store(in: &subscriptions)
 
             viewModel
-                .$presentedWebReaderURL
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] url in
-                    self?.present(url: url)
-                }
-                .store(in: &subscriptions)
-
-            viewModel
                 .$sharedActivity
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] activity in
@@ -359,11 +350,7 @@ class ReadableViewController: UIViewController {
             scrollToLastKnownPosition()
             hasAppearedAfterLoading = true
         }
-        // do not vend the tip on syndicated articles
-        if readableViewModel is SavedItemViewModel {
-            PocketTipEvents.showSwipeHighlightsTip.sendDonation()
-            displayTip(SwipeHighlightsTip(), configuration: nil, sourceView: nil)
-        }
+
         readableViewModel.trackReaderScreenImpression()
     }
 
@@ -783,17 +770,14 @@ extension ReadableViewController {
     }
 }
 
-// MARK: TippableViewController conformance
-extension ReadableViewController: TippableViewController {}
-
 extension ReadableViewController: SFSafariViewControllerDelegate {
     func safariViewController(_ controller: SFSafariViewController, activityItemsFor URL: URL, title: String?) -> [UIActivity] {
         return webViewActivityItems(url: URL)
     }
 
-//    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-//        model.clearPresentedWebReaderURL()
-//    }
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        readableViewModel.clearPresentedWebReaderURL()
+    }
     func webViewActivityItems(url: URL) -> [UIActivity] {
         guard let item = Services.shared.source.fetchItem(url.absoluteString), let savedItem = item.savedItem else {
             return []

--- a/PocketKit/Sources/PocketKit/Home/Views/Detail views/ReaderView.swift
+++ b/PocketKit/Sources/PocketKit/Home/Views/Detail views/ReaderView.swift
@@ -16,9 +16,12 @@ struct ReaderView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         if let model = makeReadableViewModel() {
             let viewController = ReadableHostViewController(readableViewModel: model)
-            context.coordinator.parentObserver = viewController.observe(\.parent?.navigationItem.rightBarButtonItems, changeHandler: { viewController, _ in
+            context.coordinator.parentObserver = viewController.observe(\.parent?.navigationItem.rightBarButtonItems, changeHandler: { @MainActor viewController, _ in
+                guard viewController.parent?.title == nil, viewController.parent?.navigationItem.rightBarButtonItem == nil else {
+                    return
+                }
                 Task {
-                    await update(viewController: viewController)
+                    update(viewController: viewController)
                 }
             })
             return viewController

--- a/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/NoteListCell.swift
+++ b/PocketKit/Sources/PocketKit/MyList/ItemsList/UIKit/Cells/NoteListCell.swift
@@ -103,16 +103,19 @@ extension NoteCellView {
             if let title = viewModel.title {
                 Text(title)
                     .style(.listCellTitle)
-                    .lineLimit(2)
+                    .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
             }
             if let markdownContent = makeMarkdownString(viewModel.content) {
                 Text(unformattedString(markdownContent))
                     .font(.body)
                     .foregroundColor(Color(.ui.black1))
                     .lineSpacing(4)
-                    .lineLimit(2)
+                    .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.vertical, 4)
             }
         }


### PR DESCRIPTION
## Goal
* Some users were experiencing device heating by reading articles in the Reader. It came down to an observer that was launching tasks even when not needed.


## Test Steps
* The best way to test this it to build this branch attached to Xcode, open an article in Reader mode from Home (either a syndicated article one from Recent Saves, or any saved recommendation that supports the Reader), select the Debug Navigator and make sure the CPU usage stays low. If you see an initial spike when navigating to the article and then the CPU usage goes down, that's normal.

## Screenshots
